### PR TITLE
stack closures

### DIFF
--- a/contgen/contgen.c
+++ b/contgen/contgen.c
@@ -87,7 +87,7 @@ void cblock()
     p("  return _name(^~);|", "@n->l%", "@r%");
     p("}|");
 
-    p("static _rettype (**_fill_##_name(struct _closure_##_name* n, heap h^))(void *~){|", ", _l% l%", ", _r%");
+    p("static _rettype (**_fill_##_name(struct _closure_##_name* n^))(void *~){|", ", _l% l%", ", _r%");
     p("  n->_apply = _apply_##_name;|");
     p("  n->name = #_name;|");
     for (int i = 0; i < nleft ; i++)  p("  n->l% = l%;|", i, i);

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -4,7 +4,13 @@
 
 #define apply(__c, ...) (*__c)(__c, ## __VA_ARGS__)
 
+#define __closure(__p, __name, ...)\
+    _fill_##__name(__p, ##__VA_ARGS__)
+
 #define closure(__h, __name, ...)\
-    _fill_##__name(allocate(__h, sizeof(struct _closure_##__name)), __h, ##__VA_ARGS__)
+    __closure(allocate(__h, sizeof(struct _closure_##__name)), __name, ##__VA_ARGS__)
+
+#define stack_closure(__name, ...)\
+    __closure(stack_allocate(sizeof(struct _closure_##__name)), __name, ##__VA_ARGS__)
 
 #include <closure_templates.h>


### PR DESCRIPTION
Add stack_closure() for the many closures which live only within the scope of a function. Going forward, this will greatly help clean up abuses of the "transient" heap as well as allow use of closures in early init (e.g. in page table code before system heaps are established). This is also required for some upcoming page table and stage2 fixes.
