### PR TITLE
MPSC queue

### DIFF
--- a/x86_64/queue.c
+++ b/x86_64/queue.c
@@ -1,57 +1,107 @@
 #include <runtime.h>
 
-// there is a test-and-set atomic resize for the multiprocessor case?
-// this is not in x86_64
+void queue_dump(queue q)
+{
+    rprintf("queue @ %p being dumped\n", q);
+    rprintf("queue size: %p\n", q->size);
+    rprintf("queue count: %p\n", q->count);
+    for (int i = 0; i < q->size; i ++) {
+        if (i >= q->read % q->size && i < q->write % q->size) {
+            rprintf("+ ");
+        } else {
+            rprintf("- ");
+        }
 
+        rprintf("%p: ", i);
+        rprintf("%p\n", q->buf[i]);
+    }
+}
 
 boolean enqueue(queue q, void *n)
 {
-    u64 mask = q->length -1;
-    if (((q->write + 1)  & mask)  == (q->read & mask))
+    u64 count = fetch_and_add(&q->count, 1);
+    u64 write;
+    boolean r;
+
+    if (count >= q->size) {
+        // can't enqueue more elements than the bounds
+        fetch_and_add(&q->count, -1);
         return false;
-    // fix this race for multiple writers...maybe a lookaside region
-    // next to the write pointer so we can use cas128?
-    u64 f = read_flags();
-    disable_interrupts();
-    u64 slot = fetch_and_add(&q->write, 1);
-    q->body[slot & mask]= n;
-    if (f & (1 << FLAG_INTERRUPT)) enable_interrupts();
+    }
+
+    // rusty 'acquire the ownership' of the next element in the queue
+    write = fetch_and_add(&q->write, 1);
+
+    // put the data in the buf
+    r = __sync_bool_compare_and_swap(&q->buf[write % q->size], 0, n);
+    if (!r) {
+        // should never happen
+        // if it does, then something went horribly wrong.
+        queue_dump(q);
+        halt("queue is in inconsistent state");
+    }
+
+    // otherwise we are done
     return true;
 }
 
 int queue_length(queue q)
 {
-    return q->write - q->read;
+    return __atomic_load_n(&q->count, __ATOMIC_ACQUIRE);
 }
 
 void *queue_peek(queue q)
 {
-    u64 mask = q->length -1;
-    if ((q->read & mask) == (q->write & mask) )
+    if (__atomic_load_n(&q->count, __ATOMIC_ACQUIRE) == 0)
         return 0;
-    return q->body[q->read&mask];
+
+    return __atomic_load_n(&q->buf[q->read % q->size], __ATOMIC_ACQUIRE);
 }
 
+#define DEQUEUE_MAX_BACKOFF 10000
 void *dequeue(queue q)
 {
-    u64 mask = q->length -1;
-    if ((q->write & mask) == (q->read & mask) )
+    int backoff = 1;
+    int i;
+    void *r;
+
+    if (__atomic_load_n(&q->count, __ATOMIC_ACQUIRE) == 0)
         return 0;
-    
-    // this isn't necessary given single reader, but it also has
-    // the barrier
-    u64 slot = fetch_and_add(&q->read, 1);
-    return q->body[slot&mask];
+
+retry:
+    r = __atomic_exchange_n(&q->buf[q->read ++ % q->size], 0, __ATOMIC_ACQUIRE);
+    if (!r) {
+        // if we had already backed off that maximum, let the dequeueing fail
+        if (backoff >= DEQUEUE_MAX_BACKOFF)
+            return false;
+
+        // issue @backoff PAUSE instructions
+        for (i = 0; i < backoff; i ++) {
+            // make sure the compiler does not optimize away the
+            asm volatile("pause");
+        }
+
+        // exponentially increase the amount of PAUSE instructions executed
+        backoff *= 10;
+        goto retry;
+    }
+
+    // formally tell tell the queue that the element is gone
+    fetch_and_add(&q->count, -1);
+    return r;
 }
 
-
-// has to be power two
 queue allocate_queue(heap h, u64 size)
 {
     queue q = allocate(h, sizeof(struct queue) + size * sizeof(void *));
-    q->length = size; // log
+    q->size = size;
+    q->count = 0;
     q->write = q->read = 0;
     q->h = h;
+    zero(q->buf, size * sizeof(void *));
+    // XXX: we could do a release ordering here, however let's just use a full
+    // barrier for now.
+    memory_fence();
     return q;
 }
 

--- a/x86_64/x86_64.h
+++ b/x86_64/x86_64.h
@@ -148,6 +148,20 @@ static inline word fetch_and_add(word* variable, word value)
     return value;
 }
 
+static inline void store_fence()
+{
+    __asm__ volatile("sfence");
+}
+
+static inline void load_fence()
+{
+    __asm__ volatile("lfence");
+}
+
+static inline void memory_fence()
+{
+    __asm__ volatile("mfence");
+}
 
 // tuples
 #define FLAG_INTERRUPT 9
@@ -189,10 +203,12 @@ void unmap(u64 virtual, int length, heap h);
 
 // xxx - hide
 struct queue {
-    // these should be on cache lines in the mp case
-    u64 read, write, length;
+    u64 count;
+    u64 write;
+    u64 read;
+    u64 size;
     heap h;
-    void *body[];
+    void *buf[];
 };
 
 


### PR DESCRIPTION
Few XXXs that could do with some input:

- when `dequeue()`-ing there is a chance that we are unlucky and the other thread has reserved the spot, but has not yet had time to fill it in. This code will just `return false`, which makes it wait-free. Question: should we yield or spin for a bit?

- there is no memory ordering in this, because it should not be necessary; however some may prefer the `__atomic_*` intrinsics instead of the GCC ones (`__sync_*`)

Fixes: #32 