### PR TITLE
exit group system call

### DIFF
--- a/unix/syscall.c
+++ b/unix/syscall.c
@@ -495,8 +495,7 @@ static sysreturn fstat(int fd, struct stat *s)
     thread_log(current, "fd %d, stat %p\n", fd, s);
     file f = resolve_fd(current->p, fd);
     // take this from tuple space
-    if (fd == 1 || fd == 2) {
-        console("HERE......\n");
+    if (fd == 1) {
         s->st_mode = S_IFIFO;
         return 0;
     }


### PR DESCRIPTION
Add exit_group syscall, it's a no return syscall just exit exit but it make sure all threads in the process exit not just the calling thread. With out this go helloworld crash after printing hello world for me...since it start executing crap instructions after frameenter.end() label.