### PR TITLE
id heap / bitmap enhancements and fixes

### DIFF
--- a/src/runtime/bitmap.h
+++ b/src/runtime/bitmap.h
@@ -11,7 +11,7 @@ typedef struct bitmap {
 
 boolean bitmap_range_check_and_set(bitmap b, u64 start, u64 nbits, boolean validate, boolean set);
 u64 bitmap_alloc(bitmap b, u64 size);
-u64 bitmap_alloc_with_offset(bitmap b, u64 size, u64 offset);
+u64 bitmap_alloc_within_range(bitmap b, u64 nbits, u64 start, u64 end);
 boolean bitmap_dealloc(bitmap b, u64 bit, u64 size);
 bitmap allocate_bitmap(heap h, u64 length);
 void deallocate_bitmap(bitmap b);

--- a/src/runtime/heap/heap.h
+++ b/src/runtime/heap/heap.h
@@ -17,7 +17,12 @@ boolean id_heap_add_range(heap h, u64 base, u64 length);
 boolean id_heap_set_area(heap h, u64 base, u64 length, boolean validate, boolean allocate);
 u64 id_heap_total(heap h);
 void id_heap_set_randomize(heap h, boolean randomize);
-u64 id_heap_alloc_gte(heap h, u64 min);
+u64 id_heap_alloc_subrange(heap h, bytes count, u64 start, u64 end);
+static inline u64 id_heap_alloc_gte(heap h, bytes count, u64 min)
+{
+    return id_heap_alloc_subrange(h, count, min, infinity);
+}
+
 heap wrap_freelist(heap meta, heap parent, bytes size);
 heap allocate_objcache(heap meta, heap parent, bytes objsize, bytes pagesize);
 boolean objcache_validate(heap h);

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -107,7 +107,8 @@ static u64 id_alloc_from_range(id_heap i, id_range r, u64 pages, range subrange)
         return INVALID_PHYSICAL;
 
     /* check for randomization, else check for next fit */
-    u64 max_start = range_span(ri) > pages_rounded ? (range_span(ri) & (pages_rounded - 1)) - 1 : 0;
+    u64 max_start = range_span(ri) > pages_rounded ?
+        (range_span(ri) & ~(pages_rounded - 1)) - pages_rounded : 0;
     u64 start_bit = ri.start;
     if ((i->flags & ID_HEAP_FLAG_RANDOMIZE) && max_start > 0)
         start_bit += random_u64() % max_start;

--- a/src/runtime/range.h
+++ b/src/runtime/range.h
@@ -100,3 +100,8 @@ static inline boolean range_equal(range a, range b)
 {
     return (a.start == b.start) && (a.end == b.end);
 }
+
+static inline boolean range_valid(range r)
+{
+    return r.start <= r.end;
+}

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -33,7 +33,7 @@ u64 allocate_fd(process p, void *f)
 
 u64 allocate_fd_gte(process p, u64 min, void *f)
 {
-    u64 fd = id_heap_alloc_gte(p->fdallocator, min);
+    u64 fd = id_heap_alloc_gte(p->fdallocator, 1, min);
     if (fd == INVALID_PHYSICAL) {
         msg_err("failed\n");
     }

--- a/test/unit/id_heap_test.c
+++ b/test/unit/id_heap_test.c
@@ -175,12 +175,12 @@ static boolean alloc_gte_test(heap h)
         msg_err("cannot create heap\n");
         return false;
     }
-    if (id_heap_alloc_gte(idh, GTE_TEST_MAX) != INVALID_PHYSICAL) {
+    if (id_heap_alloc_gte(idh, 1, GTE_TEST_MAX) != INVALID_PHYSICAL) {
         msg_err("allocation should have failed for id %ld\n", GTE_TEST_MAX);
         return false;
     }
     for (u64 id = 0; id < GTE_TEST_MAX; id++) {
-        u64 allocated = id_heap_alloc_gte(idh, id);
+        u64 allocated = id_heap_alloc_gte(idh, 1, id);
         if (allocated != id) {
             if (allocated == INVALID_PHYSICAL) {
                 msg_err("allocation failed for id %ld\n", id);
@@ -197,7 +197,7 @@ static boolean alloc_gte_test(heap h)
         deallocate_u64(idh, id, 1);
     }
     for (u64 id = GTE_TEST_MAX - 1; (s64)id >= 0; id--) {
-        u64 allocated = id_heap_alloc_gte(idh, id);
+        u64 allocated = id_heap_alloc_gte(idh, 1, id);
         if (allocated != id) {
             if (allocated == INVALID_PHYSICAL) {
                 msg_err("allocation failed for id %ld\n", id);
@@ -214,7 +214,7 @@ static boolean alloc_gte_test(heap h)
         deallocate_u64(idh, id, 1);
     }
     for (u64 id = 0; ; id++) {
-        u64 allocated = id_heap_alloc_gte(idh, 0);
+        u64 allocated = id_heap_alloc_gte(idh, 1, 0);
         if (allocated == INVALID_PHYSICAL) {
             if (id != GTE_TEST_MAX) {
                 msg_err("allocation failed for id %ld\n", id);


### PR DESCRIPTION
In order to enable more accurate tracking of user address space, the id heap has been enhanced to allow allocation from within a specified region of space. This will allow us to, for instance, use the process virtual32 heap to track all of the lower 32-bit address space. Allocations may then be confined to specific portions of that space (e.g. MAP_32BIT allocations can come out of the top 2gb of this space, the process stack can be allocated from the top of the lower 2gb space under the kernel reserved area, etc. - these are coming in a follow-up PR).

Along the way, some bugs were found in the bitmap code that led to incorrect handling of given start and end points for an allocation. The id heap unit test has been expanded to test the id_heap_alloc_subrange() as well as various alignment conditions. As a minor optimization, the internally-kept ranges in the id heap are now in units of pages rather than bytes. Also, uses of closures internal to id.c now use stack closures rather than the transient heap.
