### PR TITLE
syscall: Create stubs for wait4/wait3

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -52,8 +52,8 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, link, 0);
     register_syscall(map, unlink, 0);
     register_syscall(map, symlink, 0);
-    register_syscall(map, chmod, 0);
-    register_syscall(map, fchmod, 0);
+    register_syscall(map, chmod, syscall_ignore);
+    register_syscall(map, fchmod, syscall_ignore);
     register_syscall(map, fchown, 0);
     register_syscall(map, lchown, 0);
     register_syscall(map, umask, 0);
@@ -199,7 +199,7 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, renameat, 0);
     register_syscall(map, linkat, 0);
     register_syscall(map, symlinkat, 0);
-    register_syscall(map, fchmodat, 0);
+    register_syscall(map, fchmodat, syscall_ignore);
     register_syscall(map, faccessat, 0);
     register_syscall(map, unshare, 0);
     register_syscall(map, set_robust_list, 0);


### PR DESCRIPTION
I was not sure where should I set the handlers for stubbed syscalls to `syscall_ignore`, so for now have added them to `register_other_syscalls` function, however all other calls in the function has 0 as the handler which makes it very inconsistent. 