### PR TITLE
Optimized memcpy implementation

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -7,6 +7,7 @@ SRCS-stage2.elf= \
 	$(SRCDIR)/runtime/buffer.c \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/range.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/pqueue.c \

--- a/mkfs/Makefile
+++ b/mkfs/Makefile
@@ -6,6 +6,7 @@ SRCS-mkfs= \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
@@ -29,6 +30,7 @@ SRCS-dump= \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \

--- a/src/runtime/memops.c
+++ b/src/runtime/memops.c
@@ -1,0 +1,205 @@
+#include <runtime.h>
+
+/* Copy by advancing memory addresses in forward direction. */
+static inline void memcpyf_8(void *dst, const void *src, bytes len)
+{
+    for (bytes i = 0; i < len; i++) {
+        ((u8 *)dst)[i] = ((u8 *)src)[i];
+    }
+}
+
+/* Copy by advancing memory addresses in backward direction. */
+static inline void memcpyb_8(void *dst, const void *src, bytes len)
+{
+    for (bytes i = len - 1; i < len; i--) {
+        ((u8 *)dst)[i] = ((u8 *)src)[i];
+    }
+}
+
+static inline void memset_8(void *a, u8 b, bytes len)
+{
+    for (int i = 0; i < len; i++) {
+        ((u8 *)a)[i] = b;
+    }
+}
+
+static inline int memcmp_8(const void *a, const void *b, bytes len)
+{
+    int res;
+
+    for (int i = 0; i < len; i++) {
+        res = ((u8 *)a)[i] - ((u8 *)b)[i];
+        if (res != 0) {
+            return res;
+        }
+    }
+    return 0;
+}
+
+void runtime_memcpy(void *a, const void *b, bytes len)
+{
+    unsigned int src_cnt, dest_cnt;
+    bytes long_len, end_len;
+    unsigned long *p_long_src;
+    unsigned long *p_long_dest;
+    unsigned long long_word1;
+    unsigned long long_word2;
+
+    if ((unsigned long)a < (unsigned long)b) {
+        if (len < sizeof(long)) {
+            memcpyf_8(a, b, len);
+            return;
+        }
+        src_cnt = sizeof(long) - ((unsigned long)b & (sizeof(long) - 1));
+        if (src_cnt == sizeof(long)) {
+            src_cnt = 0;
+        }
+        dest_cnt = sizeof(long) - ((unsigned long)a & (sizeof(long) - 1));
+        if (dest_cnt == sizeof(long)) {
+            dest_cnt = 0;
+        }
+        else {
+            memcpyf_8(a, b, dest_cnt);
+        }
+        long_len = (len - dest_cnt) / sizeof(long);
+        end_len = (len - dest_cnt) & (sizeof(long) - 1);
+        p_long_src = (unsigned long *)((u8 *)b + src_cnt);
+        if (src_cnt > dest_cnt) {
+            p_long_src--;
+        }
+        p_long_dest = (unsigned long *)((u8 *)a + dest_cnt);
+        if (src_cnt == dest_cnt) {
+            while (long_len-- > 0) {
+                *p_long_dest++ = *p_long_src++;
+            }
+        }
+        else {
+            unsigned int alignment = (src_cnt - dest_cnt) & (sizeof(long) - 1);
+            long_word1 = *p_long_src++;
+            while (long_len-- > 0) {
+                long_word2 = *p_long_src++;
+                *p_long_dest++ =
+                        (long_word1 >> (8 * (sizeof(long) - alignment))) |
+                        (long_word2 << (8 * alignment));
+                long_word1 = long_word2;
+            }
+        }
+        memcpyf_8(p_long_dest, b + len - end_len, end_len);
+    }
+    else {
+        if (len < sizeof(long)) {
+            memcpyb_8(a, b, len);
+            return;
+        }
+        src_cnt = (unsigned long)((u8 *)b + len) & (sizeof(long) - 1);
+        dest_cnt = (unsigned long)((u8 *)a + len) & (sizeof(long) - 1);
+        p_long_src = (unsigned long *)((u8 *)b + len - dest_cnt);
+        p_long_dest = (unsigned long *)((u8 *)a + len - dest_cnt);
+        memcpyb_8(p_long_dest, p_long_src, dest_cnt);
+        p_long_src = (unsigned long *)((u8 *)b + len - src_cnt);
+        len -= dest_cnt;
+        long_len = len / sizeof(long);
+        end_len = len & (sizeof(long) - 1);
+        if (src_cnt <= dest_cnt) {
+            p_long_src--;
+        }
+        p_long_dest--;
+        if (src_cnt == dest_cnt) {
+            while (long_len-- > 0) {
+                *p_long_dest-- = *p_long_src--;
+            }
+        }
+        else {
+            unsigned int alignment = (src_cnt - dest_cnt) & (sizeof(long) - 1);
+            long_word1 = *p_long_src--;
+            while (long_len-- > 0) {
+                long_word2 = *p_long_src--;
+                *p_long_dest-- =
+                        (long_word1 << (8 * (sizeof(long) - alignment))) |
+                        (long_word2 >> (8 * alignment));
+                long_word1 = long_word2;
+            }
+        }
+        memcpyb_8(a, b, end_len);
+    }
+}
+
+void runtime_memset(u8 *a, u8 b, bytes len)
+{
+    if (len < sizeof(long)) {
+        memset_8(a, b, len);
+        return;
+    }
+    unsigned int cnt = sizeof(long) - ((unsigned long)a & (sizeof(long) - 1));
+    if (cnt == sizeof(long)) {
+        cnt = 0;
+    }
+    else {
+        memset_8(a, b, cnt);
+        len -= cnt;
+    }
+    unsigned long *dest = (unsigned long *)((u8 *)a + cnt);
+    unsigned long word = 0;
+    for (int i = 0; i < sizeof(word); i++) {
+        word = (word << 8) | b;
+    }
+    bytes long_len = len / sizeof(long);
+    bytes end_len = len & (sizeof(long) - 1);
+    while (long_len-- > 0) {
+        *dest++ = word;
+    }
+    memset_8(dest, b, end_len);
+}
+
+int runtime_memcmp(const void *a, const void *b, bytes len)
+{
+    unsigned long res;
+
+    if (len < sizeof(long)) {
+        return memcmp_8(a, b, len);
+    }
+    unsigned int a_cnt = sizeof(long) - ((unsigned long)a & (sizeof(long) - 1));
+    if (a_cnt == sizeof(long)) {
+        a_cnt = 0;
+    }
+    unsigned int b_cnt = sizeof(long) - ((unsigned long)b & (sizeof(long) - 1));
+    if (b_cnt == sizeof(long)) {
+        b_cnt = 0;
+    }
+    else {
+        res = memcmp_8(a, b, b_cnt);
+        if (res) {
+            return res;
+        }
+    }
+    bytes long_len = (len - b_cnt) / sizeof(long);
+    bytes end_len = (len - b_cnt) & (sizeof(long) - 1);
+    unsigned long *p_long_a = (unsigned long *)((u8 *)a + a_cnt);
+    if (a_cnt > b_cnt) {
+        p_long_a--;
+    }
+    unsigned long *p_long_b = (unsigned long *)((u8 *)b + b_cnt);
+    if (a_cnt == b_cnt) {
+        while (long_len-- > 0) {
+            res = *p_long_a++ - *p_long_b++;
+            if (res) {
+                return 1;
+            }
+        }
+    }
+    else {
+        unsigned int alignment = (a_cnt - b_cnt) & (sizeof(long) - 1);
+        unsigned long long_word1, long_word2;
+        long_word1 = *p_long_a++;
+        while (long_len-- > 0) {
+            long_word2 = *p_long_a++;
+            res = ((long_word1 >> (8 * (sizeof(long) - alignment))) |
+                    (long_word2 << (8 * alignment))) - *p_long_b++;
+            if (res) {
+                return 1;
+            }
+            long_word1 = long_word2;
+        }
+    }
+    return memcmp_8(a + len - end_len, p_long_b, end_len);
+}

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -35,25 +35,11 @@ extern void print_stack_from_here();
     } while(0)
 #endif
 
