### PR TITLE
Disable SSE/SSE2 for the build

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -21,6 +21,8 @@ CFLAGS	= -fno-omit-frame-pointer \
 		  -fno-stack-protector \
 		  -g \
 		  -O \
+		  -mno-sse \
+		  -mno-sse2 \
 		  -fdata-sections \
 		  -ffunction-sections \
 		  $(includes)

--- a/contgen/contgen.c
+++ b/contgen/contgen.c
@@ -1,5 +1,5 @@
 #include <stdarg.h>
-#include <stdlib.h>
+//#include <stdlib.h>
 #include <unistd.h>
 
 /* Helper functions to ignore unused result (eliminate CC warning) */

--- a/src/unix_process/socket_user.c
+++ b/src/unix_process/socket_user.c
@@ -2,7 +2,7 @@
 
 #include <runtime.h>
 #include <sys/socket.h>
-#include <stdlib.h>
+//#include <stdlib.h>
 #include <netinet/in.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/unix_process/unix_process_runtime.c
+++ b/src/unix_process/unix_process_runtime.c
@@ -1,6 +1,6 @@
 #include <runtime.h>
 #include <unistd.h>
-#include <stdlib.h>
+//#include <stdlib.h>
 #include <sys/mman.h>
 #include <sys/time.h>
 #include <string.h>

--- a/test/id_heap_test.c
+++ b/test/id_heap_test.c
@@ -1,5 +1,7 @@
 #include <runtime.h>
-#include <stdlib.h>
+//#include <stdlib.h>
+#define EXIT_FAILURE 1
+#define EXIT_SUCCESS 0
 
 #define MAX_PAGE_ORDER		12
 #define LENGTH_ORDER		16

--- a/test/network_test.c
+++ b/test/network_test.c
@@ -1,7 +1,6 @@
 #include <runtime.h>
 #include <http.h>
 #include <socket_user.h>
-#include <stdlib.h>
 
 typedef struct stats {
     u32 connections;

--- a/test/objcache_test.c
+++ b/test/objcache_test.c
@@ -1,5 +1,7 @@
 #include <runtime.h>
-#include <stdlib.h>
+//#include <stdlib.h>
+#define EXIT_FAILURE 1
+#define EXIT_SUCCESS 0
 #include <unistd.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/test/path_test.c
+++ b/test/path_test.c
@@ -2,7 +2,9 @@
 #include <path.h>
 #include <buffer.h>
 #include <unistd.h>
-#include <stdlib.h>
+//#include <stdlib.h>
+#define EXIT_FAILURE 1
+#define EXIT_SUCCESS 0
 #include <stdio.h>
 #include <string.h>
 

--- a/test/pqueue_test.c
+++ b/test/pqueue_test.c
@@ -1,6 +1,8 @@
 //#define ENABLE_MSG_DEBUG
 #include <runtime.h>
-#include <stdlib.h>
+//#include <stdlib.h>
+#define EXIT_FAILURE 1
+#define EXIT_SUCCESS 0
 
 boolean basic_sort(void * a, void * b)
 {

--- a/test/vector_test.c
+++ b/test/vector_test.c
@@ -7,7 +7,9 @@
 
 //#define ENABLE_MSG_DEBUG
 #include <runtime.h>
-#include <stdlib.h>
+//#include <stdlib.h>
+#define EXIT_SUCCESS 0
+#define EXIT_FAILURE 1
 
 boolean basic_test(heap h)
 {


### PR DESCRIPTION
Otherwise we choke on instructions like this:

```
8227:       f3 0f 7e 44 24 08       movq   0x8(%esp),%xmm0
```

glibc's `stdlib.h` is so nice it has a bunch of float code in it and that makes us choke on some SSE instructions. Uncomment that include and TODO add back the declarations.

Signed-off-by: Levente Kurusa <lkurusa@acm.org>