### PR TITLE
signals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test test-noaccel: mkfs boot stage3
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	creat fst getdents getrandom hw hws mkdir pipe vsyscall write
+RUNTIME_TESTS=	creat fst getdents getrandom hw hws mkdir pipe signal vsyscall write
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -604,7 +604,7 @@ static sysreturn mmap(void *target, u64 size, int prot, int flags, int fd, u64 o
     buffer b = allocate_buffer(mh, pad(len, mh->pagesize));
     filesystem_read(p->fs, f->n, buffer_ref(b, 0), len, offset,
                     closure(h, mmap_read_complete, current, where, len, mapped, b, page_map_flags(vmflags)));
-    runloop();
+    thread_sleep_uninterruptible();
 }
 
 static CLOSURE_1_1(dealloc_phys_page, void, heap, range);

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -130,7 +130,7 @@ static sysreturn pipe_read_bh(pipe_file pf, thread t, void *dest, u64 length,
         if (pf->pipe->files[PIPE_WRITE].fd == -1)
             goto out;
         if (pf->f.flags & O_NONBLOCK) {
-            real_length = -EAGAIN;
+            rv = -EAGAIN;
             goto out;
         }
         return infinity;

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -111,15 +111,22 @@ static sysreturn pipe_close(pipe_file pf)
     return 0;
 }
 
-static CLOSURE_5_1(pipe_read_bh, sysreturn,
-        pipe_file, thread, void *, u64, io_completion,
-        boolean);
+static CLOSURE_5_2(pipe_read_bh, sysreturn,
+                   pipe_file, thread, void *, u64, io_completion,
+                   boolean, boolean);
 static sysreturn pipe_read_bh(pipe_file pf, thread t, void *dest, u64 length,
-        io_completion completion, boolean blocked)
+                              io_completion completion, boolean blocked, boolean nullify)
 {
+    int rv;
+
+    if (nullify) {
+        rv = -EINTR;
+        goto out;
+    }
+
     buffer b = pf->pipe->data;
-    int real_length = MIN(buffer_length(b), length);
-    if (real_length == 0) {
+    rv = MIN(buffer_length(b), length);
+    if (rv == 0) {
         if (pf->pipe->files[PIPE_WRITE].fd == -1)
             goto out;
         if (pf->f.flags & O_NONBLOCK) {
@@ -129,7 +136,7 @@ static sysreturn pipe_read_bh(pipe_file pf, thread t, void *dest, u64 length,
         return infinity;
     }
 
-    buffer_read(b, dest, real_length);
+    buffer_read(b, dest, rv);
     pipe_notify_writer(pf, EPOLLOUT);
 
     // If we have consumed all of the buffer, reset it. This might prevent future writes to allocte new buffer
@@ -140,9 +147,9 @@ static sysreturn pipe_read_bh(pipe_file pf, thread t, void *dest, u64 length,
     }
   out:
     if (blocked)
-        blockq_set_completion(pf->bq, completion, t, real_length);
+        blockq_set_completion(pf->bq, completion, t, rv);
 
-    return real_length;
+    return rv;
 }
 
 static CLOSURE_1_6(pipe_read, sysreturn,
@@ -156,16 +163,22 @@ static sysreturn pipe_read(pipe_file pf, void *dest, u64 length, u64 offset_arg,
 
     blockq_action ba = closure(pf->pipe->h, pipe_read_bh, pf, t, dest, length,
             completion);
-    return blockq_check(pf->bq, !bh ? t : 0, ba);
+    return blockq_check(pf->bq, t, ba, bh);
 }
 
-static CLOSURE_5_1(pipe_write_bh, sysreturn,
-        pipe_file, thread, void *, u64, io_completion,
-        boolean);
+static CLOSURE_5_2(pipe_write_bh, sysreturn,
+                   pipe_file, thread, void *, u64, io_completion,
+                   boolean, boolean);
 static sysreturn pipe_write_bh(pipe_file pf, thread t, void *dest, u64 length,
-        io_completion completion, boolean blocked)
+                               io_completion completion, boolean blocked, boolean nullify)
 {
     sysreturn rv = 0;
+
+    if (nullify) {
+        rv = -EINTR;
+        goto out;
+    }
+
     pipe p = pf->pipe;
     buffer b = p->data;
     u64 avail = p->max_size - buffer_length(b);
@@ -208,7 +221,7 @@ static sysreturn pipe_write(pipe_file pf, void * dest, u64 length, u64 offset,
 
     blockq_action ba = closure(pf->pipe->h, pipe_write_bh, pf, t, dest, length,
             completion);
-    return blockq_check(pf->bq, !bh ? t : 0, ba);
+    return blockq_check(pf->bq, t, ba, bh);
 }
 
 static CLOSURE_1_0(pipe_read_events, u32, pipe_file);

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -415,7 +415,7 @@ sysreturn epoll_wait(int epfd,
     }
     epoll_debug("   sleeping...\n");
     w->sleeping = true;
-    thread_sleep(current);
+    thread_sleep_uninterruptible(); /* XXX move to blockq */
     return 0;			/* suppress warning */
 }
 
@@ -691,7 +691,7 @@ static sysreturn select_internal(int nfds,
     }
     epoll_debug("   sleeping...\n");
     w->sleeping = true;
-    thread_sleep(current);
+    thread_sleep_uninterruptible(); /* XXX move to blockq */
     return 0;			/* suppress warning */
 }
 
@@ -840,7 +840,7 @@ check_rv_timeout:
     }
     epoll_debug("   sleeping...\n");
     w->sleeping = true;
-    thread_sleep(current);
+    thread_sleep_uninterruptible(); /* XXX move to blockq */
     return 0; /* suppress warning */
 }
 

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -1,10 +1,171 @@
 #include <unix_internal.h>
 
