### PR TITLE
[do not merge] fix loading large files on boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /examples/soop.data
 /tests/.staging/*
 /tests/image
+/tests/instance.img
 /tags
 
 # Default build directiory

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -363,11 +363,11 @@ static tuple soft_create(filesystem fs, tuple t, symbol a, merge m)
 
 /* create a new extent in the filesystem
 
-   The life an extent depends on a particular allocation of contiguous
-   storage space. The extent is tied to this allocated area (nominally
-   page size). Only the extent data length may be updated; the file
-   offset, block start and allocation size are immutable. As an
-   optimization, adjacent extents on the disk could be joined into
+   The life of an extent depends on a particular allocation of
+   contiguous storage space. The extent is tied to this allocated area
+   (nominally page size). Only the extent data length may be updated;
+   the file offset, block start and allocation size are immutable. As
+   an optimization, adjacent extents on the disk could be joined into
    larger extents with only a meta update.
 
 */
@@ -601,7 +601,11 @@ void filesystem_write(filesystem fs, tuple t, buffer b, u64 offset, io_status_ha
 
             do {
                 /* create_extent will allocate a minimum of pagesize */
+#ifdef HOST_BUILD
+                u64 length = remain; /* mkfs: one large extent */
+#else
                 u64 length = MIN(MAX_EXTENT_SIZE, remain);
+#endif
                 range r = irange(curr, curr + length);
                 extent ex = create_extent(f, r, m_meta);
                 if (ex == INVALID_ADDRESS) {

--- a/src/virtio/virtqueue.c
+++ b/src/virtio/virtqueue.c
@@ -212,7 +212,7 @@ status virtqueue_enqueue(struct virtqueue *vq,
     }
 
     vq->desc_idx = idx;
-    fetch_and_add(&vq->free_cnt, -1);
+    fetch_and_add(&vq->free_cnt, -segments);
 
     u16 avail_idx  = vq->avail->idx & (vq->entries - 1);
     vq->avail->ring[avail_idx] = hidx;


### PR DESCRIPTION
This reverts mkfs to using one large extent per file and fixes the virtqueue overflow detect. I should have a PR coming soon which removes issues with virtqueue overflows anyway - this is just to unblock Tijoy for the moment.
