### PR TITLE
clone(): return error when child_stack argument is zero

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -56,6 +56,9 @@ sysreturn clone(unsigned long flags, void *child_stack, int *ptid, int *ctid, un
     thread_log(current, "clone: flags %lx, child_stack %p, ptid %p, ctid %p, newtls %lx",
         flags, child_stack, ptid, ctid, newtls);
 
+    if (!child_stack)   /* this is actually a fork() */
+        return set_syscall_error(current, ENOSYS);
+
     /* clone thread context up to FRAME_VECTOR */
     thread t = create_thread(current->p);
     runtime_memcpy(t->frame, current->frame, sizeof(u64) * FRAME_ERROR_CODE);


### PR DESCRIPTION
clone() may be called with child_stack set to zero, in which case
the child inherits the stack from the parent and then gets
separate copies of stack pages (using copy-on-write semantics)
when either the parent or the child modifies the stack: in other
words, in this case clone() is being used to fork a new process.
In fact, since version 2.3.3, rather than invoking the kernel's
fork() system call, the glibc fork() wrapper that is provided as
part of the NPTL threading implementation invokes clone(2) with
flags that provide the same effect as the traditional system call.

Since we don't support running multiple processes, clone() should
error out when child_stack is zero, instead of causing a crash
(unix_fault_page error, due to the invalid stack pointer value) as
soon as the child process starts executing.