-sysreturn sigaction(int signum,
-              const struct sigaction *act,
-              struct sigaction *oldact)
+#define SIGNAL_DEBUG
+#ifdef SIGNAL_DEBUG
+#define sig_debug(x, ...) do {log_printf(" SIG", "%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#else
+#define sig_debug(x, ...)
+#endif
+
+/* 
+
+   syscalls:
+
+      kill *
+      pause
+      restart_syscall ?
+      seccomp ?
+   
+      rt_sigaction *
+      sigaltstack *
+      signal *
+      signalfd
+      sigpending *
+      rt_sigprocmask *
+      sigqueue ?
+      rt_sigreturn *
+      sigsuspend
+
+
+
+
+   signal mask
+   queueable / level?
+   
+
+   sig actions / defaults
+
+   
+
+
+
+
+ */
+
+typedef void * signal_handler;
+
+static void __attribute__((section (".vdso"))) signal_trampoline(u32 signum,
+                                                                 u64 sa_flags,
+                                                                 signal_handler handler)
 {
-    if (oldact) oldact->_u._sa_handler = SIG_DFL;
+    /* XXX need to add mux for sigaction */
+    if (handler) {
+#if 0
+        // XXX siginfo
+        if ((sa_flags & SA_SIGINFO)) {
+
+        }
+#endif
+        ((__sighandler_t)handler)(signum);
+    }
+
+    sysreturn rv;
+    asm("syscall" : "=a" (rv) : "0" (SYS_rt_sigreturn) : "memory");
+    /* shouldn't return, handle error otherwise */
+}
+
+void setup_sigframe(thread t, int signum, signal_handler handler)
+{
+    /* XXX prob should zero most of this, but not sure yet what needs
+     * to be carried over */
+    runtime_memcpy(t->sigframe, t->frame, sizeof(u64) * FRAME_MAX);
+
+    /* XXX check for altstack */
+    t->sigframe[FRAME_RIP] = u64_from_pointer(signal_trampoline);
+    t->sigframe[FRAME_RDI] = signum;
+    t->sigframe[FRAME_RSI] = 0; // XXX sa_mask
+    t->sigframe[FRAME_RDX] = u64_from_pointer(handler);
+}
+
+/* XXX lock down / use access fns */
+void dispatch_signals(thread t)
+{
+    /* propagate process pending into thread pending */
+    t->sigpending = t->p->sigpending;
+    
+    /* get masked pending signals */
+    u64 masked = t->sigpending & t->sigmask;
+    if (masked == 0)
+        return;
+
+    /* select signal to dispatch and get disposition */
+    int signum = msb(masked) + 1;  /* XXX TMP */
+    signal_handler sigact = t->p->sigacts[signum];
+
+    /* XXX core dump */
+    if (sigact == SIG_ERR) {
+        msg_err("thread %d: core dump unimpl\n", t->tid);
+        return;
+    } else if (sigact == SIG_IGN) {
+        sig_debug("sigact == SIG_IGN\n");
+        return;
+    } else if (sigact == SIG_DFL) {
+        // XXX lookup if SIG_DFL
+        return;
+    }
+
+    /* save current sigmask, mask sig */
+    /* XXX wrap these up in static inlines */
+    u64 sigword = U64_FROM_BIT(signum - 1);
+    t->sigsaved = t->sigmask;
+    t->sigmask |= sigword;
+    t->sigpending &= ~sigword;
+    
+    /* set up and switch to the signal context */
+    setup_sigframe(t, signum, sigact);
+    running_frame = t->sigframe;
+}
+
+sysreturn rt_sigreturn()
+{
+    thread t = current;
+
+    if (running_frame != t->sigframe) {
+        msg_err("foooooo\n");
+    }
+
+    /* reset signal mask */
+    t->sigmask = t->sigsaved;
+    t->sigsaved = infinity;
+
+    /* restore saved context */
+    running_frame = t->frame;
+
+    /* return - XXX or reschedule? */
+    IRETURN(running_frame);
+    return 0;
+}
+
+sysreturn rt_sigaction(int signum,
+                       const struct sigaction *act,
+                       struct sigaction *oldact,
+                       u64 sigsetsize)
+{
+    if (oldact)
+        oldact->_u._sa_handler = SIG_DFL;
+
+    if (sigsetsize != (NSIG / 8)) {
+        msg_err("sigsetsize (%ld) != NSIG (%ld)\n", sigsetsize, NSIG);
+        return -EINVAL;
+    }
+
+    if (signum > NSIG) {
+        msg_err("signum %d greater than NSIG\n", signum);
+        return -EINVAL;
+    }
+
+    if (!act)
+        return 0;
+
+#if 0
+    if ((act->sa_flags & SA_SIGINFO)) {
+
+    }
+#endif
+
+    /* XXX some sanitizing of enum vals in order */
+    current->p->sigacts[signum] = (signal_handler)act->_u._sa_handler;
+
     return 0;
 }
 
@@ -16,9 +177,16 @@ sysreturn rt_sigprocmask(int how, const sigset_t *set, sigset_t *oldset, u64 sig
     return 0;
 }
 
+sysreturn sigaltstack(const stack_t *ss, stack_t *oss)
+{
+
+    return 0;
+}
+
 void register_signal_syscalls(struct syscall *map)
 {
     register_syscall(map, rt_sigprocmask, rt_sigprocmask);
-    register_syscall(map, rt_sigaction, sigaction);
+    register_syscall(map, rt_sigaction, rt_sigaction);
+    register_syscall(map, rt_sigreturn, rt_sigreturn);
     register_syscall(map, sigaltstack, syscall_ignore);
 }

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -35,24 +35,35 @@ static inline u64 mask_from_sig(int sig)
 
 static inline u64 get_masked(thread t)
 {
+    /* Propagate process-level pending and mask before evaluating our own
+       XXX p spinlock */
+    t->sigpending |= t->p->sigpending;
+    t->sigmask |= t->p->sigmask;
+
     return t->sigpending &
         (~t->sigmask | mask_from_sig(SIGKILL) | mask_from_sig(SIGSTOP));
 }
 
