### PR TITLE
clear up low virtual address space

### DIFF
--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -65,13 +65,7 @@ static void __attribute__((noinline)) kernel_read_complete(buffer kb)
     // used in stage3
     stack -= (STACKLEN - 4);	/* XXX b0rk b0rk b0rk */
     map(stack, stack, (u64)STACKLEN, pages);
-
-    // should drop this in stage3? ... i think we just need
-    // service32 and the stack.. this doesn't show up in the e820 regions
-    // stack is currently in the first page, so lets leave it mapped
-    // and take it out later...ideally move the stack here
-    // could put the stack at the top of the page region?
-    map(0, 0, 0xa000, pages);
+    map(0, 0, INITIAL_MAP_SIZE, pages);
 
     // stash away kernel elf image for use in stage3
     create_region(u64_from_pointer(buffer_ref(kb, 0)), pad(buffer_length(kb), PAGESIZE), REGION_KERNIMAGE);

--- a/src/x86_64/crt0.s
+++ b/src/x86_64/crt0.s
@@ -238,6 +238,45 @@ _start:
         hlt
 .end:
 
+global_func move_gdt
+move_gdt:
+        lgdt [GDT64.Pointer]
+        ret
+.end:
 
+        ;; set this crap up again so we can remove the stage2 one from low memory
+align 16                        ; necessary?
+GDT64:  ; Global Descriptor Table (64-bit).
+        ;;  xxx - clean this up with a macro
+        .Null: equ $ - GDT64 ; The null descriptor.
+        dw 0  ; Limit (low).
+        dw 0  ; Base (low).
+        db 0  ; Base (middle)
+        db 0  ; Access.
+        db 0  ; Granularity.
+        db 0  ; Base (high).
+        .Code: equ $ - GDT64 ; The code descriptor.
+        dw 0  ; Limit (low).
+        dw 0  ; Base (low).
+        db 0  ; Base (middle)
+        db 10011010b    ; Access (exec/read).
+        db 00100000b    ; Granularity.
+        db 0            ; Base (high).
+        .Data: equ $ - GDT64 ; The data descriptor.
+        dw 0         ; Limit (low).
+        dw 0         ; Base (low).
+        db 0         ; Base (middle)
+        db 10010010b ; Access (read/write).
+        db 00000000b ; Granularity.
+        db 0         ; Base (high).
+        .DataAgain: equ $ - GDT64 ; The data descriptor, a copy for sysret
+        dw 0         ; Limit (low).
+        dw 0         ; Base (low).
+        db 0         ; Base (middle)
+        db 10010010b ; Access (read/write).
+        db 00000000b ; Granularity.
+        db 0         ; Base (high).
 
-
+        .Pointer:    ; The GDT-pointer.
+        dw $ - GDT64 - 1    ; Limit.
+        dq GDT64            ; 64 bit Base.

--- a/src/x86_64/x86_64.h
+++ b/src/x86_64/x86_64.h
@@ -10,6 +10,8 @@
 #define LSTAR_MSR 0xc0000082
 #define SFMASK_MSR 0xc0000084
 
+#define INITIAL_MAP_SIZE (0xa000)
+
 extern u64 cpuid();
 extern u64 read_msr(u64);
 extern void write_msr(u64, u64);


### PR DESCRIPTION
This addresses crashing caused by programs loading elf segments over low memory (e.g. at 0, which turns out to be quite typical). The identity heap now lives at the top of the highest physical region (from bios e820) in 32-bit space (so it can be used by stage2), and the GDT is relocated to kernel address space in stage3 init. Region tables are presumed to be irrelevant after initialization.

This should address many of the issues referenced by #201, at least moving the needle past the loader and into program execution, e.g.:

```
$ ./stage && nvm run -p 8080 -c config.json php
booting image ...
qemu-system-x86_64 -drive file=image,format=raw,index=0 -display none -serial stdio -nodefaults -no-reboot -m 2G -device isa-debug-exit -drive file=image,format=raw,if=virtio -device virtio-net,netdev=n0 -netdev user,id=n0,hostfwd=tcp::8\
080-:8080
create fs
kernel complete
pages heap: 000000007fb92000, length 00000000002f7000
physical memory:
   base 0000000000200000, length 000000007f600000
Using HPET clock source.
init net page alloc 0000000000f027620
assigned: 10.0.2.15
read program complete: 00000020000000000 (children:(usr:(children:(lib:(children:(x86_64-linux-gnu:(children:(libicui18n.so.57:(extents:(0:(length:2591816 offset:3072)) filelength:2591816) libxml2.so.2:(extents:(0:(length:1809656 offset:\
34695168)) filelength:1809656) libstdc++.so.6:(extents:(0:(length:1566168 offset:2595328)) filelength:1566168) libssl.so.1.1:(extents:(0:(length:442920 offset:32524288)) filelength:442920) libicudata.so.57:(extents:(0:(length:25675624 of\
fset:4161536)) filelength:25675624) libicuuc.so.57:(extents:(0:(length:1727216 offset:32967680)) filelength:1727216) libcrypto.so.1.1:(extents:(0:(length:2686672 offset:29837312)) filelength:2686672))))))) lib:(children:(x86_64-linux-gnu\
:(children:(libgcc_s.so.1:(extents:(0:(length:92584 offset:42663424)) filelength:92584) libdl.so.2:(extents:(0:(length:14640 offset:40980480)) filelength:14640) liblzma.so.5:(extents:(0:(length:154376 offset:42756096)) filelength:154376)\
 libpthread.so.0:(extents:(0:(length:135440 offset:42527744)) filelength:135440) libz.so.1:(extents:(0:(length:105088 offset:42910720)) filelength:105088) libpcre.so.3:(extents:(0:(length:468920 offset:42058752)) filelength:468920) libre\
solv.so.2:(extents:(0:(length:84848 offset:40895488)) filelength:84848) libm.so.6:(extents:(0:(length:1063328 offset:40995328)) filelength:1063328) libc.so.6:(extents:(0:(length:1689360 offset:43016192)) filelength:1689360))))) lib64:(ch\
ildren:(ld-linux-x86-64.so.2:(extents:(0:(length:153288 offset:44705792)) filelength:153288))) kernel:(extents:(0:(length:1339216 offset:44859392)) filelength:1339216) php:(extents:(0:(length:4389936 offset:36505088)) filelength:4389936)\
) program:/php environment:() arguments:(0:php))
build exec stack 00000020000000000
enq
open /etc/ld.so.cache - not found
open /lib/x86_64-linux-gnu/tls/libresolv.so.2 - not found
open /lib/x86_64-linux-gnu/libxml2.so.2 - not found
open /usr/lib/x86_64-linux-gnu/tls/libxml2.so.2 - not found
open /lib/x86_64-linux-gnu/libssl.so.1.1 - not found
open /lib/x86_64-linux-gnu/libcrypto.so.1.1 - not found
open /lib/x86_64-linux-gnu/libicui18n.so.57 - not found
open /lib/x86_64-linux-gnu/libicuuc.so.57 - not found
open /lib/x86_64-linux-gnu/libicudata.so.57 - not found
open /lib/x86_64-linux-gnu/libstdc++.so.6 - not found
nosyscall set_robust_list
nosyscall madvise
open /etc/localtime - not found
open /etc/php/7.0/cli/php-cli.ini - not found
open /etc/php/7.0/cli/php.ini - not found
open /etc/php/7.0/cli/conf.d - not found
nosyscall time
nosyscall sysinfo
nosyscall ioctl

Fatal error: Unknown: Failed opening required '-' (include_path='.:/usr/share/php') in Unknown on line 0
exit_groupexit status 1
```
