### PR TITLE
WIP: Preserve physical addresses in mremap

### DIFF
--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -206,15 +206,10 @@ sysreturn mremap(void *old_address, u64 old_size, u64 new_size, int flags, void 
     }
     thread_log(current, "   new physical pages at 0x%lx, size %ld", dphys, dlen);
 
-    /* remove old mapping */
-    u64 oldphys = physical_from_virtual(old_address);
-    thread_log(current, "   old mapping at phys addr 0x%lx, unmapping", oldphys);
-    unmap(u64_from_pointer(old_address), old_size, pages);
-
-    /* map existing portion */
+    /* Remap existing portion to new address, preserving flags and
+       physical mappings. */
     u64 mapflags = page_map_flags(vm->flags);
-    thread_log(current, "   mapping existing portion at 0x%lx", vnew);
-    map(vnew, oldphys, old_size, mapflags, pages);
+    vremap(old_address, old_size, vnew, mapflags, pages);
 
     /* map new portion and zero */
     thread_log(current, "   mapping and zeroing new portion at 0x%lx", vnew + old_size);

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -400,6 +400,25 @@ void map(u64 virtual, physical p, int length, u64 flags, heap h)
     map_range(virtual, p, length, flags | PAGE_PRESENT, h);
 }
 
+void vremap(void* old_virtual, u64 old_size, u64 new_virtual, u64 flags, heap h)
+{
+    physical phys;
+    u64 crt_off = 0;
+    u64 stride = PAGESIZE;
+
+    while (crt_off < old_size)
+    {
+        phys = physical_from_virtual(pointer_from_u64(old_virtual + crt_off));
+        if (phys == INVALID_PHYSICAL)
+                continue;
+        
+        unmap(u64_from_pointer(old_virtual + crt_off), PAGESIZE, h);
+        map(new_virtual + crt_off, phys, PAGESIZE, flags, h);
+
+        crt_off += stride;
+    }
+}
+
 void unmap(u64 virtual, int length, heap h)
 {
     map_range(virtual, 0, length, 0, h);

--- a/src/x86_64/page.h
+++ b/src/x86_64/page.h
@@ -18,4 +18,6 @@
 #define PAGE_DEV_FLAGS (PAGE_WRITABLE | PAGE_WRITETHROUGH | PAGE_NO_EXEC)
 
 void map(u64 virtual, physical p, int length, u64 flags, heap h);
+void vremap(void *old_virtual, u64 old_size,
+            u64 new_virtual, u64 flags, heap h);
 void unmap(u64 virtual, int length, heap h);

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -68,7 +68,7 @@ func testPackages(t *testing.T) {
 		prebuild func(t *testing.T)
 		skip     bool
 	}{
-		{name: "python_3.6.7", pkg: "python_3.6.7", dir: "python_3.6.7", request: "http://0.0.0.0:8000", skip: true},
+		{name: "python_3.6.7", pkg: "python_3.6.7", dir: "python_3.6.7", request: "http://0.0.0.0:8000"},
 		{name: "node_v11.5.0", pkg: "node_v11.5.0", dir: "node_v11.5.0", request: "http://0.0.0.0:8083"},
 		{name: "nginx_1.15.6", pkg: "nginx_1.15.6", dir: "nginx_1.15.6", request: "http://0.0.0.0:8084"},
 		{name: "php_7.3.5", pkg: "php_7.3.5", dir: "php_7.3.5", request: "http://0.0.0.0:9501"},


### PR DESCRIPTION
Ensure that, when resizing a memory region via mremap, the existing
virtual -> physical mappings of the previously mapped pages from the
original region are preserved in the new region.

Tentative fix for #901.

Signed-off-by: Alexandru Lazar <alazar@startmail.com>