### PR TITLE
randomize heap and stack

### DIFF
--- a/src/runtime/bitmap.h
+++ b/src/runtime/bitmap.h
@@ -11,7 +11,8 @@ typedef struct bitmap {
 
 boolean bitmap_reserve(bitmap b, u64 start, u64 nbits);
 u64 bitmap_alloc(bitmap b, int order);
-boolean bitmap_dealloc(bitmap b, u64 bit, u64 order);
+u64 bitmap_alloc_with_offset(bitmap b, int order, u64 offset);
+boolean bitmap_dealloc(bitmap b, u64 bit, int order);
 bitmap allocate_bitmap(heap h, u64 length);
 void deallocate_bitmap(bitmap b);
 bitmap bitmap_wrap(heap h, u64 * map, u64 length);

--- a/src/runtime/heap/heap.h
+++ b/src/runtime/heap/heap.h
@@ -16,6 +16,7 @@ heap allocate_id_heap(heap h, bytes pagesize); /* id heap with no ranges */
 boolean id_heap_add_range(heap h, u64 base, u64 length);
 boolean id_heap_reserve(heap h, u64 base, u64 length);
 u64 id_heap_total(heap h);
+void id_heap_set_randomize(heap h, boolean randomize);
 heap wrap_freelist(heap meta, heap parent, bytes size);
 heap allocate_objcache(heap meta, heap parent, bytes objsize, bytes pagesize);
 boolean objcache_validate(heap h);


### PR DESCRIPTION
This will add a random component to allocation of the user program's heap and stack when "aslr" is set in the config:

From #706 / testaslr.c:

```
#include <stdio.h>
#include <stdlib.h>

void foo(){}

int main(int argc, char *argv[]){
    int y;
    char *x = (char *) malloc(128);

    printf("Library functions: %016x, Heap: %016x, Stack: %016x, Binary: %016x\n",
           malloc, x, &y, &foo);
}
```

and config:

```
 { "Boot":"output/boot/boot.img",
   "Kernel":"output/stage3/bin/stage3.img",
   "Mkfs":"output/mkfs/bin/mkfs",
   "Env" : {},
   "Debugflags" : ["aslr"]
 }
```

we get:

```
$ ops run testaslr -c config.json 
Finding dependent shared libs
booting /home/wjhun/.ops/images/testaslr.img ...
assigned: 10.0.2.15
Library functions: 000000000007af10, Heap: 0000000003991010, Stack: 00000000dddffe74, Binary: 000000000375b6f0
exit status 1
$ ops run testaslr -c config.json 
Finding dependent shared libs
booting /home/wjhun/.ops/images/testaslr.img ...
assigned: 10.0.2.15
Library functions: 000000000007af10, Heap: 0000000007821010, Stack: 000000001fbffe74, Binary: 00000000075516f0
exit status 1
$ ops run testaslr -c config.json 
Finding dependent shared libs
booting /home/wjhun/.ops/images/testaslr.img ...
assigned: 10.0.2.15
Library functions: 000000000007af10, Heap: 000000000733c010, Stack: 00000000eabffe74, Binary: 0000000006d3b6f0
exit status 1
$ ops run testaslr -c config.json 
Finding dependent shared libs
booting /home/wjhun/.ops/images/testaslr.img ...
assigned: 10.0.2.15
Library functions: 000000000007af10, Heap: 000000000278c010, Stack: 00000000de7ffe74, Binary: 00000000022a86f0
exit status 1
```

Note that the address of malloc doesn't seem to change. This appears to be a separate issue with dynamic linking as this isn't a valid address.
