### PR TITLE
only build $(TARGET) for image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test-nokvm: test-build
 
 target: $(TARGET)
 
-$(TARGET): contgen
+$(TARGET):
 	$(MAKE) -C test/runtime $(TARGET)
 
 gitversion.c : .git/index .git/HEAD


### PR DESCRIPTION
Don't build everything under test/runtime for each image build, only $(TARGET).
