### PR TITLE
more table fixes

### DIFF
--- a/src/runtime/table.h
+++ b/src/runtime/table.h
@@ -1,7 +1,7 @@
 #pragma once
 
-/* Keep buckets bounded so that we can reliably use PAGESIZE mcache heaps for tables. */
-#define TABLE_MAX_BUCKETS       256
+/* Keep buckets bounded so that we can reliably use PAGESIZE_2M mcache heaps for tables. */
+#define TABLE_MAX_BUCKETS       131072
 
 typedef struct table *table;
 
@@ -24,6 +24,7 @@ struct table {
 };
 
 table allocate_table(heap h, key (*key_function)(void *x), boolean (*equal_function)(void *x, void *y));
+void table_validate(table t, char *n);
 int table_elements(table t);
 void *table_find(table t, void *c);
 //void *table_find_key (table t, void *c, void **kr);

--- a/src/runtime/table.h
+++ b/src/runtime/table.h
@@ -1,8 +1,5 @@
 #pragma once
 
-/* Keep buckets bounded so that we can reliably use PAGESIZE_2M mcache heaps for tables. */
-#define TABLE_MAX_BUCKETS       131072
-
 typedef struct table *table;
 
 typedef u64 key;

--- a/src/runtime/uniboot.h
+++ b/src/runtime/uniboot.h
@@ -4,17 +4,20 @@
 
 #ifdef BOOT
 #include <def32.h>
+/* Keep this reasonable so we don't blow the stage2 working heap. */
+#define TABLE_MAX_BUCKETS       1024
 #else
 
 #include <def64.h>
 #define user_va_tag_offset 44
 #ifdef STAGE3
-// each type gets 1T
-// this is to avoid colliding with the kernel when running on stage3.
-#define va_tag_offset 40
+#define va_tag_offset 40        /* 1TB */
 #else
 #define va_tag_offset user_va_tag_offset
 #endif
+
+/* maximum buckets that can fit within a PAGESIZE_2M mcache */
+#define TABLE_MAX_BUCKETS       131072
 
 static inline void* tag(void* v, u64 tval) {
   return pointer_from_u64((tval << va_tag_offset) | u64_from_pointer(v));
@@ -26,6 +29,6 @@ static inline u16 tagof(void* v) {
 
 #define valueof(__x) (__x)
 
-#endif // BOOT
+#endif /* BOOT */
 
 #include <x86.h>

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -32,9 +32,9 @@ heap allocate_tagged_region(kernel_heaps kh, u64 tag)
     if (backed == INVALID_ADDRESS)
         return backed;
 
-    /* 16 bytes on low end (symbol), half page at high (256 table buckets) */
-    build_assert(TABLE_MAX_BUCKETS * sizeof(void *) <= 1 << 11);
-    return allocate_mcache(h, backed, 4, 11, PAGESIZE);
+    /* tagged mcache range of 32 to 1M bytes (131072 table buckets) */
+    build_assert(TABLE_MAX_BUCKETS * sizeof(void *) <= 1 << 20);
+    return allocate_mcache(h, backed, 5, 20, PAGESIZE_2M);
 }
 
 #define BOOTSTRAP_REGION_SIZE_KB	2048


### PR DESCRIPTION
- only perform table validation in table ops if built with TABLE_PARANOIA (but still validate in unit test); otherwise performance is abysmal for large tables
- invalid comparison was preventing resize to TABLE_MAX_BUCKETS
- use 2M pages for stage3 tagged region, allowing increase to 128k table buckets (256 was too deleterious towards performance with large tables)
- add large table stress test (and complete removal validation) to table unit test
