### PR TITLE
write(2): Advance f->offset properly

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -393,9 +393,7 @@ sysreturn write(int fd, u8 *body, bytes length)
         return set_syscall_error(current, EBADF);
     if (!f->write)
         return set_syscall_error(current, EINVAL);
-    int res = apply(f->write, body, length, f->offset);
-    f->offset += length;
-    return res;
+    return apply(f->write, body, length, infinity);
 }
 
 sysreturn mkdir(const char *pathname, int mode)


### PR DESCRIPTION
write(2): Advance f->offset properly: "f->offset += length" line
is never executed because file_write() does thread_sleep(current).