### PR TITLE
build: fix 'make clean' issue #175

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ gotest: image
 	$(MAKE) -C $(subst -clean,,$@) clean
 
 clean:
-	$(MAKE) {contgen,boot,stage3,mkfs,examples,test}-clean
+	$(MAKE) $(addsuffix -clean,contgen boot stage3 mkfs examples test)
 	$(MAKE) -C gotests clean
 	$(Q) $(RM) -f $(FS) $(IMAGE) $(IMAGE).dup
 	$(Q) $(RM) -fd $(dir $(IMAGE)) output


### PR DESCRIPTION
Remove Bourne shell expansion in command.

Make invokes /bin/sh, which is not necessarily bash, and
recongize bash sppecific syntax.