### PR TITLE
Issue #297 - use page-flush when compiling for 32bits

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -3,7 +3,7 @@ include ../common.mk
 
 OUT		?= $(ROOT)/output/boot
 
-CFLAGS		+= -m32 -DBOOT -nostdinc
+CFLAGS		+= -m32 -DBOOT -nostdinc -DPAGE_USE_FLUSH
 LDFLAGS		+= -T linker_script
 AFLAGS		+= -felf
 NASMFLAGS	= -l $@.lst -dSTAGE1SIZE=512 -dSTAGE2SIZE=$(shell stat -c %s $(OUT)/stage2.pad)

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -164,7 +164,7 @@ static inline boolean map_page(page base, u64 v, physical p, heap h, boolean fat
 #ifdef PAGE_USE_FLUSH
         flush_tlb();
 #else
-        asm volatile("invlpg (%0)" :: "r" ((unsigned long)v) : "memory");
+        asm volatile("invlpg (%0)" :: "r" (v) : "memory");
 #endif
     }
     return true;


### PR DESCRIPTION
Minor change. Issue found when enabling compiler warnings. Boot stage code is compiled with -m32 and asm code for invlpg has issue with 64bit parameter. 

Use PAGE_USE_FLUSH/flush_tlb instead of invlpg when compiling -m32 to avoid this.