### PR TITLE
only restore ucontext for sigactions with SA_SIGINFO in rt_sigreturn; align stack in setup_sigframe

### DIFF
--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -703,8 +703,8 @@ static void setup_sigframe(thread t, int signum, struct siginfo *si, void * ucon
         t->sigframe[FRAME_RSP] = 0; /* TODO */
         halt("SA_ONSTACK ...\n");
     } else {
-        /* must avoid redzone */
-        t->sigframe[FRAME_RSP] -= 128;
+        /* 16-byte alignment; avoid redzone */
+        t->sigframe[FRAME_RSP] = (t->sigframe[FRAME_RSP] & ~15) - 128;
     }
 
     /* arguments to trampoline */

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -369,15 +369,18 @@ static void restore_ucontext(struct ucontext * uctx, context f)
 sysreturn rt_sigreturn(void)
 {
     struct rt_sigframe * frame;
+    sigaction sa;
     thread t = current;
 
     /* sigframe sits at top of the stack */
     frame = (struct rt_sigframe *)(t->sigframe[FRAME_RSP]);
     sig_debug("rt_sigreturn: frame:0x%lx\n", (unsigned long)frame);
+    sa = get_sigaction(frame->info.si_signo);
 
-    /* restore signal mask and saved context */
+    /* restore signal mask and saved context, if applicable */
     reset_sigmask(t);
-    restore_ucontext(&(frame->uc), t->frame);
+    if (sa->sa_flags & SA_SIGINFO)
+        restore_ucontext(&(frame->uc), t->frame);
     running_frame = t->frame;
 
     sig_debug("switching to thread frame %p\n", running_frame);


### PR DESCRIPTION
An unconditional restore_ucontext in rt_sigreturn was causing a trashed thread frame when a ANSI/BSD-style signal handler (non-siginfo) was used. This led to the signal runtime test hanging in one case where the return to the (corrupted) thread frame was triggering an endless succession of page fault / SIGSEGVs. This change makes the restore conditional on the presence of SA_SIGINFO in the associated sigaction.

Incidentally, setup_sigframe should enforce a 16-byte alignment for the stack pointer before pushing the siginfo / ucontext and/or returning to the signal trampoline. It was, on some test setups, leading to an unaligned stack pointer and incorrect execution for e.g. 'movaps %xmm0, 0x50(%rsp)'.
