### PR TITLE
Fix mac build

### DIFF
--- a/test/runtime/signal.c
+++ b/test/runtime/signal.c
@@ -277,7 +277,6 @@ void test_rt_sigqueueinfo(void)
 static volatile int rt_sigsuspend_handler_reached;
 static volatile int rt_sigsuspend_handler_2_reached;
 static volatile int rt_sigsuspend_next_sig;
-static volatile int rt_sigsuspend_caught_on_unmask;
 
 static void test_rt_sigsuspend_handler(int sig, siginfo_t *si, void *ucontext)
 {


### PR DESCRIPTION
This addresses recent failures in the mac build. Note that the e2e tests need to consider whether cross-building is being performed for go and rust (local builds with "prebuild" compile step). go is a no brainer; just set "GOOS" "GOARCH" before the build. rustc is a little more involved and may require additional tools (a quick search brings up "rustup" which could do the job with some further investigation). So I added a "nocross" flag to the e2e tests which allows the test to be skipped if not building on Linux. If we ever need to care about testing e2e rust with the macos build, someone can pick this up and figure out how to script a rustup (or whatever) cross build.

@x64k I'm not quite sure why the random test wasn't able to parse the ent output on mac. I verified that the output (for a given test string) was identical on linux vs mac. So perhaps there's some variation in the way strcspn works or the reading of the results file. Running on the mac detected an out of bounds access of the stats array (segfault), so I tried to sanitize the way it is indexed. If you could look it over and make sure it's doing what you intended, I'd appreciate it.
