### PR TITLE
struct heap bootstrap shouldn't be allocated on stack

### DIFF
--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -244,9 +244,10 @@ static heap init_physical_id_heap(heap h)
     return physical;
 }
 
+struct heap bootstrap;
+
 static void init_kernel_heaps()
 {
-    struct heap bootstrap;
     bootstrap.alloc = bootstrap_alloc;
     bootstrap.dealloc = leak;
 


### PR DESCRIPTION
see #377 
