### PR TITLE
fixes for large number of files

### DIFF
--- a/src/runtime/buffer.c
+++ b/src/runtime/buffer.c
@@ -3,15 +3,19 @@
 buffer allocate_buffer(heap h, bytes s)
 {
     buffer b = allocate(h, sizeof(struct buffer));
+    if (b == INVALID_ADDRESS)
+        return b;
     b->start = 0;
     b->end = 0;
     b->length = s;
     b->wrapped = false;
     b->h = h;
-    // two allocations to remove the deallocate ambiguity, otherwise
-    // we'd prefer to do it in one
     b->contents = allocate(h, s);
-    return(b);
+    if (b->contents == INVALID_ADDRESS) {
+        deallocate(h, b, sizeof(struct buffer));
+        return INVALID_ADDRESS;
+    }
+    return b;
 }
 
 void buffer_append(buffer b,

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -35,6 +35,8 @@ extern void print_stack_from_here();
     } while(0)
 #endif
 
+#define build_assert(x) _Static_assert((x), "build assertion failure")
+
 void runtime_memcpy(void *a, const void *b, bytes len);
 
 void runtime_memset(u8 *a, u8 b, bytes len);
@@ -208,8 +210,7 @@ extern status_handler ignore_status;
 #define MB (KB*KB)
 #define GB (KB*MB)
 
-// fix transient - also should be legit to use the space between end and length w/o penalty
-#define cstring(__b) ({buffer n = little_stack_buffer(512); push_buffer(n, __b); push_u8(n, 0); n->contents;})
+#define cstring(b, t) ({buffer_clear(t); push_buffer((t), (b)); push_u8((t), 0); (char*)(t)->contents;})
 
 extern heap transient;
 