-typedef void * signal_handler;
+static inline sigaction get_sigaction(int signum)
+{
+    return &current->p->sigactions[signum - 1];
+}
+
+static inline list get_sighead(thread t, int signum)
+{
+    assert(signum > 0 && signum <= 64);
+    return &t->sigheads[signum - 1];
+}
 
 static void __attribute__((section (".vdso"))) signal_trampoline(u32 signum,
-                                                                 u64 sa_flags,
-                                                                 signal_handler handler)
+                                                                 void *handler,
+                                                                 siginfo_t *siginfo,
+                                                                 void *ucontext)
 {
     /* XXX need to add mux for sigaction */
-    if (handler) {
-#if 0
-        // XXX siginfo
-        if ((sa_flags & SA_SIGINFO)) {
-
-        }
-#endif
+    if (siginfo) {
+        ((__sigaction_t)handler)(signum, siginfo, ucontext);
+    } else {
         ((__sighandler_t)handler)(signum);
     }
 
@@ -63,8 +74,17 @@ static void __attribute__((section (".vdso"))) signal_trampoline(u32 signum,
     assert(0);
 }
 
-void setup_sigframe(thread t, int signum, signal_handler handler)
+typedef struct queued_signal {
+    struct siginfo si;
+    struct list l;
+} *queued_signal;
+
+void setup_sigframe(thread t, int signum, struct siginfo *si, void * ucontext)
 {
+    sigaction sa = get_sigaction(signum);
+
+    assert(sizeof(struct siginfo) == 128);
+
     /* XXX prob should zero most of this, but not sure yet what needs
      * to be carried over */
     runtime_memcpy(t->sigframe, t->frame, sizeof(u64) * FRAME_MAX);
@@ -72,57 +92,110 @@ void setup_sigframe(thread t, int signum, signal_handler handler)
     /* XXX hack: stash %RAX which will get clobbered in a sig handler */
     t->rax_saved = t->frame[FRAME_RAX];
 
-    /* XXX check for altstack */
+    /* return to signal trampoline */
     t->sigframe[FRAME_RIP] = u64_from_pointer(signal_trampoline);
-    t->sigframe[FRAME_RDI] = signum;
-    t->sigframe[FRAME_RSI] = 0; // XXX sa_mask
-    t->sigframe[FRAME_RDX] = u64_from_pointer(handler);
-}
 
+    /* arguments to trampoline */
+    t->sigframe[FRAME_RDI] = signum;
+    t->sigframe[FRAME_RSI] = u64_from_pointer(sa->sa_handler);
+
+    sig_debug("sa->sa_flags 0x%lx\n", sa->sa_flags);
+
+    /* check for altstack */
+    if (sa->sa_flags & SA_ONSTACK) {
+        t->sigframe[FRAME_RSP] = 0; /* TODO */
+    } else {
+        /* must avoid redzone */
+        t->sigframe[FRAME_RSP] -= 128;
+    }
+
+    if (sa->sa_flags & SA_SIGINFO) {
+        /* place a siginfo on the stack */
+        t->sigframe[FRAME_RSP] -= pad(sizeof(struct siginfo), 16);
+        siginfo_t * dest_si = pointer_from_u64(t->sigframe[FRAME_RSP]);
+        sig_debug("copying siginfo to [%p, %p)\n", dest_si, ((void *)dest_si) + sizeof(struct siginfo));
+        runtime_memcpy(dest_si, si, sizeof(struct siginfo));
+        t->sigframe[FRAME_RDX] = t->sigframe[FRAME_RSP];
+    } else {
+        t->sigframe[FRAME_RDX] = 0;
+    }
+
+    /* XXX ucontext, revisit later */
+    t->sigframe[FRAME_RCX] = 0;
+
+    sig_debug("sigframe tid %d, sig %d, rip 0x%lx, rsp 0x%lx, "
+              "rdi 0x%lx, rsi 0x%lx, rdx 0x%lx, rcx 0x%lx\n", t->tid, signum,
+              t->sigframe[FRAME_RIP], t->sigframe[FRAME_RSP],
+              t->sigframe[FRAME_RDI], t->sigframe[FRAME_RSI],
+              t->sigframe[FRAME_RDX], t->sigframe[FRAME_RCX]);
+}
 /* XXX lock down / use access fns */
 void dispatch_signals(thread t)
 {
-    /* propagate process pending and mask into thread */
-    t->sigpending |= t->p->sigpending;
-    t->sigmask |= t->p->sigmask;
-    
+    heap h = heap_general((kernel_heaps)&t->uh);
+
     /* get masked pending signals */
     u64 masked = get_masked(t);
     if (masked == 0)
         return;
 
-    sig_debug("tid %d, pending 0x%lx, mask 0x%lx, masked 0x%lx\n",
+    sig_debug("tid %d, t->sigpending 0x%lx, mask 0x%lx, masked 0x%lx\n",
               t->tid, t->sigpending, t->sigmask, masked);
 
-    /* select signal to dispatch and get disposition */
+    /* select signal to dispatch */
     int signum = msb(masked) + 1;  /* XXX TMP */
-    signal_handler sigact = t->p->sigacts[signum - 1];
-    sig_debug("selected signum %d, sigact %p\n", signum, sigact);
+
+    /* act on signal disposition */
+    sigaction sa = get_sigaction(signum);
+    void * handler = sa->sa_handler;
+
+    sig_debug("dispatching signal %d; sigaction handler %p, sa_mask 0x%lx, sa_flags 0x%lx\n",
+              signum, handler, sa->sa_mask.sig[0], sa->sa_flags);
+
+    //
+    //
+    //
 
     /* XXX core dump */
-    if (sigact == SIG_ERR) {
+    if (handler == SIG_ERR) {
         msg_err("thread %d: core dump unimpl\n", t->tid);
         return;
-    } else if (sigact == SIG_IGN) {
+    } else if (handler == SIG_IGN) {
         sig_debug("sigact == SIG_IGN\n");
         return;
-    } else if (sigact == SIG_DFL) {
+    } else if (handler == SIG_DFL) {
         // XXX lookup if SIG_DFL
         return;
     }
 
-    /* save current sigmask, mask sig */
-    /* XXX wrap these up in static inlines */
+    // XXX convince me
+    /* thread may have blocked while signals are still pending; flush in case */
+    blockq_flush_thread(t->blocked_on, t);
+
+    /* dequeue siginfo */
+    list l = list_get_next(get_sighead(t, signum));
+    assert(l);
+    queued_signal q = struct_from_list(l, queued_signal, l);
+
+    sig_debug("queued_signal %p, prev addr %p, prev %p, next %p\n",
+              q, &l->prev, l->prev, l->next);
+    list_delete(l);
+
+    /* stash sigmask, or in mask for handler */
     u64 mask = mask_from_sig(signum);
     t->sigsaved = t->sigmask;
-    t->sigmask |= mask;
-    t->sigpending &= ~mask;
+    t->sigmask |= mask | sa->sa_mask.sig[0];
+
+    /* XXX need lock here */
+    if (list_empty(get_sighead(t, signum)))
+        t->sigpending &= ~mask;
 
     /* XXX process too */
 
     /* set up and switch to the signal context */
-    sig_debug("switching to sigframe: tid %d, sig %d, sigact %p\n", t->tid, signum, sigact);
-    setup_sigframe(t, signum, sigact);
+    sig_debug("switching to sigframe: tid %d, sig %d, sigaction %p\n", t->tid, signum, sa);
+    setup_sigframe(t, signum, &q->si, 0);
+    deallocate(h, q, sizeof(struct queued_signal));
     running_frame = t->sigframe;
 }
 
@@ -152,8 +225,8 @@ sysreturn rt_sigaction(int signum,
 {
     sig_debug("signum %d, act %p, oldact %p, sigsetsize %ld\n", signum, act, oldact, sigsetsize);
 
-    if (oldact)
-        oldact->_u._sa_handler = SIG_DFL;
+    if (signum < 1 || signum > NSIG)
+        return -EINVAL;
 
     if (sigsetsize != (NSIG / 8)) {
         msg_err("sigsetsize (%ld) != NSIG (%ld)\n", sigsetsize, NSIG);
@@ -165,19 +238,18 @@ sysreturn rt_sigaction(int signum,
         return -EINVAL;
     }
 
+    sigaction sa = get_sigaction(signum);
+
+    if (oldact)
+        *oldact = *sa;
+
     if (!act)
         return 0;
 
-#if 0
-    if ((act->sa_flags & SA_SIGINFO)) {
-
-    }
-#endif
-
-    /* XXX some sanitizing of enum vals in order */
-    void * handler = (signal_handler)act->_u._sa_handler;
-    current->p->sigacts[signum - 1] = handler;
-    sig_debug("installed handler %p\n", handler);
+    /* we should sanitize values ... */
+    sig_debug("installing sigaction: handler %p, sa_mask 0x%lx, sa_flags 0x%lx\n",
+              act->sa_handler, act->sa_mask.sig[0], act->sa_flags);
+    runtime_memcpy(sa, act, sizeof(struct sigaction));
     return 0;
 }
 
@@ -195,27 +267,56 @@ sysreturn sigaltstack(const stack_t *ss, stack_t *oss)
     return 0;
 }
 
-/* XXX add info */
-void deliver_signal_thread(thread t, int signum)
+void deliver_signal_to_thread(thread t, struct siginfo *info)
 {
-    sig_debug("tid %d, sig %d\n", t->tid, signum);
+    sig_debug("tid %d, sig %d\n", t->tid, info->si_signo);
 
-    /* set pending */
-    t->sigpending |= mask_from_sig(signum);
+    /* check if we can post */
+    u64 sigmask = mask_from_sig(info->si_signo);
+    if (t->sigpending & sigmask) {
+        if (info->si_signo < RT_SIG_START) {
+            /* Standard signal already posted. Unless a particular
+               signal would allow the updating of posted siginfo, just
+               return here. */
+            sig_debug("already posted; ignore\n");
+            return;
+        }
+    }
+
+    /* set pending and enqueue */
+//    p->sigpending |= sigmask;   /* XXX tricky part - separate saved mask for process? */
+    t->sigpending |= sigmask;
+    heap h = heap_general((kernel_heaps)&t->uh);
+    queued_signal qs = allocate(h, sizeof(struct queued_signal));
+    assert(qs != INVALID_ADDRESS);
+    runtime_memcpy(&qs->si, info, sizeof(struct siginfo));
+    list_insert_before(get_sighead(t, info->si_signo), &qs->l);
+    sig_debug("queued_signal %p, signo %d, errno %d, code %d\n",
+              qs, qs->si.si_signo, qs->si.si_errno, qs->si.si_code);
+    sig_debug("prev %p, next %p\n", qs->l.prev, qs->l.next);
+    sig_debug("next prev %p, next %p\n", qs->l.next->prev, qs->l.next->next);
+
+    /* queue for delivery */
     u64 masked = get_masked(t);
     sig_debug("pending 0x%lx, masked 0x%lx\n", t->sigpending, masked);
-
     if (masked) {
         /* no stored blockq means we're not in an interruptible wait */
         if (!t->blocked_on)
             return;
 
         /* flush pending blockq */
-        blockq_flush_thread(t->blocked_on, t);
-
-        /* make runnable */
-        thread_wakeup(t);
+        if (blockq_flush_thread(t->blocked_on, t)) {
+            /* make runnable */
+            thread_wakeup(t);
+        }
     }
+}
+
+void init_siginfo(struct siginfo *si, int sig, s32 code)
+{
+    zero(si, sizeof(struct siginfo));
+    si->si_signo = sig;
+    si->si_code = code;
 }
 
 sysreturn tgkill(int tgid, int tid, int sig)
@@ -232,7 +333,9 @@ sysreturn tgkill(int tgid, int tid, int sig)
         !(t = vector_get(current->p->threads, tid - 1)))
         return -ESRCH;
 
-    deliver_signal_thread(t, sig);
+    struct siginfo si;
+    init_siginfo(&si, sig, SI_TKILL);
+    deliver_signal_to_thread(t, &si);
     return 0;
 }
 
@@ -254,7 +357,9 @@ sysreturn kill(int pid, int sig)
     current->p->sigpending |= mask;
     vector_foreach(current->p->threads, t) {
         if (t && (~t->sigmask & mask) != 0) {
-            deliver_signal_thread(t, sig);
+            struct siginfo si;
+            init_siginfo(&si, sig, SI_USER);
+            deliver_signal_to_thread(t, &si);
             return 0;
         }
     }
@@ -269,7 +374,12 @@ static CLOSURE_1_2(pause_bh, sysreturn,
 static sysreturn pause_bh(thread t, boolean blocked, boolean nullify)
 {
     sig_debug("tid %d, blocked %d, nullify %d\n", t->tid, blocked, nullify);
-    return nullify ? set_syscall_return(t, -EINTR) : infinity;
+
+    if (nullify || get_masked(t))
+        return set_syscall_return(t, -EINTR);
+
+    sig_debug("-> block\n");
+    return infinity;
 }
 
 sysreturn pause(void)

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -84,7 +84,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, capget, 0);
     register_syscall(map, capset, 0);
     register_syscall(map, rt_sigtimedwait, 0);
-    register_syscall(map, rt_sigsuspend, 0);
     register_syscall(map, utime, 0);
     register_syscall(map, mknod, 0);
     register_syscall(map, uselib, 0);
@@ -216,7 +215,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, inotify_init1, 0);
     register_syscall(map, preadv, 0);
     register_syscall(map, pwritev, 0);
-    register_syscall(map, rt_tgsigqueueinfo, 0);
     register_syscall(map, perf_event_open, 0);
     register_syscall(map, recvmmsg, 0);
     register_syscall(map, fanotify_init, 0);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -84,7 +84,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, capget, 0);
     register_syscall(map, capset, 0);
     register_syscall(map, rt_sigtimedwait, 0);
