### PR TITLE
Implement generic (non-QEMU) halt

### DIFF
--- a/src/x86_64/kvm_platform.h
+++ b/src/x86_64/kvm_platform.h
@@ -8,5 +8,10 @@ static inline void QEMU_HALT(u8 code)
 {
     /* special qemu debug exit; returns ((code << 1) | 1) to shell */
     out8(0x501, code);
+
+    /* fallback (when no QEMU) */
+    __asm__("cli");
+    __asm__("hlt");
+
     while (1);
 }


### PR DESCRIPTION
This fixes GCE entering infinite loop on halt() due to missing QEMU debug hook port.