### PR TITLE
unix/exec: fix envc double count

### DIFF
--- a/unix/exec.c
+++ b/unix/exec.c
@@ -37,6 +37,7 @@ static void build_exec_stack(heap sh, thread t, Elf64_Ehdr * e, void *start, u64
     char **argv = stack_allocate(vector_length(arguments) * sizeof(u64));
     int envc = table_elements(environment);
     char **envp = stack_allocate(envc * sizeof(u64));
+    envc = 0;
     buffer a;
     vector_foreach(arguments, a)  argv[argc++] = ppush(s, b, "%b\0", a);
     table_foreach(environment, n, v)  envp[envc++] = ppush(s, b, "%b=%b\0", symbol_string(n), v);


### PR DESCRIPTION
This fixes #137 for me, although I'll wait for @eyberg's ack before closing that issue.