### PR TITLE
getsockopt(2): add stub handler for SO_SNDBUF

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1455,6 +1455,9 @@ sysreturn getsockopt(int sockfd, int level, int optname, void *optval, socklen_t
     case SO_TYPE:
         ret_optval.val = s->type;
         break;
+    case SO_SNDBUF:
+        ret_optval.val = 2048;  /* minimum value for this option in Linux */
+        break;
     default:
         msg_warn("getsockopt unimplemented optname: fd %d, level %d, optname %d\n",
             sockfd, level, optname);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -377,6 +377,7 @@ typedef u32 gid_t;
 
 /* set/getsockopt optnames */
 #define SO_TYPE 3
+#define SO_SNDBUF   7
 
 
 /* eventfd flags */


### PR DESCRIPTION
This is needed by Vert.x (ticket #824).

Closes #853.