### PR TITLE
Initialize max_target properly

### DIFF
--- a/src/virtio/scsi.c
+++ b/src/virtio/scsi.c
@@ -17,17 +17,18 @@ int scsi_data_len(u8 cmd)
 
 static void scsi_bdump_sense(buffer b, const u8 *sense, int length)
 {
-    assert(length >= 14);
-    for (int i = 0; i < MIN(length, 16); i++) {
+    assert(length >= sizeof(struct scsi_sense_data));
+    for (int i = 0; i < sizeof(struct scsi_sense_data); i++) {
         bprintf(b, "%s%P", i > 0 ? " " : "", (u64) sense[i]);
     }
-    bprintf(b, ": key %P, asc %P/%P",
-        (u64) (sense[2] & 0xf), (u64) sense[12], (u64) sense[13]);
+    struct scsi_sense_data *ssd = (struct scsi_sense_data *) sense;
+    bprintf(b, ": KEY %P, ASC/ASCQ %P/%P",
+        (u64) (ssd->flags & SSD_KEY), (u64) ssd->asc, (u64) ssd->ascq);
 }
 
 void scsi_dump_sense(const u8 *sense, int length)
 {
     buffer b = little_stack_buffer(1024);
     scsi_bdump_sense(b, sense, length);
-    rprintf("sense %b\n", b);
+    rprintf("SCSI SENSE %b\n", b);
 }

--- a/src/virtio/scsi.h
+++ b/src/virtio/scsi.h
@@ -15,6 +15,53 @@
 #define SCSI_STATUS_ACA_ACTIVE          0x30
 #define SCSI_STATUS_TASK_ABORTED        0x40
 
+/*
+ * Fixed format sense data.
+ */
+struct scsi_sense_data
+{
+	u8 error_code;
+#define	SSD_ERRCODE			0x7F
+#define		SSD_CURRENT_ERROR	0x70
+#define		SSD_DEFERRED_ERROR	0x71
+#define	SSD_ERRCODE_VALID	0x80
+	u8 segment;
+	u8 flags;
+#define	SSD_KEY				0x0F
+#define		SSD_KEY_NO_SENSE	0x00
+#define		SSD_KEY_RECOVERED_ERROR	0x01
+#define		SSD_KEY_NOT_READY	0x02
+#define		SSD_KEY_MEDIUM_ERROR	0x03
+#define		SSD_KEY_HARDWARE_ERROR	0x04
+#define		SSD_KEY_ILLEGAL_REQUEST	0x05
+#define		SSD_KEY_UNIT_ATTENTION	0x06
+#define		SSD_KEY_DATA_PROTECT	0x07
+#define		SSD_KEY_BLANK_CHECK	0x08
+#define		SSD_KEY_Vendor_Specific	0x09
+#define		SSD_KEY_COPY_ABORTED	0x0a
+#define		SSD_KEY_ABORTED_COMMAND	0x0b
+#define		SSD_KEY_EQUAL		0x0c
+#define		SSD_KEY_VOLUME_OVERFLOW	0x0d
+#define		SSD_KEY_MISCOMPARE	0x0e
+#define		SSD_KEY_COMPLETED	0x0f
+#define	SSD_SDAT_OVFL	0x10
+#define	SSD_ILI		0x20
+#define	SSD_EOM		0x40
+#define	SSD_FILEMARK	0x80
+	u8 info[4];
+	u8 extra_len;
+	u8 cmd_spec_info[4];
+	u8 asc;
+	u8 ascq;
+	u8 fru;
+	u8 sense_key_spec[3];
+#define	SSD_SCS_VALID		0x80
+#define	SSD_FIELDPTR_CMD	0x40
+#define	SSD_BITPTR_VALID	0x08
+#define	SSD_BITPTR_VALUE	0x07
+	u8 extra_bytes[14];
+} __attribute__((packed));
+
 #define SCSI_CMD_TEST_UNIT_READY        0x00
 #define SCSI_CMD_INQUIRY                0x12
 #define SCSI_CMD_READ_16                0x88

--- a/src/virtio/virtio_scsi.c
+++ b/src/virtio/virtio_scsi.c
@@ -104,6 +104,7 @@ struct virtio_scsi {
     u64 capacity;
     u64 block_size;
     u16 max_target;
+    u16 max_lun;
 
     u16 target;
     u16 lun;
@@ -196,9 +197,11 @@ static void virtio_scsi_io_done(status_handler sh, void *buf, u64 len, virtio_sc
         __func__, s->target, s->lun, resp->response, resp->status);
 
     status st = 0;
-    if (resp->status != SCSI_STATUS_OK) {
+    if (resp->response != VIRTIO_SCSI_S_OK) {
+        st = timm("result", "response %d", (u64) resp->response);
+    } else if (resp->status != SCSI_STATUS_OK) {
         scsi_dump_sense(resp->sense, sizeof(resp->sense));
-        st = timm("result", "%d", resp->status);
+        st = timm("result", "status %d", (u64) resp->status);
     }
     apply(sh, st);
 }
@@ -234,9 +237,10 @@ static void virtio_scsi_read_capacity_done(storage_attach a, u16 target, u16 lun
     struct virtio_scsi_resp_cmd *resp = &r->resp;
     virtio_scsi_debug("%s: target %d, lun %d, response %d, status %d\n",
         __func__, target, lun, resp->response, resp->status);
-    if (resp->status != SCSI_STATUS_OK || resp->response != VIRTIO_SCSI_S_OK) {
-        if (resp->status != SCSI_STATUS_OK)
-            scsi_dump_sense(resp->sense, sizeof(resp->sense));
+    if (resp->response != VIRTIO_SCSI_S_OK)
+        return;
+    if (resp->status != SCSI_STATUS_OK) {
+        scsi_dump_sense(resp->sense, sizeof(resp->sense));
         return;
     }
 
@@ -281,14 +285,17 @@ static void virtio_scsi_test_unit_ready_done(storage_attach a, u16 target, u16 l
     struct virtio_scsi_resp_cmd *resp = &r->resp;
     virtio_scsi_debug("%s: target %d, lun %d, response %d, status %d\n",
         __func__, target, lun, resp->response, resp->status);
-    if (resp->status != SCSI_STATUS_OK || resp->response != VIRTIO_SCSI_S_OK) {
-        if (resp->status != SCSI_STATUS_OK)
-            scsi_dump_sense(resp->sense, sizeof(resp->sense));
+    if (resp->response != VIRTIO_SCSI_S_OK) {
+        virtio_scsi_next_target(s, a, target);
+        return;
+    }
+    if (resp->status != SCSI_STATUS_OK) {
         if (retry_count < 3) {
             r = virtio_scsi_alloc_request(s, target, lun, SCSI_CMD_TEST_UNIT_READY);
             virtio_scsi_enqueue_request(s, r, r->data, r->alloc_len,
                 closure(s->v->general, virtio_scsi_test_unit_ready_done, a, target, lun, retry_count + 1));
         } else {
+            scsi_dump_sense(resp->sense, sizeof(resp->sense));
             virtio_scsi_next_target(s, a, target);
         }
         return;
@@ -309,7 +316,7 @@ static void virtio_scsi_inquiry_done(storage_attach a, u16 target, u16 lun, virt
     struct virtio_scsi_resp_cmd *resp = &r->resp;
     virtio_scsi_debug("%s: target %d, lun %d, response %d, status %d\n",
         __func__, target, lun, resp->response, resp->status);
-    if (resp->status != SCSI_STATUS_OK || resp->response != VIRTIO_SCSI_S_OK) {
+    if (resp->response != VIRTIO_SCSI_S_OK || resp->status != SCSI_STATUS_OK) {
         if (resp->status != SCSI_STATUS_OK)
             scsi_dump_sense(resp->sense, sizeof(resp->sense));
         virtio_scsi_next_target(s, a, target);
@@ -337,7 +344,7 @@ static void virtio_scsi_report_luns_done(storage_attach a, u16 target, virtio_sc
     struct virtio_scsi_resp_cmd *resp = &r->resp;
     virtio_scsi_debug("%s: target %d, response %d, status %d\n",
         __func__, target, resp->response, resp->status);
-    if (resp->status != SCSI_STATUS_OK || resp->response != VIRTIO_SCSI_S_OK) {
+    if (resp->response != VIRTIO_SCSI_S_OK || resp->status != SCSI_STATUS_OK) {
         if (resp->status != SCSI_STATUS_OK)
             scsi_dump_sense(resp->sense, sizeof(resp->sense));
         virtio_scsi_next_target(s, a, target);
@@ -347,7 +354,7 @@ static void virtio_scsi_report_luns_done(storage_attach a, u16 target, virtio_sc
     struct scsi_res_report_luns *res = (struct scsi_res_report_luns *) r->data;
     u32 length = be32toh(res->length);
     virtio_scsi_debug("%s: got %d luns\n", __func__, length / sizeof(res->lundata[0]));
-    for (u32 i = 0; i < length / sizeof(res->lundata[0]); i++) {
+    for (u32 i = 0; i < MIN(s->max_lun, length / sizeof(res->lundata[0])); i++) {
         u16 lun = (res->lundata[i] & 0xffff) >> 8;
         virtio_scsi_debug("%s: got lun %d (lundata 0x%P)\n", __func__, lun, res->lundata[i]);
 
@@ -394,13 +401,13 @@ static void virtio_scsi_attach(heap general, storage_attach a, heap page_allocat
 
     u32 max_channel = in16(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_SCSI_R_MAX_CHANNEL);
     virtio_scsi_debug("max channel %d\n", (u64) max_channel);
+#endif
 
     s->max_target = in16(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_SCSI_R_MAX_TARGET);
     virtio_scsi_debug("max target %d\n", (u64) s->max_target);
 
-    u32 max_lun = in32(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_SCSI_R_MAX_LUN);
+    s->max_lun = in32(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_SCSI_R_MAX_LUN);
     virtio_scsi_debug("max lun %d\n", (u64) max_lun);
-#endif
 
     status st = vtpci_alloc_virtqueue(s->v, 0, &s->command);
     assert(st == STATUS_OK);


### PR DESCRIPTION
- properly initialize max_target
- get and use max_lun from the device
- do not print sense if TEST_READY fails and retries count not reached