### PR TITLE
socket shutdown support

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -331,18 +331,18 @@ static sysreturn sock_read_bh(sock s, thread t, void *dest, u64 length,
         struct pbuf *cur_buf = pbuf;
 
         do {
-            if (cur_buf->len == 0) {
-                cur_buf = cur_buf->next;
-                continue;
+            if (cur_buf->len > 0) {
+                u64 xfer = MIN(length, cur_buf->len);
+                runtime_memcpy(dest, cur_buf->payload, xfer);
+                pbuf_consume(cur_buf, xfer);
+                length -= xfer;
+                xfer_total += xfer;
+                dest = (char *) dest + xfer;
+                if (s->type == SOCK_STREAM)
+                    tcp_recved(s->info.tcp.lw, xfer);
             }
-            u64 xfer = MIN(length, cur_buf->len);
-            runtime_memcpy(dest, cur_buf->payload, xfer);
-            pbuf_consume(cur_buf, xfer);
-            length -= xfer;
-            xfer_total += xfer;
-            dest = (char *) dest + xfer;
-            if (s->type == SOCK_STREAM)
-                tcp_recved(s->info.tcp.lw, xfer);
+            if (cur_buf->len == 0)
+                cur_buf = cur_buf->next;
         } while ((length > 0) && cur_buf);
 
         if (!cur_buf || (s->type == SOCK_DGRAM)) {
@@ -612,6 +612,16 @@ static sysreturn socket_ioctl(sock s, unsigned long request, vlist ap)
         addr->family = AF_INET;
         runtime_memcpy(&addr->address, netif_ip4_addr(netif),
                 sizeof(ip4_addr_t));
+        return 0;
+    }
+    case FIONBIO: {
+        int opt = varg(ap, int);
+        if (opt) {
+            s->f.flags |= SOCK_NONBLOCK;
+        }
+        else {
+            s->f.flags &= ~SOCK_NONBLOCK;
+        }
         return 0;
     }
     default:

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -381,7 +381,6 @@ sysreturn epoll_wait(int epfd,
 	epollfd efd = vector_get(e->events, fd);
 	assert(efd);
         assert(efd->fd == fd);
-        assert(efd->registered);
 
         if (efd->zombie)
             continue;
@@ -395,7 +394,8 @@ sysreturn epoll_wait(int epfd,
 
         /* event transitions may in some cases need to be polled for
            (e.g. due to change in lwIP internal state), so request a check */
-        check_fdesc(f);
+        if (efd->registered)
+            check_fdesc(f);
     }
 
     int eventcount = w->user_events->end/sizeof(struct epoll_event);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -57,7 +57,11 @@ sysreturn clone(unsigned long flags, void *child_stack, int *ptid, int *ctid, un
         flags, child_stack, ptid, ctid, newtls);
 
     if (!child_stack)   /* this is actually a fork() */
+    {
+        thread_log(current, "attempted to fork by passing "
+                   "null child stack, aborting.");
         return set_syscall_error(current, ENOSYS);
+    }
 
     /* clone thread context up to FRAME_VECTOR */
     thread t = create_thread(current->p);


### PR DESCRIPTION
Socket shutdown is implemented. 
I validated the code using some sample code to make sure newly added is called without any side effect.

Following are the UT logs:
[1562779066.620564]  NET: socket: new tcp fd 3, pcb 0x0000000102001100
    2 direct return: 3, rsp 0x702f1ffd98
    2 bind
[1562779066.623466]  NET: bind: sock 3, type 1
[1562779066.624628]  NET: bind: calling tcp_bind, pcb 0x0000000102001100, ip 0, port 5309
[1562779066.626710] LWIP: tcp_bind: bind to port 5309
    2 direct return: 0, rsp 0x702f1ffd98
    2 shutdown
[1562779066.629271]  NET: shutdown: sock 3, type 1, how 0
[1562779066.630559] LWIP: tcp_shutdown: shutdown in shut_rx:1  shut_tx:0     2 direct return: 0, rsp 0x702f1ffd98
    2 shutdown
[1562779066.633550]  NET: shutdown: sock 3, type 1, how 1
[1562779066.634940] LWIP: tcp_shutdown: shutdown in shut_rx:0  shut_tx:1     2 direct return: 0, rsp 0x702f1ffd98
    2 shutdown
[1562779066.637999]  NET: shutdown: sock 3, type 1, how 2
[1562779066.639284] LWIP: tcp_shutdown: shutdown in shut_rx:1  shut_tx:1     2 direct return: 0, rsp 0x702f1ffd98
    2 close
    2 close: fd 3
[1562779066.642762]  NET: socket_close: sock 3, type 1
[1562779066.644079] LWIP: tcp_close: closing in [1562779066.645137] LWIP: State: CLOSED 