### PR TITLE
clone(2) should set RAX to 0 in child thread frame

### DIFF
--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -30,7 +30,7 @@ void deallocate_fd(process p, int fd)
     deallocate_u64(p->fdallocator, fd, 1);
 }
 
-void default_fault_handler(thread t, context frame)
+context default_fault_handler(thread t, context frame)
 {
     print_frame(t->frame);
     print_stack(t->frame);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -219,8 +219,7 @@ boolean pipe_init(unix_heaps uh);
 #define sysreturn_from_pointer(__x) ((s64)u64_from_pointer(__x));
 
 extern sysreturn syscall_ignore();
-//CLOSURE_1_1(default_fault_handler, void, thread, context);
-void default_fault_handler(thread t, context frame);
+context default_fault_handler(thread t, context frame);
 void thread_log_internal(thread t, char *desc, ...);
 #define thread_log(__t, __desc, ...) thread_log_internal(__t, __desc, ##__VA_ARGS__)
 // this should always be current

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -128,7 +128,7 @@ char *register_name(u64 s)
 }
 
 static thunk *handlers;
-u64 *frame;
+context frame;
 
 void *apic_base = (void *)0xfee00000;
 

--- a/src/x86_64/x86_64.h
+++ b/src/x86_64/x86_64.h
@@ -194,7 +194,7 @@ void elf_symbols(buffer elf, closure_type(each, void, char *, u64, u64, u8));
 #define mov_to_cr(__x, __y) __asm__("mov %0,%%"__x : : "a"(__y) : "memory");
 #define mov_from_cr(__x, __y) __asm__("mov %%"__x", %0" : "=a"(__y) : : "memory");
 
-typedef closure_type(fault_handler, u64 *, context);
+typedef closure_type(fault_handler, context, context);
 
 void configure_timer(timestamp rate, thunk t);
 


### PR DESCRIPTION
I tripped on this while working on another feature. Turns out we never really set %rax to 0 for the child frame; it must have just been 0 by chance. I hit a case where pthread create resulted in a crash because the child thread was following the same path as the parent after clone(2). Also clean up type stuff in preparation for page fault handling in unix land. And don't overwrite the child thread's own closure for the fault handler.