### PR TITLE
Fix -enable-kvm

### DIFF
--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -211,6 +211,9 @@ static void init_vnet(heap general, heap page_allocator,
     vn->empty = allocate(dev->contiguous, dev->contiguous->pagesize);
     for (int i = 0; i < NET_HEADER_LENGTH ; i++)  ((u8 *)vn->empty)[i] = 0;
     vn->n->state = vn;
+    // initialization complete
+    vtpci_set_status(dev, VIRTIO_CONFIG_STATUS_DRIVER_OK);
+
     netif_add(vn->n,
               0, 0, 0, 
               vn,

--- a/src/virtio/virtio_pci.h
+++ b/src/virtio/virtio_pci.h
@@ -71,10 +71,11 @@
 #define VIRTIO_PCI_QUEUE_ADDR_SHIFT	12
 #define VIRTIO_PCI_VRING_ALIGN	4096
 
+vtpci attach_vtpci(heap h, heap page_allocator, int bus, int slot, int func, u64 feature_mask);
 status vtpci_alloc_virtqueue(vtpci dev,
                               int idx,
                               struct virtqueue **result);
-vtpci attach_vtpci();
+void vtpci_set_status(vtpci dev, u8 status);
 
 /* VirtIO PCI vendor/device ID. */
 #define VIRTIO_PCI_VENDORID	0x1AF4

--- a/src/virtio/virtio_storage.c
+++ b/src/virtio/virtio_storage.c
@@ -164,6 +164,9 @@ static void attach(heap general, storage_attach a, heap page_allocator, heap pag
 		   ((u64) in32(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_BLK_R_CAPACITY_HIGH) << 32)) * s->block_size;
     pci_set_bus_master(bus, slot, function);
     vtpci_alloc_virtqueue(s->v, 0, &s->command);
+    // initialization complete
+    vtpci_set_status(s->v, VIRTIO_CONFIG_STATUS_DRIVER_OK);
+
     block_read in = closure(general, storage_read, s);
     block_write out = closure(general, storage_write, s);
     apply(a, in, out, s->capacity);


### PR DESCRIPTION
1) Per "3.1.1 Driver Requirements: Device Initialization":  
- virtqueues (and interrupts) should be configured before setting DRIVER_OK status bit
- the driver MUST NOT notify the device before setting DRIVER_OK

This fixes virtio-blk and virtio-scsi virtqueue interrupts in -enable-kvm mode

2) Per "4.1.5.1.3.2 Driver Requirements: MSI-X Vector Configuration":
After mapping an event to vector, the driver MUST verify success by reading
the vector field value.