### PR TITLE
add centos changes

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -27,6 +27,7 @@ CFLAG_WARNINGS = \
     -Werror
 
 CFLAGS	= -fno-omit-frame-pointer \
+		  -std=gnu99 \
 		  -fno-stack-protector \
 		  -g \
 		  -O \

--- a/contgen/Makefile
+++ b/contgen/Makefile
@@ -6,6 +6,7 @@ CFLAGS  = -fno-stack-protector
 CFLAGS  += -g
 CFLAGS  += -fdata-sections -ffunction-sections
 CFLAGS  += $(includes)
+CFLAGS  += -std=c99
 
 all: contgen
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -8,6 +8,7 @@ CFLAGS = -g \
 	 -DENABLE_MSG_DEBUG \
 	 $(includes)
 CFLAGS+= $(CFLAG_WARNINGS) \
+	-std=gnu99 \
          -Wformat
 
 all: fst hw hws hwg getdents udploop web webg webgs webs getrandom mkdir time \

--- a/mkfs/Makefile
+++ b/mkfs/Makefile
@@ -7,6 +7,7 @@ CFLAGS	+= -g
 CFLAGS	+= -fdata-sections -ffunction-sections
 CFLAGS	+= $(includes) -DHOST_BUILD
 CFLAGS  += $(CFLAG_WARNINGS) -Wformat
+CFLAGS  += -std=gnu99
 
 all: mkfs dump
 


### PR DESCRIPTION
Not sure how others feel about this, but these are changes I need to apply before building on centos. 
It would be nice to get them merged in.

Also, some of examples's manifests have coded pathname for libc.so.6 that aren't valid for centos. I am not attempting to address that. 