### PR TITLE
fix unmap, page.c cleanup

### DIFF
--- a/src/runtime/heap/debug_heap.c
+++ b/src/runtime/heap/debug_heap.c
@@ -1,4 +1,5 @@
 #include <runtime.h>
+#include <page.h>
 
 typedef struct dheap {
     struct heap h;

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -163,19 +163,6 @@ typedef closure_type(thunk, void);
 #define PAGESIZE U64_FROM_BIT(PAGELOG)
 #define PAGELOG_2M 21
 #define PAGESIZE_2M U64_FROM_BIT(PAGELOG_2M)
-#ifndef physical_from_virtual
-physical physical_from_virtual(void *x);
-#endif
-void dump_ptes(void *x);
-void update_map_flags(u64 vaddr, u64 length, u64 flags);
-void zero_mapped_pages(u64 vaddr, u64 length);
-void unmap_pages_with_handler(u64 virtual, u64 length, range_handler rh);
-static inline void unmap_pages(u64 virtual, u64 length)
-{
-    unmap_pages_with_handler(virtual, length, 0);
-}
-
-void remap_pages(u64 vaddr_new, u64 vaddr_old, u64 length, heap h);
 
 typedef closure_type(buffer_handler, void, buffer);
 typedef closure_type(block_io, void, void *, range, status_handler);

--- a/src/virtio/virtqueue.c
+++ b/src/virtio/virtqueue.c
@@ -27,6 +27,7 @@
  */
 
 #include <x86_64.h>
+#include <page.h>
 
 #include "virtio_internal.h"
 

--- a/src/x86_64/clock.c
+++ b/src/x86_64/clock.c
@@ -1,5 +1,6 @@
 #include <runtime.h>
 #include <x86_64.h>
+#include <page.h>
 #include "hpet.h"
 #include "rtc.h"
 

--- a/src/x86_64/page.h
+++ b/src/x86_64/page.h
@@ -17,5 +17,21 @@
 #define PAGE_PROT_FLAGS (PAGE_NO_EXEC | PAGE_USER | PAGE_WRITABLE)
 #define PAGE_DEV_FLAGS (PAGE_WRITABLE | PAGE_WRITETHROUGH | PAGE_NO_EXEC)
 
-void map(u64 virtual, physical p, int length, u64 flags, heap h);
-void unmap(u64 virtual, int length, heap h);
+#ifndef physical_from_virtual
+physical physical_from_virtual(void *x);
+#endif
+
+void map(u64 virtual, physical p, u64 length, u64 flags, heap h);
+void unmap(u64 virtual, u64 length, heap h);
+void unmap_pages_with_handler(u64 virtual, u64 length, range_handler rh);
+
+static inline void unmap_pages(u64 virtual, u64 length)
+{
+    unmap_pages_with_handler(virtual, length, 0);
+}
+
+void update_map_flags(u64 vaddr, u64 length, u64 flags);
+void zero_mapped_pages(u64 vaddr, u64 length);
+void remap_pages(u64 vaddr_new, u64 vaddr_old, u64 length, heap h);
+
+void dump_ptes(void *x);


### PR DESCRIPTION
map_range had a bug which was preventing the correct determination of 4k / 2M pages on unmap, so just use the newer, cleaner unmap_pages. This employs stack closures in uses of traverse_entries(), enabling use of the unmap functions in early init, prior to heap setup.

