### PR TITLE
Fix futex(FUTEX_WAKE_OP)

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -128,8 +128,8 @@ static sysreturn futex(int *uaddr, int futex_op, int val,
                 thread_log(current, "futex wake op: [%d %p %d] %p %d %d %d %d\n",  current->tid, uaddr, *uaddr, uaddr2, cmparg, oparg, cmp, op);
             int oldval = *(int *) uaddr2;
             
-            switch (cmp) {
-            case FUTEX_OP_SET:   *uaddr  = oparg; break;
+            switch (op) {
+            case FUTEX_OP_SET:   *uaddr2 = oparg; break;
             case FUTEX_OP_ADD:   *uaddr2 += oparg; break;
             case FUTEX_OP_OR:    *uaddr2 |= oparg; break;
             case FUTEX_OP_ANDN:  *uaddr2 &= ~oparg; break;


### PR DESCRIPTION
- FUTEX_OP_* should be acted on "op", not "cmp"
- FUTEX_OP_SET should modify *uaddr2, not *uaddr

This fixes pthread_cond_signal/pthread_cond_wait