### PR TITLE
don't make special files (or associated paths) persistent on storage

### DIFF
--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -43,9 +43,9 @@ typedef enum {
     FS_STATUS_NOTDIR,
 } fs_status;
 
-fs_status filesystem_mkentry(filesystem fs, tuple root, char *fp, tuple entry);
-fs_status filesystem_mkdir(filesystem fs, tuple root, char *fp);
-fs_status filesystem_creat(filesystem fs, tuple root, char *fp);
+fs_status filesystem_mkentry(filesystem fs, tuple root, char *fp, tuple entry, boolean persistent);
+fs_status filesystem_mkdir(filesystem fs, tuple root, char *fp, boolean persistent);
+fs_status filesystem_creat(filesystem fs, tuple root, char *fp, boolean persistent);
 
 tuple filesystem_getroot(filesystem fs);
 extern const char *gitversion;

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -50,7 +50,7 @@ void register_special_files(process p)
     buffer root = alloca_wrap_buffer(ROOT, sizeof(ROOT));
 
     /* TODO: create parent directories */
-    res = filesystem_mkdir(p->fs, 0, canonicalize_path(h, root, wrap_buffer_cstring(h, "/dev")));
+    res = filesystem_mkdir(p->fs, 0, canonicalize_path(h, root, wrap_buffer_cstring(h, "/dev")), false);
 
     for (int i = 0; i < sizeof(special_files) / sizeof(special_files[0]); i++) {
         special_file *sf = special_files + i;
@@ -60,8 +60,8 @@ void register_special_files(process p)
         buffer b = wrap_buffer(h, sf, sizeof(*sf));
         table_set(entry, sym(special), b);
         res = filesystem_mkentry(p->fs, 0,
-            canonicalize_path(h, root, wrap_buffer_cstring(h, (char *) sf->path)),
-            entry);
+                                 canonicalize_path(h, root, wrap_buffer_cstring(h, (char *) sf->path)),
+                                 entry, false);
     }
 }
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -474,8 +474,8 @@ static sysreturn do_mkent(tuple root, const char *pathname, int mode, boolean di
     thread_log(current, "%s: %s (mode %d) pathname %s => %s",
                __func__, dir ? "mkdir" : "creat", mode, pathname, final_path);
 
-    fs_status status = dir ? filesystem_mkdir(current->p->fs, root, final_path) :
-        filesystem_creat(current->p->fs, root, final_path);
+    fs_status status = dir ? filesystem_mkdir(current->p->fs, root, final_path, true) :
+        filesystem_creat(current->p->fs, root, final_path, true);
     return set_syscall_return(current, sysreturn_from_fs_status(status));
 }
 


### PR DESCRIPTION
This was causing the following errors (really debugs that were enabled for runtime tests) when booting an image that was previously booted:

```
filesystem_mkentry error: final path component ("dev") already exists
filesystem_mkentry error: final path component ("urandom") already exists
filesystem_mkentry error: final path component ("null") already exists
```

This PR prevents such special entries from being logged to persistent meta.
