### PR TITLE
xennet: handle EAGAIN temporary failure when posting transaction to backend

### DIFF
--- a/src/runtime/status.h
+++ b/src/runtime/status.h
@@ -34,11 +34,16 @@ static inline tuple timm_internal(char *first, ...)
 // fix for zero argument case
 #define timm(first, ...)  timm_internal(first, __VA_ARGS__, INVALID_ADDRESS)
 
+// build up status chain
+#define timm_up(sd, first, ...)                     \
+    ({                                              \
+        tuple __up = timm(first, __VA_ARGS__);      \
+        table_set(__up, sym(down), sd);             \
+        __up;                                       \
+    })
+
 #define STATUS_OK ((tuple)0)
 static inline boolean is_ok(status s)
 {
     return (s == STATUS_OK);
 }
-
-
-

--- a/src/xen/xen.c
+++ b/src/xen/xen.c
@@ -555,16 +555,6 @@ static s64 xenstore_read_internal(buffer b, s64 length)
     return result;
 }
 
-/*
-   xenstore_transaction - Take a buffer of data to write to the
-      xenstore as well as a buffer to fill with the response
-      data. Call the status handler with the status of the operation.
-
-   xenstore_sync_transaction - same as xenstore_transaction but
-      without asynchronous blocking; returns status
-
-*/
-
 static inline status xenstore_sync_write(const void *data, s64 length)
 {
     if (length > 0) {
@@ -636,7 +626,8 @@ status xenstore_sync_request(u32 tx_id, enum xsd_sockmsg_type type, buffer reque
     }
 
     if (rmsg->type == XS_ERROR) {
-        s = timm("result", "xen store error response: \"%s\"", buffer_ref(response, 0));
+        s = timm("result", "xen store error",
+                 "errno", "%s", buffer_ref(response, 0));
         goto out_dealloc;
     }
   out_dealloc:

--- a/src/xen/xennet.c
+++ b/src/xen/xennet.c
@@ -99,60 +99,74 @@ struct xennet_dev {
     struct list tx_free;
 };
 
+#define XENNET_INFORM_BACKEND_RETRIES 128
+
 static status xennet_inform_backend(xennet_dev xd)
 {
     status s = STATUS_OK;
     xennet_debug("%s: dev id %d", __func__, xd->if_id);
 
     u32 tx_id;
-    boolean again = false;
     char *node;
-    do {
-        s = xenstore_transaction_start(&tx_id);
-        if (!is_ok(s))
-            return s;
+    int retries = XENNET_INFORM_BACKEND_RETRIES;
 
-        node = "vifname";
-        s = xenstore_sync_printf(tx_id, xd->frontend, node, "vif%d", xd->if_id);
-        if (!is_ok(s))
-            goto abort;
+  again:
+    node = "transaction start";
+    s = xenstore_transaction_start(&tx_id);
+    if (!is_ok(s))
+        return s;
 
-        node = "rx-ring-ref";
-        s = xenstore_sync_printf(tx_id, xd->frontend, node, "%d", xd->rx_ring_gntref);
-        if (!is_ok(s))
-            goto abort;
+    node = "vifname";
+    s = xenstore_sync_printf(tx_id, xd->frontend, node, "vif%d", xd->if_id);
+    if (!is_ok(s))
+        goto abort;
 
-        node = "tx-ring-ref";
-        s = xenstore_sync_printf(tx_id, xd->frontend, node, "%d", xd->tx_ring_gntref);
-        if (!is_ok(s))
-            goto abort;
+    node = "rx-ring-ref";
+    s = xenstore_sync_printf(tx_id, xd->frontend, node, "%d", xd->rx_ring_gntref);
+    if (!is_ok(s))
+        goto abort;
 
-        node = "request-rx-copy";
-        s = xenstore_sync_printf(tx_id, xd->frontend, node, "%d", 1);
-        if (!is_ok(s))
-            goto abort;
+    node = "tx-ring-ref";
+    s = xenstore_sync_printf(tx_id, xd->frontend, node, "%d", xd->tx_ring_gntref);
+    if (!is_ok(s))
+        goto abort;
 
-        node = "feature-rx-notify";
-        s = xenstore_sync_printf(tx_id, xd->frontend, node, "%d", 1);
-        if (!is_ok(s))
-            goto abort;
+    node = "request-rx-copy";
+    s = xenstore_sync_printf(tx_id, xd->frontend, node, "%d", 1);
+    if (!is_ok(s))
+        goto abort;
 
-        node = "event-channel";
-        s = xenstore_sync_printf(tx_id, xd->frontend, node, "%d", xd->evtchn);
-        if (!is_ok(s))
-            goto abort;
+    node = "feature-rx-notify";
+    s = xenstore_sync_printf(tx_id, xd->frontend, node, "%d", 1);
+    if (!is_ok(s))
+        goto abort;
 
-        s = xenstore_transaction_end(tx_id, false);
-        if (!is_ok(s)) {
-            /* XXX check for EAGAIN */
-            goto abort;
+    node = "event-channel";
+    s = xenstore_sync_printf(tx_id, xd->frontend, node, "%d", xd->evtchn);
+    if (!is_ok(s))
+        goto abort;
+
+    node = "transaction end";
+    s = xenstore_transaction_end(tx_id, false);
+    if (!is_ok(s)) {
+        value v = table_find(s, "errno");
+        if (v) {
+            if (!runtime_strcmp("EAGAIN", buffer_ref((buffer)v, 0))) {
+                deallocate_tuple(s);
+                if (retries-- == 0) {
+                    s = timm("result", "%s failed: transaction end returned EAGAIN after %d tries",
+                             __func__, XENNET_INFORM_BACKEND_RETRIES);
+                    goto abort;
+                }
+                goto again;
+            }
         }
-    } while (again);
+        goto abort;
+    }
     return s;
   abort:
     xenstore_transaction_end(tx_id, true);
-    return timm("result", "%s: transaction aborted; interim error \"%v\""
-                " while writing to node \"%s\"", __func__, s, node);
+    return timm("result", "%s: transaction aborted; step \"%s\" failed with error \"%v\"", __func__, node, s);
 }
 
 static inline u32 xennet_form_tx_id(xennet_tx_buf txb, int pageidx)

--- a/src/xen/xennet.c
+++ b/src/xen/xennet.c
@@ -149,7 +149,7 @@ static status xennet_inform_backend(xennet_dev xd)
     node = "transaction end";
     s = xenstore_transaction_end(tx_id, false);
     if (!is_ok(s)) {
-        value v = table_find(s, "errno");
+        value v = table_find(s, sym(errno));
         if (v) {
             if (!runtime_strcmp("EAGAIN", buffer_ref((buffer)v, 0))) {
                 deallocate_tuple(s);


### PR DESCRIPTION
An XS_TRANSACTION_END request may return an XS_ERROR with a value of EAGAIN, indicating that the transaction should be retried. This amends xennet_inform_backend to retry some number of times after receiving EAGAIN.
