### PR TITLE
readv() fix - use and update file offset properly

### DIFF
--- a/test/runtime/read_contents/hello
+++ b/test/runtime/read_contents/hello
@@ -1,1 +1,1 @@
-one six four
+pad one six four


### PR DESCRIPTION
In scope of #543 - it's a fix of existing implementation to better conform reference readv() behavior - start reading from current file offset and updated it after write.

Redundant allocation issue is not fixed here; as the whole readv() is going to be rewritten in scope of #859, but unit test should be still relevant.