### PR TITLE
Fix rprintf() and friends

### DIFF
--- a/boot/def32.h
+++ b/boot/def32.h
@@ -50,10 +50,3 @@ static inline void *valueof(void *v)
      __q = a|(((u64)b)<<32);                                  \
      __r = d;\
  }
-
-void print_number(buffer s, u64 x, int base, int pad);
-static inline void format_pointer(buffer dest, buffer fmt, vlist *a)
-{
-    u64 x = varg(*a, u32);
-    print_number(dest, x, 16, 8);
-}

--- a/config.mk
+++ b/config.mk
@@ -39,6 +39,7 @@ CFLAG_WARNINGS = \
     -Wunused-label \
     -Wunused-value \
     -Wunused-variable \
+    -Wformat \
     -Werror
 
 CFLAGS	= -fno-omit-frame-pointer \

--- a/mkfs/Makefile
+++ b/mkfs/Makefile
@@ -6,7 +6,7 @@ CFLAGS	= -fno-stack-protector
 CFLAGS	+= -g
 CFLAGS	+= -fdata-sections -ffunction-sections
 CFLAGS	+= $(includes) -DHOST_BUILD
-CFLAGS  += $(CFLAG_WARNINGS) -Wformat
+CFLAGS  += $(CFLAG_WARNINGS)
 CFLAGS  += -std=gnu11
 
 all: mkfs dump

--- a/mkfs/dump.c
+++ b/mkfs/dump.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <tfs.h>
 #include <errno.h>
+#include <string.h>
 
 static CLOSURE_1_3(bwrite, void, descriptor, void *, range, status_handler);
 static void bwrite(descriptor d, void * s, range blocks, status_handler c)
@@ -22,7 +23,7 @@ static void bread(descriptor d, void *dest, range blocks, status_handler c)
     while (total < length) {
         xfer = pread(d, dest + total , length - total, offset + total);
         if (xfer == 0) apply(c, 0);
-        if (xfer == -1) apply(c, timm("read-error", "%E", errno));
+        if (xfer == -1) apply(c, timm("read-error", "%s", strerror(errno)));
         total += xfer;
     }
     apply(c, STATUS_OK);

--- a/src/gdb/gdbstub.c
+++ b/src/gdb/gdbstub.c
@@ -24,8 +24,8 @@ static void reset_parser(gdb g)
 
 static context gdb_handle_exception (gdb g, context frame)
 {
-    int exceptionVector = frame[FRAME_VECTOR];
-    //     rprintf ("gdb exception: %d %p [%p %p] %p %p\n", exceptionVector, g, frame, g->t->frame, frame[FRAME_RIP], *(u64 *)frame[FRAME_RIP]);
+    u64 exceptionVector = frame[FRAME_VECTOR];
+    //     rprintf ("gdb exception: %ld %p [%p %p] %p %p\n", exceptionVector, g, frame, g->t->frame, frame[FRAME_RIP], *(u64 *)frame[FRAME_RIP]);
     sigval = computeSignal(exceptionVector);
     reset_buffer(g->output);
     /*

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -44,7 +44,7 @@ void sys_timeouts_init(void)
         register_periodic_timer(milliseconds(t->interval_ms),
                                 closure(lwip_heap, dispatch_lwip_timer, t->handler, t->name));
 #ifdef LWIP_DEBUG
-        lwip_debug("registered %s timer with period of %d ms\n", t->name, t->interval_ms);
+        lwip_debug("registered %s timer with period of %ld ms\n", t->name, t->interval_ms);
 #endif
     }
 }

--- a/src/runtime/bitmap.c
+++ b/src/runtime/bitmap.c
@@ -105,19 +105,19 @@ boolean bitmap_dealloc(bitmap b, u64 bit, u64 order)
 
     /* XXX maybe error code instead of msg_err... */
     if (bit & (nbits - 1)) {
-	msg_err("bitmap %p, bit %d is not aligned to order %d\n",
+	msg_err("bitmap %p, bit %ld is not aligned to order %ld\n",
 		b, bit, order);
 	return false;
     }
 
     if (bit + nbits > b->maxbits) {
-	msg_err("bitmap %p, bit %d, order %d: exceeds bit length %d\n",
+	msg_err("bitmap %p, bit %ld, order %ld: exceeds bit length %ld\n",
 		b, bit, order, b->maxbits);
 	return false;
     }
 
     if (!for_range_in_map(mapbase, bit, nbits, false, true)) {
-	msg_err("bitmap %p, bit %d, order %d: not allocated in map; leaking\n",
+	msg_err("bitmap %p, bit %ld, order %ld: not allocated in map; leaking\n",
 		b, bit, order);
 	return false;
     }

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -250,10 +250,10 @@ static inline boolean buffer_compare(void *za, void *zb)
 
 
 // the ascii subset..utf8 me
-#define foreach_character(__i, __s)                          \
-    for (u32 __x = 0, __i, __limit = buffer_length(__s);   \
-         __i = *(u8 *)buffer_ref(__s, __x), __x<__limit;    \
-         __x++)
+#define foreach_character(__i, __c, __s)                   \
+    for (u32 __i = 0, __c, __limit = buffer_length(__s);   \
+         __c = *(u8 *)buffer_ref(__s, __i), __i<__limit;   \
+         __i++)
              
 
 // alternate stack, real heap, say no to alloca

--- a/src/runtime/extra_prints.c
+++ b/src/runtime/extra_prints.c
@@ -39,7 +39,7 @@ void print_csum_buffer(buffer s, buffer b)
     u64 csum = 0;
     for (int i = 0; i < buffer_length(b); i++)
         csum += *(u8*)buffer_ref(b, i);
-    bprintf(s, "%d", csum);
+    bprintf(s, "%lx", csum);
 }
 
 void print_tuple(buffer b, tuple z)
@@ -63,12 +63,12 @@ void print_tuple(buffer b, tuple z)
     bprintf(b, ")");
 }
 
-static void format_tuple(buffer dest, buffer fmt, vlist *v)
+static void format_tuple(buffer dest, struct formatter_state *s, vlist *v)
 {
     print_tuple(dest, varg(*v, tuple));
 }
 
-static void format_value(buffer dest, buffer fmt, vlist *v)
+static void format_value(buffer dest, struct formatter_state *s, vlist *v)
 {
     buffer b;
     value x = varg(*v, value);
@@ -93,50 +93,40 @@ static void format_value(buffer dest, buffer fmt, vlist *v)
     }
 }
 
-static void format_cstring(buffer dest, buffer fmt, vlist *a)
-{
-    char *c = varg(*a, char *);
-    if (!c) c = (char *)"(null)";
-    int len = runtime_strlen(c);
-    buffer_write(dest, c, len);    
-}
-
-static void format_hex_buffer(buffer dest, buffer fmt, vlist *a)
+static void format_hex_buffer(buffer dest, struct formatter_state *s, vlist *a)
 {
     buffer b = varg(*a, buffer);
     print_hex_buffer(dest, b);
 }
 
-static void format_csum_buffer(buffer dest, buffer fmt, vlist *a)
+static void format_csum_buffer(buffer dest, struct formatter_state *s, vlist *a)
 {
     buffer b = varg(*a, buffer);
     print_csum_buffer(dest, b);
 }
 
-static void format_timestamp(buffer dest, buffer fmt, vlist *a)
+static void format_timestamp(buffer dest, struct formatter_state *s, vlist *a)
 {
     timestamp t = varg(*a, timestamp);
 #ifdef BOOT
-    print_number(dest, t, 10, 1);
+    print_number(dest, t, 10, 0);
 #else
     print_timestamp(dest, t);
 #endif
 }
 
-static void format_range(buffer dest, buffer fmt, vlist *a)
+static void format_range(buffer dest, struct formatter_state *s, vlist *a)
 {
     range r = varg(*a, range);
-    bprintf(dest, "[%d %d)", r.start, r.end);
+    bprintf(dest, "[%ld %ld)", r.start, r.end);
 }
 
 void init_extra_prints()
 {
-    register_format('t', format_tuple);
-    register_format('v', format_value);
-    register_format('s', format_cstring);
-    register_format('X', format_hex_buffer);
-    register_format('T', format_timestamp);
-    register_format('R', format_range);
-    register_format('C', format_csum_buffer);
+    register_format('t', format_tuple, 0);
+    register_format('v', format_value, 0);
+    register_format('X', format_hex_buffer, 0);
+    register_format('T', format_timestamp, 0);
+    register_format('R', format_range, 0);
+    register_format('C', format_csum_buffer, 0);
 }
-

--- a/src/runtime/format.h
+++ b/src/runtime/format.h
@@ -1,18 +1,23 @@
 #pragma once
+
 extern void vbprintf(buffer s, buffer fmt, vlist *ap);
 
-extern void log_vprintf(char * prefix, char * log_format, vlist *a);
-extern void log_printf(char * prefix, char * log_format, ...);
+extern void log_vprintf(const char *prefix, const char *log_format, vlist *a);
+extern void log_printf(const char *prefix, const char *log_format, ...);
+
+struct formatter_state {
+    int state;
+    int format;    // format character ('s', 'd', ...)
+    int modifier;  // format modifier ('l')
+    int width;     // format width
+};
 
 // make sure its safe to read more than one format char ala %02x
 // if we parameterize newline we can do some nicer formatting tricks
-typedef void (*formatter)(buffer dest, buffer fmt, vlist *ap);
-void register_format(character c, formatter f);
-// indent?
+typedef void (*formatter)(buffer dest, struct formatter_state *s, vlist *ap);
+void register_format(character c, formatter f, int accepts_long);
 
-buffer aprintf(heap h, char *fmt, ...);
+buffer aprintf(heap h, const char *fmt, ...);
 void bbprintf(buffer b, buffer fmt, ...);
-void bprintf(buffer b, char *fmt, ...);
-void rprintf(char *format, ...);
-
-
+void bprintf(buffer b, const char *fmt, ...);
+void rprintf(const char *format, ...);

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -42,7 +42,7 @@ static id_range id_add_range(id_heap i, u64 base, u64 length)
 	u64 r_end = r->base + r->length - 1;
 	if ((base >= r->base && base <= r_end) ||
 	    (end >= r->base && end <= r_end)) {
-	    msg_err("range [%P, %P] overlaps range [%P, %P]; fail\n",
+	    msg_err("range [%lx, %lx] overlaps range [%lx, %lx]; fail\n",
 		    base, end, r->base, r_end);
 	    return INVALID_ADDRESS;
 	}
@@ -60,7 +60,7 @@ static id_range id_add_range(id_heap i, u64 base, u64 length)
     }
     vector_push(i->ranges, r);
 #ifdef ID_HEAP_DEBUG
-    msg_debug("added range base %P, length %P\n", base, length);
+    msg_debug("added range base %lx, length %lx\n", base, length);
 #endif
     return r;
 }
