### PR TITLE
fix sockaddr length

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -244,19 +244,21 @@ static sysreturn sock_read_bh(sock s, thread t, void *dest, u64 length,
     }
 
     if (src_addr) {
-        struct sockaddr_in sin;
-        sin.family = AF_INET;
+        struct sockaddr sa;
+        zero(&sa, sizeof(sa));
+        struct sockaddr_in * sin = (struct sockaddr_in *)&sa;
+        sin->family = AF_INET;
         if (s->type == SOCK_STREAM) {
-	    sin.address = ip4_addr_get_u32(&s->info.tcp.lw->remote_ip);
-	    sin.port = htons(s->info.tcp.lw->remote_port);
+	    sin->address = ip4_addr_get_u32(&s->info.tcp.lw->remote_ip);
+	    sin->port = htons(s->info.tcp.lw->remote_port);
         } else {
             struct udp_entry * e = p;
-            sin.address = e->raddr;
-            sin.port = htons(e->rport);
+            sin->address = e->raddr;
+            sin->port = htons(e->rport);
         }
         u32 len = MIN(sizeof(struct sockaddr), *addrlen);
-        *addrlen = len;
-        runtime_memcpy(src_addr, &sin, len);
+        *addrlen = sizeof(struct sockaddr);
+        runtime_memcpy(src_addr, sin, len);
     }
 
     u64 xfer_total = 0;
@@ -969,20 +971,22 @@ sysreturn accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 sysreturn getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 {
     sock s = resolve_fd(current->p, sockfd);
-    struct sockaddr_in sin;
-    sin.family = AF_INET;
+    struct sockaddr sa;
+    zero(&sa, sizeof(sa));
+    struct sockaddr_in * sin = (struct sockaddr_in *)&sa;
+    sin->family = AF_INET;
     if (s->type == SOCK_STREAM) {
-	sin.port = ntohs(s->info.tcp.lw->local_port);
-	sin.address = ip4_addr_get_u32(&s->info.tcp.lw->local_ip);
+	sin->port = ntohs(s->info.tcp.lw->local_port);
+	sin->address = ip4_addr_get_u32(&s->info.tcp.lw->local_ip);
     } else if (s->type == SOCK_DGRAM) {
-	sin.port = ntohs(s->info.udp.lw->local_port);
-	sin.address = ip4_addr_get_u32(&s->info.udp.lw->local_ip);
+	sin->port = ntohs(s->info.udp.lw->local_port);
+	sin->address = ip4_addr_get_u32(&s->info.udp.lw->local_ip);
     } else {
 	msg_warn("not supported for socket type %d\n", s->type);
 	return -EINVAL;
     }
-    u64 len = MIN(*addrlen, sizeof(sin));
-    runtime_memcpy(addr, &sin, len);
+    u64 len = MIN(*addrlen, sizeof(struct sockaddr));
+    runtime_memcpy(addr, sin, len);
     *addrlen = sizeof(struct sockaddr);
     return 0;
 }
@@ -990,10 +994,11 @@ sysreturn getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 sysreturn getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 {
     sock s = resolve_fd(current->p, sockfd);
-    struct sockaddr_in sin;
-    remote_sockaddr_in(s, &sin);
+    struct sockaddr sa;
+    zero(&sa, sizeof(sa));
+    remote_sockaddr_in(s, (struct sockaddr_in *)&sa);
     u64 len = MIN(*addrlen, sizeof(struct sockaddr));
-    runtime_memcpy(addr, &sin, len);
+    runtime_memcpy(addr, &sa, len);
     *addrlen = sizeof(struct sockaddr);
     return 0;    
 }


### PR DESCRIPTION
Apparently, returning the actual length of sockaddr_in (8) from get{sock,peer}name(2) isn't satisfactory; getnameinfo(3) was failing with EAI_FAMILY when passed a sockaddr of length 8.

Also, the various functions that store the sockinfo length should store the _actual_ sockinfo length, even if it needs to be truncated. This indicates to the caller that the sockinfo is longer than the provided buffer would allow.

Addresses the getnameinfo(3) failure in #526 (ruby w/ sinatra).
