### PR TITLE
new closures

### DIFF
--- a/contgen/contgen.c
+++ b/contgen/contgen.c
@@ -78,6 +78,8 @@ void cblock()
     p("struct _closure_##_name{|");
     p("  _rettype (*_apply)(void *~);|", ", _r%");
     p("  char *name;|");
+    p("  heap h;|");
+    p("  bytes size;|");
     for (int i = 0; i < nleft ; i++)  p("  _l% l%;|", i, i);
     p("};|");
 
@@ -87,9 +89,11 @@ void cblock()
     p("  return _name(^~);|", "@n->l%", "@r%");
     p("}|");
 
-    p("static _rettype (**_fill_##_name(struct _closure_##_name* n^))(void *~){|", ", _l% l%", ", _r%");
+    p("static _rettype (**_fill_##_name(heap h, struct _closure_##_name* n, bytes s^))(void *~){|", ", _l% l%", ", _r%");
     p("  n->_apply = _apply_##_name;|");
     p("  n->name = #_name;|");
+    p("  n->h = h;|");
+    p("  n->size = s;|");
     for (int i = 0; i < nleft ; i++)  p("  n->l% = l%;|", i, i);
     p("  return (_rettype (**)(void *~))n;|", ", _r%");
     p("}\n\n");

--- a/contgen/contgen.c
+++ b/contgen/contgen.c
@@ -31,7 +31,7 @@ void pi(char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    for (char *i = fmt; *i ; i ++) {
+    for (char *i = fmt; *i ; i++) {
         int count = nright;
         switch (*i) {
         case '@':
@@ -52,10 +52,11 @@ void pi(char *fmt, ...)
         case '~':
             {
                 char *subformat = va_arg(ap, char *);
-                for (int i = 0 ; i< count; i++)  {
+                if (count == 0)
+                    break;
+                for (int i = 0 ; i < count; i++)
                     pi(subformat, i, i);
-                    twiggy = 1;
-                }
+                twiggy = 1;
                 break;
             }
         case '|':
@@ -72,30 +73,25 @@ void pi(char *fmt, ...)
 
 void cblock()
 {
-    p("#define CLOSURE_%_%(_name, _rettype^~)|", nleft, nright, ", _l%", ", _r%");
-    p("_rettype _name(^~);|", "@_l%", "@_r%");
+    p("#define CLOSURE_%_%(_rettype, _name^~)|", nleft, nright, ", _lt%, _ln%", ", _rt%, _rn%");
+    p("struct _closure_##_name;|");
+    p("static _rettype _name(struct _closure_##_name *~);|", ", _rt%");
 
-    p("struct _closure_##_name{|");
-    p("  _rettype (*_apply)(void *~);|", ", _r%");
+    p("struct _closure_##_name {|");
+    p("  _rettype (*_apply)(struct _closure_##_name *~);|", ", _rt%");
     p("  struct _closure_common c;|");
-    for (int i = 0; i < nleft ; i++)  p("  _l% l%;|", i, i);
+    for (int i = 0; i < nleft ; i++)  p("  _lt% _ln%;|", i, i);
     p("};|");
 
-    p("static _rettype _apply_##_name(void *z~){|", ", _r% r%");
-    if (nleft)
-        p("  struct _closure_##_name *n = z; |");
-    p("  _apply_setup(z);|");
-    p("  return _name(^~);|", "@n->l%", "@r%");
-    p("}|");
-
-    p("static _rettype (**_fill_##_name(heap h, struct _closure_##_name* n, bytes s^))(void *~){|", ", _l% l%", ", _r%");
-    p("  n->_apply = _apply_##_name;|");
+    p("static _rettype (**_fill_##_name(heap h, struct _closure_##_name* n, bytes s^))(void *~) {|", ", _lt% l%", ", _rt%");
+    p("  n->_apply = _name;|");
     p("  n->c.name = #_name;|");
     p("  n->c.h = h;|");
     p("  n->c.size = s;|");
-    for (int i = 0; i < nleft ; i++)  p("  n->l% = l%;|", i, i);
-    p("  return (_rettype (**)(void *~))n;|", ", _r%");
-    p("}\n\n");
+    for (int i = 0; i < nleft ; i++)  p("  n->_ln% = l%;|", i, i);
+    p("  return (_rettype (**)(void *~))n;|", ", _rt%");
+    p("}|");
+    p("static _rettype _name(struct _closure_##_name *__self~)\n\n\n", ", _rt% _rn%");
 }
 
 int main(int argc, char **argv)

--- a/contgen/contgen.c
+++ b/contgen/contgen.c
@@ -78,16 +78,16 @@ void cblock()
     p("static _rettype _name(struct _closure_##_name *~);|", ", _rt%");
 
     p("struct _closure_##_name {|");
-    p("  _rettype (*_apply)(struct _closure_##_name *~);|", ", _rt%");
-    p("  struct _closure_common c;|");
+    p("  _rettype (*__apply)(struct _closure_##_name *~);|", ", _rt%");
+    p("  struct _closure_common __c;|");
     for (int i = 0; i < nleft ; i++)  p("  _lt% _ln%;|", i, i);
     p("};|");
 
     p("static _rettype (**_fill_##_name(heap h, struct _closure_##_name* n, bytes s^))(void *~) {|", ", _lt% l%", ", _rt%");
-    p("  n->_apply = _name;|");
-    p("  n->c.name = #_name;|");
-    p("  n->c.h = h;|");
-    p("  n->c.size = s;|");
+    p("  n->__apply = _name;|");
+    p("  n->__c.name = #_name;|");
+    p("  n->__c.h = h;|");
+    p("  n->__c.size = s;|");
     for (int i = 0; i < nleft ; i++)  p("  n->_ln% = l%;|", i, i);
     p("  return (_rettype (**)(void *~))n;|", ", _rt%");
     p("}|");

--- a/contgen/contgen.c
+++ b/contgen/contgen.c
@@ -76,24 +76,23 @@ void cblock()
     p("_rettype _name(^~);|", "@_l%", "@_r%");
 
     p("struct _closure_##_name{|");
+    p("  struct _closure_common c;|");
     p("  _rettype (*_apply)(void *~);|", ", _r%");
-    p("  char *name;|");
-    p("  heap h;|");
-    p("  bytes size;|");
     for (int i = 0; i < nleft ; i++)  p("  _l% l%;|", i, i);
     p("};|");
 
     p("static _rettype _apply_##_name(void *z~){|", ", _r% r%");
     if (nleft)
         p("  struct _closure_##_name *n = z; |");
+    p("  _apply_setup(z);|");
     p("  return _name(^~);|", "@n->l%", "@r%");
     p("}|");
 
     p("static _rettype (**_fill_##_name(heap h, struct _closure_##_name* n, bytes s^))(void *~){|", ", _l% l%", ", _r%");
+    p("  n->c.name = #_name;|");
+    p("  n->c.h = h;|");
+    p("  n->c.size = s;|");
     p("  n->_apply = _apply_##_name;|");
-    p("  n->name = #_name;|");
-    p("  n->h = h;|");
-    p("  n->size = s;|");
     for (int i = 0; i < nleft ; i++)  p("  n->l% = l%;|", i, i);
     p("  return (_rettype (**)(void *~))n;|", ", _r%");
     p("}\n\n");

--- a/contgen/contgen.c
+++ b/contgen/contgen.c
@@ -76,8 +76,8 @@ void cblock()
     p("_rettype _name(^~);|", "@_l%", "@_r%");
 
     p("struct _closure_##_name{|");
-    p("  struct _closure_common c;|");
     p("  _rettype (*_apply)(void *~);|", ", _r%");
+    p("  struct _closure_common c;|");
     for (int i = 0; i < nleft ; i++)  p("  _l% l%;|", i, i);
     p("};|");
 
@@ -89,10 +89,10 @@ void cblock()
     p("}|");
 
     p("static _rettype (**_fill_##_name(heap h, struct _closure_##_name* n, bytes s^))(void *~){|", ", _l% l%", ", _r%");
+    p("  n->_apply = _apply_##_name;|");
     p("  n->c.name = #_name;|");
     p("  n->c.h = h;|");
     p("  n->c.size = s;|");
-    p("  n->_apply = _apply_##_name;|");
     for (int i = 0; i < nleft ; i++)  p("  n->l% = l%;|", i, i);
     p("  return (_rettype (**)(void *~))n;|", ", _r%");
     p("}\n\n");

--- a/src/drivers/ata-pci.c
+++ b/src/drivers/ata-pci.c
@@ -73,11 +73,11 @@ static struct ata *ata_pci_alloc(heap general, pci_dev d)
     return dev;
 }
 
-CLOSURE_2_3(ata_io_cmd, void, void *, int, void *, range, status_handler);
-
-static CLOSURE_2_1(ata_pci_probe, boolean, heap, storage_attach, pci_dev);
-static boolean ata_pci_probe(heap general, storage_attach a, pci_dev d)
+closure_function(2, 1, boolean, ata_pci_probe,
+                 heap, general, storage_attach, a,
+                 pci_dev, d)
 {
+    heap general = bound(general);
     if (pci_get_class(d) != PCIC_STORAGE || pci_get_subclass(d) != PCIS_STORAGE_IDE)
         return false;
 
@@ -88,9 +88,9 @@ static boolean ata_pci_probe(heap general, storage_attach a, pci_dev d)
     }
 
     // attach
-    block_io in = closure(general, ata_io_cmd, dev, ATA_READ48);
-    block_io out = closure(general, ata_io_cmd, dev, ATA_WRITE48);
-    apply(a, in, out, ata_get_capacity(dev));
+    block_io in = create_ata_io(general, dev, ATA_READ48);
+    block_io out = create_ata_io(general, dev, ATA_WRITE48);
+    apply(bound(a), in, out, ata_get_capacity(dev));
     return true;
 }
 

--- a/src/drivers/ata.c
+++ b/src/drivers/ata.c
@@ -183,9 +183,9 @@ static int ata_io_loop(struct ata *dev, int cmd, void *buf, u64 nsectors)
     }
 }
 
-void ata_io_cmd(void *_dev, int cmd, void *buf, range blocks, status_handler s)
+void ata_io_cmd(void * _dev, int cmd, void * buf, range blocks, status_handler s)
 {
-    struct ata *dev = (struct ata *) _dev;
+    struct ata *dev = (struct ata *)_dev;
     const char *err;
 
     u64 lba = blocks.start;
@@ -231,6 +231,18 @@ timeout:
     err = "ata_io_cmd: device timeout";
     msg_err("%s\n", err);
     apply(s, timm("result", "%s", err));
+}
+
+closure_function(2, 3, void, ata_io_cmd_cfn,
+                 void *, _dev, int, cmd,
+                 void *, buf, range, blocks, status_handler, s)
+{
+    ata_io_cmd(bound(_dev), bound(cmd), buf, blocks, s);
+}
+
+block_io create_ata_io(heap h, void * dev, int cmd)
+{
+    return closure(h, ata_io_cmd_cfn, dev, cmd);
 }
 
 struct ata *ata_alloc(heap general)

--- a/src/drivers/ata.h
+++ b/src/drivers/ata.h
@@ -92,3 +92,4 @@ u64 ata_get_capacity(struct ata *);
 #define ATA_SET_MAX_ADDRESS             0xf9    /* set max address */
 
 void ata_io_cmd(void *dev, int cmd, void *buf, range blocks, status_handler s);
+block_io create_ata_io(heap h, void * dev, int cmd);

--- a/src/drivers/console.c
+++ b/src/drivers/console.c
@@ -25,8 +25,8 @@ void console_write(char *s, bytes count)
     }
 }
 
-static CLOSURE_0_1(attach_console, void, struct console_driver *)
-static void attach_console(struct console_driver *d)
+closure_function(0, 1, void, attach_console,
+                 struct console_driver *, d)
 {
     struct console_driver **pd;
 

--- a/src/drivers/vga.c
+++ b/src/drivers/vga.c
@@ -171,20 +171,21 @@ static void vga_console_write(void *_d, char *s, bytes count)
     vga_set_cursor(d, d->cur_x, d->cur_y);
 }
 
