### PR TITLE
fix eventfd runtime test for mac (add ssp.c)

### DIFF
--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -28,6 +28,7 @@ LDFLAGS-creat=		-static
 
 SRCS-eventfd= \
 	$(CURDIR)/eventfd.c \
+	$(SRCDIR)/unix_process/ssp.c
 
 LDFLAGS-eventfd=	-static
 LIBS-eventfd=		-lpthread


### PR DESCRIPTION
trivial