@@ -84,7 +84,7 @@ static u64 id_alloc_from_range(id_heap i, id_range r, int order)
     u64 offset = bit << page_order(i);
     i->h.allocated += alloc_bits;
 #ifdef ID_HEAP_DEBUG
-    msg_debug("heap %p, size %d: got offset (%d << %d = %P)\t>%P\n",
+    msg_debug("heap %p, size %ld: got offset (%ld << %ld = %lx)\t>%lx\n",
 	      i, alloc_bits, bit, page_order(i), offset, r->base + offset);
 #endif
     return r->base + offset;
@@ -143,7 +143,7 @@ static void id_dealloc(heap h, u64 a, bytes count)
     }
     s = "allocation doesn't match any range";
   fail:
-    msg_err("heap %p, offset %P, count %d: %s; leaking\n", h, a, count, s);
+    msg_err("heap %p, offset %lx, count %d: %s; leaking\n", h, a, count, s);
 }
 
 static void id_destroy(heap h)

--- a/src/runtime/symbol.c
+++ b/src/runtime/symbol.c
@@ -12,7 +12,7 @@ struct symbol {
 symbol intern_u64(u64 u)
 {
     buffer b = little_stack_buffer(10);
-    print_number(b, u, 10, 1);
+    print_number(b, u, 10, 0);
     return intern(b);
 }
 

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -89,7 +89,7 @@ timestamp parse_time(string b)
 {
     u64 s = 0, frac = 0, fracnorm = 0;
 
-    foreach_character (c, b) {
+    foreach_character (_, c, b) {
         if (c == '.')  {
             fracnorm = 1;
         } else {
@@ -107,7 +107,7 @@ timestamp parse_time(string b)
 
 void print_timestamp(string b, timestamp t)
 {
-    u64 s= t>>32;
+    u32 s= t>>32;
     u64 f= t&MASK(32);
 
     bprintf(b, "%d", s);

--- a/src/runtime/tuple_parser.c
+++ b/src/runtime/tuple_parser.c
@@ -118,7 +118,7 @@ static parser dispatch_property(heap h, parser pv, err_internal e, character x)
         return pv;
 
     default:
-        return apply(e, aprintf(h, "unknown property descriminator %c", x));
+        return apply(e, aprintf(h, "unknown property discriminator %d", x));
         break;
     }
     

--- a/src/runtime/vector.h
+++ b/src/runtime/vector.h
@@ -64,7 +64,7 @@ static inline vector split(heap h, buffer source, char divider)
 {
     vector result = allocate_vector(h, 10);
     buffer each = allocate_buffer(h, 10);
-    foreach_character(i, source) {
+    foreach_character(_, i, source) {
         if (i == divider)  {
             vector_push(result, each);
             each = allocate_buffer(h, 10);

--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -139,7 +139,7 @@ void log_read_complete(log tl, status_handler sh, status s)
         }
         
         if (f && filelength != infinity) {
-            tlog_debug("   update fsfile length to %d\n", filelength);
+            tlog_debug("   update fsfile length to %ld\n", filelength);
             fsfile_set_length(f, filelength);
         }
     }

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -98,7 +98,7 @@ static inline void blockq_restart_timer_locked(blockq bq)
 
 sysreturn blockq_check(blockq bq, thread t, blockq_action a)
 {
-    blockq_debug("for \"%s\", tid %d, action %p, apply:\n", blockq_name(bq), t->tid, a);
+    blockq_debug("for \"%s\", tid %ld, action %p, apply:\n", blockq_name(bq), t->tid, a);
     /* XXX grab irqsafe mutex/spinlock
 
        presently a no-op because
@@ -114,7 +114,7 @@ sysreturn blockq_check(blockq bq, thread t, blockq_action a)
     sysreturn rv = apply(a, false);
     if (rv != infinity) {
         /* XXX release spinlock */
-        blockq_debug(" - direct return: %d\n", rv);
+        blockq_debug(" - direct return: %ld\n", rv);
         return rv;
     }
 
@@ -171,7 +171,7 @@ void blockq_wake_one(blockq bq)
 
     blockq_debug(" - applying %p:\n", a);
     sysreturn rv = apply(a, true);
-    blockq_debug("   - returned %d\n", rv);
+    blockq_debug("   - returned %ld\n", rv);
     if (rv != 0) {
         assert(dequeue(bq->waiters));
 
@@ -191,7 +191,7 @@ void blockq_wake_one(blockq bq)
 
 blockq allocate_blockq(heap h, char * name, u64 size, timestamp timeout_interval)
 {
-    blockq_debug("name \"%s\", size %d, timeout_interval %T\n", name, size, timeout_interval);
+    blockq_debug("name \"%s\", size %ld, timeout_interval %T\n", name, size, timeout_interval);
     blockq bq = allocate(h, sizeof(struct blockq));
     if (bq == INVALID_ADDRESS)
         return bq;

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -150,16 +150,16 @@ process exec_elf(buffer ex, process kp)
                XXX Replace 27 with limit derived from kernel start. */
             load_offset += (random_u64() & ~MASK(PAGELOG)) & MASK(27);
         }
-        exec_debug("placing PIE at 0x%P\n", load_offset);
+        exec_debug("placing PIE at 0x%lx\n", load_offset);
         load_start += load_offset;
         load_end += load_offset;
     }
 
-    exec_debug("load start 0x%P, end 0x%P, offset 0x%P\n",
+    exec_debug("load start 0x%lx, end 0x%lx, offset 0x%lx\n",
                load_start, load_end, load_offset);
     void * entry = load_elf(ex, load_offset, heap_pages(kh), heap_physical(kh));
     proc->brk = pointer_from_u64(pad(load_end, PAGESIZE));
-    exec_debug("entry 0x%P, brk 0x%p\n", entry, proc->brk);
+    exec_debug("entry %p, brk 0x%p\n", entry, proc->brk);
     build_exec_stack(heap_backed(kh), t, e, entry, load_start, root);
 
     if (interp) {

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -154,7 +154,7 @@ static sysreturn pipe_read(pipe_file pf, void *dest, u64 length, u64 offset_arg)
 
     /* XXX ideally we could just prevent this case if we had growing
        queues... for now bark and return EAGAIN */
-    msg_err("thread %d unable to block; queue full\n", current->tid);
+    msg_err("thread %ld unable to block; queue full\n", current->tid);
     return -EAGAIN;
 }
 
@@ -203,7 +203,7 @@ static sysreturn pipe_write(pipe_file pf, void * dest, u64 length, u64 offset)
         return rv;
 
     /* bogus */
-    msg_err("thread %d unable to block; queue full\n", current->tid);
+    msg_err("thread %ld unable to block; queue full\n", current->tid);
     return set_syscall_error(current, EAGAIN);
 }
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -45,7 +45,7 @@ sysreturn arch_prctl(int code, unsigned long a)
 
 sysreturn clone(unsigned long flags, void *child_stack, int *ptid, int *ctid, unsigned long newtls)
 {
-    thread_log(current, "clone: flags %P, child_stack %p, ptid %p, ctid %p, newtls %P",
+    thread_log(current, "clone: flags %lx, child_stack %p, ptid %p, ctid %p, newtls %lx",
         flags, child_stack, ptid, ctid, newtls);
 
     /* clone thread context up to FRAME_VECTOR */
@@ -99,7 +99,7 @@ static int futex_wake(fut f, int val, boolean verbose, int *uaddr)
     while (result < val && (w = dequeue(f->waiters))) {
         result++;
         if (verbose) {
-            thread_log(current, "futex_wake [%d %p %d] %p %d/%d",
+            thread_log(current, "futex_wake [%ld %p %d] %p %d/%d",
                 current->tid, uaddr, *uaddr, w, result, val);
         }
         futex_thread_wakeup(f, w);
@@ -135,7 +135,7 @@ static sysreturn futex(int *uaddr, int futex_op, int val,
     case FUTEX_WAIT:
         if (*uaddr == val) {
             if (verbose) {
-                thread_log(current, "futex_wait [%d %p %d] %d %p",
+                thread_log(current, "futex_wait [%ld %p %d] %d %p",
                     current->tid, uaddr, *uaddr, val, timeout);
             }
             // if we resume we are woken up
@@ -155,7 +155,7 @@ static sysreturn futex(int *uaddr, int futex_op, int val,
     case FUTEX_REQUEUE: rprintf("futex_requeue not implemented\n"); break;
     case FUTEX_CMP_REQUEUE:
         if (verbose) {
-            thread_log(current, "futex_cmp_requeue [%d %p %d] %d %p %d",
+            thread_log(current, "futex_cmp_requeue [%ld %p %d] %d %p %d",
                 current->tid, uaddr, *uaddr, val3, uaddr2, *uaddr2);
         }
         if (*uaddr == val3) {
@@ -167,7 +167,7 @@ static sysreturn futex(int *uaddr, int futex_op, int val,
                 while (result2 < val2 && (w = dequeue(f->waiters))) {
                     result2++;
                     if (verbose) {
-                        thread_log(current, "futex_cmp_requeue [%d %p %d] %p %d/%d",
+                        thread_log(current, "futex_cmp_requeue [%ld %p %d] %p %d/%d",
                             current->tid, uaddr2, *uaddr2, w, result2, val2);
                     }
                     enqueue(f2->waiters, w);
@@ -186,7 +186,7 @@ static sysreturn futex(int *uaddr, int futex_op, int val,
             unsigned int op = (val3 >> 28) & MASK(4);
 
             if (verbose) {
-                thread_log(current, "futex_wake_op: [%d %p %d] %p %d %d %d %d",
+                thread_log(current, "futex_wake_op: [%ld %p %d] %p %d %d %d %d",
                     current->tid, uaddr, *uaddr, uaddr2, cmparg, oparg, cmp, op);
             }
 
@@ -223,7 +223,7 @@ static sysreturn futex(int *uaddr, int futex_op, int val,
     case FUTEX_WAIT_BITSET:
         if (*uaddr == val) {
             if (verbose) {
-                thread_log(current, "futex_wait_bitset [%d %p %d] %d %p %d",
+                thread_log(current, "futex_wait_bitset [%ld %p %d] %d %p %d",
                     current->tid, uaddr, *uaddr, val, timeout, val3);
             }
             set_syscall_return(current, 0);
@@ -260,7 +260,7 @@ void thread_log_internal(thread t, char *desc, ...)
         vlist ap;
         vstart (ap, desc);        
         buffer b = allocate_buffer(transient, 100);
-        bprintf (b, "%n %d ", (t->tid - 1)*8, t->tid, desc);
+        bprintf(b, "%n%d ", (int) ((t->tid - 1) * 8), t->tid);
         buffer f = alloca_wrap_buffer(desc, runtime_strlen(desc));
         vbprintf(b, f, &ap);
         push_u8(b, '\n');
@@ -290,7 +290,7 @@ void thread_sleep(thread t)
 
 void thread_wakeup(thread t)
 {
-    thread_log(current, "wakeup %d->%d %p", current->tid, t->tid, t->frame[FRAME_RIP]);
+    thread_log(current, "wakeup %ld->%ld %p", current->tid, t->tid, t->frame[FRAME_RIP]);
     enqueue(runqueue, t->run);
 }
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -64,7 +64,7 @@ context default_fault_handler(thread t, context frame)
 static CLOSURE_0_3(dummy_read, sysreturn, void *, u64, u64);
 static sysreturn dummy_read(void *dest, u64 length, u64 offset_arg)
 {
-    thread_log(current, "%s: dest %p, length %d, offset_arg %d",
+    thread_log(current, "%s: dest %p, length %ld, offset_arg %ld",
 	       __func__, dest, length, offset_arg);
     return 0;
 }

--- a/src/unix_process/mmap_heap.c
+++ b/src/unix_process/mmap_heap.c
@@ -1,11 +1,12 @@
 #include <runtime.h>
 #include <sys/mman.h>
 #include <errno.h>
+#include <string.h>
 
 void mmapheap_dealloc(heap h, u64 x, bytes size)
 {
     if (munmap((void *)x, size))
-        halt("munmap failed %E\n", errno);
+        halt("munmap failed %s\n", strerror(errno));
 }
 
 u64 mmapheap_alloc(heap h, bytes size)
@@ -13,7 +14,7 @@ u64 mmapheap_alloc(heap h, bytes size)
     void * rv = mmap(0, size + h->pagesize, PROT_READ | PROT_WRITE,
 		     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (rv == MAP_FAILED) {
-	msg_err("mmap() failed: errno %E", errno);
+	msg_err("mmap() failed: errno %s", strerror(errno));
 	return INVALID_PHYSICAL;
     } else {
         return (u64_from_pointer(rv) + h->pagesize - 1) & ~(h->pagesize - 1);

--- a/src/unix_process/socket_user.c
+++ b/src/unix_process/socket_user.c
@@ -55,7 +55,7 @@ static inline void select_bitmaps_init(heap h, select_bitmaps * b)
 static boolean select_register(notifier n, descriptor f, u32 events, thunk a)
 {
 #ifdef SOCKET_USER_EPOLL_DEBUG
-    rprintf("select_register: notifier %p, fd %d, events %P, thunk %p\n", n, f, events, a);
+    rprintf("select_register: notifier %p, fd %d, events %x, thunk %p\n", n, f, events, a);
 #endif
     select_notifier s = (select_notifier)n;
     registration new = allocate(n->h, sizeof(struct registration));
@@ -117,12 +117,12 @@ static void select_spin(notifier n)
 	u64 * ep = bitmap_base(s->tmp.e);
 #ifdef SOCKET_USER_EPOLL_DEBUG
 	rprintf("   calling select with nfds = %d\n", s->nfds);
-	rprintf("      r: %P\tw: %P\te: %P\n", *rp, *wp, *ep);
+	rprintf("      r: %lx\tw: %lx\te: %lx\n", *rp, *wp, *ep);
 #endif
 	int res = select(s->nfds, (fd_set*)rp, (fd_set*)wp, (fd_set*)ep, 0);
 #ifdef SOCKET_USER_EPOLL_DEBUG
 	rprintf("   returned %d\n", res);
-	rprintf("      r: %P\tw: %P\te: %P\n", *rp, *wp, *ep);
+	rprintf("      r: %lx\tw: %lx\te: %lx\n", *rp, *wp, *ep);
 #endif
         if (res == -1)
 	    halt ("select failed with %s (%d)\n", strerror(errno), errno);
@@ -143,13 +143,13 @@ static void select_spin(notifier n)
 		if (*wp & mask)
 		    events |= EPOLLPRI;
 #ifdef SOCKET_USER_EPOLL_DEBUG
-		rprintf("   fd %d, events %P:\n", fd, events);
+		rprintf("   fd %d, events %x:\n", fd, events);
 #endif
 		registration r = vector_get(s->registrations, fd);
 		do {
 		    if (r->events & events) {
 #ifdef SOCKET_USER_EPOLL_DEBUG
-			rprintf("      match events %P, applying thunk %p\n",
+			rprintf("      match events %x, applying thunk %p\n",
 				r->events, r->a);
 #endif
 			apply(r->a);
@@ -189,7 +189,7 @@ typedef struct poll_notifier {
 static boolean poll_register(notifier n, descriptor f, u32 events, thunk a)
 {
 #ifdef SOCKET_USER_EPOLL_DEBUG
-    rprintf("poll_register: notifier %p, fd %d, events %P, thunk %p\n", n, f, events, a);
+    rprintf("poll_register: notifier %p, fd %d, events %x, thunk %p\n", n, f, events, a);
 #endif
     poll_notifier p = (poll_notifier)n;
     registration new = allocate(n->h, sizeof(struct registration));
@@ -245,7 +245,7 @@ static void poll_spin(notifier n)
         for (int i = 0; i < NFDS(p->poll_fds); i++) {
             fds[i].revents = 0;
 #ifdef SOCKET_USER_EPOLL_DEBUG
-            rprintf("      fd %d, events %P, revents %P\n", fds[i].fd, fds[i].events, fds[i].revents);
+            rprintf("      fd %d, events %x, revents %x\n", fds[i].fd, fds[i].events, fds[i].revents);
 #endif
         }
 
@@ -254,13 +254,13 @@ static void poll_spin(notifier n)
         rprintf("   returned %d\n", res);
 #endif
         if (res == -1)
-            halt("poll failed with %s (%d)\n", strerror(errno));
+            halt("poll failed with %s (%d)\n", strerror(errno), errno);
         for (int i = 0; i < NFDS(p->poll_fds); i++) {
             if (fds[i].revents == 0)
                 continue;
 
 #ifdef SOCKET_USER_EPOLL_DEBUG
-            rprintf("   fd %d, events %P, revents %P:\n", fds[i], fds[i].events, fds[i].revents);
+            rprintf("   fd %d, events %x, revents %x:\n", fds[i], fds[i].events, fds[i].revents);
 #endif
             if (fds[i].revents & POLLHUP) {
                 rprintf("   fd %d: POLLHUP, closing\n", fds[i].fd);
@@ -274,7 +274,7 @@ static void poll_spin(notifier n)
             do {
                 if (r->events & fds[i].revents) {
 #ifdef SOCKET_USER_EPOLL_DEBUG
-                    rprintf("      match events %P, applying thunk %p\n",
+                    rprintf("      match events %x, applying thunk %p\n",
                         r->events, r->a);
 #endif
                     apply(r->a);
@@ -314,7 +314,7 @@ typedef struct epoll_notifier {
 static boolean epoll_register(notifier n, descriptor f, u32 events, thunk a)
 {
 #ifdef SOCKET_USER_EPOLL_DEBUG
-    rprintf("epoll register fd: notifier %p, fd %d, events %P, thunk %p\n", n, f, events, a);
+    rprintf("epoll register fd: notifier %p, fd %d, events %x, thunk %p\n", n, f, events, a);
 #endif
     epoll_notifier e = (epoll_notifier)n;
     registration new = allocate(n->h, sizeof(struct registration));
@@ -361,11 +361,11 @@ static void epoll_spin(notifier n)
     while (1) {
         int res = epoll_wait(e->fd, ev, sizeof(ev)/sizeof(struct epoll_event), -1);
         if (res == -1)
-	    halt ("epoll failed with %s (%d)\n", strerror(errno));
+	    halt("epoll failed with %s (%d)\n", strerror(errno), errno);
         for (int i = 0; i < res; i++) {
             registration r = ev[i].data.ptr;
 #ifdef SOCKET_USER_EPOLL_DEBUG
-	    rprintf("   fd %d, events %P\n", r->fd, ev[i].events);
+	    rprintf("   fd %d, events %x\n", r->fd, ev[i].events);
 #endif
             if (ev[i].events & EPOLLHUP)  {
                 descriptor fd = r->fd;
@@ -401,7 +401,7 @@ void set_nonblocking(descriptor d)
 {
     int flags = fcntl(d, F_GETFL);
     if (fcntl(d, F_SETFL, flags | O_NONBLOCK)) {
-        halt("fcntl %E\n", errno);
+        halt("fcntl %s\n", strerror(errno));
     }
 }
 
@@ -465,7 +465,7 @@ static void accepting(heap h, notifier n, descriptor c, new_connection nc )
     struct sockaddr_in where;
     socklen_t len = sizeof(struct sockaddr_in);
     int s = accept(c, (struct sockaddr *)&where, &len);
-    if (s < 0 ) halt("accept %E\n", errno);
+    if (s < 0 ) halt("accept %s\n", strerror(errno));
     buffer_handler out = closure(h, connection_output, s, n);
     buffer_handler in = apply(nc, out);
     register_descriptor(h, n, s, closure(h, connection_input, h, s, n, in));
@@ -501,7 +501,7 @@ void connection(heap h,
     if (res) {
         rprintf("zikkay %d %p\n", res, failure);        
         apply(failure, timm("errno", "%d", errno,
-                            "errstr", "%E", errno));
+                            "errstr", "%s", strerror(errno)));
     } else {
         register_descriptor_write(h, n, s, closure(h, connection_start, h, s, n, c));
     }
@@ -521,10 +521,10 @@ void listen_port(heap h, notifier n, u16 port, new_connection nc)
         perror("setsockopt(SO_REUSEADDR) failed");
     
     if (bind(service, (struct sockaddr *)&where, sizeof(struct sockaddr_in)))
-        halt("bind %E", errno);
+        halt("bind %s", strerror(errno));
 
     if (listen(service, 5))
-        halt("listen %E", errno);
+        halt("listen %s", strerror(errno));
 
     register_descriptor(h, n, service, closure(h, accepting, h, n, service, nc));
 }

--- a/src/unix_process/unix_process_runtime.c
+++ b/src/unix_process/unix_process_runtime.c
@@ -86,14 +86,6 @@ heap allocate_tagged_region(kernel_heaps kh, u64 tag)
     return create_id_heap(heap_general(kh), u64_from_pointer(region), size, 1);
 }
 
-
-static void format_errno(buffer dest, buffer fmt, vlist *a)
-{
-    char *e = strerror(varg(*a, int));
-    int len = runtime_strlen(e);
-    buffer_write(dest, e, len);
-}
-
 // xxx - not the kernel
 static struct kernel_heaps heaps; /* really just for init_runtime() */
 
@@ -106,8 +98,6 @@ heap init_process_runtime()
     init_runtime(&heaps);
     init_extra_prints();
     signal(SIGPIPE, SIG_IGN);
-    // unix errno print formatter
-    register_format('E', format_errno);
     return heaps.general;
 }
 

--- a/src/virtio/scsi.c
+++ b/src/virtio/scsi.c
@@ -19,11 +19,11 @@ static void scsi_bdump_sense(buffer b, const u8 *sense, int length)
 {
     assert(length >= sizeof(struct scsi_sense_data));
     for (int i = 0; i < sizeof(struct scsi_sense_data); i++) {
-        bprintf(b, "%s%P", i > 0 ? " " : "", (u64) sense[i]);
+        bprintf(b, "%s%02x", i > 0 ? " " : "", sense[i]);
     }
     struct scsi_sense_data *ssd = (struct scsi_sense_data *) sense;
-    bprintf(b, ": KEY %P, ASC/ASCQ %P/%P",
-        (u64) (ssd->flags & SSD_KEY), (u64) ssd->asc, (u64) ssd->ascq);
+    bprintf(b, ": KEY %x, ASC/ASCQ %02x/%02x",
+        (ssd->flags & SSD_KEY), ssd->asc, ssd->ascq);
 }
 
 void scsi_dump_sense(const u8 *sense, int length)

--- a/src/virtio/virtio_scsi.c
+++ b/src/virtio/virtio_scsi.c
@@ -121,7 +121,7 @@ static void virtio_scsi_enqueue_event(virtio_scsi s, virtio_scsi_event e);
 static CLOSURE_2_1(virtio_scsi_event_complete, void, virtio_scsi, virtio_scsi_event, u64);
 static void virtio_scsi_event_complete(virtio_scsi s, virtio_scsi_event e, u64 len)
 {
-    virtio_scsi_debug("%s: event %P\n", __func__, (u64) e->event);
+    virtio_scsi_debug("%s: event 0x%x\n", __func__, e->event);
     virtio_scsi_enqueue_event(s, e);
 }
 
@@ -151,7 +151,7 @@ static void virtio_scsi_request_complete(vsr_complete c, virtio_scsi s, virtio_s
 static virtio_scsi_request virtio_scsi_alloc_request(virtio_scsi s, u16 target, u16 lun, u8 cmd)
 {
     int alloc_len = scsi_data_len(cmd);
-    virtio_scsi_debug("%s: cmd 0x%P, data len %d\n", __func__, (u64) cmd, alloc_len);
+    virtio_scsi_debug("%s: cmd 0x%x, data len %d\n", __func__, cmd, alloc_len);
 
     virtio_scsi_request r = allocate(s->v->contiguous, sizeof(*r) + alloc_len);
     zero((void *) &r->req, sizeof(r->req));
@@ -198,10 +198,10 @@ static void virtio_scsi_io_done(status_handler sh, void *buf, u64 len, virtio_sc
 
     status st = 0;
     if (resp->response != VIRTIO_SCSI_S_OK) {
-        st = timm("result", "response %d", (u64) resp->response);
+        st = timm("result", "response %d", resp->response);
     } else if (resp->status != SCSI_STATUS_OK) {
         scsi_dump_sense(resp->sense, sizeof(resp->sense));
-        st = timm("result", "status %d", (u64) resp->status);
+        st = timm("result", "status %d", resp->status);
     }
     apply(sh, st);
 }
@@ -213,8 +213,8 @@ static void virtio_scsi_io(virtio_scsi s, u8 cmd, void *buf, range blocks, statu
     u32 nblocks = range_span(blocks);
     cdb->addr = htobe64(blocks.start);
     cdb->length = htobe32(nblocks);
-    virtio_scsi_debug("%s: cmd %d, blocks %R, addr 0x%P, length 0x%P\n",
-        __func__, cmd, blocks, cdb->addr, (u64) cdb->length);
+    virtio_scsi_debug("%s: cmd %d, blocks %R, addr 0x%016lx, length 0x%08x\n",
+        __func__, cmd, blocks, cdb->addr, cdb->length);
     virtio_scsi_enqueue_request(s, r, buf, nblocks * s->block_size,
         closure(s->v->general, virtio_scsi_io_done, sh, buf, nblocks * s->block_size));
 }
@@ -263,7 +263,7 @@ static void virtio_scsi_read_capacity_done(storage_attach a, u16 target, u16 lun
     s->capacity = sectors * s->block_size;
     s->target = target;
     s->lun = lun;
-    virtio_scsi_debug("%s: target %d, lun %d, block size 0x%P, capacity 0x%P\n",
+    virtio_scsi_debug("%s: target %d, lun %d, block size 0x%lx, capacity 0x%lx\n",
         __func__, target, lun, s->block_size, s->capacity);
 
     enqueue(runqueue, closure(s->v->general, virtio_scsi_init_done, s, a));
@@ -367,7 +367,7 @@ static void virtio_scsi_report_luns_done(storage_attach a, u16 target, virtio_sc
     virtio_scsi_debug("%s: got %d luns\n", __func__, length / sizeof(res->lundata[0]));
     for (u32 i = 0; i < MIN(s->max_lun, length / sizeof(res->lundata[0])); i++) {
         u16 lun = (res->lundata[i] & 0xffff) >> 8;
-        virtio_scsi_debug("%s: got lun %d (lundata 0x%P)\n", __func__, lun, res->lundata[i]);
+        virtio_scsi_debug("%s: got lun %d (lundata 0x%08lx)\n", __func__, lun, res->lundata[i]);
 
         // inquiry
         virtio_scsi_request r = virtio_scsi_alloc_request(s, target, lun, SCSI_CMD_INQUIRY);
@@ -394,33 +394,33 @@ static void virtio_scsi_attach(heap general, storage_attach a, heap page_allocat
     virtio_scsi s = allocate(general, sizeof(struct virtio_scsi));
     s->v = attach_vtpci(general, page_allocator, bus, slot, function, 0);
 
-    virtio_scsi_debug("features 0x%P\n", (u64) s->v->features);
+    virtio_scsi_debug("features 0x%lx\n", s->v->features);
 
 #ifdef VIRTIO_SCSI_DEBUG
     u32 num_queues = in32(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_SCSI_R_NUM_QUEUES);
-    virtio_scsi_debug("num queues %d\n", (u64) num_queues);
+    virtio_scsi_debug("num queues %d\n", num_queues);
 
     u32 seg_max = in32(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_SCSI_R_SEG_MAX);
-    virtio_scsi_debug("seg max %d\n", (u64) seg_max);
+    virtio_scsi_debug("seg max %d\n", seg_max);
 
     u32 max_sectors = in32(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_SCSI_R_MAX_SECTORS);
-    virtio_scsi_debug("max sectors %d\n", (u64) max_sectors);
+    virtio_scsi_debug("max sectors %d\n", max_sectors);
 
     u32 cmd_per_lun = in32(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_SCSI_R_CMD_PER_LUN);
-    virtio_scsi_debug("cmd per lun %d\n", (u64) cmd_per_lun);
+    virtio_scsi_debug("cmd per lun %d\n", cmd_per_lun);
 
     u32 event_info_size = in32(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_SCSI_R_EVENT_INFO_SIZE);
-    virtio_scsi_debug("event info size %d\n", (u64) event_info_size);
+    virtio_scsi_debug("event info size %d\n", event_info_size);
 
     u32 max_channel = in16(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_SCSI_R_MAX_CHANNEL);
-    virtio_scsi_debug("max channel %d\n", (u64) max_channel);
+    virtio_scsi_debug("max channel %d\n", max_channel);
 #endif
 
     s->max_target = in16(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_SCSI_R_MAX_TARGET);
-    virtio_scsi_debug("max target %d\n", (u64) s->max_target);
+    virtio_scsi_debug("max target %d\n", s->max_target);
 
     s->max_lun = in32(s->v->base + VIRTIO_MSI_DEVICE_CONFIG + VIRTIO_SCSI_R_MAX_LUN);
-    virtio_scsi_debug("max lun %d\n", (u64) s->max_lun);
+    virtio_scsi_debug("max lun %d\n", s->max_lun);
 
     status st = vtpci_alloc_virtqueue(s->v, 0, &s->command);
     assert(st == STATUS_OK);

--- a/src/virtio/virtio_storage.c
+++ b/src/virtio/virtio_storage.c
@@ -107,7 +107,7 @@ static inline void storage_rw_internal(storage st, boolean write, void * buf,
                                        range sectors, status_handler sh)
 {
     char * err = 0;
-    virtio_blk_debug("virtio_%s: block range %R cap %d\n", write ? "write" : "read", sectors, st->capacity);
+    virtio_blk_debug("virtio_%s: block range %R cap %ld\n", write ? "write" : "read", sectors, st->capacity);
 
     /* XXX so no, not page aligned but what? 16? */
     if ((u64_from_pointer(buf) & 15)) {

--- a/src/x86_64/backed_heap.c
+++ b/src/x86_64/backed_heap.c
@@ -11,7 +11,7 @@ static void physically_backed_dealloc(heap h, u64 x, bytes length)
 {
     backed b = (backed)h;
     if ((x & (h->pagesize-1)) | (length & (h->pagesize-1))) {
-	msg_err("attempt to free unaligned area at %P, length %P; leaking\n", x, length);
+	msg_err("attempt to free unaligned area at %lx, length %x; leaking\n", x, length);
 	return;
     }
 

--- a/src/x86_64/def64.h
+++ b/src/x86_64/def64.h
@@ -33,12 +33,6 @@ typedef u64 bytes;
  }
 
 void print_number(buffer s, u64 x, int base, int pad);
-static inline void format_pointer(buffer dest, buffer fmt, vlist *a)
-{
-    u64 x = varg(*a, u64);
-    // ?
-    print_number(dest, x, 16, 17);
-}
 
 /* These are defined as functions to avoid multiple evaluation of x. */
 static inline u16

--- a/src/x86_64/elf.c
+++ b/src/x86_64/elf.c
@@ -83,7 +83,7 @@ void *load_elf(buffer elf, u64 offset, heap pages, heap bss)
             s64 bss_size = p->p_memsz - p->p_filesz;
 
             if (bss_size < 0)
-                halt("load_elf with p->p_memsz (%d) < p->p_filesz (%d)\n",
+                halt("load_elf with p->p_memsz (%ld) < p->p_filesz (%ld)\n",
                      p->p_memsz, p->p_filesz);
             else if (bss_size == 0)
                 continue;

--- a/src/x86_64/serial.c
+++ b/src/x86_64/serial.c
@@ -39,6 +39,6 @@ void console(char *x)
 
 void debug(buffer b)
 {
-    foreach_character(i, b) serial_out(i);
+    foreach_character(_, i, b) serial_out(i);
 }
 

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -122,7 +122,8 @@ static void read_kernel_syms()
 	    u64 v = allocate_u64(heap_virtual_huge(&heaps), kern_length);
 	    map(v, kern_base, kern_length, heap_pages(&heaps));
 #ifdef ELF_SYMTAB_DEBUG
-	    rprintf("kernel ELF image at %P, length %d, mapped at %P\n",
+	    rprintf("xxx\n");
+	    rprintf("kernel ELF image at 0x%lx, length %ld, mapped at 0x%lx\n",
 		    kern_base, kern_length, v);
 #endif
 	    add_elf_syms(alloca_wrap_buffer(v, kern_length));

--- a/src/x86_64/symtab.c
+++ b/src/x86_64/symtab.c
@@ -39,8 +39,7 @@ void elf_symtable_add(char * name, u64 a, u64 len, u8 info)
     boolean match = rangemap_range_lookup(elf_symtable, r, 0);
     if (match) {
 #ifdef ELF_SYMTAB_DEBUG
-	msg_err("\"%s\" %R would overlap in rangemap with \"%s\" %R; skipping\n",
-		name, r, match->name, range_from_rmnode(&match->node));
+	msg_err("\"%s\" %R would overlap in rangemap; skipping\n", name, r);
 #endif
 	return;
     }

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -8,9 +8,7 @@ CFLAGS = -g \
 	 -DHOST_BUILD \
 	 -DENABLE_MSG_DEBUG \
 	 $(includes)
-CFLAGS+= $(CFLAG_WARNINGS) \
-	-std=gnu11 \
-         -Wformat
+CFLAGS+= $(CFLAG_WARNINGS) -std=gnu11
 ifeq ($(UNAME_s),Darwin)
 CFLAGS += -target x86_64-elf --sysroot $(TARGET_ROOT)
 HOSTLD = x86_64-elf-ld

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -7,7 +7,7 @@ TESTSRC = $(ROOT)/test/unit
 CFLAGS  = -fno-stack-protector
 CFLAGS  += -fdata-sections -ffunction-sections
 CFLAGS  += $(includes)
-CFLAGS  += -g -std=gnu11 -DHOST_BUILD $(CFLAG_WARNINGS) -Wformat $(PLATFORM_CFLAGS)
+CFLAGS  += -g -std=gnu11 -DHOST_BUILD $(CFLAG_WARNINGS) $(PLATFORM_CFLAGS)
 ifeq ($(UNAME_s),Darwin)
 CFLAGS  += -DNO_EPOLL
 endif

--- a/test/unit/buffer_test.c
+++ b/test/unit/buffer_test.c
@@ -148,6 +148,57 @@ boolean concat_tests(heap h)
     return failure;
 }
 
+#define VBPRINTF_TEST(b, orig, fmt, ...)                                                 \
+    do {                                                                                 \
+        buffer_clear(b);                                                                 \
+	bbprintf(b, alloca_wrap_buffer(fmt, runtime_strlen(fmt)), ##__VA_ARGS__);        \
+        rprintf("b: [%b]\n", b); \
+	test_assert(buffer_compare(b, alloca_wrap_buffer(orig, runtime_strlen(orig))));  \
+    } while (0)
+
+boolean vbprintf_tests(heap h)
+{
+    boolean failure = true;
+    buffer b = allocate_buffer(h, 10);
+
+    // %s
+    VBPRINTF_TEST(b, "hello, world", "%s", "hello, world");
+    VBPRINTF_TEST(b, "(null)", "%s", "(null)");
+
+    // %p
+    void *p = (void *) 0x123456780000;
+    VBPRINTF_TEST(b, "0x0000123456780000", "%p", p);
+
+    // System V AMD64 ABI calling convention:
+    // the first six integer or pointer arguments are passed in registers
+    //
+    // first two arguments of bbprintf() are buffer and format
+    // so add 4 more dummy arguments to test va_arg() stack arguments
+
+    // %c
+    VBPRINTF_TEST(b, "xxxxab", "%c%c%c%c%c%c", 'x', 'x', 'x', 'x', 'a', 'b');
+
+    // %d
+    u8 x = 12;
+    u16 y = 3456;
+    int z = 7890;
+    VBPRINTF_TEST(b, "0 0 0 0 12 3456 7890", "%d %d %d %d %d %d %d", 0, 0, 0, 0, x, y, z);
+    VBPRINTF_TEST(b, "0 0 0 0 1234 -42", "%d %d %d %d %ld %d", 0, 0, 0, 0, 1234l, -42);
+
+    // %x
+    u64 w = 0x1122334455667788;
+    VBPRINTF_TEST(b, "0 0 0 0 1234 0x1122334455667788", "%x %x %x %x %x 0x%lx", 0, 0, 0, 0, 0x1234, w);
+
+    // invalid format
+    VBPRINTF_TEST(b, "[invalid format %y]", "%y", 0);
+    VBPRINTF_TEST(b, "[invalid format %ls]", "%ls", 0);
+
+    failure = false;
+
+fail:
+    deallocate_buffer(b);
+    return failure;
+}
 
 int main(int argc, char **argv)
 {
@@ -157,6 +208,7 @@ int main(int argc, char **argv)
     failure |= basic_tests(h);
     failure |= byteorder_tests(h);
     failure |= concat_tests(h);
+    failure |= vbprintf_tests(h);
 
     if (failure) {
         msg_err("Test failed\n");

--- a/test/unit/id_heap_test.c
+++ b/test/unit/id_heap_test.c
@@ -17,22 +17,22 @@ static boolean basic_test(heap h)
 	u64 pages = length / pagesize;
 	heap id = create_id_heap(h, base, length, pagesize);
 
-	msg_debug("*** allocated id heap %p at length %d (%d pages), pagesize %d\n",
+	msg_debug("*** allocated id heap %p at length %ld (%ld pages), pagesize %ld\n",
 		  id, pagesize * pages, pages, pagesize);
 
 	for (int alloc_order=0; alloc_order <= (LENGTH_ORDER - page_order); alloc_order++) {
 	    u64 n = U64_FROM_BIT(alloc_order);
-	    msg_debug(">>> allocations of %d page(s) ... ", n);
+	    msg_debug(">>> allocations of %ld page(s) ... ", n);
 
 	    for (int i=0; i < pages; i += n) {
 		u64 a = allocate_u64(id, pagesize * n);
 		if (a == INVALID_PHYSICAL) {
-		    msg_err("!!! allocation failed for page %d\n", i);
+		    msg_err("!!! allocation failed for page %ld\n", i);
 		    return false;
 		}
 		u64 expect = base + i * pagesize;
 		if (a != expect) {
-		    msg_err("!!! allocation for page %d returned %P, expecting %P\n",
+		    msg_err("!!! allocation for page %ld returned %lx, expecting %lx\n",
 			    i, a, expect);
 		    return false;
 		}
@@ -73,7 +73,7 @@ static boolean random_test(heap h, heap rh, u64 page_order, int churn)
     zero(alloc_result_vec, VEC_LEN * sizeof(u64));
 
     heap id = create_id_heap_backed(h, rh, pagesize);
-    msg_debug("*** allocated id heap %p, parent heap %p, pagesize %d\n",
+    msg_debug("*** allocated id heap %p, parent heap %p, pagesize %ld\n",
 	      id, rh, pagesize);
 
     do {
@@ -86,9 +86,9 @@ static boolean random_test(heap h, heap rh, u64 page_order, int churn)
 		continue;
 
 	    alloc_result_vec[o] = allocate_u64(id, alloc_size_vec[o]);
-	    msg_debug("alloc %d, size %d, result %P\n", o, alloc_size_vec[o], alloc_result_vec[o]);
+	    msg_debug("alloc %d, size %ld, result %lx\n", o, alloc_size_vec[o], alloc_result_vec[o]);
 	    if (alloc_result_vec[o] == INVALID_PHYSICAL) {
-		msg_err("alloc of size %d failed\n", alloc_size_vec[o]);
+		msg_err("alloc of size %ld failed\n", alloc_size_vec[o]);
 		goto fail;
 	    }
 	}
@@ -120,7 +120,7 @@ static boolean random_test(heap h, heap rh, u64 page_order, int churn)
 		continue;
 	    int o = (i + start) % VEC_LEN;
 	    if (alloc_result_vec[o]) {
-		msg_debug("dealloc %d, size %d\n", o, alloc_size_vec[o]);
+		msg_debug("dealloc %d, size %ld\n", o, alloc_size_vec[o]);
 		deallocate_u64(id, alloc_result_vec[o], alloc_size_vec[o]);
 		alloc_result_vec[o] = 0;
 	    }
@@ -137,7 +137,7 @@ static boolean random_test(heap h, heap rh, u64 page_order, int churn)
   fail:
     msg_err("test vector:\ni\t(alloc,\tresult)\n");
     for (int i=0; i < VEC_LEN; i++) {
-	rprintf("%d\t(%d,\t%P)\n", i, alloc_size_vec[i], alloc_result_vec[i]);
+	rprintf("%d\t(%ld,\t%lx)\n", i, alloc_size_vec[i], alloc_result_vec[i]);
     }
     return false;
 }

--- a/test/unit/pqueue_test.c
+++ b/test/unit/pqueue_test.c
@@ -12,14 +12,14 @@ boolean basic_sort(void * a, void * b)
 boolean peek_check(pqueue q, u64 v)
 {
     void * rv = pqueue_peek(q);
-    msg_debug("peek_check: want %d, got %d\n", v, (long)rv);
+    msg_debug("peek_check: want %ld, got %ld\n", v, (u64)rv);
     return rv == (void *)v;
 }
 
 boolean pop_check(pqueue q, u64 v)
 {
     void * rv = pqueue_pop(q);
-    msg_debug("pop_check: want %d, got %d\n", v, (long)rv);
+    msg_debug("pop_check: want %ld, got %ld\n", v, (u64)rv);
     return rv == (void *)v;
 }
 
@@ -146,7 +146,7 @@ boolean random_test(heap h, int n, int passes)
         remain = n - npop;
         for (int i = 0; i < npop; i++) {
             u64 v = (u64)pqueue_pop(q);
-            msg_debug("  pop %d\n", v);
+            msg_debug("  pop %ld\n", v);
             if (v > last) {
                 msg = "pop out of order";
                 goto fail;

--- a/test/unit/vector_test.c
+++ b/test/unit/vector_test.c
@@ -62,7 +62,7 @@ boolean basic_test(heap h)
 
         /* Attempt to detect resize and check content */
         if (prev != v->contents || i == n - 1) {
-            msg_debug("resize detected at index %d\n", i);
+            msg_debug("resize detected at index %ld\n", i);
             for (long j = 0; j < i + 1; j++) {
                 if (vector_get(v, j) != (void *)j) {
                     msg = "resize: content mismatch";


### PR DESCRIPTION
1) System V AMD64 ABI calling convention is:
the first six integer or pointer arguments are passed in registers
the remaining arguments are pushed on stack.

2) "char" and "short" are promoted to "int" (32-bit on AMD64) when passed as varargs

3) %P and %d expected 64-bit integer before

So 8, 16 and 32-bit integer arguments (starting from 4th or 5th)
for rprintf() and friends are not printed properly.

Fix this by the following:
- %d now expects "int"
- implement l-modifier (%ld) to print 64-bit int
- implement %x (hex-formatted int) and %lx
- implement width modifier for %d and %x (%02x)
only zero-padding (no space-padding) is implemented for now
- move %s to common runtime
- remove %P (%lx should be used instead)
- remove %E (use %s and strerror(errno) instead)
- format_number: fix printing 0 when pad == 0 (some callers used pad == 0)
- vbprintf() tests

Note that %ld in 32-bit code (-DBITS32) also expects 64-bit (not "long").
We never use "long" and always use "u64" or "s64" explicitly.