### PR TITLE
socket code was not properly using lwIP accept backlog

### DIFF
--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -50,6 +50,7 @@
 
 #define LWIP_WND_SCALE 1
 #define TCP_RCV_SCALE 0         /* XXX check */
+#define TCP_LISTEN_BACKLOG 1
 #define LWIP_DHCP 1
 // would prefer to set this dynamically...also,
 // seems better to allow some progress to be made


### PR DESCRIPTION
lwIP maintains a backlog of connections on a listening socket, but we were not properly using its interface (which isn't really documented in rawapi.txt). This turns it on, allowing the system to give backpressure for a large number of incoming connections. The effective tcp_abort (reset) in #820 is instead used as a last resort if somehow the incoming queue fills up (which should never happen if the lwIP backlog and our queue stay in sync).

This should finally resolve #762.
