### PR TITLE
PTE traversal update and mincore reimplementation

### DIFF
--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -217,7 +217,7 @@ boolean mincore_fill_vec(u64 base, u64 nr_pgs, u8 * vec, int level, u64 addr, u6
 static CLOSURE_0_1(mincore_vmap_gap, void, range);
 static void mincore_vmap_gap(range r)
 {
-    thread_log(current, "   found gap [0x%lx, 0x%lx)\n", r.start, r.end);
+    thread_log(current, "   found gap [0x%lx, 0x%lx)", r.start, r.end);
 }
 
 static sysreturn mincore(void *addr, u64 length, u8 *vec)

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -13,52 +13,12 @@
 #define page_debug(x, ...)
 #endif
 
-
-#define PAGEMASK MASK(PAGELOG)
-typedef u64 *page;
-
 #define PT1 39
 #define PT2 30
 #define PT3 21
 #define PT4 12
 
 static const int level_shift[5] = { -1, PT1, PT2, PT3, PT4 };
-
-static inline u64 phys_from_pte(u64 pte)
-{
-    /* page directory pointer base address [51:12] */
-    return pte & (MASK(52) & ~PAGEMASK);
-}
-
-static inline page page_from_pte(u64 pte)
-{
-    return (page)pointer_from_u64(phys_from_pte(pte));
-}
-
-static inline u64 flags_from_pte(u64 pte)
-{
-    return pte & PAGE_FLAGS_MASK;
-}
-
-static inline u64 pindex(u64 x, u64 offset)
-{
-    return ((x >> offset) & MASK(9));
-}
-
-static inline boolean entry_is_present(u64 entry)
-{
-    return (entry & PAGE_PRESENT) != 0;
-}
-
-static inline boolean entry_is_fat(int level, u64 entry)
-{
-    return level == 3 && (entry & PAGE_2M_SIZE) != 0;
-}
-
-static inline boolean entry_is_pte(int level, u64 entry)
-{
-    return level == 4 || entry_is_fat(level, entry);
-}
 
 static inline page pagebase()
 {
@@ -202,7 +162,7 @@ static boolean force_entry(heap h, page b, u64 v, physical p, int level,
 	return true;
     } else {
 	if (*pte & PAGE_PRESENT) {
-            if (entry_is_fat(level, *pte)) {
+            if (pt_entry_is_fat(level, *pte)) {
                 console("\nforce_entry fail: attempting to map a 4K page over an "
                         "existing 2M mapping\n");
                 return false;
@@ -277,26 +237,24 @@ static inline u64 pt_level_end(u64 p, int level)
              addr ## level < levelend;                                  \
          addr ## level = next ## level)
 
-typedef closure_type(entry_handler, boolean /* success */, int /* level */, u64 /* vaddr */, u64 * /* entry */);
-
-static boolean traverse_entries(u64 vaddr, u64 length, entry_handler ph)
+boolean traverse_ptes(u64 vaddr, u64 length, entry_handler ph)
 {
     u64 end = vaddr + length;
 
     for_level(pagebase(), vaddr, end, 1, end) {
         if (!apply(ph, 1, addr1, pte1))
             return false;
-        if (!entry_is_present(*pte1))
+        if (!pt_entry_is_present(*pte1))
             continue;
         for_level(page_from_pte(*pte1), addr1, end, 2, end1) {
             if (!apply(ph, 2, addr2, pte2))
                 return false;
-            if (!entry_is_present(*pte2))
+            if (!pt_entry_is_present(*pte2))
                 continue;
             for_level(page_from_pte(*pte2), addr2, end, 3, end2) {
                 if (!apply(ph, 3, addr3, pte3))
                     return false;
-                if (!entry_is_present(*pte3))
+                if (!pt_entry_is_present(*pte3))
                     continue;
                 if ((*pte3 & PAGE_2M_SIZE) == 0) {
                     for_level(page_from_pte(*pte3), addr3, end, 4, end3) {
@@ -314,14 +272,14 @@ static boolean traverse_entries(u64 vaddr, u64 length, entry_handler ph)
 static CLOSURE_0_3(validate_entry, boolean, int, u64, u64 *);
 static boolean validate_entry(int level, u64 vaddr, u64 * entry)
 {
-    return entry_is_present(*entry);
+    return pt_entry_is_present(*entry);
 }
 
 /* validate that all pages in vaddr range [base, base + length) are present */
 boolean validate_virtual(void * base, u64 length)
 {
     page_debug("base %p, length 0x%lx\n", base, length);
-    return traverse_entries(u64_from_pointer(base), length, stack_closure(validate_entry));
+    return traverse_ptes(u64_from_pointer(base), length, stack_closure(validate_entry));
 }
 
 static CLOSURE_1_3(update_pte_flags, boolean, u64, int, u64, u64 *);
@@ -329,7 +287,7 @@ static boolean update_pte_flags(u64 flags, int level, u64 addr, u64 * entry)
 {
     /* we only care about present ptes */
     u64 old = *entry;
-    if (!entry_is_present(old) || !entry_is_pte(level, old))
+    if (!pt_entry_is_present(old) || !pt_entry_is_pte(level, old))
         return true;
 
     *entry = (old & ~PAGE_PROT_FLAGS) | flags;
@@ -346,7 +304,7 @@ void update_map_flags(u64 vaddr, u64 length, u64 flags)
     flags &= ~PAGE_NO_FAT;
     page_debug("vaddr 0x%lx, length 0x%lx, flags 0x%lx\n", vaddr, length, flags);
 
-    traverse_entries(vaddr, length, stack_closure(update_pte_flags, flags));
+    traverse_ptes(vaddr, length, stack_closure(update_pte_flags, flags));
 }
 
 static CLOSURE_3_3(remap_entry, boolean, u64, u64, heap, int, u64, u64 *);
@@ -363,7 +321,7 @@ static boolean remap_entry(u64 new, u64 old, heap h, int level, u64 curr, u64 * 
 #endif
 
     /* transpose any unmapped gaps to target */
-    if (!entry_is_present(oldentry)) {
+    if (!pt_entry_is_present(oldentry)) {
         u64 len = U64_FROM_BIT(level_shift[level]);
 #ifdef PAGE_UPDATE_DEBUG
         page_debug("unmapping [0x%lx, 0x%lx)\n", new_curr, new_curr + len);
@@ -373,11 +331,11 @@ static boolean remap_entry(u64 new, u64 old, heap h, int level, u64 curr, u64 * 
     }
 
     /* only look at ptes at this point */
-    if (!entry_is_pte(level, oldentry))
+    if (!pt_entry_is_pte(level, oldentry))
         return true;
 
     /* transpose mapped page */
-    map_page(pagebase(), new_curr, phys, h, entry_is_fat(level, oldentry), flags, 0);
+    map_page(pagebase(), new_curr, phys, h, pt_entry_is_fat(level, oldentry), flags, 0);
 
     /* reset old entry */
     *entry = 0;
@@ -391,7 +349,7 @@ static boolean remap_entry(u64 new, u64 old, heap h, int level, u64 curr, u64 * 
 /* We're just going to do forward traversal, for we don't yet need to
    support overlapping moves. Should the latter become necessary
    (e.g. to support MREMAP_FIXED in mremap(2) without depending on
-   MREMAP_MAYMOVE), write a "traverse_entries_reverse" to walk pages
+   MREMAP_MAYMOVE), write a "traverse_ptes_reverse" to walk pages
    from high address to low (like memcpy).
 */
 void remap_pages(u64 vaddr_new, u64 vaddr_old, u64 length, heap h)
@@ -401,15 +359,15 @@ void remap_pages(u64 vaddr_new, u64 vaddr_old, u64 length, heap h)
         return;
     assert(range_empty(range_intersection(irange(vaddr_new, vaddr_new + length),
                                           irange(vaddr_old, vaddr_old + length))));
-    traverse_entries(vaddr_old, length, stack_closure(remap_entry, vaddr_new, vaddr_old, h));
+    traverse_ptes(vaddr_old, length, stack_closure(remap_entry, vaddr_new, vaddr_old, h));
 }
 
 static CLOSURE_0_3(zero_page, boolean, int, u64, u64 *);
 static boolean zero_page(int level, u64 addr, u64 * entry)
 {
     u64 e = *entry;
-    if (entry_is_present(e) && entry_is_pte(level, e)) {
-        u64 size = entry_is_fat(level, e) ? PAGESIZE_2M : PAGESIZE;
+    if (pt_entry_is_present(e) && pt_entry_is_pte(level, e)) {
+        u64 size = pt_entry_is_fat(level, e) ? PAGESIZE_2M : PAGESIZE;
 #ifdef PAGE_UPDATE_DEBUG
         page_debug("addr 0x%lx, size 0x%lx\n", addr, size);
 #endif
@@ -420,14 +378,43 @@ static boolean zero_page(int level, u64 addr, u64 * entry)
 
 void zero_mapped_pages(u64 vaddr, u64 length)
 {
-    traverse_entries(vaddr, length, stack_closure(zero_page));
+    traverse_ptes(vaddr, length, stack_closure(zero_page));
+}
+
+static CLOSURE_3_3(is_page_mapped, boolean, u64, u64, u8 *, int, u64, u64 *);
+boolean is_page_mapped(u64 base, u64 nr_pgs, u8 * vec, int level, u64 addr, u64 * entry)
+{
+    u64 e = *entry;
+    u64 pgoff, i;
+
+    if (pt_entry_is_present(e)) {
+        pgoff = (addr - base) >> PAGELOG;
+
+        if (pt_entry_is_fat(level, e)) {
+            /* whole level is mapped */
+            for (i = 0; i < 512 && (pgoff + i < nr_pgs); i++) {
+                vec[pgoff + i] = 1;
+	    }
+        } else if (pt_entry_is_pte(level, e)) {
+            vec[pgoff] = 1;
+        }
+    }
+
+    return true;
+}
+
+void mincore_pages(u64 vaddr, u64 length, u8 *vec)
+{
+    traverse_ptes(vaddr, length, 
+	stack_closure(is_page_mapped, vaddr, length >> PAGELOG, vec)
+    );
 }
 
 static CLOSURE_1_3(unmap_page, boolean, range_handler, int, u64, u64 *);
 boolean unmap_page(range_handler rh, int level, u64 vaddr, u64 * entry)
 {
     u64 old_entry = *entry;
-    if (entry_is_present(old_entry) && entry_is_pte(level, old_entry)) {
+    if (pt_entry_is_present(old_entry) && pt_entry_is_pte(level, old_entry)) {
 #ifdef PAGE_UPDATE_DEBUG
         page_debug("rh %p, level %d, vaddr 0x%lx, entry %p, *entry 0x%lx\n",
                    rh, level, vaddr, entry, *entry);
@@ -436,7 +423,7 @@ boolean unmap_page(range_handler rh, int level, u64 vaddr, u64 * entry)
         page_invalidate(vaddr);
         if (rh) {
             u64 phys = phys_from_pte(old_entry);
-            range p = irange(phys, phys + (entry_is_fat(level, old_entry) ? PAGESIZE_2M : PAGESIZE));
+            range p = irange(phys, phys + (pt_entry_is_fat(level, old_entry) ? PAGESIZE_2M : PAGESIZE));
             apply(rh, p);
         }
     }
@@ -446,7 +433,7 @@ boolean unmap_page(range_handler rh, int level, u64 vaddr, u64 * entry)
 void unmap_pages_with_handler(u64 virtual, u64 length, range_handler rh)
 {
     assert(!((virtual & PAGEMASK) || (length & PAGEMASK)));
-    traverse_entries(virtual, length, stack_closure(unmap_page, rh));
+    traverse_ptes(virtual, length, stack_closure(unmap_page, rh));
 }
 
 // error processing

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -381,35 +381,6 @@ void zero_mapped_pages(u64 vaddr, u64 length)
     traverse_ptes(vaddr, length, stack_closure(zero_page));
 }
 
-static CLOSURE_3_3(is_page_mapped, boolean, u64, u64, u8 *, int, u64, u64 *);
-boolean is_page_mapped(u64 base, u64 nr_pgs, u8 * vec, int level, u64 addr, u64 * entry)
-{
-    u64 e = *entry;
-    u64 pgoff, i;
-
-    if (pt_entry_is_present(e)) {
-        pgoff = (addr - base) >> PAGELOG;
-
-        if (pt_entry_is_fat(level, e)) {
-            /* whole level is mapped */
-            for (i = 0; i < 512 && (pgoff + i < nr_pgs); i++) {
-                vec[pgoff + i] = 1;
-	    }
-        } else if (pt_entry_is_pte(level, e)) {
-            vec[pgoff] = 1;
-        }
-    }
-
-    return true;
-}
-
-void mincore_pages(u64 vaddr, u64 length, u8 *vec)
-{
-    traverse_ptes(vaddr, length, 
-	stack_closure(is_page_mapped, vaddr, length >> PAGELOG, vec)
-    );
-}
-
 static CLOSURE_1_3(unmap_page, boolean, range_handler, int, u64, u64 *);
 boolean unmap_page(range_handler rh, int level, u64 vaddr, u64 * entry)
 {

--- a/src/x86_64/page.h
+++ b/src/x86_64/page.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <runtime.h>
+
 #define INITIAL_MAP_SIZE (0xa000)
 
 #define PAGE_NO_EXEC       U64_FROM_BIT(63)
@@ -13,9 +15,48 @@
 #define PAGE_WRITABLE      0x0002
 #define PAGE_PRESENT       0x0001
 
+#define PAGEMASK           MASK(PAGELOG)
 #define PAGE_FLAGS_MASK    (PAGE_NO_EXEC | PAGEMASK)
-#define PAGE_PROT_FLAGS (PAGE_NO_EXEC | PAGE_USER | PAGE_WRITABLE)
-#define PAGE_DEV_FLAGS (PAGE_WRITABLE | PAGE_WRITETHROUGH | PAGE_NO_EXEC)
+#define PAGE_PROT_FLAGS    (PAGE_NO_EXEC | PAGE_USER | PAGE_WRITABLE)
+#define PAGE_DEV_FLAGS     (PAGE_WRITABLE | PAGE_WRITETHROUGH | PAGE_NO_EXEC)
+
+typedef u64 *page;
+
+static inline u64 phys_from_pte(u64 pte)
+{
+    /* page directory pointer base address [51:12] */
+    return pte & (MASK(52) & ~PAGEMASK);
+}
+
+static inline page page_from_pte(u64 pte)
+{
+    return (page)pointer_from_u64(phys_from_pte(pte));
+}
+
+static inline u64 flags_from_pte(u64 pte)
+{
+    return pte & PAGE_FLAGS_MASK;
+}
+
+static inline u64 pindex(u64 x, u64 offset)
+{
+    return ((x >> offset) & MASK(9));
+}
+
+static inline boolean pt_entry_is_present(u64 entry)
+{
+    return (entry & PAGE_PRESENT) != 0;
+}
+
+static inline boolean pt_entry_is_fat(int level, u64 entry)
+{
+    return level == 3 && (entry & PAGE_2M_SIZE) != 0;
+}
+
+static inline boolean pt_entry_is_pte(int level, u64 entry)
+{
+    return level == 4 || pt_entry_is_fat(level, entry);
+}
 
 #ifndef physical_from_virtual
 physical physical_from_virtual(void *x);
@@ -33,5 +74,10 @@ static inline void unmap_pages(u64 virtual, u64 length)
 void update_map_flags(u64 vaddr, u64 length, u64 flags);
 void zero_mapped_pages(u64 vaddr, u64 length);
 void remap_pages(u64 vaddr_new, u64 vaddr_old, u64 length, heap h);
+void mincore_pages(u64 vaddr, u64 length, u8 * vec);
 
 void dump_ptes(void *x);
+
+typedef closure_type(entry_handler, boolean /* success */, int /* level */,
+        u64 /* vaddr */, u64 * /* entry */);
+boolean traverse_ptes(u64 vaddr, u64 length, entry_handler eh);

--- a/src/x86_64/page.h
+++ b/src/x86_64/page.h
@@ -74,7 +74,6 @@ static inline void unmap_pages(u64 virtual, u64 length)
 void update_map_flags(u64 vaddr, u64 length, u64 flags);
 void zero_mapped_pages(u64 vaddr, u64 length);
 void remap_pages(u64 vaddr_new, u64 vaddr_old, u64 length, heap h);
-void mincore_pages(u64 vaddr, u64 length, u8 * vec);
 
 void dump_ptes(void *x);
 

--- a/test/runtime/mmap.c
+++ b/test/runtime/mmap.c
@@ -521,7 +521,7 @@ static void mincore_test(void)
             }
         }
 
-        printf("  performing mincore on sparsely paged anonymous mmap (0x%lx)...\n,",
+        printf("  performing mincore on sparsely paged anonymous mmap (0x%lx)...\n",
             (unsigned long)addr);
         __mincore(addr, PAGESIZE*512, vec, expected);
 


### PR DESCRIPTION
This PR externalizes an interface to walk page tables via src/x86_64/page.h:walk_ptes(), and uses
the interface to implement mincore. We also externalize various PTE helper functions in page.h

Also included are minor updates to the mincore portion of the mmap runtime test.