-static CLOSURE_3_1(vga_pci_probe, boolean, heap, heap, console_attach, pci_dev);
-static boolean vga_pci_probe(heap general, heap pages, console_attach a, pci_dev _d)
+closure_function(3, 1, boolean, vga_pci_probe,
+                 heap, general, heap, pages, console_attach, a,
+                 pci_dev, _d)
 {
     if (pci_get_class(_d) != PCIC_DISPLAY)
         return false;
 
     vga_debug("%s: VGA PCI\n", __func__);
-    struct vga_console_driver *d = allocate(general, sizeof(*d));
+    struct vga_console_driver *d = allocate(bound(general), sizeof(*d));
     assert(d != INVALID_ADDRESS);
     d->c.write = vga_console_write;
     d->crtc_addr = 0x3d4;
     d->buffer = pointer_from_u64(VGA_BUF_BASE);
     d->buffer_size = VGA_BUF_SIZE / sizeof(*d->buffer);
-    map(u64_from_pointer(d->buffer), VGA_BUF_BASE, VGA_BUF_SIZE, PAGE_DEV_FLAGS, pages);
+    map(u64_from_pointer(d->buffer), VGA_BUF_BASE, VGA_BUF_SIZE, PAGE_DEV_FLAGS, bound(pages));
     // assume VGA mode 3 upon initialization
     d->width = 80;
     d->height = 25;
@@ -195,7 +196,7 @@ static boolean vga_pci_probe(heap general, heap pages, console_attach a, pci_dev
     vga_debug("%s: max buffer lines %d\n", __func__, d->max_lines);
     vga_set_offset(d, d->y_offset);
 
-    apply(a, &d->c);
+    apply(bound(a), &d->c);
     return true;
 }
 

--- a/src/gdb/gdbstub.c
+++ b/src/gdb/gdbstub.c
@@ -12,8 +12,6 @@ int computeSignal (int exceptionVector)
 
 static int sigval;
 
-static CLOSURE_1_1(gdb_handle_exception, context, gdb, context);
-
 static void reset_parser(gdb g)
 {
     g->checksum =0;
@@ -23,8 +21,11 @@ static void reset_parser(gdb g)
     g->sent_checksum = -1;
 }
 
-static context gdb_handle_exception (gdb g, context frame)
+closure_function(1, 1, context, gdb_handle_exception,
+                 gdb, g,
+                 context, frame)
 {
+    gdb g = bound(g);
     u64 exceptionVector = frame[FRAME_VECTOR];
     //     rprintf ("gdb exception: %ld %p [%p %p] %p %p\n", exceptionVector, g, frame, g->t->frame, frame[FRAME_RIP], *(u64 *)frame[FRAME_RIP]);
     sigval = computeSignal(exceptionVector);
@@ -307,9 +308,11 @@ static boolean handle_request(gdb g, buffer b, buffer output)
 
 #define ASCII_CONTROL_C 0x03
 // not completely reassembling (meaning we dont handle fragments?)
-static CLOSURE_1_1(gdbserver_input, void, gdb, buffer);
-static void gdbserver_input(gdb g, buffer b)
+closure_function(1, 1, void, gdbserver_input,
+                 gdb, g,
+                 buffer, b)
 {
+    gdb g = bound(g);
     char ch = '0';
     /* wait around for the start character, ignore all other characters */
     while (buffer_length(b) && ((ch = get_char(b)) != '$')) {

--- a/src/gdb/gdbtcp.c
+++ b/src/gdb/gdbtcp.c
@@ -5,13 +5,14 @@ typedef struct tcpgdb{
     struct tcp_pcb *p;
 } *tcpgdb;
     
-static CLOSURE_1_1(gdb_send, void, tcpgdb, buffer);
-static void gdb_send(tcpgdb g, buffer b)
+closure_function(1, 1, void, gdb_send,
+                 tcpgdb, g,
+                 buffer, b)
 {
     //    u64 len = tcp_sndbuf(g->pcb);
     // flags can force a stack copy or toggle push
     // pool?
-    tcp_write(g->p, buffer_ref(b, 0), buffer_length(b), TCP_WRITE_FLAG_COPY);
+    tcp_write(bound(g)->p, buffer_ref(b, 0), buffer_length(b), TCP_WRITE_FLAG_COPY);
 }
 
 err_t gdb_input(void *z, struct tcp_pcb *pcb, struct pbuf *p, err_t err)

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -27,13 +27,13 @@ static struct net_lwip_timer net_lwip_timers[] = {
 
 /* We could dispatch lwip timer callbacks as thunks, but breaking it
    out here gives us a single point of entry for debugging. */
-static CLOSURE_2_0(dispatch_lwip_timer, void, lwip_cyclic_timer_handler, const char *);
-void dispatch_lwip_timer(lwip_cyclic_timer_handler handler, const char * name)
+closure_function(2, 0, void, dispatch_lwip_timer,
+                 lwip_cyclic_timer_handler, handler, const char *, name)
 {
 #ifdef LWIP_DEBUG
-    lwip_debug("dispatching timer for %s\n", name);
+    lwip_debug("dispatching timer for %s\n", bound(name));
 #endif
-    handler();
+    bound(handler)();
 }
 
 void sys_timeouts_init(void)

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -136,9 +136,10 @@ typedef struct sock {
 #define net_debug(x, ...)
 #endif
 
-static CLOSURE_1_0(socket_events, u32, sock);
-static inline u32 socket_events(sock s)
+closure_function(1, 0, u32, socket_events,
+                 sock, s)
 {
+    sock s = bound(s);
     boolean in = queue_length(s->incoming) > 0;
 
     /* XXX socket state isn't giving a complete picture; needs to specify
@@ -161,7 +162,7 @@ static inline u32 socket_events(sock s)
 
 static inline void notify_sock(sock s)
 {
-    u32 events = socket_events(s);
+    u32 events = apply(s->f.events);
     net_debug("sock %d, events %lx\n", s->fd, events);
     notify_dispatch(s->f.ns, events);
 }
@@ -265,14 +266,11 @@ struct udp_entry {
     u16 rport;
 };
 
-/* called with corresponding blockq lock held */
-static CLOSURE_7_2(sock_read_bh, sysreturn,
-                   sock, thread, void *, u64, struct sockaddr *, socklen_t *, io_completion,
-                   boolean, boolean);
-static sysreturn sock_read_bh(sock s, thread t, void *dest, u64 length,
-                              struct sockaddr *src_addr, socklen_t *addrlen,
-                              io_completion completion, boolean blocked, boolean nullify)
+static sysreturn sock_read_bh_internal(sock s, thread t, void * dest, u64 length, struct sockaddr * src_addr,
+                                       socklen_t * addrlen, io_completion completion,
+                                       boolean blocked, boolean nullify)
 {
+    /* called with corresponding blockq lock held */
     sysreturn rv = 0;
     err_t err = get_lwip_error(s);
     net_debug("sock %d, thread %ld, dest %p, len %ld, blocked %d, lwip err %d\n",
@@ -369,12 +367,15 @@ static sysreturn sock_read_bh(sock s, thread t, void *dest, u64 length,
     return rv;
 }
 
-static CLOSURE_5_2(
-        recvmsg_complete, void,
-        sock, struct msghdr *, void *, u64, boolean,
-        thread, sysreturn);
-static void recvmsg_complete(sock s, struct msghdr *msg, void *dest, u64 length,
-        boolean blocked, thread t, sysreturn rv)
+closure_function(7, 2, sysreturn, sock_read_bh,
+                 sock, s, thread, t, void *, dest, u64, length, struct sockaddr *, src_addr, socklen_t *, addrlen, io_completion, completion,
+                 boolean, blocked, boolean, nullify)
+{
+    return sock_read_bh_internal(bound(s), bound(t), bound(dest), bound(length), bound(src_addr), bound(addrlen), bound(completion), blocked, nullify);
+}
+
+static void recvmsg_complete_internal(sock s, struct msghdr * msg, void * dest, u64 length, boolean blocked,
+                                      thread t, sysreturn rv)
 {
     s64 offset = 0;
     int iv = 0;
@@ -394,26 +395,28 @@ static void recvmsg_complete(sock s, struct msghdr *msg, void *dest, u64 length,
         thread_wakeup(t);
 }
 
-static CLOSURE_5_2(recvmsg_bh, sysreturn, sock, thread, void *, u64,
-                   struct msghdr *, boolean, boolean);
-static sysreturn recvmsg_bh(sock s, thread t, void *dest, u64 length,
-                            struct msghdr *msg, boolean blocked, boolean nullify)
+closure_function(5, 2, void, recvmsg_complete,
+                 sock, s, struct msghdr *, msg, void *, dest, u64, length, boolean, blocked,
+                 thread, t, sysreturn, rv)
 {
-    io_completion completion = closure(s->h, recvmsg_complete, s, msg, dest,
-                                       length, true);
-    return sock_read_bh(s, t, dest, length, msg->msg_name,
-                        &msg->msg_namelen, completion, blocked, nullify);
+    recvmsg_complete_internal(bound(s), bound(msg), bound(dest), bound(length), bound(blocked), t, rv);
 }
 
-static CLOSURE_0_2(syscall_io_complete, void,
-        thread, sysreturn);
-
-static CLOSURE_1_6(socket_read, sysreturn,
-        sock,
-        void *, u64, u64, thread, boolean, io_completion);
-static sysreturn socket_read(sock s, void *dest, u64 length, u64 offset,
-        thread t, boolean bh, io_completion completion)
+closure_function(5, 2, sysreturn, recvmsg_bh,
+                 sock, s, thread, t, void *, dest, u64, length, struct msghdr *, msg,
+                 boolean, blocked, boolean, nullify)
 {
+    io_completion completion = closure(bound(s)->h, recvmsg_complete, bound(s), bound(msg), bound(dest),
+                                       bound(length), true);
+    return sock_read_bh_internal(bound(s), bound(t), bound(dest), bound(length), bound(msg)->msg_name,
+                                 &bound(msg)->msg_namelen, completion, blocked, nullify);
+}
+
+closure_function(1, 6, sysreturn, socket_read,
+                 sock, s,
+                 void *, dest, u64, length, u64, offset, thread, t, boolean, bh, io_completion, completion)
+{
+    sock s = bound(s);
     net_debug("sock %d, type %d, thread %ld, dest %p, length %ld, offset %ld\n",
 	      s->fd, s->type, t->tid, dest, length, offset);
     if (s->type == SOCK_STREAM && s->info.tcp.state != TCP_SOCK_OPEN)
@@ -424,10 +427,8 @@ static sysreturn socket_read(sock s, void *dest, u64 length, u64 offset,
     return blockq_check(s->rxbq, t, ba, bh);
 }
 
-static CLOSURE_5_2(socket_write_tcp_bh, sysreturn, sock, thread, void *, u64,
-                   io_completion, boolean, boolean);
-static sysreturn socket_write_tcp_bh(sock s, thread t, void * buf, u64 remain, io_completion completion,
-                                     boolean blocked, boolean nullify)
+static sysreturn socket_write_tcp_bh_internal(sock s, thread t, void * buf, u64 remain, io_completion completion,
+                                              boolean blocked, boolean nullify)
 {
     sysreturn rv = 0;
     err_t err = get_lwip_error(s);
@@ -509,6 +510,14 @@ static sysreturn socket_write_tcp_bh(sock s, thread t, void * buf, u64 remain, i
     return rv;
 }
 
+closure_function(5, 2, sysreturn, socket_write_tcp_bh,
+                 sock, s, thread, t, void *, buf, u64, remain, io_completion, completion,
+                 boolean, blocked, boolean, nullify)
+{
+    return socket_write_tcp_bh_internal(bound(s), bound(t), bound(buf), bound(remain), bound(completion),
+                                        blocked, nullify);
+}
+
 static sysreturn socket_write_udp(sock s, void *source, u64 length)
 {
     err_t err = ERR_OK;
@@ -531,7 +540,7 @@ static sysreturn socket_write_udp(sock s, void *source, u64 length)
 }
 
 static sysreturn socket_write_internal(sock s, void *source, u64 length,
-        thread t, boolean bh, io_completion completion)
+                                       thread t, boolean bh, io_completion completion)
 {
     sysreturn rv;
 
@@ -543,7 +552,7 @@ static sysreturn socket_write_internal(sock s, void *source, u64 length,
             goto out;
         }
         blockq_action ba = closure(s->h, socket_write_tcp_bh, s, t,
-                source, length, completion);
+                                   source, length, completion);
         rv = blockq_check(s->txbq, t, ba, bh);
     } else if (s->type == SOCK_DGRAM) {
         rv = socket_write_udp(s, source, length);
@@ -556,20 +565,21 @@ out:
     return rv;
 }
 
-static CLOSURE_1_6(socket_write, sysreturn,
-        sock,
-        void *, u64, u64, thread, boolean, io_completion);
-static sysreturn socket_write(sock s, void *source, u64 length, u64 offset,
-        thread t, boolean bh, io_completion completion)
+closure_function(1, 6, sysreturn, socket_write,
+                 sock, s,
+                 void *, source, u64, length, u64, offset, thread, t, boolean, bh, io_completion, completion)
 {
+    sock s = bound(s);
     net_debug("sock %d, type %d, thread %ld, source %p, length %ld, offset %ld\n",
-	      s->fd, s->type, current->tid, source, length, offset);
+	      s->fd, s->type, t->tid, source, length, offset);
     return socket_write_internal(s, source, length, t, bh, completion);
 }
 
-static CLOSURE_1_2(socket_ioctl, sysreturn, sock, unsigned long, vlist);
-static sysreturn socket_ioctl(sock s, unsigned long request, vlist ap)
+closure_function(1, 2, sysreturn, socket_ioctl,
+                 sock, s,
+                 unsigned long, request, vlist, ap)
 {
+    sock s = bound(s);
     net_debug("sock %d, request 0x%x\n", s->fd, request);
     switch (request) {
     case SIOCGIFCONF: {
@@ -640,9 +650,10 @@ static sysreturn socket_ioctl(sock s, unsigned long request, vlist ap)
 
 #define SOCK_QUEUE_LEN 128
 
-static CLOSURE_1_0(socket_close, sysreturn, sock);
-static sysreturn socket_close(sock s)
+closure_function(1, 0, sysreturn, socket_close,
+                 sock, s)
 {
+    sock s = bound(s);
     net_debug("sock %d, type %d\n", s->fd, s->type);
     switch (s->type) {
     case SOCK_STREAM:
@@ -965,9 +976,11 @@ static err_t lwip_tcp_sent(void * arg, struct tcp_pcb * pcb, u16 len)
     return ERR_OK;
 }
 
-static CLOSURE_1_1(connect_tcp_bh, void, thread, err_t);
-static void connect_tcp_bh(thread t, err_t lwip_status)
+closure_function(1, 1, void, connect_tcp_bh,
+                 thread, t,
+                 err_t, lwip_status)
 {
+    thread t = bound(t);
     net_debug("thread %ld, lwip_status %d\n", t->tid, lwip_status);
     set_syscall_return(t, lwip_to_errno(lwip_status));
     thread_wakeup(t);
@@ -1103,8 +1116,7 @@ sysreturn sendto(int sockfd, void * buf, u64 len, int flags,
     if (rv < 0) {
         return set_syscall_return(current, rv);
     }
-    io_completion completion = closure(s->h, syscall_io_complete);
-    return socket_write_internal(s, buf, len, current, false, completion);
+    return socket_write_internal(s, buf, len, current, false, syscall_io_complete);
 }
 
 static sysreturn sendmsg_prepare(sock s, const struct msghdr *msg, int flags,
@@ -1138,17 +1150,20 @@ static sysreturn sendmsg_prepare(sock s, const struct msghdr *msg, int flags,
     return *len;
 }
 
-static CLOSURE_4_2(
-        sendmsg_complete, void,
-        sock, void *, u64, boolean,
-        thread, sysreturn);
-static void sendmsg_complete(sock s, void *buf, u64 len, boolean blocked,
-        thread t, sysreturn rv)
+static void sendmsg_complete_internal(sock s, void * buf, u64 len, boolean blocked,
+                                      thread t, sysreturn rv)
 {
     deallocate(s->h, buf, len);
     set_syscall_return(t, rv);
     if (blocked)
         thread_wakeup(t);
+}
+
+closure_function(4, 2, void, sendmsg_complete,
+                 sock, s, void *, buf, u64, len, boolean, blocked,
+                 thread, t, sysreturn, rv)
+{
+    sendmsg_complete_internal(bound(s), bound(buf), bound(len), bound(blocked), t, rv);
 }
 
 sysreturn sendmsg(int sockfd, const struct msghdr *msg, int flags)
@@ -1166,28 +1181,30 @@ sysreturn sendmsg(int sockfd, const struct msghdr *msg, int flags)
     io_completion completion = closure(s->h, sendmsg_complete, s, buf, len,
             true);
     rv = socket_write_internal(s, buf, len, current, false, completion);
-    sendmsg_complete(s, buf, len, false, current, rv);
+    sendmsg_complete_internal(s, buf, len, false, current, rv);
     return rv;
 }
 
-static CLOSURE_3_2(
-        sendmmsg_buf_complete, void,
-        sock, void *, u64,
-        thread, sysreturn);
-static void sendmmsg_buf_complete(sock s, void *buf, u64 len, thread t,
-        sysreturn rv)
+closure_function(3, 2, void, sendmmsg_buf_complete,
+                 sock, s, void *, buf, u64, len,
+                 thread, t, sysreturn, rv)
 {
-    deallocate(s->h, buf, len);
+    deallocate(bound(s)->h, bound(buf), bound(len));
 }
 
-static CLOSURE_7_2(sendmmsg_tcp_bh, sysreturn, sock, thread, void *, u64, int, struct mmsghdr *, unsigned int,
-                   boolean, boolean);
-static sysreturn sendmmsg_tcp_bh(sock s, thread t, void *buf, u64 len, int flags, struct mmsghdr *msgvec, unsigned int vlen,
-                                 boolean blocked, boolean nullify)
+closure_function(7, 2, sysreturn, sendmmsg_tcp_bh,
+                 sock, s, thread, t, void *, buf, u64, len, int, flags, struct mmsghdr *, msgvec, unsigned int, vlen,
+                 boolean, blocked, boolean, nullify)
 {
+    sock s = bound(s);
+    thread t = bound(t);
+    void * buf = bound(buf);
+    u64 len = bound(len);
+    struct mmsghdr * msgvec = bound(msgvec);
+
     io_completion completion = closure(s->h, sendmmsg_buf_complete, s, buf,
-            len);
-    sysreturn rv = socket_write_tcp_bh(s, t, buf, len, completion, true, nullify);
+                                       len);
+    sysreturn rv = socket_write_tcp_bh_internal(s, t, buf, len, completion, true, nullify);
 
     while (true) {
         if (rv == infinity) {
@@ -1200,13 +1217,13 @@ static sysreturn sendmmsg_tcp_bh(sock s, thread t, void *buf, u64 len, int flags
             break;
         }
         msgvec[s->msg_count++].msg_len = rv;
-        if (s->msg_count == vlen) {
+        if (s->msg_count == bound(vlen)) {
             break;
         }
-        rv = sendmsg_prepare(s, &msgvec[s->msg_count].msg_hdr, flags, &buf, &len);
+        rv = sendmsg_prepare(s, &msgvec[s->msg_count].msg_hdr, bound(flags), &buf, &len);
         if (rv > 0) {
             completion = closure(s->h, sendmmsg_buf_complete, s, buf, len);
-            rv = socket_write_tcp_bh(s, t, buf, len, completion, true, nullify);
+            rv = socket_write_tcp_bh_internal(s, t, buf, len, completion, true, nullify);
         }
     }
 
@@ -1275,9 +1292,8 @@ sysreturn recvfrom(int sockfd, void * buf, u64 len, int flags,
     if (len == 0)
         return 0;
 
-    io_completion completion = closure(s->h, syscall_io_complete);
     blockq_action ba = closure(s->h, sock_read_bh, s, current, buf, len,
-            src_addr, addrlen, completion);
+                               src_addr, addrlen, syscall_io_complete);
     return blockq_check(s->rxbq, current, ba, false);
 }
 
@@ -1305,7 +1321,7 @@ sysreturn recvmsg(int sockfd, struct msghdr *msg, int flags)
     blockq_action ba = closure(s->h, recvmsg_bh, s, current, buf, total_len,
             msg);
     sysreturn rv = blockq_check(s->rxbq, current, ba, false);
-    recvmsg_complete(s, msg, buf, total_len, false, current, rv);
+    recvmsg_complete_internal(s, msg, buf, total_len, false, current, rv);
     return rv;
 }
 
@@ -1368,9 +1384,12 @@ sysreturn listen(int sockfd, int backlog)
     return 0;    
 }
 
-static CLOSURE_5_2(accept_bh, sysreturn, sock, thread, struct sockaddr *, socklen_t *, int, boolean, boolean);
-static sysreturn accept_bh(sock s, thread t, struct sockaddr *addr, socklen_t *addrlen, int flags, boolean blocked, boolean nullify)
+closure_function(5, 2, sysreturn, accept_bh,
+                 sock, s, thread, t, struct sockaddr *, addr, socklen_t *, addrlen, int, flags,
+                 boolean, blocked, boolean, nullify)
 {
+    sock s = bound(s);
+    thread t = bound(t);
     sysreturn rv = 0;
 
     if (nullify) {
@@ -1397,11 +1416,11 @@ static sysreturn accept_bh(sock s, thread t, struct sockaddr *addr, socklen_t *a
 
     net_debug("child sock %d\n", sn->fd);
 
-    sn->f.flags = flags;
-    if (addr)
-        remote_sockaddr_in(sn, (struct sockaddr_in *)addr);
-    if (addrlen)
-        *addrlen = sizeof(struct sockaddr);
+    sn->f.flags = bound(flags);
+    if (bound(addr))
+        remote_sockaddr_in(sn, (struct sockaddr_in *)bound(addr));
+    if (bound(addrlen))
+        *bound(addrlen) = sizeof(struct sockaddr);
 
     /* report falling edge in case of edge trigger */
     if (queue_length(s->incoming) == 0)

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -7,9 +7,11 @@
 #define __closure(__h, __p, __s, __name, ...)    \
     _fill_##__name(__h, __p, __s, ##__VA_ARGS__)
 
-#define closure(__h, __name, ...)\
-    __closure(__h, allocate(__h, sizeof(struct _closure_##__name)), \
-              sizeof(struct _closure_##__name), __name, ##__VA_ARGS__)
+#define closure(__h, __name, ...) ({                                    \
+    struct _closure_##__name * __n = allocate(__h, sizeof(struct _closure_##__name)); \
+    (__n == INVALID_ADDRESS ? INVALID_ADDRESS :                         \
+        __closure(__h, __n,                                             \
+                  sizeof(struct _closure_##__name), __name, ##__VA_ARGS__));})
 
 #define stack_closure(__name, ...)\
     __closure(0, stack_allocate(sizeof(struct _closure_##__name)), \
@@ -22,7 +24,7 @@ struct _closure_common {
 };
 
 #define bound(name) (__self->name)
-#define __closure_name(nl, nr) CLOSURE_ ## nl ## _ ## nr
-#define define_closure(nl, nr, ...) __closure_name(nl, nr)(__VA_ARGS__)
+#define __closure_define(nl, nr) CLOSURE_ ## nl ## _ ## nr
+#define closure_function(nl, nr, ...) __closure_define(nl, nr)(__VA_ARGS__)
 
 #include <closure_templates.h>

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -21,7 +21,7 @@ struct _closure_common {
     bytes size;
 };
 
-#define upvalue(name) (__self->name)
+#define bound(name) (__self->name)
 #define __closure_name(nl, nr) CLOSURE_ ## nl ## _ ## nr
 #define define_closure(nl, nr, ...) __closure_name(nl, nr)(__VA_ARGS__)
 

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -15,4 +15,22 @@
     __closure(0, stack_allocate(sizeof(struct _closure_##__name)), \
               sizeof(struct _closure_##__name), __name, ##__VA_ARGS__)
 
+void _apply_dealloc(void);
+
+#define _apply_setup(z) \
+    asm volatile("push %0" :: "r" (z)); \
+    asm volatile("push %0" :: "r" (&_apply_dealloc));
+
+struct _closure_common {
+    char *name;
+    heap h;
+    bytes size;
+};
+
+#define return_without_dealloc                   \
+    u64 discard0, discard1;                      \
+    asm volatile("pop %0" : "=r" (discard0));    \
+    asm volatile("pop %0" : "=r" (discard1));    \
+    return
+
 #include <closure_templates.h>

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -18,8 +18,7 @@
 void _apply_dealloc(void);
 
 #define _apply_setup(z) \
-    asm volatile("push %0" :: "r" (z)); \
-    asm volatile("push %0" :: "r" (&_apply_dealloc));
+    asm volatile("push %0; push %1" :: "r" (z), "r" (&_apply_dealloc));
 
 struct _closure_common {
     char *name;
@@ -27,10 +26,9 @@ struct _closure_common {
     bytes size;
 };
 
-#define return_without_dealloc                   \
-    u64 discard0, discard1;                      \
-    asm volatile("pop %0" : "=r" (discard0));    \
-    asm volatile("pop %0" : "=r" (discard1));    \
+#define closure_return_nodealloc                                        \
+    u64 discard0, discard1;                                             \
+    asm volatile("pop %0; pop %1" : "=r" (discard0), "=r" (discard1));  \
     return
 
 #include <closure_templates.h>

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -2,7 +2,7 @@
 
 #define closure_type(__x, __ret, ...) __ret (**__x)(void *, ## __VA_ARGS__)
 
-#define apply(__c, ...) (*__c)(__c, ## __VA_ARGS__)
+#define apply(__c, ...) (*(__c))((void *)(__c), ## __VA_ARGS__)
 
 #define __closure(__h, __p, __s, __name, ...)    \
     _fill_##__name(__h, __p, __s, ##__VA_ARGS__)
@@ -23,8 +23,20 @@ struct _closure_common {
     bytes size;
 };
 
-#define bound(name) (__self->name)
 #define __closure_define(nl, nr) CLOSURE_ ## nl ## _ ## nr
 #define closure_function(nl, nr, ...) __closure_define(nl, nr)(__VA_ARGS__)
+
+#define bound(v) (__self->v)
+#define closure_self() (&(__self->__apply))
+
+/* XXX type safety, possibly tag */
+static inline void deallocate_closure(void *p)
+{
+    struct _closure_common *c = p + sizeof(void *); /* skip __apply */
+    if (c->h && c->size > 0)
+        deallocate(c->h, p, c->size);
+}
+
+#define closure_finish() do { deallocate_closure(__self); __self = 0; } while(0)
 
 #include <closure_templates.h>

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -4,13 +4,15 @@
 
 #define apply(__c, ...) (*__c)(__c, ## __VA_ARGS__)
 
-#define __closure(__p, __name, ...)\
-    _fill_##__name(__p, ##__VA_ARGS__)
+#define __closure(__h, __p, __s, __name, ...)    \
+    _fill_##__name(__h, __p, __s, ##__VA_ARGS__)
 
 #define closure(__h, __name, ...)\
-    __closure(allocate(__h, sizeof(struct _closure_##__name)), __name, ##__VA_ARGS__)
+    __closure(__h, allocate(__h, sizeof(struct _closure_##__name)), \
+              sizeof(struct _closure_##__name), __name, ##__VA_ARGS__)
 
 #define stack_closure(__name, ...)\
-    __closure(stack_allocate(sizeof(struct _closure_##__name)), __name, ##__VA_ARGS__)
+    __closure(0, stack_allocate(sizeof(struct _closure_##__name)), \
+              sizeof(struct _closure_##__name), __name, ##__VA_ARGS__)
 
 #include <closure_templates.h>

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -15,20 +15,14 @@
     __closure(0, stack_allocate(sizeof(struct _closure_##__name)), \
               sizeof(struct _closure_##__name), __name, ##__VA_ARGS__)
 
-void _apply_dealloc(void);
-
-#define _apply_setup(z) \
-    asm volatile("push %0; push %1" :: "r" (z), "r" (&_apply_dealloc));
-
 struct _closure_common {
     char *name;
     heap h;
     bytes size;
 };
 
-#define closure_return_nodealloc                                        \
-    u64 discard0, discard1;                                             \
-    asm volatile("pop %0; pop %1" : "=r" (discard0), "=r" (discard1));  \
-    return
+#define upvalue(name) (__self->name)
+#define __closure_name(nl, nr) CLOSURE_ ## nl ## _ ## nr
+#define define_closure(nl, nr, ...) __closure_name(nl, nr)(__VA_ARGS__)
 
 #include <closure_templates.h>

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -154,9 +154,9 @@ static u64 id_alloc(heap h, bytes count)
     return INVALID_PHYSICAL;
 }
 
-define_closure(2, 1, void, dealloc_from_range,
-               id_heap, i, range, q,
-               rmnode, n)
+closure_function(2, 1, void, dealloc_from_range,
+                 id_heap, i, range, q,
+                 rmnode, n)
 {
     id_heap i = bound(i);
     range q = bound(q);
@@ -239,9 +239,9 @@ boolean id_heap_add_range(heap h, u64 base, u64 length)
     return id_add_range((id_heap)h, base, length) != INVALID_ADDRESS;
 }
 
-define_closure(4, 1, void, set_intersection,
-               range, q, boolean *, fail, boolean, validate, boolean, allocate,
-               rmnode, n)
+closure_function(4, 1, void, set_intersection,
+                 range, q, boolean *, fail, boolean, validate, boolean, allocate,
+                 rmnode, n)
 {
     range ri = range_intersection(bound(q), n->r);
     id_range r = (id_range)n;

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -154,9 +154,12 @@ static u64 id_alloc(heap h, bytes count)
     return INVALID_PHYSICAL;
 }
 
-static CLOSURE_2_1(dealloc_from_range, void, id_heap, range, rmnode);
-static void dealloc_from_range(id_heap i, range q, rmnode n)
+define_closure(2, 1, void, dealloc_from_range,
+               id_heap, i, range, q,
+               rmnode, n)
 {
+    id_heap i = bound(i);
+    range q = bound(q);
     range ri = range_intersection(q, n->r);
     id_range r = (id_range)n;
 
@@ -236,15 +239,16 @@ boolean id_heap_add_range(heap h, u64 base, u64 length)
     return id_add_range((id_heap)h, base, length) != INVALID_ADDRESS;
 }
 
-static CLOSURE_5_1(set_intersection, void, id_heap, range, boolean *, boolean, boolean, rmnode);
-static void set_intersection(id_heap i, range q, boolean * fail, boolean validate, boolean allocate, rmnode n)
+define_closure(4, 1, void, set_intersection,
+               range, q, boolean *, fail, boolean, validate, boolean, allocate,
+               rmnode, n)
 {
-    range ri = range_intersection(q, n->r);
+    range ri = range_intersection(bound(q), n->r);
     id_range r = (id_range)n;
 
     int bit = ri.start - n->r.start;
-    if (!bitmap_range_check_and_set(r->b, bit, range_span(ri), validate, allocate))
-        *fail = true;
+    if (!bitmap_range_check_and_set(r->b, bit, range_span(ri), bound(validate), bound(allocate)))
+        *bound(fail) = true;
 }
 
 boolean id_heap_set_area(heap h, u64 base, u64 length, boolean validate, boolean allocate)
@@ -255,7 +259,7 @@ boolean id_heap_set_area(heap h, u64 base, u64 length, boolean validate, boolean
 
     range q = irange(base >> page_order(i), (base + length) >> page_order(i));
     boolean fail = false;
-    rmnode_handler nh = stack_closure(set_intersection, i, q, &fail, validate, allocate);
+    rmnode_handler nh = stack_closure(set_intersection, q, &fail, validate, allocate);
     boolean result = rangemap_range_lookup(i->ranges, q, nh);
     return result && !fail;
 }

--- a/src/runtime/merge.c
+++ b/src/runtime/merge.c
@@ -10,9 +10,9 @@ struct merge {
    status last_status;
 };
 
-static CLOSURE_1_1(merge_join, void, merge, status);
-static void merge_join(merge m, status s)
+define_closure(1, 1, void, merge_join, merge, m, status, s)
 {
+    merge m = bound(m);
     if (s != STATUS_OK)
         m->last_status = s; // last failed status
 
@@ -23,11 +23,10 @@ static void merge_join(merge m, status s)
     }
 }
 
-static CLOSURE_2_0(merge_add, status_handler, merge, status_handler);
-static status_handler merge_add(merge m, status_handler sh)
+define_closure(2, 0, status_handler, merge_add, merge, m, status_handler, sh)
 {
-    fetch_and_add(&m->count, 1);
-    return sh;
+    fetch_and_add(&bound(m)->count, 1);
+    return bound(sh);
 }
 
 merge allocate_merge(heap h, status_handler completion)

--- a/src/runtime/merge.c
+++ b/src/runtime/merge.c
@@ -10,7 +10,9 @@ struct merge {
    status last_status;
 };
 
-define_closure(1, 1, void, merge_join, merge, m, status, s)
+closure_function(1, 1, void, merge_join,
+                 merge, m,
+                 status, s)
 {
     merge m = bound(m);
     if (s != STATUS_OK)
@@ -23,7 +25,8 @@ define_closure(1, 1, void, merge_join, merge, m, status, s)
     }
 }
 
-define_closure(2, 0, status_handler, merge_add, merge, m, status_handler, sh)
+closure_function(2, 0, status_handler, merge_add,
+                 merge, m, status_handler, sh)
 {
     fetch_and_add(&bound(m)->count, 1);
     return bound(sh);

--- a/src/runtime/runtime_init.c
+++ b/src/runtime/runtime_init.c
@@ -2,8 +2,7 @@
 
 void initialize_buffer();
 
-static inline CLOSURE_0_0(ignore_body, void);
-static inline void ignore_body(){}
+define_closure(0, 0, void, ignore_body) {}
 thunk ignore;
 status_handler ignore_status;
 static char *hex_digits="0123456789abcdef";

--- a/src/runtime/runtime_init.c
+++ b/src/runtime/runtime_init.c
@@ -2,7 +2,7 @@
 
 void initialize_buffer();
 
-define_closure(0, 0, void, ignore_body) {}
+closure_function(0, 0, void, ignore_body) {}
 thunk ignore;
 status_handler ignore_status;
 static char *hex_digits="0123456789abcdef";

--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -22,14 +22,15 @@ typedef struct log {
     heap h;
 } *log;
 
-static CLOSURE_1_1(log_write_completion, void, vector, status);
-static void log_write_completion(vector v, status s)
+closure_function(1, 1, void, log_write_completion,
+                 vector, v,
+                 status, s)
 {
     // reclaim the buffer now and the vector...make it a whole thing
     status_handler i;
-    int len = vector_length(v);
+    int len = vector_length(bound(v));
     for (int count = 0; count < len; count++) {
-        i = vector_delete(v, 0);
+        i = vector_delete(bound(v), 0);
         apply(i, s);
     }
 }
@@ -105,9 +106,12 @@ void log_write(log tl, tuple t, status_handler sh)
     tl->dirty = true;
 }
 
-CLOSURE_2_1(log_read_complete, void, log, status_handler, status);
-void log_read_complete(log tl, status_handler sh, status s)
+closure_function(2, 1, void, log_read_complete,
+                 log, tl, status_handler, sh,
+                 status, s)
 {
+    log tl = bound(tl);
+    status_handler sh = bound(sh);
     buffer b = tl->staging;
     u8 frame = 0;
 

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -148,9 +148,12 @@ static void blockq_apply_bi_locked(blockq bq, blockq_item bi,
  * Invoke its action and remove it from the list of waiters,
  * if applicable
  */
-CLOSURE_2_0(blockq_item_timeout, void, blockq, blockq_item)
-void blockq_item_timeout(blockq bq, blockq_item bi)
+closure_function(2, 0, void, blockq_item_timeout,
+                 blockq, bq, blockq_item, bi)
 {
+    blockq bq = bound(bq);
+    blockq_item bi = bound(bi);
+
     blockq_debug("bq %p (\"%s\") bi %p (tid:%ld)\n",
         bq, blockq_name(bq), bi, bi->t->tid);
 

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -122,16 +122,18 @@ void start_process(thread t, void *start)
     }
 }
 
-static CLOSURE_0_1(load_interp_fail, void, status);
-static void load_interp_fail(status s)
+closure_function(0, 1, void, load_interp_fail,
+                 status, s)
 {
     console("interp fail\n");
     halt("read interp failed %v\n", s);
 }
 
-static CLOSURE_2_4(exec_elf_map, void, process, kernel_heaps, u64, u64, u64, u64);
-static void exec_elf_map(process p, kernel_heaps kh, u64 vaddr, u64 paddr, u64 size, u64 flags)
+closure_function(2, 4, void, exec_elf_map,
+                 process, p, kernel_heaps, kh,
+                 u64, vaddr, u64, paddr, u64, size, u64, flags)
 {
+    kernel_heaps kh = bound(kh);
     u64 target = vaddr;
     u64 vmflags = 0;
     if ((flags & PAGE_NO_EXEC) == 0)
@@ -139,7 +141,7 @@ static void exec_elf_map(process p, kernel_heaps kh, u64 vaddr, u64 paddr, u64 s
     if (flags & PAGE_WRITABLE)
         vmflags |= VMAP_FLAG_WRITABLE;
 
-    assert(allocate_vmap(p->vmaps, irange(target, target + size), vmflags) != INVALID_ADDRESS);
+    assert(allocate_vmap(bound(p)->vmaps, irange(target, target + size), vmflags) != INVALID_ADDRESS);
     boolean is_bss = paddr == INVALID_PHYSICAL;
     if (is_bss) {
         /* bss */
@@ -152,9 +154,13 @@ static void exec_elf_map(process p, kernel_heaps kh, u64 vaddr, u64 paddr, u64 s
     }
 }
 
-CLOSURE_2_1(load_interp_complete, void, thread, kernel_heaps, buffer);
-void load_interp_complete(thread t, kernel_heaps kh, buffer b)
+closure_function(2, 1, void, load_interp_complete,
+                 thread, t, kernel_heaps, kh,
+                 buffer, b)
 {
+    thread t = bound(t);
+    kernel_heaps kh = bound(kh);
+
     exec_debug("interpreter load complete, reading elf\n");
     u64 where = allocate_u64(heap_virtual_huge(kh), HUGE_PAGESIZE);
     void * start = load_elf(b, where, stack_closure(exec_elf_map, t->p, kh));

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -84,11 +84,12 @@ static int futex_wake_many(struct futex * f, int val)
  *  -EINTR: if we're being nullified
  *  0: thread woken up
  */
-static CLOSURE_3_2(futex_bh, sysreturn, struct futex *, thread, timestamp,
-                   boolean, boolean);
-static sysreturn futex_bh(struct futex * f, thread t, timestamp ts,
-                          boolean blocked, boolean nullify)
+closure_function(3, 2, sysreturn, futex_bh,
+                 struct futex *, f, thread, t, timestamp, ts,
+                 boolean, blocked, boolean, nullify)
 {
+    thread t = bound(t);
+    timestamp ts = bound(ts);
     sysreturn rv;
 
     if (current == t)

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -124,19 +124,18 @@ static inline void pipe_dealloc_end(pipe p, pipe_file pf)
     }
 }
 
-static CLOSURE_1_0(pipe_close, sysreturn, pipe_file);
-static sysreturn pipe_close(pipe_file pf)
+closure_function(1, 0, sysreturn, pipe_close,
+                 pipe_file, pf)
 {
-    pipe_dealloc_end(pf->pipe, pf);
+    pipe_dealloc_end(bound(pf)->pipe, bound(pf));
     return 0;
 }
 
-static CLOSURE_5_2(pipe_read_bh, sysreturn,
-                   pipe_file, thread, void *, u64, io_completion,
-                   boolean, boolean);
-static sysreturn pipe_read_bh(pipe_file pf, thread t, void *dest, u64 length,
-                              io_completion completion, boolean blocked, boolean nullify)
+closure_function(5, 2, sysreturn, pipe_read_bh,
+                 pipe_file, pf, thread, t, void *, dest, u64, length, io_completion, completion,
+                 boolean, blocked, boolean, nullify)
 {
+    pipe_file pf = bound(pf);
     int rv;
 
     if (nullify) {
@@ -145,7 +144,7 @@ static sysreturn pipe_read_bh(pipe_file pf, thread t, void *dest, u64 length,
     }
 
     buffer b = pf->pipe->data;
-    rv = MIN(buffer_length(b), length);
+    rv = MIN(buffer_length(b), bound(length));
     if (rv == 0) {
         if (pf->pipe->files[PIPE_WRITE].fd == -1)
             goto out;
@@ -156,7 +155,7 @@ static sysreturn pipe_read_bh(pipe_file pf, thread t, void *dest, u64 length,
         return infinity;
     }
 
-    buffer_read(b, dest, rv);
+    buffer_read(b, bound(dest), rv);
     pipe_notify_writer(pf, EPOLLOUT);
 
     // If we have consumed all of the buffer, reset it. This might prevent future writes to allocte new buffer
@@ -167,17 +166,17 @@ static sysreturn pipe_read_bh(pipe_file pf, thread t, void *dest, u64 length,
     }
   out:
     if (blocked)
-        blockq_set_completion(pf->bq, completion, t, rv);
+        blockq_set_completion(pf->bq, bound(completion), bound(t), rv);
 
     return rv;
 }
 
-static CLOSURE_1_6(pipe_read, sysreturn,
-        pipe_file,
-        void *, u64, u64, thread, boolean, io_completion);
-static sysreturn pipe_read(pipe_file pf, void *dest, u64 length, u64 offset_arg,
-        thread t, boolean bh, io_completion completion)
+closure_function(1, 6, sysreturn, pipe_read,
+                 pipe_file, pf,
+                 void *, dest, u64, length, u64, offset_arg, thread, t, boolean, bh, io_completion, completion)
 {
+    pipe_file pf = bound(pf);
+
     if (length == 0)
         return 0;
 
@@ -186,19 +185,19 @@ static sysreturn pipe_read(pipe_file pf, void *dest, u64 length, u64 offset_arg,
     return blockq_check(pf->bq, t, ba, bh);
 }
 
-static CLOSURE_5_2(pipe_write_bh, sysreturn,
-                   pipe_file, thread, void *, u64, io_completion,
-                   boolean, boolean);
-static sysreturn pipe_write_bh(pipe_file pf, thread t, void *dest, u64 length,
-                               io_completion completion, boolean blocked, boolean nullify)
+closure_function(5, 2, sysreturn, pipe_write_bh,
+                 pipe_file, pf, thread, t, void *, dest, u64, length, io_completion, completion,
+                 boolean, blocked, boolean, nullify)
 {
     sysreturn rv = 0;
+    pipe_file pf = bound(pf);
 
     if (nullify) {
         rv = -EINTR;
         goto out;
     }
 
+    u64 length = bound(length);
     pipe p = pf->pipe;
     buffer b = p->data;
     u64 avail = p->max_size - buffer_length(b);
@@ -216,7 +215,7 @@ static sysreturn pipe_write_bh(pipe_file pf, thread t, void *dest, u64 length,
     }
 
     u64 real_length = MIN(length, avail);
-    buffer_write(b, dest, real_length);
+    buffer_write(b, bound(dest), real_length);
     if (avail == length)
         notify_dispatch(pf->f.ns, 0); /* for edge trigger */
 
@@ -225,28 +224,28 @@ static sysreturn pipe_write_bh(pipe_file pf, thread t, void *dest, u64 length,
     rv = real_length;
   out:
     if (blocked)
-        blockq_set_completion(pf->bq, completion, t, rv);
+        blockq_set_completion(pf->bq, bound(completion), bound(t), rv);
 
     return rv;
 }
 
-static CLOSURE_1_6(pipe_write, sysreturn,
-        pipe_file,
-        void *, u64, u64, thread, boolean, io_completion);
-static sysreturn pipe_write(pipe_file pf, void * dest, u64 length, u64 offset,
-        thread t, boolean bh, io_completion completion)
+closure_function(1, 6, sysreturn, pipe_write,
+                 pipe_file, pf,
+                 void *, dest, u64, length, u64, offset, thread, t, boolean, bh, io_completion, completion)
 {
     if (length == 0)
         return 0;
 
+    pipe_file pf = bound(pf);
     blockq_action ba = closure(pf->pipe->h, pipe_write_bh, pf, t, dest, length,
             completion);
     return blockq_check(pf->bq, t, ba, bh);
 }
 
-static CLOSURE_1_0(pipe_read_events, u32, pipe_file);
-static u32 pipe_read_events(pipe_file pf)
+closure_function(1, 0, u32, pipe_read_events,
+                 pipe_file, pf)
 {
+    pipe_file pf = bound(pf);
     assert(pf->f.read);
     u32 events = buffer_length(pf->pipe->data) ? EPOLLIN : 0;
     if (pf->pipe->files[PIPE_WRITE].fd == -1)
@@ -254,9 +253,10 @@ static u32 pipe_read_events(pipe_file pf)
     return events;
 }
 
-static CLOSURE_1_0(pipe_write_events, u32, pipe_file);
-static u32 pipe_write_events(pipe_file pf)
+closure_function(1, 0, u32, pipe_write_events,
+                 pipe_file, pf)
 {
+    pipe_file pf = bound(pf);
     assert(pf->f.write);
     u32 events = buffer_length(pf->pipe->data) < pf->pipe->max_size ? EPOLLOUT : 0;
     if (pf->pipe->files[PIPE_READ].fd == -1)

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -471,12 +471,12 @@ sysreturn rt_sigprocmask(int how, const u64 *set, u64 *oldset, u64 sigsetsize)
     return 0;
 }
 
-static CLOSURE_2_2(rt_sigsuspend_bh, sysreturn,
-                   thread, u64,
-                   boolean, boolean);
-static sysreturn rt_sigsuspend_bh(thread t, u64 saved_mask, boolean blocked, boolean nullify)
+closure_function(2, 2, sysreturn, rt_sigsuspend_bh,
+                 thread, t, u64, saved_mask,
+                 boolean, blocked, boolean, nullify)
 {
-    sig_debug("tid %d, saved_mask 0x%lx blocked %d, nullify %d\n", t->tid, saved_mask, blocked, nullify);
+    thread t = bound(t);
+    sig_debug("tid %d, saved_mask 0x%lx blocked %d, nullify %d\n", t->tid, bound(saved_mask), blocked, nullify);
 
     if (nullify || get_dispatchable_signals(t)) {
         if (blocked)
@@ -617,11 +617,11 @@ sysreturn tkill(int tid, int sig)
     return tgkill(1, tid, sig);
 }
 
-static CLOSURE_1_2(pause_bh, sysreturn,
-                   thread,
-                   boolean, boolean);
-static sysreturn pause_bh(thread t, boolean blocked, boolean nullify)
+closure_function(1, 2, sysreturn, pause_bh,
+                 thread, t,
+                 boolean, blocked, boolean, nullify)
 {
+    thread t = bound(t);
     sig_debug("tid %d, blocked %d, nullify %d\n", t->tid, blocked, nullify);
 
     if (nullify || get_dispatchable_signals(t)) {

--- a/src/unix/socketpair.c
+++ b/src/unix/socketpair.c
@@ -109,12 +109,15 @@ static inline void sockpair_notify_writer(sockpair_socket s, int events)
     }
 }
 
-static CLOSURE_5_2(sockpair_read_bh, sysreturn,
-                   sockpair_socket, thread, void *, u64, io_completion,
-                   boolean, boolean);
-static sysreturn sockpair_read_bh(sockpair_socket s, thread t, void *dest,
-                                  u64 length, io_completion completion, boolean blocked, boolean nullify)
+closure_function(5, 2, sysreturn, sockpair_read_bh,
+                 sockpair_socket, s, thread, t, void *, dest, u64, length, io_completion, completion,
+                 boolean, blocked, boolean, nullify)
 {
+    sockpair_socket s = bound(s);
+    thread t = bound(t);
+    void * dest = bound(dest);
+    u64 length = bound(length);
+
     buffer b = s->sockpair->data;
     int real_length;
     int dgram_length;
@@ -158,17 +161,16 @@ static sysreturn sockpair_read_bh(sockpair_socket s, thread t, void *dest,
     }
 out:
     if (blocked) {
-        blockq_set_completion(s->read_bq, completion, t, real_length);
+        blockq_set_completion(s->read_bq, bound(completion), t, real_length);
     }
     return real_length;
 }
 
-static CLOSURE_1_6(sockpair_read, sysreturn,
-        sockpair_socket,
-        void *, u64, u64, thread, boolean, io_completion);
-static sysreturn sockpair_read(sockpair_socket s, void *dest, u64 length,
-        u64 offset_arg, thread t, boolean bh, io_completion completion)
+closure_function(1, 6, sysreturn, sockpair_read,
+                 sockpair_socket, s,
+                 void *, dest, u64, length, u64, offset_arg, thread, t, boolean, bh, io_completion, completion)
 {
+    sockpair_socket s = bound(s);
     if (length == 0) {
         return 0;
     }
@@ -178,12 +180,13 @@ static sysreturn sockpair_read(sockpair_socket s, void *dest, u64 length,
     return blockq_check(s->read_bq, t, ba, bh);
 }
 
-static CLOSURE_5_2(sockpair_write_bh, sysreturn,
-        sockpair_socket, thread, void *, u64, io_completion,
-                   boolean, boolean);
-static sysreturn sockpair_write_bh(sockpair_socket s, thread t, void *dest,
-                                   u64 length, io_completion completion, boolean blocked, boolean nullify)
+closure_function(5, 2, sysreturn, sockpair_write_bh,
+                 sockpair_socket, s, thread, t, void *, dest, u64, length, io_completion, completion,
+                 boolean, blocked, boolean, nullify)
 {
+    sockpair_socket s = bound(s);
+    u64 length = bound(length);
+    
     sysreturn rv = 0;
     buffer b = s->sockpair->data;
 
@@ -209,7 +212,7 @@ static sysreturn sockpair_write_bh(sockpair_socket s, thread t, void *dest,
     }
 
     u64 real_length = MIN(length, avail);
-    buffer_write(b, dest, real_length);
+    buffer_write(b, bound(dest), real_length);
     if (s->sockpair->type == SOCK_DGRAM) {
         sockpair_dgram_set_len(s->sockpair, length);
     }
@@ -217,17 +220,16 @@ static sysreturn sockpair_write_bh(sockpair_socket s, thread t, void *dest,
     rv = real_length;
 out:
     if (blocked) {
-        blockq_set_completion(s->write_bq, completion, t, rv);
+        blockq_set_completion(s->write_bq, bound(completion), bound(t), rv);
     }
     return rv;
 }
 
-static CLOSURE_1_6(sockpair_write, sysreturn,
-        sockpair_socket,
-        void *, u64, u64, thread, boolean, io_completion);
-static sysreturn sockpair_write(sockpair_socket s, void * dest, u64 length,
-        u64 offset, thread t, boolean bh, io_completion completion)
+closure_function(1, 6, sysreturn, sockpair_write,
+                 sockpair_socket, s,
+                 void *, dest, u64, length, u64, offset, thread, t, boolean, bh, io_completion, completion)
 {
+    sockpair_socket s = bound(s);
     if (length == 0) {
         return 0;
     }
@@ -237,9 +239,10 @@ static sysreturn sockpair_write(sockpair_socket s, void * dest, u64 length,
     return blockq_check(s->write_bq, t, ba, bh);
 }
 
-static CLOSURE_1_0(sockpair_events, u32, sockpair_socket);
-static u32 sockpair_events(sockpair_socket s)
+closure_function(1, 0, u32, sockpair_events,
+                 sockpair_socket, s)
 {
+    sockpair_socket s = bound(s);
     u32 events = 0;
     if (buffer_length(s->sockpair->data) != 0) {
         events |= EPOLLIN;
@@ -281,11 +284,11 @@ static void sockpair_release(struct sockpair *sockpair)
     }
 }
 
-static CLOSURE_1_0(sockpair_close, sysreturn, sockpair_socket);
-static sysreturn sockpair_close(sockpair_socket s)
+closure_function(1, 0, sysreturn, sockpair_close,
+                 sockpair_socket, s)
 {
-    sockpair_dealloc_sock(s);
-    sockpair_release(s->sockpair);
+    sockpair_dealloc_sock(bound(s));
+    sockpair_release(bound(s)->sockpair);
     return 0;
 }
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -2,8 +2,6 @@
 
 thread current;
 
-CLOSURE_1_1(default_fault_handler, context, thread, context);
-
 sysreturn gettid()
 {
     return current->tid;
@@ -104,10 +102,10 @@ void thread_log_internal(thread t, const char *desc, ...)
     }
 }
 
-
-CLOSURE_1_0(run_thread, void, thread);
-void run_thread(thread t)
+closure_function(1, 0, void, run_thread,
+                 thread, t)
 {
+    thread t = bound(t);
     current = t;
     thread_log(t, "run frame %p, RIP=%p", t->frame, t->frame[FRAME_RIP]);
     proc_enter_user(current->p);
@@ -197,7 +195,7 @@ thread create_thread(process p)
     t->clear_tid = 0;
     t->name[0] = '\0';
     zero(t->frame, sizeof(t->frame));
-    t->frame[FRAME_FAULT_HANDLER] = u64_from_pointer(closure(h, default_fault_handler, t));
+    t->frame[FRAME_FAULT_HANDLER] = u64_from_pointer(create_fault_handler(h, t));
     t->run = closure(h, run_thread, t);
     vector_push(p->threads, t);
     t->blocked_on = 0;

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -7,11 +7,11 @@ sysreturn gettimeofday(struct timeval *tv, void *tz)
     return 0;
 }
 
-static CLOSURE_2_0(nanosleep_timeout, void, thread, boolean *);
-static void nanosleep_timeout(thread t, boolean *dead)
+closure_function(2, 0, void, nanosleep_timeout,
+                 thread, t, boolean *, dead)
 {
-    set_syscall_return(t, 0);
-    thread_wakeup(t);
+    set_syscall_return(bound(t), 0);
+    thread_wakeup(bound(t));
 }
 
 sysreturn nanosleep(const struct timespec* req, struct timespec* rem)

--- a/src/unix_process/http.c
+++ b/src/unix_process/http.c
@@ -69,9 +69,11 @@ static void reset_parser(http_parser p)
 // we're going to patch the connection together by looking at the
 // leftover bits in buffer...defer until we need to actually
 // switch protocols
-CLOSURE_1_1(http_recv, void, http_parser, buffer);
-void http_recv(http_parser p, buffer b)
+closure_function(1, 1, void, http_recv,
+                 http_parser, p,
+                 buffer, b)
 {
+    http_parser p = bound(p);
     int i;
 
     if (!b) {

--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -67,13 +67,14 @@ typedef struct xpbuf
 } *xpbuf;
 
 
-static CLOSURE_1_1(tx_complete, void, struct pbuf *, u64);
-static void tx_complete(struct pbuf *p, u64 len)
+closure_function(1, 1, void, tx_complete,
+                 struct pbuf *, p,
+                 u64, len)
 {
     // unfortunately we dont have control over the allocation
     // path (?)
     // free me!
-    pbuf_free(p);
+    pbuf_free(bound(p));
 }
 
 
@@ -115,9 +116,11 @@ static void receive_buffer_release(struct pbuf *p)
 
 static void post_receive(vnet vn);
 
-static CLOSURE_1_1(input, void, xpbuf, u64);
-static void input(xpbuf x, u64 len)
+closure_function(1, 1, void, input,
+                 xpbuf, x,
+                 u64, len)
 {
+    xpbuf x = bound(x);
     vnet vn= x->vn;
     // under what conditions does a virtio queue give us zero?
     if (x != NULL) {
@@ -215,13 +218,14 @@ static void virtio_net_attach(heap general, heap page_allocator, pci_dev d)
               ethernet_input);
 }
 
-static CLOSURE_2_1(virtio_net_probe, boolean, heap, heap, pci_dev);
-static boolean virtio_net_probe(heap general, heap page_allocator, pci_dev d)
+closure_function(2, 1, boolean, virtio_net_probe,
+                 heap, general, heap, page_allocator,
+                 pci_dev, d)
 {
     if (pci_get_vendor(d) != VIRTIO_PCI_VENDORID || pci_get_device(d) != VIRTIO_PCI_DEVICEID_NETWORK)
         return false;
 
-    virtio_net_attach(general, page_allocator, d);
+    virtio_net_attach(bound(general), bound(page_allocator), d);
     return true;
 }
 

--- a/src/virtio/virtio_scsi.c
+++ b/src/virtio/virtio_scsi.c
@@ -123,11 +123,12 @@ typedef struct virtio_scsi *virtio_scsi;
 
 static void virtio_scsi_enqueue_event(virtio_scsi s, virtio_scsi_event e);
 
-static CLOSURE_2_1(virtio_scsi_event_complete, void, virtio_scsi, virtio_scsi_event, u64);
-static void virtio_scsi_event_complete(virtio_scsi s, virtio_scsi_event e, u64 len)
+closure_function(2, 1, void, virtio_scsi_event_complete,
+                 virtio_scsi, s, virtio_scsi_event, e,
+                 u64, len)
 {
-    virtio_scsi_debug("%s: event 0x%x\n", __func__, e->event);
-    virtio_scsi_enqueue_event(s, e);
+    virtio_scsi_debug("%s: event 0x%x\n", __func__, bound(e)->event);
+    virtio_scsi_enqueue_event(bound(s), bound(e));
 }
 
 static void virtio_scsi_enqueue_event(virtio_scsi s, virtio_scsi_event e)
@@ -146,10 +147,13 @@ static void virtio_scsi_enqueue_event(virtio_scsi s, virtio_scsi_event e)
 
 typedef closure_type(vsr_complete, void, virtio_scsi, virtio_scsi_request);
 
-static CLOSURE_3_1(virtio_scsi_request_complete, void, vsr_complete, virtio_scsi, virtio_scsi_request, u64);
-static void virtio_scsi_request_complete(vsr_complete c, virtio_scsi s, virtio_scsi_request r, u64 len)
+closure_function(3, 1, void, virtio_scsi_request_complete,
+                 vsr_complete, c, virtio_scsi, s, virtio_scsi_request, r,
+                 u64, len)
 {
-    apply(c, s, r);
+    virtio_scsi s = bound(s);
+    virtio_scsi_request r = bound(r);
+    apply(bound(c), s, r);
     deallocate(s->v->contiguous, r, pad(sizeof(*r) + r->alloc_len, s->v->contiguous->pagesize));
 }
 
@@ -194,8 +198,9 @@ static void virtio_scsi_enqueue_request(virtio_scsi s, virtio_scsi_request r, vo
 /*
  * Device driver hooks
  */
-static CLOSURE_3_2(virtio_scsi_io_done, void, status_handler, void *, u64, virtio_scsi, virtio_scsi_request);
-static void virtio_scsi_io_done(status_handler sh, void *buf, u64 len, virtio_scsi s, virtio_scsi_request r)
+closure_function(3, 2, void, virtio_scsi_io_done,
+                 status_handler, sh, void *, buf, u64, len,
+                 virtio_scsi, s, virtio_scsi_request, r)
 {
     struct virtio_scsi_resp_cmd *resp = &r->resp;
     virtio_scsi_debug("%s: target %d, lun %d, response %d, status %d\n",
@@ -208,7 +213,7 @@ static void virtio_scsi_io_done(status_handler sh, void *buf, u64 len, virtio_sc
         scsi_dump_sense(resp->sense, sizeof(resp->sense));
         st = timm("result", "status %d", resp->status);
     }
-    apply(sh, st);
+    apply(bound(sh), st);
 }
 
 static void virtio_scsi_io(virtio_scsi s, u8 cmd, void *buf, range blocks, status_handler sh)
@@ -224,29 +229,35 @@ static void virtio_scsi_io(virtio_scsi s, u8 cmd, void *buf, range blocks, statu
         closure(s->v->general, virtio_scsi_io_done, sh, buf, nblocks * s->block_size));
 }
 
-static CLOSURE_1_3(virtio_scsi_write, void, virtio_scsi, void *, range, status_handler);
-static void virtio_scsi_write(virtio_scsi s, void *buf, range blocks, status_handler sh)
+closure_function(1, 3, void, virtio_scsi_write,
+                 virtio_scsi, s,
+                 void *, buf, range, blocks, status_handler, sh)
 {
-    virtio_scsi_io(s, SCSI_CMD_WRITE_16, buf, blocks, sh);
+    virtio_scsi_io(bound(s), SCSI_CMD_WRITE_16, buf, blocks, sh);
 }
 
-static CLOSURE_1_3(virtio_scsi_read, void, virtio_scsi, void *, range, status_handler);
-static void virtio_scsi_read(virtio_scsi s, void *buf, range blocks, status_handler sh)
+closure_function(1, 3, void, virtio_scsi_read,
+                 virtio_scsi, s,
+                 void *, buf, range, blocks, status_handler, sh)
 {
-    virtio_scsi_io(s, SCSI_CMD_READ_16, buf, blocks, sh);
+    virtio_scsi_io(bound(s), SCSI_CMD_READ_16, buf, blocks, sh);
 }
 
-static CLOSURE_2_0(virtio_scsi_init_done, void, virtio_scsi, storage_attach);
-static void virtio_scsi_init_done(virtio_scsi s, storage_attach a)
+closure_function(2, 0, void, virtio_scsi_init_done,
+                 virtio_scsi, s, storage_attach, a)
 {
+    virtio_scsi s = bound(s);
     block_io in = closure(s->v->general, virtio_scsi_read, s);
     block_io out = closure(s->v->general, virtio_scsi_write, s);
-    apply(a, in, out, s->capacity);
+    apply(bound(a), in, out, s->capacity);
 }
 
-static CLOSURE_3_2(virtio_scsi_read_capacity_done, void, storage_attach, u16, u16, virtio_scsi, virtio_scsi_request);
-static void virtio_scsi_read_capacity_done(storage_attach a, u16 target, u16 lun, virtio_scsi s, virtio_scsi_request r)
+closure_function(3, 2, void, virtio_scsi_read_capacity_done,
+                 storage_attach, a, u16, target, u16, lun,
+                 virtio_scsi, s, virtio_scsi_request, r)
 {
+    u16 target = bound(target);
+    u16 lun = bound(lun);
     struct virtio_scsi_resp_cmd *resp = &r->resp;
     virtio_scsi_debug("%s: target %d, lun %d, response %d, status %d\n",
         __func__, target, lun, resp->response, resp->status);
@@ -271,7 +282,7 @@ static void virtio_scsi_read_capacity_done(storage_attach a, u16 target, u16 lun
     virtio_scsi_debug("%s: target %d, lun %d, block size 0x%lx, capacity 0x%lx\n",
         __func__, target, lun, s->block_size, s->capacity);
 
-    enqueue(runqueue, closure(s->v->general, virtio_scsi_init_done, s, a));
+    enqueue(runqueue, closure(s->v->general, virtio_scsi_init_done, s, bound(a)));
 }
 
 static void virtio_scsi_report_luns(virtio_scsi s, storage_attach a, u16 target);
@@ -290,9 +301,15 @@ static void virtio_scsi_next_target(virtio_scsi s, storage_attach a, u16 target)
     virtio_scsi_report_luns(s, a, target + 1);
 }
 
-static CLOSURE_4_2(virtio_scsi_test_unit_ready_done, void, storage_attach, u16, u16, int, virtio_scsi, virtio_scsi_request);
-static void virtio_scsi_test_unit_ready_done(storage_attach a, u16 target, u16 lun, int retry_count, virtio_scsi s, virtio_scsi_request r)
+closure_function(4, 2, void, virtio_scsi_test_unit_ready_done,
+                 storage_attach, a, u16, target, u16, lun, int, retry_count,
+                 virtio_scsi, s, virtio_scsi_request, r)
 {
+    storage_attach a = bound(a);
+    u16 target = bound(target);
+    u16 lun = bound(lun);
+    int retry_count = bound(retry_count);
+
     struct virtio_scsi_resp_cmd *resp = &r->resp;
     virtio_scsi_debug("%s: target %d, lun %d, response %d, status %d\n",
         __func__, target, lun, resp->response, resp->status);
@@ -321,16 +338,19 @@ static void virtio_scsi_test_unit_ready_done(storage_attach a, u16 target, u16 l
         closure(s->v->general, virtio_scsi_read_capacity_done, a, target, lun));
 }
 
-static CLOSURE_3_2(virtio_scsi_inquiry_done, void, storage_attach, u16, u16, virtio_scsi, virtio_scsi_request);
-static void virtio_scsi_inquiry_done(storage_attach a, u16 target, u16 lun, virtio_scsi s, virtio_scsi_request r)
+closure_function(3, 2, void, virtio_scsi_inquiry_done,
+                 storage_attach, a, u16, target, u16, lun,
+                 virtio_scsi, s, virtio_scsi_request, r)
 {
+    u16 target = bound(target);
+    u16 lun = bound(lun);
     struct virtio_scsi_resp_cmd *resp = &r->resp;
     virtio_scsi_debug("%s: target %d, lun %d, response %d, status %d\n",
         __func__, target, lun, resp->response, resp->status);
     if (resp->response != VIRTIO_SCSI_S_OK || resp->status != SCSI_STATUS_OK) {
         if (resp->status != SCSI_STATUS_OK)
             scsi_dump_sense(resp->sense, sizeof(resp->sense));
-        virtio_scsi_next_target(s, a, target);
+        virtio_scsi_next_target(s, bound(a), target);
         return;
     }
 
@@ -351,19 +371,21 @@ static void virtio_scsi_inquiry_done(storage_attach a, u16 target, u16 lun, virt
     // test unit ready
     r = virtio_scsi_alloc_request(s, target, lun, SCSI_CMD_TEST_UNIT_READY);
     virtio_scsi_enqueue_request(s, r, r->data, r->alloc_len,
-        closure(s->v->general, virtio_scsi_test_unit_ready_done, a, target, lun, 0));
+                                closure(s->v->general, virtio_scsi_test_unit_ready_done, bound(a), target, lun, 0));
 }
 
-static CLOSURE_2_2(virtio_scsi_report_luns_done, void, storage_attach, u16, virtio_scsi, virtio_scsi_request);
-static void virtio_scsi_report_luns_done(storage_attach a, u16 target, virtio_scsi s, virtio_scsi_request r)
+closure_function(2, 2, void, virtio_scsi_report_luns_done,
+                 storage_attach, a, u16, target,
+                 virtio_scsi, s, virtio_scsi_request, r)
 {
+    u16 target = bound(target);
     struct virtio_scsi_resp_cmd *resp = &r->resp;
     virtio_scsi_debug("%s: target %d, response %d, status %d\n",
         __func__, target, resp->response, resp->status);
     if (resp->response != VIRTIO_SCSI_S_OK || resp->status != SCSI_STATUS_OK) {
         if (resp->status != SCSI_STATUS_OK)
             scsi_dump_sense(resp->sense, sizeof(resp->sense));
-        virtio_scsi_next_target(s, a, target);
+        virtio_scsi_next_target(s, bound(a), target);
         return;
     }
 
@@ -379,7 +401,7 @@ static void virtio_scsi_report_luns_done(storage_attach a, u16 target, virtio_sc
         struct scsi_cdb_inquiry *cdb = (struct scsi_cdb_inquiry *) r->req.cdb;
         cdb->length = htobe16(r->alloc_len);
         virtio_scsi_enqueue_request(s, r, r->data, r->alloc_len,
-            closure(s->v->general, virtio_scsi_inquiry_done, a, target, lun));
+                                    closure(s->v->general, virtio_scsi_inquiry_done, bound(a), target, lun));
     }
 }
 
@@ -448,13 +470,14 @@ static void virtio_scsi_attach(heap general, storage_attach a, heap page_allocat
     virtio_scsi_report_luns(s, a, 0);
 }
 
-static CLOSURE_4_1(virtio_scsi_probe, boolean, heap, storage_attach, heap, heap, pci_dev);
-static boolean virtio_scsi_probe(heap general, storage_attach a, heap page_allocator, heap pages, pci_dev d)
+closure_function(4, 1, boolean, virtio_scsi_probe,
+                 heap, general, storage_attach, a, heap, page_allocator, heap, pages,
+                 pci_dev, d)
 {
     if (pci_get_vendor(d) != VIRTIO_PCI_VENDORID || pci_get_device(d) != VIRTIO_PCI_DEVICEID_SCSI)
         return false;
 
-    virtio_scsi_attach(general, a, page_allocator, pages, d);
+    virtio_scsi_attach(bound(general), bound(a), bound(page_allocator), bound(pages), d);
     return true;
 }
 

--- a/src/virtio/virtio_storage.c
+++ b/src/virtio/virtio_storage.c
@@ -92,14 +92,15 @@ static void deallocate_virtio_blk_req(storage st, virtio_blk_req req)
                pad(sizeof(struct virtio_blk_req), st->v->contiguous->pagesize));
 }
 
-static CLOSURE_4_1(complete, void, storage, status_handler, u8 *, virtio_blk_req, u64);
-static void complete(storage s, status_handler f, u8 *result, virtio_blk_req req, u64 len)
+closure_function(4, 1, void, complete,
+                 storage, s, status_handler, f, u8 *, result, virtio_blk_req, req,
+                 u64, len)
 {
     status st = 0;
     // 1 is io error, 2 is unsupported operation
-    if (*result) st = timm("result", "%d", *result);
-    apply(f, st);
-    deallocate_virtio_blk_req(s, req);
+    if (*bound(result)) st = timm("result", "%d", *bound(result));
+    apply(bound(f), st);
+    deallocate_virtio_blk_req(bound(s), bound(req));
     //    s->command->avail->flags &= ~VRING_AVAIL_F_NO_INTERRUPT;
     // used isn't valid?
     //    rprintf("used: %d\n",  s->command->vq_ring.used->idx);    
@@ -142,16 +143,18 @@ static inline void storage_rw_internal(storage st, boolean write, void * buf,
     apply(sh, timm("result", "%s", err));
 }
 
-static CLOSURE_1_3(storage_write, void, storage, void *, range, status_handler);
-static void storage_write(storage st, void * source, range blocks, status_handler s)
+closure_function(1, 3, void, storage_write,
+                 storage, st,
+                 void *, source, range, blocks, status_handler, s)
 {
-    storage_rw_internal(st, true, source, blocks, s);
+    storage_rw_internal(bound(st), true, source, blocks, s);
 }
 
-static CLOSURE_1_3(storage_read, void, storage, void *, range, status_handler);
-static void storage_read(storage st, void * target, range blocks, status_handler s)
+closure_function(1, 3, void, storage_read,
+                 storage, st,
+                 void *, target, range, blocks, status_handler, s)
 {
-    storage_rw_internal(st, false, target, blocks, s);
+    storage_rw_internal(bound(st), false, target, blocks, s);
 }
 
 static void virtio_blk_attach(heap general, storage_attach a, heap page_allocator, heap pages, pci_dev d)
@@ -171,13 +174,14 @@ static void virtio_blk_attach(heap general, storage_attach a, heap page_allocato
     apply(a, in, out, s->capacity);
 }
 
-static CLOSURE_4_1(virtio_blk_probe, boolean, heap, storage_attach, heap, heap, pci_dev);
-static boolean virtio_blk_probe(heap general, storage_attach a, heap page_allocator, heap pages, pci_dev d)
+closure_function(4, 1, boolean, virtio_blk_probe,
+                 heap, general, storage_attach, a, heap, page_allocator, heap, pages,
+                 pci_dev, d)
 {
     if (pci_get_vendor(d) != VIRTIO_PCI_VENDORID || pci_get_device(d) != VIRTIO_PCI_DEVICEID_STORAGE)
         return false;
 
-    virtio_blk_attach(general, a, page_allocator, pages, d);
+    virtio_blk_attach(bound(general), bound(a), bound(page_allocator), bound(pages), d);
     return true;
 }
 

--- a/src/virtio/virtqueue.c
+++ b/src/virtio/virtqueue.c
@@ -144,17 +144,18 @@ void vqmsg_commit(virtqueue vq, vqmsg m, vqfinish completion)
     virtqueue_fill(vq);
 }
 
-static CLOSURE_2_0(vq_complete, void, vqfinish, u16);
-static void vq_complete(vqfinish f, u16 len)
+closure_function(2, 0, void, vq_complete,
+                 vqfinish, f, u16, len)
 {
-    apply(f, len);
+    apply(bound(f), bound(len));
 }
 
-static CLOSURE_1_0(vq_interrupt, void, virtqueue);
-static void vq_interrupt(virtqueue vq)
+closure_function(1, 0, void, vq_interrupt,
+                 virtqueue, vq)
 {
     // ensure we see up-to-date used->idx (updated by host)
     memory_barrier();
+    virtqueue vq = bound(vq);
     virtqueue_debug_verbose("%s: ENTRY: vq %p: entries %d, last_used_idx %d, used->idx %d, desc_idx %d\n",
         __func__, vq, vq->entries, vq->last_used_idx, vq->used->idx, vq->desc_idx);
     

--- a/src/x86_64/apic.h
+++ b/src/x86_64/apic.h
@@ -1,4 +1,5 @@
+clock_timer lapic_runloop_timer;
+
 void lapic_eoi(void);
 void init_apic(kernel_heaps kh);
-void lapic_runloop_timer(timestamp interval);
 void configure_lapic_timer(heap h);

--- a/src/x86_64/hpet.c
+++ b/src/x86_64/hpet.c
@@ -147,14 +147,13 @@ static void timer_config(int timer, timestamp rate, thunk t, boolean periodic)
     hpet->timers[timer].comparator = comparator;
 }
 
-static CLOSURE_0_1(hpet_runloop_timer, void, timestamp);
-static void hpet_runloop_timer(timestamp duration)
+closure_function(0, 1, void, hpet_runloop_timer,
+                 timestamp, duration)
 {
     timer_config(0, duration, ignore, false);
 }
 
-static CLOSURE_0_0(hpet_now, timestamp);
-static timestamp hpet_now()
+closure_function(0, 0, timestamp, hpet_now)
 {
     return (((u128)hpet_main_counter()) * hpet_period_scaled_32) >> 32;
 }

--- a/src/x86_64/kvm_platform.c
+++ b/src/x86_64/kvm_platform.c
@@ -66,8 +66,6 @@ static boolean probe_kvm_pvclock(kernel_heaps kh)
     return true;
 }
 
-CLOSURE_0_1(lapic_runloop_timer, void, timestamp);
-
 boolean kvm_detect(kernel_heaps kh)
 {
     kvm_debug("probing for KVM...");
@@ -86,7 +84,8 @@ boolean kvm_detect(kernel_heaps kh)
         return false;
     }
     heap h = heap_general(kh);
-    register_platform_clock_timer(closure(h, lapic_runloop_timer));
+    assert(lapic_runloop_timer);
+    register_platform_clock_timer(lapic_runloop_timer);
     configure_lapic_timer(h);
     return true;
 }

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -269,8 +269,8 @@ boolean traverse_ptes(u64 vaddr, u64 length, entry_handler ph)
     return true;
 }
 
-static CLOSURE_0_3(validate_entry, boolean, int, u64, u64 *);
-static boolean validate_entry(int level, u64 vaddr, u64 * entry)
+closure_function(0, 3, boolean, validate_entry,
+                 int, level, u64, vaddr, u64 *, entry)
 {
     return pt_entry_is_present(*entry);
 }
@@ -282,15 +282,16 @@ boolean validate_virtual(void * base, u64 length)
     return traverse_ptes(u64_from_pointer(base), length, stack_closure(validate_entry));
 }
 
-static CLOSURE_1_3(update_pte_flags, boolean, u64, int, u64, u64 *);
-static boolean update_pte_flags(u64 flags, int level, u64 addr, u64 * entry)
+closure_function(1, 3, boolean, update_pte_flags,
+                 u64, flags,
+                 int, level, u64, addr, u64 *, entry)
 {
     /* we only care about present ptes */
     u64 old = *entry;
     if (!pt_entry_is_present(old) || !pt_entry_is_pte(level, old))
         return true;
 
-    *entry = (old & ~PAGE_PROT_FLAGS) | flags;
+    *entry = (old & ~PAGE_PROT_FLAGS) | bound(flags);
 #ifdef PAGE_UPDATE_DEBUG
     page_debug("update 0x%lx: pte @ 0x%lx, 0x%lx -> 0x%lx\n", addr, entry, old, *entry);
 #endif
@@ -307,12 +308,13 @@ void update_map_flags(u64 vaddr, u64 length, u64 flags)
     traverse_ptes(vaddr, length, stack_closure(update_pte_flags, flags));
 }
 
-static CLOSURE_3_3(remap_entry, boolean, u64, u64, heap, int, u64, u64 *);
-static boolean remap_entry(u64 new, u64 old, heap h, int level, u64 curr, u64 * entry)
+closure_function(3, 3, boolean, remap_entry,
+                 u64, new, u64, old, heap, h,
+                 int, level, u64, curr, u64 *, entry)
 {
-    u64 offset = curr - old;
+    u64 offset = curr - bound(old);
     u64 oldentry = *entry;
-    u64 new_curr = new + offset;
+    u64 new_curr = bound(new) + offset;
     u64 phys = phys_from_pte(oldentry);
     u64 flags = flags_from_pte(oldentry);
 #ifdef PAGE_UPDATE_DEBUG
@@ -335,7 +337,7 @@ static boolean remap_entry(u64 new, u64 old, heap h, int level, u64 curr, u64 * 
         return true;
 
     /* transpose mapped page */
-    map_page(pagebase(), new_curr, phys, h, pt_entry_is_fat(level, oldentry), flags, 0);
+    map_page(pagebase(), new_curr, phys, bound(h), pt_entry_is_fat(level, oldentry), flags, 0);
 
     /* reset old entry */
     *entry = 0;
@@ -362,8 +364,8 @@ void remap_pages(u64 vaddr_new, u64 vaddr_old, u64 length, heap h)
     traverse_ptes(vaddr_old, length, stack_closure(remap_entry, vaddr_new, vaddr_old, h));
 }
 
-static CLOSURE_0_3(zero_page, boolean, int, u64, u64 *);
-static boolean zero_page(int level, u64 addr, u64 * entry)
+closure_function(0, 3, boolean, zero_page,
+                 int, level, u64, addr, u64 *, entry)
 {
     u64 e = *entry;
     if (pt_entry_is_present(e) && pt_entry_is_pte(level, e)) {
@@ -381,9 +383,11 @@ void zero_mapped_pages(u64 vaddr, u64 length)
     traverse_ptes(vaddr, length, stack_closure(zero_page));
 }
 
-static CLOSURE_1_3(unmap_page, boolean, range_handler, int, u64, u64 *);
-boolean unmap_page(range_handler rh, int level, u64 vaddr, u64 * entry)
+closure_function(1, 3, boolean, unmap_page,
+                 range_handler, rh,
+                 int, level, u64, vaddr, u64 *, entry)
 {
+    range_handler rh = bound(rh);
     u64 old_entry = *entry;
     if (pt_entry_is_present(old_entry) && pt_entry_is_pte(level, old_entry)) {
 #ifdef PAGE_UPDATE_DEBUG

--- a/src/x86_64/pvclock.c
+++ b/src/x86_64/pvclock.c
@@ -25,8 +25,7 @@ u64 pvclock_now_ns(void)
     return result;
 }
 
-CLOSURE_0_0(pvclock_now, timestamp);
-timestamp pvclock_now(void)
+closure_function(0, 0, timestamp, pvclock_now)
 {
     return nanoseconds(pvclock_now_ns());
 }

--- a/src/x86_64/pvclock.h
+++ b/src/x86_64/pvclock.h
@@ -16,5 +16,4 @@ struct pvclock_wall_clock {
 } __attribute__((__packed__));
 
 u64 pvclock_now_ns(void);
-timestamp pvclock_now(void);
 void init_pvclock(heap h, struct pvclock_vcpu_time_info *pvclock);

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -24,12 +24,6 @@ extern void start_interrupts(kernel_heaps kh);
 
 static struct kernel_heaps heaps;
 
-// doesnt belong here
-CLOSURE_3_0(startup, void, kernel_heaps, tuple, filesystem);
-void startup(kernel_heaps kh,
-             tuple root,
-             filesystem fs);
-
 heap allocate_tagged_region(kernel_heaps kh, u64 tag)
 {
     heap h = heap_general(kh);
@@ -114,11 +108,12 @@ void runloop()
 //#define MAX_BLOCK_IO_SIZE PAGE_SIZE
 #define MAX_BLOCK_IO_SIZE (256 * 1024)
 
-static CLOSURE_2_3(offset_block_io, void, u64, block_io, void *, range, status_handler);
-static void offset_block_io(u64 offset, block_io io, void *dest, range blocks, status_handler sh)
+closure_function(2, 3, void, offset_block_io,
+                 u64, offset, block_io, io,
+                 void *, dest, range, blocks, status_handler, sh)
 {
-    assert((offset & (SECTOR_SIZE - 1)) == 0);
-    u64 ds = offset >> SECTOR_OFFSET;
+    assert((bound(offset) & (SECTOR_SIZE - 1)) == 0);
+    u64 ds = bound(offset) >> SECTOR_OFFSET;
     blocks.start += ds;
     blocks.end += ds;
 
@@ -128,7 +123,7 @@ static void offset_block_io(u64 offset, block_io io, void *dest, range blocks, s
     status_handler k = apply_merge(m);
     while (blocks.start < blocks.end) {
         u64 span = MIN(range_span(blocks), MAX_BLOCK_IO_SIZE >> SECTOR_OFFSET);
-        apply(io, dest, irange(blocks.start, blocks.start + span), apply_merge(m));
+        apply(bound(io), dest, irange(blocks.start, blocks.start + span), apply_merge(m));
 
         // next block
         blocks.start += span;
@@ -137,17 +132,21 @@ static void offset_block_io(u64 offset, block_io io, void *dest, range blocks, s
     apply(k, STATUS_OK);
 }
 
+/* XXX some header reorg in order */
 void init_extra_prints(); 
+thunk create_init(kernel_heaps kh, tuple root, filesystem fs);
 
-static CLOSURE_1_2(fsstarted, void, tuple, filesystem, status);
-static void fsstarted(tuple root, filesystem fs, status s)
+closure_function(1, 2, void, fsstarted,
+                 tuple, root,
+                 filesystem, fs, status, s)
 {
     assert(s == STATUS_OK);
-    enqueue(runqueue, closure(heap_general(&heaps), startup, &heaps, root, fs));
+    enqueue(runqueue, create_init(&heaps, bound(root), fs));
 }
 
-static CLOSURE_2_3(attach_storage, void, tuple, u64, block_io, block_io, u64);
-static void attach_storage(tuple root, u64 fs_offset, block_io r, block_io w, u64 length)
+closure_function(2, 3, void, attach_storage,
+                 tuple, root, u64, fs_offset,
+                 block_io, r, block_io, w, u64, length)
 {
     // with filesystem...should be hidden as functional handlers on the tuplespace
     heap h = heap_general(&heaps);
@@ -155,10 +154,10 @@ static void attach_storage(tuple root, u64 fs_offset, block_io r, block_io w, u6
                       SECTOR_SIZE,
                       length,
                       heap_backed(&heaps),
-                      closure(h, offset_block_io, fs_offset, r),
-                      closure(h, offset_block_io, fs_offset, w),
-                      root,
-                      closure(h, fsstarted, root));
+                      closure(h, offset_block_io, bound(fs_offset), r),
+                      closure(h, offset_block_io, bound(fs_offset), w),
+                      bound(root),
+                      closure(h, fsstarted, bound(root)));
 }
 
 static void read_kernel_syms()

--- a/src/x86_64/symtab.c
+++ b/src/x86_64/symtab.c
@@ -22,8 +22,8 @@ static inline elfsym allocate_elfsym(range r, char * name)
     return es;
 }
 
-CLOSURE_0_4(elf_symtable_add, void, char *, u64, u64, u8);
-void elf_symtable_add(char * name, u64 a, u64 len, u8 info)
+closure_function(0, 4, void, elf_symtable_add,
+                 char *, name, u64, a, u64, len, u8, info)
 {
     int type = ELF64_ST_TYPE(info);
 

--- a/src/xen/xen.c
+++ b/src/xen/xen.c
@@ -94,8 +94,7 @@ boolean xen_detected(void)
 
 extern u64 hypercall_page;
 
-static CLOSURE_0_0(xen_interrupt, void);
-static void xen_interrupt(void)
+closure_function(0, 0, void, xen_interrupt)
 {
     volatile struct shared_info *si = xen_info.shared_info;
     volatile struct vcpu_info *vci = &xen_info.shared_info->vcpu_info[0]; /* hardwired at this point */
@@ -235,8 +234,8 @@ void xen_revoke_page_access(grant_ref_t ref)
 
 /* Reportedly, Xen timers can fire up to 100us early. */
 #define XEN_TIMER_SLOP_NS 100000
-static CLOSURE_0_1(xen_runloop_timer, void, timestamp);
-static void xen_runloop_timer(timestamp duration)
+closure_function(0, 1, void, xen_runloop_timer,
+                 timestamp, duration)
 {
     u64 n = pvclock_now_ns();
     u64 expiry = n + MAX(nsec_from_timestamp(duration), XEN_TIMER_SLOP_NS);
@@ -248,8 +247,7 @@ static void xen_runloop_timer(timestamp duration)
     }
 }
 
-static CLOSURE_0_0(xen_runloop_timer_handler, void);
-static void xen_runloop_timer_handler(void)
+closure_function(0, 0, void, xen_runloop_timer_handler)
 {
     rprintf("%s: now %T\n", __func__, nanoseconds(pvclock_now_ns()));
     assert(xen_unmask_evtchn(xen_info.timer_evtchn) == 0);

--- a/test/runtime/web.c
+++ b/test/runtime/web.c
@@ -3,18 +3,20 @@
 #include <socket_user.h>
 #include <sys/epoll.h>
 
-
-static CLOSURE_2_1(each_request, void, heap, buffer_handler, value);
-static void each_request(heap h, buffer_handler out, value v)
+closure_function(2, 1, void, each_request,
+                 heap, h, buffer_handler, out,
+                 value, v)
 {
-    send_http_response(out,
+    send_http_response(bound(out),
                        timm("ContentType", "text/html"),
-                       aprintf(h, "unibooty!"));
+                       aprintf(bound(h), "unibooty!"));
 }
 
-CLOSURE_1_1(conn, buffer_handler, heap, buffer_handler);
-buffer_handler conn(heap h, buffer_handler out)
+closure_function(1, 1, buffer_handler, conn,
+                 heap, h,
+                 buffer_handler, out)
 {
+    heap h = bound(h);
     return allocate_http_parser(h, closure(h, each_request, h, out));
 }
 

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -1,5 +1,6 @@
 PROGRAMS= \
 	buffer_test \
+	closure_test \
 	id_heap_test \
 	memops_test \
 	network_test \
@@ -16,6 +17,27 @@ SKIP_TEST=	network_test udp_test
 
 SRCS-buffer_test= \
 	$(CURDIR)/buffer_test.c \
+	$(SRCDIR)/runtime/bitmap.c \
+	$(SRCDIR)/runtime/buffer.c \
+	$(SRCDIR)/runtime/extra_prints.c \
+	$(SRCDIR)/runtime/format.c \
+	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/memops.c \
+	$(SRCDIR)/runtime/merge.c \
+	$(SRCDIR)/runtime/pqueue.c \
+	$(SRCDIR)/runtime/random.c \
+	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/runtime_init.c \
+	$(SRCDIR)/runtime/symbol.c \
+	$(SRCDIR)/runtime/table.c \
+	$(SRCDIR)/runtime/timer.c \
+	$(SRCDIR)/runtime/tuple.c \
+	$(SRCDIR)/runtime/string.c \
+	$(SRCDIR)/runtime/crypto/chacha.c \
+	$(SRCDIR)/unix_process/unix_process_runtime.c
+
+SRCS-closure_test= \
+	$(CURDIR)/closure_test.c \
 	$(SRCDIR)/runtime/bitmap.c \
 	$(SRCDIR)/runtime/buffer.c \
 	$(SRCDIR)/runtime/extra_prints.c \

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -338,12 +338,12 @@ CFLAGS+=	-I$(SRCDIR)/runtime \
 CLEANDIRS+=	$(OBJDIR)/test
 
 # gcov support
-#CFLAGS+=	-fprofile-arcs -ftest-coverage
-#LDFLAGS+=	-fprofile-arcs
-#GCDAFILES=	$(sort $(foreach p,$(PROGRAMS),$(patsubst %.o,%.gcda,$(OBJS-$p))))
-#GCOVFILES=	$(sort $(foreach p,$(PROGRAMS),$(patsubst %.o,%.gcno,$(OBJS-$p))))
-#GCOVFILES+=	$(GCDAFILES) $(OBJDIR)/gcov-tests.info
-#CLEANFILES+=	$(GCOVFILES)
+CFLAGS+=	-fprofile-arcs -ftest-coverage
+LDFLAGS+=	-fprofile-arcs
+GCDAFILES=	$(sort $(foreach p,$(PROGRAMS),$(patsubst %.o,%.gcda,$(OBJS-$p))))
+GCOVFILES=	$(sort $(foreach p,$(PROGRAMS),$(patsubst %.o,%.gcno,$(OBJS-$p))))
+GCOVFILES+=	$(GCDAFILES) $(OBJDIR)/gcov-tests.info
+CLEANFILES+=	$(GCOVFILES)
 
 all: $(PROGRAMS)
 

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -338,12 +338,12 @@ CFLAGS+=	-I$(SRCDIR)/runtime \
 CLEANDIRS+=	$(OBJDIR)/test
 
 # gcov support
-CFLAGS+=	-fprofile-arcs -ftest-coverage
-LDFLAGS+=	-fprofile-arcs
-GCDAFILES=	$(sort $(foreach p,$(PROGRAMS),$(patsubst %.o,%.gcda,$(OBJS-$p))))
-GCOVFILES=	$(sort $(foreach p,$(PROGRAMS),$(patsubst %.o,%.gcno,$(OBJS-$p))))
-GCOVFILES+=	$(GCDAFILES) $(OBJDIR)/gcov-tests.info
-CLEANFILES+=	$(GCOVFILES)
+#CFLAGS+=	-fprofile-arcs -ftest-coverage
+#LDFLAGS+=	-fprofile-arcs
+#GCDAFILES=	$(sort $(foreach p,$(PROGRAMS),$(patsubst %.o,%.gcda,$(OBJS-$p))))
+#GCOVFILES=	$(sort $(foreach p,$(PROGRAMS),$(patsubst %.o,%.gcno,$(OBJS-$p))))
+#GCOVFILES+=	$(GCDAFILES) $(OBJDIR)/gcov-tests.info
+#CLEANFILES+=	$(GCOVFILES)
 
 all: $(PROGRAMS)
 

--- a/test/unit/closure_test.c
+++ b/test/unit/closure_test.c
@@ -1,30 +1,15 @@
 #include <runtime.h>
 #include <stdlib.h>
 
-/* this would exist within the runtime environment */
-void _apply_dealloc(void)
-{
-    void *p;
-    asm volatile("pop %0" : "=r" (p));
-    struct _closure_common *c = p + sizeof(void*);
-    rprintf("p %p, dealloc h %p, c %p, size %d\n", p, c->h, c, c->size);
-    deallocate(c->h, p, c->size);
-}
-
-static CLOSURE_0_0(test0, u64);
-u64 test0(void)
+define_closure(0, 0, u64, test0)
 {
     rprintf("test0\n");
-    u64 rv = 0xdeadbeef;
-    closure_return_nodealloc rv;
+    return 0xdeadbeef;
 }
 
-static CLOSURE_0_0(test1, void);
-void test1(void)
+define_closure(0, 0, void, test1)
 {
-    void *self;
-    asm volatile("mov 8(%%rsp), %0" : "=r"(self));
-    rprintf("test1, self = %p\n", self);
+    rprintf("test1, self = %p\n", __self);
 }
 
 typedef closure_type(footype, u64);

--- a/test/unit/closure_test.c
+++ b/test/unit/closure_test.c
@@ -1,26 +1,43 @@
 #include <runtime.h>
 #include <stdlib.h>
 
+/* this would exist within the runtime environment */
 void _apply_dealloc(void)
 {
-    struct _closure_common *c;
-    asm volatile("pop %0" : "=r" (c));
-    rprintf("dealloc %p\n", c);
-    deallocate(c->h, c, c->size);
+    void *p;
+    asm volatile("pop %0" : "=r" (p));
+    struct _closure_common *c = p + sizeof(void*);
+    rprintf("p %p, dealloc h %p, c %p, size %d\n", p, c->h, c, c->size);
+    deallocate(c->h, p, c->size);
 }
 
-static CLOSURE_0_0(test0, void);
-void test0(void)
+static CLOSURE_0_0(test0, u64);
+u64 test0(void)
 {
     rprintf("test0\n");
-    return_without_dealloc;
+    u64 rv = 0xdeadbeef;
+    closure_return_nodealloc rv;
 }
+
+static CLOSURE_0_0(test1, void);
+void test1(void)
+{
+    void *self;
+    asm volatile("mov 8(%%rsp), %0" : "=r"(self));
+    rprintf("test1, self = %p\n", self);
+}
+
+typedef closure_type(footype, u64);
 
 int main(int argc, char **argv)
 {
     heap h = init_process_runtime();
-    thunk t = closure(h, test0);
-    rprintf("closure alloc %p\n", t);
+    rprintf("runtime heap %p\n", h);
+    footype f = closure(h, test0);
+    rprintf("closure alloc %p\n", f);
+    assert(apply(f) == 0xdeadbeef);
+    thunk t = closure(h, test1);
+    rprintf("test1 %p\n", t);
     apply(t);
     rprintf("end\n");
 }

--- a/test/unit/closure_test.c
+++ b/test/unit/closure_test.c
@@ -1,13 +1,13 @@
 #include <runtime.h>
 #include <stdlib.h>
 
-define_closure(0, 0, u64, test0)
+closure_function(0, 0, u64, test0)
 {
     rprintf("test0\n");
     return 0xdeadbeef;
 }
 
-define_closure(0, 0, void, test1)
+closure_function(0, 0, void, test1)
 {
     rprintf("test1, self = %p\n", __self);
 }

--- a/test/unit/closure_test.c
+++ b/test/unit/closure_test.c
@@ -1,28 +1,63 @@
 #include <runtime.h>
 #include <stdlib.h>
 
-closure_function(0, 0, u64, test0)
+#define TEST_L -1ull
+#define TEST_R -5ull
+#define TEST_RV 3
+
+closure_function(1, 1, u64, test0,
+                 u64, l,
+                 u64, r)
 {
-    rprintf("test0\n");
-    return 0xdeadbeef;
+    if (bound(l) != TEST_L || r != TEST_R) {
+        msg_err("argument mismatch\n");
+        exit(EXIT_FAILURE);
+    }
+    closure_finish();
+    return TEST_RV;
 }
 
-closure_function(0, 0, void, test1)
+static boolean terminate_reached;
+
+closure_function(0, 2, void, test1,
+                 void *, self, boolean, terminate)
 {
-    rprintf("test1, self = %p\n", __self);
+    if (terminate) {
+        terminate_reached = true;
+        return;
+    }
+    if (closure_self() != self) {
+        msg_err("self mismatch: %p, %p, terminate %d\n", closure_self(), self, terminate);
+        exit(EXIT_FAILURE);
+    }
+    apply(closure_self(), self, true);
 }
 
-typedef closure_type(footype, u64);
+typedef closure_type(test0_type, u64, u64);
+typedef closure_type(test1_type, void, void *, boolean);
 
 int main(int argc, char **argv)
 {
     heap h = init_process_runtime();
-    rprintf("runtime heap %p\n", h);
-    footype f = closure(h, test0);
-    rprintf("closure alloc %p\n", f);
-    assert(apply(f) == 0xdeadbeef);
-    thunk t = closure(h, test1);
-    rprintf("test1 %p\n", t);
-    apply(t);
-    rprintf("end\n");
+    u64 heap_occupancy = h->allocated;
+    test0_type f = closure(h, test0, TEST_L);
+    if (apply(f, TEST_R) != TEST_RV) {
+        msg_err("return value mismatch\n");
+        return EXIT_FAILURE;
+    }
+    if (h->allocated > heap_occupancy) {
+        msg_err("leak after closure_finish(): prev %ld, now %ld\n",
+                heap_occupancy, h->allocated);
+        return EXIT_FAILURE;
+    }
+    heap_occupancy = h->allocated;
+    test1_type t = closure(h, test1);
+    apply(t, t, false);
+    deallocate_closure(t);
+    if (h->allocated > heap_occupancy) {
+        msg_err("leak after deallocate_closure(): prev %ld, now %ld\n",
+                heap_occupancy, h->allocated);
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
 }

--- a/test/unit/closure_test.c
+++ b/test/unit/closure_test.c
@@ -1,0 +1,26 @@
+#include <runtime.h>
+#include <stdlib.h>
+
+void _apply_dealloc(void)
+{
+    struct _closure_common *c;
+    asm volatile("pop %0" : "=r" (c));
+    rprintf("dealloc %p\n", c);
+    deallocate(c->h, c, c->size);
+}
+
+static CLOSURE_0_0(test0, void);
+void test0(void)
+{
+    rprintf("test0\n");
+    return_without_dealloc;
+}
+
+int main(int argc, char **argv)
+{
+    heap h = init_process_runtime();
+    thunk t = closure(h, test0);
+    rprintf("closure alloc %p\n", t);
+    apply(t);
+    rprintf("end\n");
+}

--- a/test/unit/closure_test.c
+++ b/test/unit/closure_test.c
@@ -19,10 +19,15 @@ closure_function(1, 1, u64, test0,
 
 static boolean terminate_reached;
 
-closure_function(0, 2, void, test1,
+closure_function(1, 2, void, test1,
+                 int, count,
                  void *, self, boolean, terminate)
 {
     if (terminate) {
+        if (bound(count) != 1) {
+            msg_err("bound variable value mismatch\n");
+            exit(EXIT_FAILURE);
+        }
         terminate_reached = true;
         return;
     }
@@ -30,6 +35,7 @@ closure_function(0, 2, void, test1,
         msg_err("self mismatch: %p, %p, terminate %d\n", closure_self(), self, terminate);
         exit(EXIT_FAILURE);
     }
+    bound(count)++;
     apply(closure_self(), self, true);
 }
 
@@ -51,7 +57,7 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
     heap_occupancy = h->allocated;
-    test1_type t = closure(h, test1);
+    test1_type t = closure(h, test1, 0);
     apply(t, t, false);
     deallocate_closure(t);
     if (h->allocated > heap_occupancy) {

--- a/test/unit/parser_test.c
+++ b/test/unit/parser_test.c
@@ -31,8 +31,9 @@ if (strcmp(s1, s2) != 0) { \
 } while (0)
 
 tuple root;
-CLOSURE_1_1(finish, void, heap, void*);
-void finish(heap h, void *v)
+closure_function(1, 1, void, finish,
+                 heap, h,
+                 void *, v)
 {
     root = v;
 }
@@ -42,8 +43,8 @@ string last_error;
 
 parser p;
 
-CLOSURE_0_1(perr, void, string);
-void perr(string s)
+closure_function(0, 1, void, perr,
+                 string, s)
 {
     errors_count++;
     last_error = s; // TODO: copy string here

--- a/test/unit/range_test.c
+++ b/test/unit/range_test.c
@@ -21,8 +21,8 @@ typedef struct test_node {
     int val;
 } *test_node;
 
-static CLOSURE_0_1(basic_test_validate, void, rmnode);
-static void basic_test_validate(rmnode node)
+closure_function(0, 1, void, basic_test_validate,
+                 rmnode, node)
 {
     static int count = 0;
     int nresults = sizeof(rm_results) / sizeof(struct rm_result);


### PR DESCRIPTION
This PR introduces a slight variation of the syntax and semantics of closures. A pointer to the closure allocation, __self, is passed to closure functions in lieu of unpacking the left hand side environment and passing (immutable) values individually as arguments.

This has a few significant implications:

- Closures may be readily deallocated within the closure function (previously there was no way to access the structure from within the function, let alone the heap from which it was allocated or its size). See deallocate_closure() and closure_finish().
- A closure function can now modify its environment (enclosed variables) directly. Previously these variables were copied into the function arguments on apply, thus acting as immutable, constant values set on closure creation. This means that a closure can readily update its internal state without needing to re-create a new closure.
- A closure may refer to itself within its function as "closure_self()". After updating the environment, the closure can then be queued for use again or even applied directly in a recursive manner (i.e. "apply(closure_self(), <rhs args>)").

This change has been largely dressed up in syntactical sugar which generates the function prototypes. The old format of e.g.

static CLOSURE_1_1(foo, void, ltype, ltype, rtype, rtype);
static void foo(ltype lname, rtype rname) {
    ...
}

now takes the following form:

closure_function(1, 1, void, foo, ltype, lname, rtype, rname) {
    ....
}

One slight annoyance to arise out of this is that enclosed variables must be accessed with the "bound(var)" macro (which just equates to __self->var), whereas previously they were simply accessed as function arguments. However, bound() may also be used in the left hand side of an assignment.

This PR just introduces the closure changes along with conversions for the 194 closure definitions throughout the tree. Closure deallocations and other optimizations (e.g. the tuple parser has a y combinator which should no longer need to re-create closures, and some other blocking operations have been split into multiple closures which may be reduced to one) will be addressed in a follow-up PR.