-    register_syscall(map, rt_sigqueueinfo, 0);
     register_syscall(map, rt_sigsuspend, 0);
     register_syscall(map, utime, 0);
     register_syscall(map, mknod, 0);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -38,7 +38,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, shmget, 0);
     register_syscall(map, shmat, 0);
     register_syscall(map, shmctl, 0);
-    register_syscall(map, pause, 0);
     register_syscall(map, getitimer, 0);
     register_syscall(map, alarm, 0);
     register_syscall(map, setitimer, 0);
@@ -46,7 +45,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, vfork, 0);
     register_syscall(map, execve, 0);
     register_syscall(map, wait4, syscall_ignore);
-    register_syscall(map, kill, 0);
     register_syscall(map, semget, 0);
     register_syscall(map, semop, 0);
     register_syscall(map, semctl, 0);
@@ -153,7 +151,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, removexattr, 0);
     register_syscall(map, lremovexattr, 0);
     register_syscall(map, fremovexattr, 0);
-    register_syscall(map, tkill, 0);
     register_syscall(map, set_thread_area, 0);
     register_syscall(map, io_setup, 0);
     register_syscall(map, io_destroy, 0);
@@ -174,7 +171,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, timer_getoverrun, 0);
     register_syscall(map, timer_delete, 0);
     register_syscall(map, clock_settime, 0);
-    register_syscall(map, tgkill, 0);
     register_syscall(map, utimes, 0);
     register_syscall(map, vserver, 0);
     register_syscall(map, mbind, 0);
@@ -1894,7 +1890,8 @@ static context syscall_frame;
 
 static void syscall_debug()
 {
-    u64 *f = current->frame;
+//    u64 *f = current->frame;
+    u64 *f = running_frame;     /* usually current->frame, except for sigreturn */
     int call = f[FRAME_VECTOR];
     if (call < 0 || call >= sizeof(_linux_syscalls) / sizeof(_linux_syscalls[0])) {
         thread_log(current, "invalid syscall %d", call);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -34,7 +34,6 @@ sysreturn close(int fd);
 
 void register_other_syscalls(struct syscall *map)
 {
-    register_syscall(map, rt_sigreturn, 0);
     register_syscall(map, msync, 0);
     register_syscall(map, shmget, 0);
     register_syscall(map, shmat, 0);
@@ -1935,6 +1934,8 @@ static void syscall_debug()
     }
     set_syscall_return(current, res);
     current->syscall = -1;
+
+    dispatch_signals(current);
 }
 
 boolean syscall_notrace(int syscall)

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -243,7 +243,6 @@ struct rlimit {
 #define SIGILL		 4
 #define SIGTRAP		 5
 #define SIGABRT		 6
-#define SIGIOT		 6
 #define SIGBUS		 7
 #define SIGFPE		 8
 #define SIGKILL		 9
@@ -267,7 +266,8 @@ struct rlimit {
 #define SIGPROF		27
 #define SIGWINCH	28
 #define SIGIO		29
-
+#define SIGPWR          30
+#define SIGSYS          31
 
 #define SIGINFO_SIZE        128
 #define SIGINFO_UNION_ALIGN 16

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -337,8 +337,8 @@ typedef struct siginfo {
             u64 call_addr;
             s32 syscall;
             u32 arch;
-        } _sigsys;
-    } _sifields;
+        } sigsys;
+    } sifields;
 } __attribute__((aligned(8))) siginfo_t;
 
 #define SI_USER     0
@@ -430,6 +430,10 @@ struct sigaction {
 
 #define SA_NOMASK  SA_NODEFER
 #define SA_ONESHOT SA_RESETHAND
+
+#define SIG_BLOCK   0
+#define SIG_UNBLOCK 1
+#define SIG_SETMASK 2
 
 typedef struct {
     void *ss_sp;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -336,6 +336,14 @@ thread create_thread(process p)
     t->frame[FRAME_FAULT_HANDLER] = u64_from_pointer(closure(h, default_fault_handler, t));
     t->run = closure(h, run_thread, t);
     vector_push(p->threads, t);
+    t->blocked_on = 0;
+    t->blocked_on_action = 0;
+    t->dummy_blockq = allocate_blockq(h, "dummy", 1, 0);
+    t->sigmask = 0;
+    t->sigpending = 0;
+    t->sigsaved = 0;
+    // XXX queues
+    // XXX sigframe
     return t;
 }
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -51,6 +51,13 @@ sysreturn arch_prctl(int code, unsigned long addr)
     return 0;
 }
 
