### PR TITLE
epoll_pwait -> epoll_wait, restore USERNET for run make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ run-nokvm: image
 	- $(QEMU) $(BOOT) $(DISPLAY) -m 2G -device isa-debug-exit $(STORAGE) $(USERNET)
 
 run: image
-	- $(QEMU) $(BOOT) $(DISPLAY) -m 2G -device isa-debug-exit $(STORAGE) $(USERNET) $(KVM)
+	- $(QEMU) $(BOOT) $(DISPLAY) -m 2G -device isa-debug-exit $(STORAGE) $(NET) $(KVM)
 
 runnew: image
 	- ~/qemu/x86_64-softmmu/qemu-system-x86_64 -hda image $(DISPLAY) -m 2G -device isa-debug-exit $(STORAGE) $(USERNET) $(KVM)


### PR DESCRIPTION
Later versions of go want epoll_pwait, just point it at epoll_wait since we don't use the sigmask.