### PR TITLE
register clock sys calls

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -1,6 +1,6 @@
 VPATH += $(ROOT)/unix
 
-UNIX = unix.o syscall.o vdso.o signal.o thread.o mmap.o clock.o poll.o exec.o
+UNIX = unix.o syscall.o vdso.o signal.o thread.o mmap.o unix_clock.o poll.o exec.o
 
 INCLUDES += -I$(ROOT)/unix
 

--- a/unix/unix.c
+++ b/unix/unix.c
@@ -169,6 +169,7 @@ kernel init_unix(heap h,
     register_mmap_syscalls(linux_syscalls);
     register_thread_syscalls(linux_syscalls);
     register_poll_syscalls(linux_syscalls);
+    register_clock_syscalls(linux_syscalls);
     //buffer b = install_syscall(h);
     //syscall = b->contents;
     // debug the synthesized version later, at least we have the table dispatch

--- a/unix/unix_clock.c
+++ b/unix/unix_clock.c
@@ -10,10 +10,16 @@ int gettimeofday(struct timeval *tv, void *tz)
     return 0;
 }
 
+int nanosleep(const struct timespec* req, struct timespec* rem)
+{
+    // TODO:
+    return 0;
+}
 
-void register_clock_syscalls(void *map)
+void register_clock_syscalls(void **map)
 {
     register_syscall(map, SYS_clock_gettime, syscall_ignore);
     register_syscall(map, SYS_clock_getres, syscall_ignore);
     register_syscall(map, SYS_gettimeofday, gettimeofday);
+    register_syscall(map, SYS_nanosleep, nanosleep);
 }

--- a/unix/unix_internal.h
+++ b/unix/unix_internal.h
@@ -122,6 +122,7 @@ void register_signal_syscalls(void **);
 void register_mmap_syscalls(void **);
 void register_thread_syscalls(void **);
 void register_poll_syscalls(void **);
+void register_clock_syscalls(void **);
 
 boolean poll_init(kernel k);
 


### PR DESCRIPTION
- For some reason the clock sys calls were never registered, not sure if it was intentional.
- clock.c  under x86_x64 and clock.c under unix , both compile to clock.o and the last one wins, so renaming unix/clock.c to unix/cunix_clock.c