+static inline void thread_make_runnable(thread t)
+{
+    t->blocked_on = 0;
+    t->syscall = -1;
+    enqueue(runqueue, t->run);
+}
+
 sysreturn clone(unsigned long flags, void *child_stack, int *ptid, int *ctid, unsigned long newtls)
 {
     thread_log(current, "clone: flags %lx, child_stack %p, ptid %p, ctid %p, newtls %lx",
@@ -75,7 +82,7 @@ sysreturn clone(unsigned long flags, void *child_stack, int *ptid, int *ctid, un
         *ptid = t->tid;
     if (flags & CLONE_CHILD_CLEARTID)
         t->clear_tid = ctid;
-    thread_wakeup(t);
+    thread_make_runnable(t);
     return t->tid;
 }
 
@@ -160,7 +167,7 @@ static sysreturn futex(int *uaddr, int futex_op, int val,
                 register_futex_timer(current, f, timeout);
             // atomic 
             enqueue(f->waiters, current);
-            thread_sleep(current);
+            thread_sleep_uninterruptible(); /* XXX move to blockq */
         }
         return -EAGAIN;
             
@@ -246,7 +253,7 @@ static sysreturn futex(int *uaddr, int futex_op, int val,
             if (timeout)
                 register_futex_timer(current, f, timeout);                          
             enqueue(f->waiters, current);
-            thread_sleep(current);
+            thread_sleep_uninterruptible(); /* XXX move to blockq */
         }
         return -EAGAIN;
 
@@ -296,6 +303,9 @@ void run_thread(thread t)
     proc_enter_user(current->p);
     running_frame = t->frame;
 
+    /* cover wake-before-sleep situations (e.g. sched yield, fs ops that don't go to disk, etc.) */
+    current->blocked_on = 0;
+
     /* check if we have a pending signal */
     dispatch_signals(t);
 
@@ -303,21 +313,51 @@ void run_thread(thread t)
     IRETURN(running_frame);
 }
 
-// it might be easier, if a little skeezy, to use the return value
-// to genericize the handling of suspended threads. given that there
-// are already conventions (i.e. negative errors) on the interface
-void thread_sleep(thread t)
+void thread_sleep_interruptible(void)
 {
-    // config from the filesystem
-    thread_log(t, "sleep",  0);
+    assert(current->blocked_on);
+    thread_log(current, "sleep interruptible (on \"%s\")", blockq_name(current->blocked_on));
+    runloop();
+}
+
+void thread_sleep_uninterruptible(void)
+{
+    assert(!current->blocked_on);
+    current->blocked_on = INVALID_ADDRESS;
+    thread_log(current, "sleep uninterruptible");
+    runloop();
+}
+
+void thread_yield(void)
+{
+    thread_log(current, "yield %d \%rip 0x%lx", current->tid, current->frame[FRAME_RIP]);
+    assert(!current->blocked_on);
+    current->syscall = -1;
+    set_syscall_return(current, 0);
+    enqueue(runqueue, current->run);
     runloop();
 }
 
 void thread_wakeup(thread t)
 {
-    thread_log(current, "wakeup %ld->%ld %p", current->tid, t->tid, t->frame[FRAME_RIP]);
-    t->syscall = -1;
-    enqueue(runqueue, t->run);
+    thread_log(current, "%s: %ld->%ld blocked_on %p, rip 0x%lx", __func__, current->tid, t->tid,
+               t->blocked_on, t->frame[FRAME_RIP]);
+    thread_make_runnable(t);
+}
+
+boolean thread_attempt_interrupt(thread t)
+{
+    thread_log(current, "%s: tid %d\n", __func__, t->tid);
+    if (!thread_in_interruptible_sleep(t)) {
+        thread_log(current, "uninterruptible or already running");
+        return false;
+    }
+
+    /* flush pending blockq */
+    thread_log(current, "... interrupting blocked thread %d\n", t->tid);
+    assert(blockq_flush_thread(t->blocked_on, t));
+    assert(thread_is_runnable(t));
+    return true;
 }
 
 thread create_thread(process p)
@@ -340,15 +380,9 @@ thread create_thread(process p)
     t->blocked_on = 0;
     t->blocked_on_action = 0;
     t->dummy_blockq = allocate_blockq(h, "dummy", 1, 0);
-    t->sigmask = 0;
-    t->sigpending = 0;
-    t->sigsaved = 0;
-    for(int i = 0; i < NSIG; i += 4) {
-        list_init(&t->sigheads[i]);
-        list_init(&t->sigheads[i + 1]);
-        list_init(&t->sigheads[i + 2]);
-        list_init(&t->sigheads[i + 3]);
-    }
+    init_sigstate(&t->signals);
+    t->dispatch_sigstate = 0;
+
     // XXX sigframe
     return t;
 }

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -330,7 +330,7 @@ void thread_sleep_uninterruptible(void)
 
 void thread_yield(void)
 {
-    thread_log(current, "yield %d \%rip 0x%lx", current->tid, current->frame[FRAME_RIP]);
+    thread_log(current, "yield %d, RIP=0x%lx", current->tid, current->frame[FRAME_RIP]);
     assert(!current->blocked_on);
     current->syscall = -1;
     set_syscall_return(current, 0);
@@ -340,7 +340,7 @@ void thread_yield(void)
 
 void thread_wakeup(thread t)
 {
-    thread_log(current, "%s: %ld->%ld blocked_on %p, rip 0x%lx", __func__, current->tid, t->tid,
+    thread_log(current, "%s: %ld->%ld blocked_on %p, RIP=0x%lx", __func__, current->tid, t->tid,
                t->blocked_on, t->frame[FRAME_RIP]);
     thread_make_runnable(t);
 }
@@ -387,6 +387,7 @@ thread create_thread(process p)
     return t;
 }
 
+/* XXX this is seriously next */
 void exit_thread(thread t)
 {
     if (t->clear_tid) {
@@ -394,9 +395,12 @@ void exit_thread(thread t)
         futex(t->clear_tid, FUTEX_WAKE, 1, 0, 0, 0);
     }
 
+    /* Like an uninterruptible sleep for all eternity. */
+    t->blocked_on = INVALID_ADDRESS;
+
     /* TODO: remove also from p->threads (but it is not currently used) */
-    heap h = heap_general((kernel_heaps)t->p->uh);
-    deallocate(h, t, sizeof(struct thread));
+//    heap h = heap_general((kernel_heaps)t->p->uh);
+//    deallocate(h, t, sizeof(struct thread));
 }
 
 void init_threads(process p)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -295,6 +295,10 @@ void run_thread(thread t)
     thread_log(t, "run frame %p, RIP=%p", t->frame, t->frame[FRAME_RIP]);
     proc_enter_user(current->p);
     running_frame = t->frame;
+
+    /* check if we have a pending signal */
+    dispatch_signals(t);
+
     running_frame[FRAME_FLAGS] |= U64_FROM_BIT(FLAG_INTERRUPT);
     IRETURN(running_frame);
 }

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -378,7 +378,6 @@ thread create_thread(process p)
     t->run = closure(h, run_thread, t);
     vector_push(p->threads, t);
     t->blocked_on = 0;
-    t->blocked_on_action = 0;
     t->dummy_blockq = allocate_blockq(h, "dummy", 1, 0);
     init_sigstate(&t->signals);
     t->dispatch_sigstate = 0;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -316,6 +316,7 @@ void thread_sleep(thread t)
 void thread_wakeup(thread t)
 {
     thread_log(current, "wakeup %ld->%ld %p", current->tid, t->tid, t->frame[FRAME_RIP]);
+    t->syscall = -1;
     enqueue(runqueue, t->run);
 }
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -398,7 +398,7 @@ void exit_thread(thread t)
     /* Like an uninterruptible sleep for all eternity. */
     t->blocked_on = INVALID_ADDRESS;
 
-    /* TODO: remove also from p->threads (but it is not currently used) */
+    vector_set(t->p->threads, t->tid - 1, 0);
 //    heap h = heap_general((kernel_heaps)t->p->uh);
 //    deallocate(h, t, sizeof(struct thread));
 }

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -342,7 +342,12 @@ thread create_thread(process p)
     t->sigmask = 0;
     t->sigpending = 0;
     t->sigsaved = 0;
