### PR TITLE
fix bios_tty_write

### DIFF
--- a/boot/service32.s
+++ b/boot/service32.s
@@ -296,10 +296,16 @@ bios_tty_write:
 	mov esi, [ebp + 8]
 	mov ecx, [ebp + 12]
 
+	; get data segment of pointer
+	mov edx, esi
+	shr edx, 16
+	shl edx, 12
+
 	ENTER_REAL
 	cld
 	mov ah, 0xe	; teletype output
 	xor bh, bh	; page 0
+	mov ds, dx
 .loop:
 	lodsb		; AL = character
 	int 0x10


### PR DESCRIPTION
The bios_tty_write call, needed for stage2 console / debug on xen/aws, was failing on pointers past 16-bit space. This trivial fix computes the data segment for the string pointer and installs it after switching to real mode.
