### PR TITLE
Fix sequential read from file

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -24,6 +24,7 @@ boot-srcs = \
 	$(ROOT)/boot/stage2.c \
 	$(ROOT)/boot/service32.s \
 	$(SRC)/runtime/buffer.c \
+	$(SRC)/runtime/extra_prints.c \
 	$(SRC)/runtime/format.c \
 	$(SRC)/runtime/random.c \
 	$(SRC)/runtime/rtrie.c \

--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -43,10 +43,12 @@ static void stage2_empty_write(buffer b, u64 offset, status_handler completion)
 {
 }
 
+extern void init_extra_prints();
+
 CLOSURE_0_1(fail, void, status);
 void fail(status s)
 {
-    halt("filesystem_read_entire failed: %v", s);
+    halt("filesystem_read_entire failed: %v\n", s);
 }
 
 static CLOSURE_0_1(kernel_read_complete, void, buffer);
@@ -147,8 +149,10 @@ void newstack()
 void centry()
 {
     workings.alloc = stage2_allocator;
+    workings.dealloc = leak;
     kh.general = &workings;
     init_runtime(&kh);		/* we know only general is used */
+    init_extra_prints();
     u32 fsb = filesystem_base();
 
     u32 cr0, cr4;

--- a/src/runtime/extra_prints.c
+++ b/src/runtime/extra_prints.c
@@ -101,7 +101,11 @@ static void format_hex_buffer(buffer dest, buffer fmt, vlist *a)
 static void format_timestamp(buffer dest, buffer fmt, vlist *a)
 {
     timestamp t = varg(*a, timestamp);
+#ifdef BOOT
+    print_number(dest, t, 10, 1);
+#else
     print_timestamp(dest, t);
+#endif
 }
 
 void init_extra_prints()

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -8,7 +8,7 @@ LDFLAGS 	+= -n -T linker_script -nostdlib
 OBJDUMPFLAGS	+= -d -S
 GITFLAGS	+= --depth 1 http://git.savannah.nongnu.org/git/lwip.git -b STABLE-2_0_3_RELEASE
 
-#CFLAGS = -DLWIP_DEBUG -DEPOLL_DEBUG -DNETSYSCALL_DEBUG -DKERNEL_DEBUG
+#CFLAGS += -DLWIP_DEBUG -DEPOLL_DEBUG -DNETSYSCALL_DEBUG -DKERNEL_DEBUG
 
 all: stage3
 


### PR DESCRIPTION
fs_read_extent() now handles q.start properly

so that "offset" argument of filesystem_read() is handled properly

Most interpreters (Ruby, Python) read from files sequentially using
I/O buffer of 8192 bytes.

PS File extents are not fs->blocksize aligned. Not sure this was the intention but block_read/block_write interface of FS was initially supposed to be able to do only block-aligned I/O I guess