### PR TITLE
clock_gettime(2): properly handle monotonic clock

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1773,7 +1773,7 @@ sysreturn sysinfo(struct sysinfo *info)
 
     kernel_heaps kh = get_kernel_heaps();
     runtime_memset((u8 *) info, 0, sizeof(*info));
-    info->uptime = uptime();
+    info->uptime = sec_from_timestamp(uptime());
     info->totalram = id_heap_total(kh->physical);
     info->freeram = info->totalram < kh->physical->allocated ? 0 : info->totalram - kh->physical->allocated;
     info->procs = 1;

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -168,6 +168,14 @@ typedef struct iovec {
 
 typedef int clockid_t;
 
+#define CLOCK_REALTIME              0
+#define CLOCK_MONOTONIC             1
+#define CLOCK_PROCESS_CPUTIME_ID    2
+#define CLOCK_THREAD_CPUTIME_ID     3
+#define CLOCK_MONOTONIC_RAW         4
+#define CLOCK_REALTIME_COARSE       5
+#define CLOCK_MONOTONIC_COARSE      6
+
 struct timespec {
 	u64 ts_sec;
 	u64 ts_nsec;

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -48,7 +48,25 @@ sysreturn times(struct tms *buf)
 sysreturn clock_gettime(clockid_t clk_id, struct timespec *tp)
 {
     thread_log(current, "clock_gettime: clk_id %d", clk_id);
-    timespec_from_time(tp, now());
+    timestamp t;
+    switch (clk_id) {
+    case CLOCK_REALTIME:
+    case CLOCK_REALTIME_COARSE:
+        t = now();
+        break;
+    case CLOCK_PROCESS_CPUTIME_ID:
+        t = proc_utime(current->p) + proc_stime(current->p);
+        break;
+    case CLOCK_MONOTONIC:
+    case CLOCK_MONOTONIC_COARSE:
+    case CLOCK_MONOTONIC_RAW:
+        t = uptime();
+        break;
+    default:
+        msg_warn("clock id %d not supported\n", clk_id);
+        return -EINVAL;
+    }
+    timespec_from_time(tp, t);
     return 0;
 }
 


### PR DESCRIPTION
clock_gettime(2): properly handle monotonic clock

The now() function returns the wall clock time, so it will be subject to discontinuities if the system time is changed (when support for changing the system time is actually implemented), and for this reason it should not be used as time source in clock_gettime() in case the requested clock is a monotonic clock. This commit uses uptime() as time source in such cases.

Closes #357.