### PR TITLE
[WIP] Fix crash in unregister_epollfd

### DIFF
--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -104,8 +104,11 @@ static void release_epollfd(epollfd efd)
 static void unregister_epollfd(epollfd efd)
 {
     epoll_debug("efd %d\n", efd->fd);
-    epoll_debug("efd->e->f.ns %p\n", efd->e->f.ns);
-    notify_remove(efd->e->f.ns, efd->notify_handle);
+
+    fdesc f = resolve_fd_noret(current->p, efd->fd);
+    assert(f);
+    epoll_debug("f->ns %p\n", f->ns);
+    notify_remove(f->ns, efd->notify_handle);
     efd->registered = false;
     efd->notify_handle = 0;
 }


### PR DESCRIPTION
Opening to get feedback, since there's a good chance I'm way off on this one (please bear with me, I'm still unfamiliar with the code; normally I'd poke someone over IRC/Slack/whatever with a question, but I guess this will have to do?). It's a tentative fix for https://github.com/nanovms/nanos/issues/901 .

Original commit message follows, more details in the comment after this one.

When registering an epollfd via register_epollfd, we add a notify_handle
to the notify set f->ns, where f is the fdesc of this efd's fd.

However, unregister_epollfd attempted to remove efd's notify_handle from
efd->e->f.ns, where it hadn't been registered (in fact, I'm not even
sure it can access it, or that it's pointing at anything valid right
now).

Removing efd->notify_handle from the notify set on which it's actually
registered (f->ns) seems to solve the crash.

Signed-off-by: Alexandru Lazar <alazar@startmail.com>