### PR TITLE
remap_pages() bugfix

### DIFF
--- a/src/runtime/range.h
+++ b/src/runtime/range.h
@@ -96,6 +96,11 @@ static inline boolean ranges_intersect(range a, range b)
     return !range_empty(range_intersection(a, b));
 }
 
+static inline boolean range_contains(range a, range b)
+{
+    return a.start <= b.start && a.end >= b.end;
+}
+
 static inline boolean range_equal(range a, range b)
 {
     return (a.start == b.start) && (a.end == b.end);

--- a/src/runtime/range.h
+++ b/src/runtime/range.h
@@ -98,7 +98,7 @@ static inline boolean ranges_intersect(range a, range b)
 
 static inline boolean range_contains(range a, range b)
 {
-    return a.start <= b.start && a.end >= b.end;
+    return (a.start <= b.start) && (a.end >= b.end);
 }
 
 static inline boolean range_equal(range a, range b)

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -322,18 +322,8 @@ closure_function(3, 3, boolean, remap_entry,
                level, curr, phys, new_curr, entry, *entry, flags);
 #endif
 
-    /* transpose any unmapped gaps to target */
-    if (!pt_entry_is_present(oldentry)) {
-        u64 len = U64_FROM_BIT(level_shift[level]);
-#ifdef PAGE_UPDATE_DEBUG
-        page_debug("unmapping [0x%lx, 0x%lx)\n", new_curr, new_curr + len);
-#endif
-        unmap_pages(new_curr, len);
-        return true;
-    }
-
     /* only look at ptes at this point */
-    if (!pt_entry_is_pte(level, oldentry))
+    if (!pt_entry_is_present(oldentry) || !pt_entry_is_pte(level, oldentry))
         return true;
 
     /* transpose mapped page */


### PR DESCRIPTION
bugfix: remap_pages() can overwrite PTEs beyond the range of the target destination address range when it encounters missing PTE entries. This leads to occasional failures in the mmap runtime test, or anything using mremap