### PR TITLE
open(2): support O_APPEND

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -721,8 +721,8 @@ sysreturn open_internal(tuple root, char *name, int flags, int mode)
     f->f.check = closure(h, file_check, f, fsf);
     f->n = n;
     f->length = length;
-    f->offset = 0;
-    thread_log(current, "   fd %d, file length %d", fd, f->length);
+    f->offset = (flags & O_APPEND) ? length : 0;
+    thread_log(current, "   fd %d, length %d, offset %d", fd, f->length, f->offset);
     return fd;
 }
 


### PR DESCRIPTION
Appears to resolve #535:

```
$ cat config.json
 { "Boot":"output/boot/boot.img",
   "Kernel":"output/stage3/stage3.img",
   "Mkfs":"output/mkfs/bin/mkfs"
 }
$ ops run persist -c config.json
Finding dependent shared libs
booting /home/wjhun/.ops/images/image ...
assigned: 10.0.2.15
appended some data
exit_group
exit status 1
$ ops run persist -s -c config.json
booting /home/wjhun/.ops/images/image ...
assigned: 10.0.2.15
appended some data
appended some data
exit_group
exit status 1
$ ops run persist -s -c config.json
booting /home/wjhun/.ops/images/image ...
assigned: 10.0.2.15
appended some data
appended some data
appended some data
exit_group
exit status 1
```

For some reason, this won't work if I don't specify the config.json, even if I 'make stage' in my nanos tree prior:

```
$ make stage
make -C mkfs
make -C boot
make -C stage3
make -C examples
make[1]: Entering directory '/share/src/nanovms/master/stage3'
make[1]: Entering directory '/share/src/nanovms/master/boot'
make[1]: Entering directory '/share/src/nanovms/master/examples'
make[1]: Entering directory '/share/src/nanovms/master/mkfs'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/share/src/nanovms/master/boot'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/share/src/nanovms/master/mkfs'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/share/src/nanovms/master/stage3'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/share/src/nanovms/master/examples'
MKFS    image
metadata (children:(kernel:() etc:(children:(ld.so.cache:())) webg:() lib:(children:(x86_64-linux-gnu:(children:(libc.so.6:() libpthread.so.0:())))) lib64:(children:(ld-linux-x86-64.so.2:()))) arguments:(0:webg 1:longargument) program:/we\
bg fault:t environment:(PWD:password USER:bobby))
mkdir -p .staging
cp -a output/mkfs/bin/mkfs .staging/mkfs
cp -a output/boot/boot.img .staging/boot.img
cp -a output/stage3/stage3.img .staging/stage3.img
$ ops run persist
Finding dependent shared libs
booting /home/wjhun/.ops/images/image ...
assigned: 10.0.2.15
appended some data
exit_group
exit status 1
$ ops run persist -s
booting /home/wjhun/.ops/images/image ...
assigned: 10.0.2.15
appended some data
exit_group
exit status 1
$
```
