### PR TITLE
fix CI failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get update
-      - run: sudo apt-get install nasm qemu ent ruby rustc
+      - run: sudo apt-get install nasm qemu-system-x86 ent ruby rustc
       - run: cd .. && git clone git@github.com:nanovms/ops.git
       - run: make
       - run: curl https://ops.city/get.sh -sSfL | sh
@@ -23,7 +23,7 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get update
-      - run: sudo apt-get install nasm qemu ent ruby rustc
+      - run: sudo apt-get install nasm qemu-system-x86 ent ruby rustc
       - run: make
       - run: curl https://ops.city/get.sh -sSfL | sh
       - run:


### PR DESCRIPTION
Apparently the 'qemu' package in the new docker image isn't sufficient to pick up qemu-system-x86_64.