-    // XXX queues
+    for(int i = 0; i < NSIG; i += 4) {
+        list_init(&t->sigheads[i]);
+        list_init(&t->sigheads[i + 1]);
+        list_init(&t->sigheads[i + 2]);
+        list_init(&t->sigheads[i + 3]);
+    }
     // XXX sigframe
     return t;
 }

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -73,7 +73,7 @@ context default_fault_handler(thread t, context frame)
     if (table_find (current->p->process_root, sym(fault))) {
         console("starting gdb\n");
         init_tcp_gdb(heap_general(get_kernel_heaps()), current->p, 9090);
-        thread_sleep(current);
+        thread_sleep_uninterruptible();
     } else {
         halt("halt\n");
     }
@@ -180,8 +180,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     p->sysctx = false;
     p->utime = p->stime = 0;
     p->start_time = now();
-    p->sigmask = 0;
-    p->sigpending = 0;
+    init_sigstate(&p->signals);
     zero(p->sigactions, sizeof(p->sigactions));
     return p;
 }

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -182,7 +182,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     p->start_time = now();
     p->sigmask = 0;
     p->sigpending = 0;
-    zero(p->sigacts, sizeof(p->sigacts));
+    zero(p->sigactions, sizeof(p->sigactions));
     return p;
 }
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -180,6 +180,9 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     p->sysctx = false;
     p->utime = p->stime = 0;
     p->start_time = now();
+    p->sigmask = 0;
+    p->sigpending = 0;
+    zero(p->sigacts, sizeof(p->sigacts));
     return p;
 }
 

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -21,7 +21,7 @@ sysreturn nanosleep(const struct timespec* req, struct timespec* rem)
     // and we sleep for the whole duration before waking up.
     register_timer(time_from_timespec(req),
 		closure(heap_general(get_kernel_heaps()), nanosleep_timeout, current, 0));
-    thread_sleep(current); 
+    thread_sleep_uninterruptible(); /* XXX move to blockq */
     return 0;
 }
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -198,29 +198,31 @@ typedef struct file *file;
 struct syscall;
 
 typedef struct process {
-    unix_heaps        uh;	/* non-thread-specific */
-    int               pid;
-    void             *brk;
-    heap              virtual;
-    heap              virtual_page;
-    heap              virtual32;
-    heap              fdallocator;
-    filesystem        fs;       /* XXX should be underneath tuple operators */
-    tuple             process_root;
-    tuple             cwd;
-    table             futices;
-    fault_handler     handler;
-    vector            threads;
-    struct syscall   *syscalls;
-    vector            files;
-    rangemap          vareas;   /* available address space */
-    rangemap          vmaps;    /* process mappings */
-    boolean           sysctx;
-    timestamp         utime, stime;
-    timestamp         start_time;
-    u64               sigmask;
-    u64               sigpending;
-    struct sigaction  sigactions[NSIG];
+    unix_heaps      uh;         /* non-thread-specific */
+    int             pid;
+    void           *brk;
+    heap            virtual;
+    heap            virtual_page;
+    heap            virtual32;
+    heap            fdallocator;
+    filesystem      fs;         /* XXX should be underneath tuple operators */
+    tuple           process_root;
+    tuple           cwd;
+    table           futices;
+    fault_handler   handler;
+    vector          threads;
+    struct syscall *syscalls;
+    vector          files;
+    rangemap        vareas;     /* available address space */
+    rangemap        vmaps;      /* process mappings */
+    boolean         sysctx;
+    timestamp       utime, stime;
+    timestamp       start_time;
+
+    u64             sigpending; /* pending at process level */
+    u64             sigmask;    /* process-level masked */
+
+    struct sigaction sigactions[NSIG];
 } *process;
 
 typedef struct sigaction *sigaction;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -125,25 +125,14 @@ static inline char * blockq_name(blockq bq)
 /* pending and masked signals for a given thread or process */
 typedef struct sigstate {
     /* these should be bitmaps, but time is of the essence, and presently NSIG=64 */
-    u64         sigpending;     /* pending and not yet dispatched */
-    u64         sigmask;        /* masked or "blocked" signals are set */
-    u64         sigsaved;       /* original mask saved on rt_sigsuspend */
-    struct list sigheads[NSIG];
+    u64         pending;        /* pending and not yet dispatched */
+    u64         mask;           /* masked or "blocked" signals are set */
+    u64         saved;          /* original mask saved on rt_sigsuspend or handler dispatch */
+    u64         ignored;        /* mask of signals set to SIG_IGN */
+    struct list heads[NSIG];
 } *sigstate;
 