--- a/src/runtime/symbol.c
+++ b/src/runtime/symbol.c
@@ -19,36 +19,35 @@ symbol intern_u64(u64 u)
 symbol intern(string name)
 {
     symbol s;
-    if (!(s=table_find(symbols, name))){
+    if (!(s = table_find(symbols, name))) {
         // shouldnt really be on transient
         buffer b = allocate_buffer(iheap, buffer_length(name));
+        if (b == INVALID_ADDRESS)
+            goto alloc_fail;
         push_buffer(b, name);
         s = allocate(sheap, sizeof(struct symbol));
+        if (s == INVALID_ADDRESS)
+            goto alloc_fail;
         symbol n = valueof(s);
         n->k = random_u64();
         n->s = b;
         table_set(symbols, b, s);
     }
     return valueof(s);
+  alloc_fail:
+    halt("intern: alloc fail\n");
 }
 
 string symbol_string(symbol s)
 {
-    return(s->s);
+    return s->s;
 }
-
-// should make a heap that unmaps and returns pages to the heap on free
-// and one that picks a new virtual address - this guy doesn't need
-// and contiguity
-// and dont forget my 2M aligned heap
-
 
 key key_from_symbol(void *z)
 {
     symbol s = z;
-    return(s->k);
+    return s->k;
 }
-
 
 void init_symbols(heap h, heap init)
 {

--- a/src/runtime/table.c
+++ b/src/runtime/table.c
@@ -55,8 +55,11 @@ static inline key position(int buckets, key x)
 static void resize_table(table z, int buckets)
 {
     assert((buckets & (buckets - 1)) == 0);
+    assert(buckets <= TABLE_MAX_BUCKETS);
     table t = valueof(z);
     entry *nentries = allocate_zero(t->h, buckets * sizeof(void *));
+    if (nentries == INVALID_ADDRESS)
+        halt("resize_table: allocate fail for %d buckets\n", buckets);
     for (int i = 0; i < t->buckets; i++) {
         for (entry n, j = t->entries[i]; j; j = n) {
             n = j->next;
@@ -115,7 +118,7 @@ void table_set(table z, void *c, void *v)
         n->next = 0;
         *e = n;
         
-        if (t->count++ > t->buckets) 
+        if (t->count++ > t->buckets && t->buckets < TABLE_MAX_BUCKETS / 2)
             resize_table(t, t->buckets*2);
     }
 }

--- a/src/runtime/table.c
+++ b/src/runtime/table.c
@@ -2,46 +2,75 @@
 
 #define EMPTY ((void *)0)
 
+boolean pointer_equal(void *a, void *b)
+{
+    return a == b;
+}
+
+key identity_key(void *a)
+{
+    return u64_from_pointer(a);
+}
+
+/* TODO: Make optional for production */
 void table_check(table t, char *n)
 {
     void *last;
-    for(int i = 0; i<t->buckets; i++){
-        entry j = t->entries[i];
-        last = j;
-        while(j) {
+    for(int i = 0; i < t->buckets; i++) {
+        for (entry j = t->entries[i]; last = j, j; j = j->next) {
             if (j == INVALID_ADDRESS) {
-                rprintf("badness 8000 %p %s %p\n", t, n, last);
-                //rprintf("build: %p\n", __builtin_return_address(1));
-                halt("zig why no format");
+                print_stack_from_here();
+                halt("table_check fail on %s: table %p, last %p\n", n, t, last);
             }
-            last = j;
-            j = j->next;
         }
     }
 }
 
-
 table allocate_table(heap h, u64 (*key_function)(void *x), boolean (*equals_function)(void *x, void *y))
 {
     table new = allocate(h, sizeof(struct table));
-    if (new == INVALID_ADDRESS) halt("allocate table failed\n");
+    if (new == INVALID_ADDRESS)
+        goto alloc_fail;
+
     table t = tablev(new);
     t->h = h;
     t->count = 0;
     t->buckets = 4;
     t->entries = allocate_zero(h, t->buckets * sizeof(void *));
+    if (t->entries == INVALID_ADDRESS)
+        goto alloc_fail;
     t->key_function = key_function;
     t->equals_function = equals_function;
-    return(new);
+    return new;
+
+  alloc_fail:
+    halt("allocation failure in allocate_table\n");
 }
 
 static inline key position(int buckets, key x)
 {
-    return(x&(buckets-1));
+    return x & (buckets-1);
 }
 
+static void resize_table(table z, int buckets)
+{
+    assert((buckets & (buckets - 1)) == 0);
+    table t = valueof(z);
+    entry *nentries = allocate_zero(t->h, buckets * sizeof(void *));
+    for (int i = 0; i < t->buckets; i++) {
+        for (entry n, j = t->entries[i]; j; j = n) {
+            n = j->next;
+            key km = position(buckets, j->k);
+            j->next = nentries[km];
+            nentries[km] = j;
+        }
+    }
+    t->entries = nentries;
+    t->buckets = buckets;
+    table_check(t, "resize");
+}
 
-void *table_find (table z, void *c)
+void *table_find(table z, void *c)
 {
     table t = valueof(z);
     assert(t);
@@ -50,60 +79,40 @@ void *table_find (table z, void *c)
         if ((i->k == k) && t->equals_function(i->c, c))
             return(i->v);
     }
-    return(EMPTY);
+    return EMPTY;
 }
 
-
-static void resize_table(table z, int buckets)
+void table_set(table z, void *c, void *v)
 {
     table t = valueof(z);
-    entry *nentries = allocate_zero(t->h, buckets * sizeof(void *));
-    for(int i = 0; i<t->buckets; i++){
-        entry j = t->entries[i];
-        while(j) {
-            entry n = j->next;
-            key km = position(buckets, j->k);
-            j->next = nentries[km];
-            nentries[km] = j;
-            j = n;
-        }
-    }
-    t->entries = nentries;
-    t->buckets = buckets;
-    table_check(t, "resize");
-}
-
-void table_set (table z, void *c, void *v)
-{
-    table t = valueof(z);
-    //    rprintf("set: %p %p %p\n", z, t->entries, __builtin_return_address(0));
     key k = t->key_function(c);
     key p = position(t->buckets, k);
     entry *e = t->entries + p;
     for (; *e; e = &(*e)->next) {
         if (((*e)->k == k) && t->equals_function((*e)->c, c)) {
             if (v == EMPTY) {
+                assert(t->count > 0);
                 t->count--;
                 entry z = *e;
                 *e = (*e)->next;
                 table_check(t, "remove");
                 deallocate(t->h, z, sizeof(struct entry));
-            } else (*e)->v = v;
+            } else {
+                (*e)->v = v;
+            }
             return;
         }
     }
 
     if (v != EMPTY) {
-        // xxx - shouldnt need to zero - messing about
-        entry n = valueof(allocate_zero(t->h, sizeof(struct entry)));
-
-        if (n == INVALID_ADDRESS) {
+        entry n = valueof(allocate(t->h, sizeof(struct entry)));
+        if (n == INVALID_ADDRESS)
             halt("couldn't allocate table entry\n");
-        }
 
-        n->k = k;
-        n->c = c; 
         n->v = v;
+        n->k = k;
+        n->c = c;
+        n->next = 0;
         *e = n;
         
         if (t->count++ > t->buckets) 

--- a/src/runtime/table.h
+++ b/src/runtime/table.h
@@ -1,4 +1,8 @@
 #pragma once
+
+/* Keep buckets bounded so that we can reliably use PAGESIZE mcache heaps for tables. */
+#define TABLE_MAX_BUCKETS       256
+
 typedef struct table *table;
 
 typedef u64 key;

--- a/src/runtime/table.h
+++ b/src/runtime/table.h
@@ -3,10 +3,6 @@ typedef struct table *table;
 
 typedef u64 key;
 
-table allocate_table(heap h, key (*key_function)(void *x), boolean (*equal_function)(void *x, void *y));
-int table_elements(table t);
-
-
 typedef struct entry {
     void *v;
     key k;
@@ -23,27 +19,20 @@ struct table {
     boolean (*equals_function)(void *x, void *y);
 };
 
-void *table_find (table t, void *c);
+table allocate_table(heap h, key (*key_function)(void *x), boolean (*equal_function)(void *x, void *y));
+int table_elements(table t);
+void *table_find(table t, void *c);
 //void *table_find_key (table t, void *c, void **kr);
-void table_set (table t, void *c, void *v);
+void table_set(table t, void *c, void *v);
 
 #define eZ(x,y) ((entry) x)->y
 
 #define tablev(__z) ((table)valueof(__z))
-// much threadsafe...think about start
 #define table_foreach(__t, __k, __v)\
     for (int __i = 0 ; __i< tablev(__t)->buckets; __i++) \
         for (void *__k, *__v, *__j = (tablev(__t)->entries[__i]), *__next;    \
              __j && (__next =  eZ((__j), next) , __k = eZ(__j, c), __v = eZ(__j, v)); \
              __j = __next)
 
-static inline boolean pointer_equal(void *a, void* b)
-{
-    return a == b;
-}
-
-// should try to fold since the lower bits are driven to zero by alignment
-static inline key identity_key(void *a)
-{
-    return u64_from_pointer(a);
-}
+boolean pointer_equal(void *a, void* b);
+key identity_key(void *a);

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -262,6 +262,8 @@ static void filesystem_read_internal(filesystem fs, fsfile f, buffer b, u64 leng
 void filesystem_read(filesystem fs, tuple t, void *dest, u64 length, u64 offset,
                      io_status_handler io_complete)
 {
+    tfs_debug("filesystem_read: t %v, dest %p, length %ld, offset %ld, completion %p\n",
+              t, dest, length, offset, io_complete);
     fsfile f;
     if (!(f = table_find(fs->files, t))) {
         tuple e = timm("result", "no such file %t", t);
@@ -293,6 +295,8 @@ static void read_entire_complete(buffer_handler bh, buffer b, status_handler sh,
 
 void filesystem_read_entire(filesystem fs, tuple t, heap bufheap, buffer_handler c, status_handler sh)
 {
+    tfs_debug("filesystem_read_entire: t %v, bufheap %p, buffer_handler %p, status_handler %p\n",
+              t, bufheap, c, sh);
     fsfile f;
     if (!(f = table_find(fs->files, t))) {
         tuple e = timm("result", "no such file %t", t);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -1,5 +1,9 @@
 // structs that live on the user-kernel boundary
 
+/* limits */
+#define NAME_MAX 255
+#define PATH_MAX 4096
+
 /* fields from linux asm/stat.h - 64-bit only */
 struct stat {
     /* 0 - 3 */

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -45,8 +45,6 @@ struct linux_dirent {
     */
 };
 
-#define NAME_MAX 255
-
 struct linux_dirent64 {
     u64            d_ino;    /* 64-bit inode number */
     u64            d_off;    /* 64-bit offset to next structure */

--- a/src/unix_process/unix_process_runtime.c
+++ b/src/unix_process/unix_process_runtime.c
@@ -64,10 +64,9 @@ void halt(char *format, ...)
 
 heap allocate_tagged_region(kernel_heaps kh, u64 tag)
 {
-    u64 size = 4*1024*1024;
+    u64 size = 256 * MB;
     void *region = mmap(pointer_from_u64(tag << va_tag_offset),
                         size, PROT_READ | PROT_WRITE, MAP_FIXED | MAP_ANON | MAP_PRIVATE, -1, 0);
-    // use a specific growable heap
     return create_id_heap(heap_general(kh), u64_from_pointer(region), size, 1);
 }
 

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -32,8 +32,8 @@ heap allocate_tagged_region(kernel_heaps kh, u64 tag)
     if (backed == INVALID_ADDRESS)
         return backed;
 
-    /* 16 bytes on low end (symbol), half page at high (256 table buckets)
-       XXX should verify this as build assert */
+    /* 16 bytes on low end (symbol), half page at high (256 table buckets) */
+    build_assert(TABLE_MAX_BUCKETS * sizeof(void *) <= 1 << 11);
     return allocate_mcache(h, backed, 4, 11, PAGESIZE);
 }
 

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -21,15 +21,20 @@ void startup(kernel_heaps kh,
              tuple root,
              filesystem fs);
 
-// xxx -this is handing out a page per object
 heap allocate_tagged_region(kernel_heaps kh, u64 tag)
 {
     heap h = heap_general(kh);
     heap pages = heap_pages(kh);
     heap physical = heap_physical(kh);
-    return physically_backed(h,
-                             create_id_heap(h, tag << va_tag_offset, 1ull<<va_tag_offset, physical->pagesize),
-                             physical, pages, physical->pagesize);
+    heap backed = physically_backed(h,
+                                    create_id_heap(h, tag << va_tag_offset, 1ull<<va_tag_offset, physical->pagesize),
+                                    physical, pages, physical->pagesize);
+    if (backed == INVALID_ADDRESS)
+        return backed;
+
+    /* 16 bytes on low end (symbol), half page at high (256 table buckets)
+       XXX should verify this as build assert */
+    return allocate_mcache(h, backed, 4, 11, PAGESIZE);
 }
 
 #define BOOTSTRAP_REGION_SIZE_KB	2048

--- a/stage3/stage3.c
+++ b/stage3/stage3.c
@@ -11,11 +11,15 @@ static void read_program_complete(process kp, tuple root, buffer b)
         rprintf("read program complete: %p ", root);
         rprintf("gitversion: %s ", gitversion);
 
+        /* XXX - disable this until we can be assured that print_root
+           won't go haywire on a large manifest... */
+#if 0
         buffer b = allocate_buffer(transient, 64);
         print_root(b, root);
         buffer_print(b);
         deallocate_buffer(b);
         rprintf("\n");
+#endif
        
     }
     exec_elf(b, kp);


### PR DESCRIPTION
This PR addresses a few issues related to crashes resulting from manifests with a large number of files:

- The unix process runtime was using a small (4MB) mapped area for tagged allocations. This was quickly exhausted with large manifests. Ideally these would come from some kind of growable heap, but for now just expand the mapping to 256MB (anonymous pages faulted in on demand).
- #946 - Tagged allocator in stage3 was handing out whole pages which is wasteful. This uses an mcache with the physically-backed, tagged heap as parent.
- cstring() was being used within loop blocks (e.g. table_foreach), inadvertently causing a blown stack from too many calls to __builtin_alloca. This changes the semantics of cstring() to require a temporary buffer which is allocated outside of said loops.
- The table code has been cleaned up, and the number of table buckets are given an upper bound so as to cooperate with a PAGESIZE mcache. (That is, tables will cease to be resized upon reaching TABLE_MAX_BUCKETS.)

This should hopefully address https://github.com/nanovms/ops/issues/382 and other issues triggered by a large number of files in the manifest. Note, however, that a limit will still be reached due to #20 (e.g. I can reliably build an image with 5K files, but 10K files causes a tlog overflow).
