### PR TITLE
deallocate_table, deallocate_tuple

### DIFF
--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -153,10 +153,10 @@ typedef closure_type(thunk, void);
 
 #include <list.h>
 #include <bitmap.h>
+#include <tuple.h>
 #include <status.h>
 #include <pqueue.h>
 #include <timer.h>
-#include <tuple.h>
 #include <range.h>
 
 #define PAGELOG 12

--- a/src/runtime/symbol.h
+++ b/src/runtime/symbol.h
@@ -15,6 +15,4 @@ string symbol_string(symbol s);
     (intern(alloca_wrap_buffer(name, runtime_strlen(name))))
 
 table symbol_table();
-typedef table tuple;
-tuple allocate_tuple();
 key key_from_symbol(void *z);

--- a/src/runtime/table.c
+++ b/src/runtime/table.c
@@ -56,6 +56,23 @@ table allocate_table(heap h, u64 (*key_function)(void *x), boolean (*equals_func
     halt("allocation failure in allocate_table\n");
 }
 
+void deallocate_table(table t)
+{
+    table_paranoia(t, "deallocate");
+    for(int i = 0; i < t->buckets; i++) {
+        entry e = t->entries[i];
+        if (!e)
+            continue;
+        while (e) {
+            entry next = e->next;
+            deallocate(t->h, e, sizeof(struct entry));
+            e = next;
+        }
+    }
+    deallocate(t->h, t->entries, t->buckets * sizeof(void *));
+    deallocate(t->h, t, sizeof(struct table));
+}
+
 static inline key position(int buckets, key x)
 {
     return x & (buckets-1);
@@ -77,6 +94,7 @@ static void resize_table(table z, int buckets)
             nentries[km] = j;
         }
     }
+    deallocate(t->h, t->entries, t->buckets * sizeof(void *));
     t->entries = nentries;
     t->buckets = buckets;
     table_paranoia(t, "resize");

--- a/src/runtime/table.c
+++ b/src/runtime/table.c
@@ -63,11 +63,11 @@ void deallocate_table(table t)
         entry e = t->entries[i];
         if (!e)
             continue;
-        while (e) {
+        do {
             entry next = e->next;
             deallocate(t->h, e, sizeof(struct entry));
             e = next;
-        }
+        } while(e);
     }
     deallocate(t->h, t->entries, t->buckets * sizeof(void *));
     deallocate(t->h, t, sizeof(struct table));

--- a/src/runtime/table.h
+++ b/src/runtime/table.h
@@ -1,5 +1,3 @@
-#pragma once
-
 typedef struct table *table;
 
 typedef u64 key;

--- a/src/runtime/table.h
+++ b/src/runtime/table.h
@@ -21,6 +21,7 @@ struct table {
 };
 
 table allocate_table(heap h, key (*key_function)(void *x), boolean (*equal_function)(void *x, void *y));
+void deallocate_table(table t);
 void table_validate(table t, char *n);
 int table_elements(table t);
 void *table_find(table t, void *c);

--- a/src/runtime/tuple.h
+++ b/src/runtime/tuple.h
@@ -1,12 +1,16 @@
-#pragma once
 typedef table tuple;
-
 typedef struct encoder *encoder;
 typedef struct dencoder *dencoder;
 
 void init_tuples(heap theap);
 void print_tuple(buffer b, tuple t);
 void print_root(buffer b, tuple t);
+
+tuple allocate_tuple();
+static inline void deallocate_tuple(tuple t)
+{
+    deallocate_table(t);
+}
 
 void encode_tuple(buffer dest, table dictionary, tuple t);
 

--- a/src/unix_process/unix_process_runtime.c
+++ b/src/unix_process/unix_process_runtime.c
@@ -33,11 +33,14 @@ u64 random_seed()
 
 static void malloc_free(heap h, u64 z, bytes length)
 {
+    assert(h->allocated >= length);
+    h->allocated -= length;
     free(pointer_from_u64(z));
 }
 
 static u64 malloc_alloc(heap h, bytes s)
 {
+    h->allocated += s;
     return (u64)malloc(s);
 }
 

--- a/test/unit/table_test.c
+++ b/test/unit/table_test.c
@@ -18,6 +18,7 @@ static inline boolean anything_equals(void *a, void* b)
 
 static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_elem)
 {
+    u64 heap_occupancy = h->allocated;
     table t = allocate_table(h, key_function, pointer_equal);
     u64 count;
 
@@ -113,11 +114,18 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
         msg_err("invalid table_elements() %d, should be 0\n");
         return false;
     }
+
+    deallocate_table(t);
+    if (h->allocated != heap_occupancy) {
+        msg_err("leak: h->allocated %ld, originally %ld\n", h->allocated, heap_occupancy);
+        return false;
+    }
     return true;
 }
 
 static boolean one_elem_table_tests(heap h, u64 n_elem)
 {
+    u64 heap_occupancy = h->allocated;
     table t = allocate_table(h, silly_key, anything_equals);
     u64 count;
 
@@ -170,6 +178,12 @@ static boolean one_elem_table_tests(heap h, u64 n_elem)
 
     if (!table_find(t, (void *)count)) {
         msg_err("element %d not found\n", count);
+        return false;
+    }
+
+    deallocate_table(t);
+    if (h->allocated != heap_occupancy) {
+        msg_err("leak: h->allocated %ld, originally %ld\n", h->allocated, heap_occupancy);
         return false;
     }
     return true;


### PR DESCRIPTION
Add table deconstruction and associated unit test. deallocate_tuple is just an alias for deallocate_table.

Resolves #974