-static inline void init_sigstate(sigstate ss)
-{
-    ss->sigpending = 0;
-    ss->sigmask = 0;
-    ss->sigsaved = 0;
-
-    for(int i = 0; i < NSIG; i += 4) {
-        list_init(&ss->sigheads[i]);
-        list_init(&ss->sigheads[i + 1]);
-        list_init(&ss->sigheads[i + 2]);
-        list_init(&ss->sigheads[i + 3]);
-    }
-}
+void init_sigstate(sigstate ss);
 
 typedef struct epoll *epoll;
 typedef struct thread {

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -160,7 +160,6 @@ typedef struct thread {
 
     /* blockq thread is waiting on, INVALID_ADDRESS for uninterruptible */
     blockq blocked_on;
-    blockq_action blocked_on_action; /* saved for ease of removal */
     blockq dummy_blockq; /* for pause(2) */
 
     struct sigstate signals;

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -112,6 +112,7 @@ SRCS-signal= \
 	$(SRCDIR)/runtime/buffer.c \
 	$(SRCDIR)/runtime/extra_prints.c \
 	$(SRCDIR)/runtime/format.c \
+	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -15,6 +15,7 @@ PROGRAMS= \
 	pipe \
 	rename \
 	sendfile \
+	signal \
 	socketpair \
 	time \
 	udploop \
@@ -103,6 +104,32 @@ LDFLAGS-rename=		-static
 
 SRCS-sendfile=		$(CURDIR)/sendfile.c
 LDFLAGS-sendfile=	-static
+
+SRCS-signal= \
+	$(CURDIR)/signal.c \
+	$(SRCDIR)/unix_process/unix_process_runtime.c \
+	$(SRCDIR)/runtime/bitmap.c \
+	$(SRCDIR)/runtime/buffer.c \
+	$(SRCDIR)/runtime/extra_prints.c \
+	$(SRCDIR)/runtime/format.c \
+	$(SRCDIR)/runtime/pqueue.c \
+	$(SRCDIR)/runtime/random.c \
+	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/runtime_init.c \
+	$(SRCDIR)/runtime/string.c \
+	$(SRCDIR)/runtime/symbol.c \
+	$(SRCDIR)/runtime/table.c \
+	$(SRCDIR)/runtime/tuple_parser.c \
+	$(SRCDIR)/runtime/tuple.c \
+	$(SRCDIR)/runtime/timer.c \
+	$(SRCDIR)/runtime/crypto/chacha.c \
+	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/heap/freelist.c \
+	$(SRCDIR)/runtime/heap/debug_heap.c \
+	$(SRCDIR)/runtime/heap/objcache.c \
+	$(SRCDIR)/runtime/heap/mcache.c
+LDFLAGS-signal=		-static
+LIBS-signal=		-lm -lpthread
 
 SRCS-socketpair= \
 	$(CURDIR)/socketpair.c \

--- a/test/runtime/signal.c
+++ b/test/runtime/signal.c
@@ -112,6 +112,21 @@ static void test_rt_signal_queueing_handler(int sig, siginfo_t *si, void *uconte
     assert(sig == SIGRTMIN);
     assert(sig == si->si_signo);
     test_rt_caught++;
+
+    sigset_t sigset;
+
+    /* test rt_sigpending */
+    long rv = syscall(SYS_rt_sigpending, &sigset);
+    if (rv < 0)
+        fail_perror("sigpending");
+
+    if (test_rt_caught < TEST_RT_NQUEUE) {
+        if (!sigismember(&sigset, sig))
+            fail_error("sig %d should still be pending until we serviced the last signal\n", sig);
+    } else {
+        if (sigismember(&sigset, sig))
+            fail_error("sig %d should not be pending; all queued signals have been handled\n", sig);
+    }
 }
 
 static void * test_rt_signal_child(void * arg)

--- a/test/runtime/signal.c
+++ b/test/runtime/signal.c
@@ -10,27 +10,35 @@
 
 #include <runtime.h>
 
-#define handle_error(msg) \
-       do { perror(msg); exit(EXIT_FAILURE); } while (0)
+//#define SIGNALTEST_DEBUG
+#ifdef SIGNALTEST_DEBUG
+#define sigtest_debug(x, ...) do {printf("%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#else
+#define sigtest_debug(x, ...)
+#endif
+
+#define sigtest_err(x, ...) do {printf("%s: " x, __func__, ##__VA_ARGS__);} while(0)
+
+#define fail_perror(msg, ...) do { sigtest_err(msg ": %s (%d)\n", ##__VA_ARGS__, strerror(errno), errno); \
+        exit(EXIT_FAILURE); } while(0)
+
+#define fail_error(msg, ...) do { sigtest_err(msg, ##__VA_ARGS__); exit(EXIT_FAILURE); } while(0)
 
 static int child_tid;
 
 static void * tgkill_test_pause(void * arg)
 {
     child_tid = syscall(SYS_gettid);
-    printf("dingus\n");
-    int rv = pause();
+    int rv = syscall(SYS_pause);
     if (rv < 0) {
         if (errno == EINTR) {
-            printf("child received signal\n");
+            sigtest_debug("child received signal\n");
             return (void*)EXIT_SUCCESS;
         } else {
-            printf("unexpected errno %d (%s)\n", errno, strerror(errno));
-            return (void*)EXIT_FAILURE;
+            fail_perror("pause unexpected errno");
         }
     }
-    printf("pause: unexepected retval %d\n", rv);
-    return (void*)EXIT_FAILURE;
+    fail_error("pause: unexpected retval %d\n", rv);
 }
 
 void test_tgkill(void)
@@ -38,74 +46,126 @@ void test_tgkill(void)
     int rv;
     pthread_t pt = 0;
     if (pthread_create(&pt, NULL, tgkill_test_pause, NULL))
-        handle_error("blocking test pthread_create");
+        fail_perror("blocking test pthread_create");
 
-    printf("sleep 1s\n");
     sleep(1);
-    if (child_tid == 0) {
-        printf("fail; no tid set from child\n");
-        exit(EXIT_FAILURE);
-    }
+    if (child_tid == 0)
+        fail_error("fail; no tid set from child\n");
 
-    printf("spawned tid %d; sending SIGUSR1\n", child_tid);
+    sigtest_debug("spawned tid %d; sending SIGUSR1\n", child_tid);
     rv = syscall(SYS_tgkill, 1, child_tid, SIGUSR1);
-    if (rv < 0) {
-        handle_error("tgkill");
-        exit(EXIT_FAILURE);
-    }
+    if (rv < 0)
+        fail_perror("tgkill");
 
     void * retval;
-    if (pthread_join(pt, &retval)) {
-        handle_error("blocking test pthread_join");
-        exit(EXIT_FAILURE);
-    }
+    if (pthread_join(pt, &retval))
+        fail_perror("blocking test pthread_join");
 
-    if (retval != (void*)EXIT_SUCCESS) {
-        printf("tgkill_test_pause child failed\n");
-        exit(EXIT_FAILURE);
-    }
+    if (retval != (void*)EXIT_SUCCESS)
+        fail_error("tgkill_test_pause child failed\n");
 }
 
 static void test_signal_catch_handler(int sig)
 {
-    printf("caught signal %d\n", sig);
+    sigtest_debug("caught signal %d\n", sig);
 }
-
 
 void test_signal_catch(void)
 {
     pthread_t pt = 0;
     if (pthread_create(&pt, NULL, tgkill_test_pause, NULL))
-        handle_error("blocking test pthread_create");
+        fail_perror("blocking test pthread_create");
 
-    printf("sleep 1s\n");
+    sigtest_debug("sleep 1s\n");
     sleep(1);
-    if (child_tid == 0) {
-        printf("fail; no tid set from child\n");
-        exit(EXIT_FAILURE);
-    }
+    if (child_tid == 0)
+        fail_error("fail; no tid set from child\n");
 
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = test_signal_catch_handler;
     int rv = sigaction(SIGUSR1, &sa, 0);
     if (rv < 0)
-        handle_error("test_signal_catch: sigaction");
+        fail_perror("test_signal_catch: sigaction");
 
     rv = syscall(SYS_tgkill, 1, child_tid, SIGUSR1);
     if (rv < 0)
-        handle_error("signal catch tgkill");
+        fail_perror("signal catch tgkill");
 
     void * retval;
-    if (pthread_join(pt, &retval)) {
-        handle_error("blocking test pthread_join");
-        exit(EXIT_FAILURE);
+    if (pthread_join(pt, &retval))
+        fail_perror("blocking test pthread_join");
+
+    if (retval != (void*)EXIT_SUCCESS)
+        fail_error("tgkill_test_pause child failed\n");
+}
+
+#define TEST_RT_NQUEUE  128
+
+static int test_rt_caught = 0;
+
+static void test_rt_signal_queueing_handler(int sig, siginfo_t *si, void *ucontext)
+{
+    assert(si);
+    sigtest_debug("sig %d, si->signo %d, si->errno %d, si->code %d, # %d\n",
+                  sig, si->si_signo, si->si_errno, si->si_code, test_rt_caught);
+    assert(sig == SIGRTMIN);
+    assert(sig == si->si_signo);
+    test_rt_caught++;
+}
+
+static void * test_rt_signal_child(void * arg)
+{
+    child_tid = syscall(SYS_gettid);
+    for(;;) {
+        int rv = syscall(SYS_pause);
+        if (rv < 0) {
+            if (errno == EINTR) {
+                if (test_rt_caught < TEST_RT_NQUEUE)
+                    continue;
+                return (void*)EXIT_SUCCESS;
+            } else {
+                sigtest_err("unexpected errno %d (%s)\n", errno, strerror(errno));
+                return (void*)EXIT_FAILURE;
+            }
+        }
+        sigtest_err("pause: unexpected retval %d\n", rv);
+        return (void*)EXIT_FAILURE;
+    }
+}
+
+/* test sigaction (siginfo) handler and queued signals */
+void test_rt_signal(void)
+{
+    pthread_t pt = 0;
+    if (pthread_create(&pt, NULL, test_rt_signal_child, NULL))
+        fail_perror("blocking test pthread_create");
+
+    sigtest_debug("sleep 1s\n");
+    sleep(1);
+    if (child_tid == 0)
+        fail_error("fail; no tid set from child\n");
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = test_rt_signal_queueing_handler;
+    sa.sa_flags |= SA_SIGINFO;
+    int rv = sigaction(SIGRTMIN, &sa, 0);
+    if (rv < 0)
+        fail_perror("test_signal_catch: sigaction");
+
+    for (int i = 0; i < TEST_RT_NQUEUE; i++) {
+        rv = syscall(SYS_tgkill, 1, child_tid, SIGRTMIN);
+        if (rv < 0)
+            fail_perror("signal catch tgkill");
     }
 
-    if (retval != (void*)EXIT_SUCCESS) {
-        printf("tgkill_test_pause child failed\n");
-        exit(EXIT_FAILURE);
-    }
+    void * retval;
+    if (pthread_join(pt, &retval))
+        fail_perror("blocking test pthread_join");
+
+    if (retval != (void*)EXIT_SUCCESS)
+        fail_error("tgkill_test_pause child failed\n");
 }
     
 table parse_arguments(heap h, int argc, char **argv);
@@ -119,6 +179,8 @@ int main(int argc, char * argv[])
     test_tgkill();
 
     test_signal_catch();
+
+    test_rt_signal();
 
     printf("signal test passed\n");
 }