-static inline void runtime_memcpy(void *a, const void *b, bytes len)
-{
-    for (int i = 0; i < len; i++) ((u8 *)a)[i] = ((u8 *)b)[i];
-}
+void runtime_memcpy(void *a, const void *b, bytes len);
 
-static inline void runtime_memset(u8 *a, u8 b, bytes len)
-{
-    for (int i = 0; i < len; i++) ((u8 *)a)[i] = b;
-}
+void runtime_memset(u8 *a, u8 b, bytes len);
 
-static inline int runtime_memcmp(const void *a, const void *b, bytes len)
-{
-    for (int i = 0; i < len; i++) {
-        int res = ((signed char *) a)[i] - ((signed char *) b)[i];
-        if (res != 0)
-            return res;
-    }
-    return 0;
-}
+int runtime_memcmp(const void *a, const void *b, bytes len);
 
 static inline int runtime_strlen(const char *a)
 {
@@ -85,29 +71,9 @@ static inline void console(char *s)
 
 #define check_flags_and_clear(x, f) ({boolean match = ((x) & (f)) != 0; (x) &= ~(f); match;})
 
-#if 0
-// this...seems to have a fault (?).. it may be the interrupt
-// machinery
 static inline void zero(void *x, bytes length)
 {
-    u64 *start = pointer_from_u64(pad(u64_from_pointer(x), 8));
-    u64 first = u64_from_pointer((void *)start - x);
-    if (first > length) first = length;
-    u64 aligned = (length - first) >>3;
-    u8 *end = (u8 *)(start + first+aligned);
-    u64 final = length - aligned*8 - first;
-
-    for (int i =0; i < first; i++) *(u8 *)(x + i) = 0;
-    // rep, movent
-    for (int i =0; i < aligned; i++) start[i] = 0;
-    for (int i =0; i < final; i++) end[i] = 0;        
-}
-#endif
-
-static inline void zero(void *x, bytes length)
-{
-    for (int i = 0; i < length; i++)
-        ((u8 *)x)[i] = 0;
+    runtime_memset(x, 0, length);
 }
 
 typedef struct heap *heap;

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -22,6 +22,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/runtime/heap/id.c \
 	$(SRCDIR)/runtime/heap/mcache.c \
 	$(SRCDIR)/runtime/heap/objcache.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -76,6 +76,7 @@ SRCS-pipe= \
 	$(SRCDIR)/runtime/buffer.c \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
@@ -130,6 +131,7 @@ SRCS-udploop= \
 	$(SRCDIR)/runtime/heap/debug_heap.c \
 	$(SRCDIR)/runtime/heap/objcache.c \
 	$(SRCDIR)/runtime/heap/mcache.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
@@ -172,6 +174,7 @@ SRCS-web= \
 	$(SRCDIR)/runtime/heap/debug_heap.c \
 	$(SRCDIR)/runtime/heap/objcache.c \
 	$(SRCDIR)/runtime/heap/mcache.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -1,6 +1,7 @@
 PROGRAMS= \
 	buffer_test \
 	id_heap_test \
+	memops_test \
 	network_test \
 	objcache_test \
 	parser_test \
@@ -20,6 +21,7 @@ SRCS-buffer_test= \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
@@ -40,6 +42,7 @@ SRCS-id_heap_test= \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
@@ -55,6 +58,25 @@ SRCS-id_heap_test= \
 	$(SRCDIR)/tfs/tlog.c \
 	$(SRCDIR)/unix_process/unix_process_runtime.c
 
+SRCS-memops_test= \
+	$(CURDIR)/memops_test.c \
+	$(SRCDIR)/runtime/bitmap.c \
+	$(SRCDIR)/runtime/buffer.c \
+	$(SRCDIR)/runtime/crypto/chacha.c \
+	$(SRCDIR)/runtime/extra_prints.c \
+	$(SRCDIR)/runtime/format.c \
+	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
+	$(SRCDIR)/runtime/pqueue.c \
+	$(SRCDIR)/runtime/random.c \
+	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/runtime_init.c \
+	$(SRCDIR)/runtime/symbol.c \
+	$(SRCDIR)/runtime/table.c \
+	$(SRCDIR)/runtime/timer.c \
+	$(SRCDIR)/runtime/tuple.c \
+	$(SRCDIR)/unix_process/unix_process_runtime.c
+
 SRCS-network_test= \
 	$(CURDIR)/network_test.c \
 	$(SRCDIR)/runtime/bitmap.c \
@@ -62,6 +84,7 @@ SRCS-network_test= \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
@@ -89,6 +112,7 @@ SRCS-objcache_test= \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
 	$(SRCDIR)/runtime/heap/objcache.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
@@ -114,6 +138,7 @@ SRCS-parser_test= \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
@@ -134,6 +159,7 @@ SRCS-pqueue_test= \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
@@ -154,6 +180,7 @@ SRCS-range_test= \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
@@ -174,6 +201,7 @@ SRCS-random_test = \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
@@ -196,6 +224,7 @@ SRCS-table_test= \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
@@ -214,6 +243,7 @@ SRCS-tuple_test= \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
@@ -234,6 +264,7 @@ SRCS-udp_test= \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
@@ -260,6 +291,7 @@ SRCS-vector_test= \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \

--- a/test/unit/memops_test.c
+++ b/test/unit/memops_test.c
@@ -1,0 +1,122 @@
+#include <runtime.h>
+#include <stdlib.h>
+
+#define MEM_BUF_SIZE    512
+
+#define test_assert(expr)   do { \
+    if (!(expr)) { \
+        msg_err("%s -- failed at %s:%d\n", #expr, __FILE__, __LINE__); \
+        exit(EXIT_FAILURE); \
+    } \
+} while (0)
+
+static void test_memcpy(long *buf1, long *buf2, unsigned long buf_size)
+{
+    for (long i = 0; i < buf_size; i++) {
+        buf1[i] = buf_size - i;
+    }
+
+    runtime_memcpy(buf2, buf1, sizeof(long) - 1);
+    test_assert(runtime_memcmp(buf1, buf2, sizeof(long) - 1) == 0);
+
+    runtime_memcpy(buf2 + 1, buf1, sizeof(long));
+    test_assert(runtime_memcmp(buf1, buf2 + 1, sizeof(long)) == 0);
+
+    runtime_memcpy((u8 *)(buf2 + 2) + 1, buf1, sizeof(long));
+    test_assert(runtime_memcmp(buf1, (u8 *)(buf2 + 2) + 1, sizeof(long)) == 0);
+
+    for (long i = 0; i < sizeof(long); i++) {
+        for (long j = 0; j < sizeof(long); j++) {
+            runtime_memcpy((u8 *)buf2 + i, (u8 *)buf1 + j,
+                    (buf_size - 1) * sizeof(long));
+            test_assert(runtime_memcmp((u8 *)buf1 + j, (u8 *)buf2 + i,
+                    (buf_size - 1) * sizeof(long)) == 0);
+        }
+    }
+}
+
+static void test_memcpy_overlap(long *buf, unsigned long buf_size)
+{
+    for (long i = 0; i < buf_size; i++) {
+        buf[i] = i;
+    }
+
+    runtime_memcpy(buf, buf + 1, (buf_size - 1) * sizeof(long));
+    for (long i = 0; i < buf_size - 1; i++) {
+        test_assert(buf[i] == i + 1);
+    }
+
+    long first_word = 0, last_word = 0;
+    for (int i = 0; i < sizeof(first_word); i++) {
+        *((u8 *)&first_word + i) = *((u8 *)buf + 1 + i);
+    }
+    for (int i = 0; i < sizeof(last_word) - 1; i++) {
+        *((u8 *)&last_word + i) =
+                *((u8 *)buf + (buf_size - 1) * sizeof(long) + 1 + i);
+    }
+    *((u8 *)&last_word + sizeof(last_word) - 1) =
+            *((u8 *)buf + buf_size * sizeof(long) - 1);
+    runtime_memcpy(buf, (u8 *)buf + 1, buf_size * sizeof(long) - 1);
+    test_assert(buf[0] == first_word);
+    test_assert(buf[buf_size - 1] == last_word);
+
+    *((u8 *)&first_word) = *((u8 *)buf);
+    for (int i = 1; i < sizeof(first_word); i++) {
+        *((u8 *)&first_word + i) = *((u8 *)buf + i - 1);
+    }
+    for (int i = 0; i < sizeof(last_word); i++) {
+        *((u8 *)&last_word + i) =
+                *((u8 *)buf + (buf_size - 1) * sizeof(long) + i - 1);
+    }
+    runtime_memcpy((u8 *)buf + 1, buf, buf_size * sizeof(long) - 1);
+    test_assert(buf[0] == first_word);
+    test_assert(buf[buf_size - 1] == last_word);
+}
+
+static void test_memset(long *buf, unsigned long buf_size)
+{
+    runtime_memset((u8 *)buf, 0xAA, sizeof(long) - 1);
+    for (int i = 0; i < sizeof(long) - 1; i++) {
+        test_assert(*((u8 *)buf + i) == 0xAA);
+    }
+
+    runtime_memset((u8 *)buf + 1, 0xBB, sizeof(long));
+    for (int i = 0; i < sizeof(long); i++) {
+        test_assert(*((u8 *)buf + 1 + i) == 0xBB);
+    }
+
+    runtime_memset((u8 *)buf + 3, 0xCC, (buf_size - 1) * sizeof(long));
+    for (int i = 0; i < (buf_size - 1) * sizeof(long); i++) {
+        test_assert(*((u8 *)buf + 3 + i) == 0xCC);
+    }
+}
+
+static void test_memcmp(long *buf, unsigned long buf_size)
+{
+    for (long i = 0; i < buf_size; i++) {
+        buf[i] = i;
+    }
+    test_assert(runtime_memcmp(buf, buf, sizeof(long) - 1) == 0);
+    test_assert(runtime_memcmp(buf, buf + 1, sizeof(long) - 1) != 0);
+    test_assert(runtime_memcmp(buf, (u8 *)buf + 1, sizeof(long)) != 0);
+    test_assert(runtime_memcmp((u8 *)buf + 1, buf, sizeof(long)) != 0);
+    test_assert(runtime_memcmp((u8 *)buf + 1, (u8 *)buf + 3,
+            sizeof(long)) != 0);
+    test_assert(runtime_memcmp((u8 *)buf + 3, (u8 *)buf + 1,
+            sizeof(long)) != 0);
+    test_assert(runtime_memcmp(buf, buf + 1, sizeof(long)) != 0);
+    test_assert(runtime_memcmp(buf, buf, buf_size * sizeof(long)) == 0);
+}
+
+int main(int argc, char *argv[])
+{
+    long buf1[MEM_BUF_SIZE], buf2[MEM_BUF_SIZE];
+
+    init_process_runtime();
+    test_memcpy(buf1, buf2, MEM_BUF_SIZE);
+    test_memcpy(buf2, buf1, MEM_BUF_SIZE);
+    test_memcpy_overlap(buf1, MEM_BUF_SIZE);
+    test_memset(buf1, MEM_BUF_SIZE);
+    test_memcmp(buf1, MEM_BUF_SIZE);
+    return 0;
+}


### PR DESCRIPTION
**Implementation Detail:**
1. Converted src and destination pointer to word alligned
2. and then made word copy

**Performance Measurement:**
I used x86 64-bit ubuntu machine to compare the performance of new code with existing approach and gcc libc memcpy.
new code shows considerable improvement.
I also included inline x86 assembly approach (code is not included in review but its performace is even better than gcc libc memcpy).
Let me know if this can be used. I will include the code in review.

**Performance Analysis Report:**	 
Following input data used in evaluating performance with different approach:
Size selection: 64B, 128B, 256B, 512B, 1K, 2K ... 1M
Combination: alligned with 64 byte address, non-aligned destination,  non-aligned destination and src
Number of Loops: From 16777216 to 1024

Complete report is attached. 
[mempcy_performance_analysis.docx](https://github.com/nanovms/nanos/files/3370869/mempcy_performance_analysis.docx)

Following is one sample.
**memcpy 2048B -- 524288 loops**
  **aligned blocks with 64 multiple**
      nanos runtime_memcpy                               2.496000 s
      nanos runtime_memcpy_e                             0.640000 s
      libc memcpy                                        0.060000 s
      memcpy using x86 inline asssembly                  0.036000 s
  **unaligned blocks , src with +0 and dst with +4**
      nanos runtime_memcpy                               2.500000 s
      nanos runtime_memcpy_e                             0.648000 s
      libc memcpy                                        0.060000 s
      memcpy using x86 inline asssembly                  0.048000 s
  **unaligned blocks , src with +10 and dst with +3**
      nanos runtime_memcpy                               2.492000 s
      nanos runtime_memcpy_e                             0.764000 s
      libc memcpy                                        0.060000 s
      memcpy using x86 inline asssembly                  0.052000 s
