### PR TITLE
nanosleep set the rem to zero 

### DIFF
--- a/unix/unix_clock.c
+++ b/unix/unix_clock.c
@@ -13,6 +13,8 @@ int gettimeofday(struct timeval *tv, void *tz)
 int nanosleep(const struct timespec* req, struct timespec* rem)
 {
     // TODO:
+    rem->ts_sec = 0;
+    rem->ts_nsec = 0;
     return 0;
 }
 


### PR DESCRIPTION
The garbage in rem makes go runtime crazy