--- a/test/runtime/signal.c
+++ b/test/runtime/signal.c
@@ -41,7 +41,7 @@ static void * tgkill_test_pause(void * arg)
     fail_error("pause: unexpected retval %d\n", rv);
 }
 
-void test_tgkill(void)
+void test_tgkill_ignore(void)
 {
     int rv;
     pthread_t pt = 0;
@@ -52,7 +52,14 @@ void test_tgkill(void)
     if (child_tid == 0)
         fail_error("fail; no tid set from child\n");
 
-    sigtest_debug("spawned tid %d; sending SIGUSR1\n", child_tid);
+    sigtest_debug("spawned tid %d; sending SIGUSR1 (set to SIG_IGN)\n", child_tid);
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = SIG_IGN;
+    rv = sigaction(SIGUSR1, &sa, 0);
+    if (rv < 0)
+        fail_perror("test_tgkill_ignore: sigaction");
+
     rv = syscall(SYS_tgkill, 1, child_tid, SIGUSR1);
     if (rv < 0)
         fail_perror("tgkill");
@@ -191,7 +198,7 @@ int main(int argc, char * argv[])
     heap h = init_process_runtime();
     parse_arguments(h, argc, argv);
 
-    test_tgkill();
+    test_tgkill_ignore();
 
     test_signal_catch();
 

--- a/test/runtime/signal.c
+++ b/test/runtime/signal.c
@@ -1,0 +1,124 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <errno.h>
+#include <signal.h>
+#include <string.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+#include <runtime.h>
+
+#define handle_error(msg) \
+       do { perror(msg); exit(EXIT_FAILURE); } while (0)
+
+static int child_tid;
+
+static void * tgkill_test_pause(void * arg)
+{
+    child_tid = syscall(SYS_gettid);
+    printf("dingus\n");
+    int rv = pause();
+    if (rv < 0) {
+        if (errno == EINTR) {
+            printf("child received signal\n");
+            return (void*)EXIT_SUCCESS;
+        } else {
+            printf("unexpected errno %d (%s)\n", errno, strerror(errno));
+            return (void*)EXIT_FAILURE;
+        }
+    }
+    printf("pause: unexepected retval %d\n", rv);
+    return (void*)EXIT_FAILURE;
+}
+
+void test_tgkill(void)
+{
+    int rv;
+    pthread_t pt = 0;
+    if (pthread_create(&pt, NULL, tgkill_test_pause, NULL))
+        handle_error("blocking test pthread_create");
+
+    printf("sleep 1s\n");
+    sleep(1);
+    if (child_tid == 0) {
+        printf("fail; no tid set from child\n");
+        exit(EXIT_FAILURE);
+    }
+
+    printf("spawned tid %d; sending SIGUSR1\n", child_tid);
+    rv = syscall(SYS_tgkill, 1, child_tid, SIGUSR1);
+    if (rv < 0) {
+        handle_error("tgkill");
+        exit(EXIT_FAILURE);
+    }
+
+    void * retval;
+    if (pthread_join(pt, &retval)) {
+        handle_error("blocking test pthread_join");
+        exit(EXIT_FAILURE);
+    }
+
+    if (retval != (void*)EXIT_SUCCESS) {
+        printf("tgkill_test_pause child failed\n");
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void test_signal_catch_handler(int sig)
+{
+    printf("caught signal %d\n", sig);
+}
+
+
+void test_signal_catch(void)
+{
+    pthread_t pt = 0;
+    if (pthread_create(&pt, NULL, tgkill_test_pause, NULL))
+        handle_error("blocking test pthread_create");
+
+    printf("sleep 1s\n");
+    sleep(1);
+    if (child_tid == 0) {
+        printf("fail; no tid set from child\n");
+        exit(EXIT_FAILURE);
+    }
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = test_signal_catch_handler;
+    int rv = sigaction(SIGUSR1, &sa, 0);
+    if (rv < 0)
+        handle_error("test_signal_catch: sigaction");
+
+    rv = syscall(SYS_tgkill, 1, child_tid, SIGUSR1);
+    if (rv < 0)
+        handle_error("signal catch tgkill");
+
+    void * retval;
+    if (pthread_join(pt, &retval)) {
+        handle_error("blocking test pthread_join");
+        exit(EXIT_FAILURE);
+    }
+
+    if (retval != (void*)EXIT_SUCCESS) {
+        printf("tgkill_test_pause child failed\n");
+        exit(EXIT_FAILURE);
+    }
+}
+    
+table parse_arguments(heap h, int argc, char **argv);
+
+int main(int argc, char * argv[])
+{
+    setbuf(stdout, NULL);
+    heap h = init_process_runtime();
+    parse_arguments(h, argc, argv);
+
+    test_tgkill();
+
+    test_signal_catch();
+
+    printf("signal test passed\n");
+}

--- a/test/runtime/signal.manifest
+++ b/test/runtime/signal.manifest
@@ -1,0 +1,15 @@
+(
+    #64 bit elf to boot from host
+    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+              #user program
+	      signal:(contents:(host:output/test/runtime/bin/signal))
+	      )
+    # filesystem path to elf for kernel to run
+    program:/signal
+#    trace:t
+#    debugsyscalls:t
+#    futex_trace:t
+#    fault:t
+    arguments:[test]
+    environment:(USER:bobby PWD:/)
+)


### PR DESCRIPTION
This introduces support for signals into the nanos kernel. Actions that block threads are now explicitly interruptible (indicated by the blockq referred to by t->blocked_on) or uninterruptible (t->blocked_on == INVALID_ADDRESS). The blockq has been converted to a list for selective deletion on traversal (i.e. to cancel blocked operations for a given thread) and extended to allow nullification of pending waiters (which then proceed to return -EINTR or restart the syscall (TODO)). Queueable real-time posix signals (sig nos 33 through 64) are supported, and the following syscalls are implemented:

kill
pause
rt_sigaction
rt_sigpending
rt_sigprocmask
rt_sigqueueinfo
rt_sigreturn
tgkill
tkill

There's still more to do to round out the implementation:

syscalls:
- sigaltstack(2) and SA_ONSTACK aren't supported (trivial)
- sigtimedwait(2) not implemented (a little more involved, will need to employ blockq timeouts)
- getitimer(2) and setitimer(2) are signal-based timers that came up in some issues
- timer_create(2) is another syscall that uses signals that popped up in an issue

addressed in update:
- ~~rt_sigsuspend(2) not implemented (trivial)~~
- ~~rt_tgsigqueueinfo(2)~~

general missing features:
- SA_RESTART (requires re-starting of interrupted waiters)
- SA_NODEFER (trivial)
- signalfd(2)
- blocking calls in a signal handler
- nested signal handlers

There are a number of uninterruptible sleeps around that should be interruptible blockqs (epoll_wait, select_internal, poll_internal, futex, nanosleep). Futexes will likely need a little bit of reworking (there's a similar thread waiter queue in futexes that was written prior to blockqs), but converting the other waiters should be trivial to do.
