### PR TITLE
bugfix: signal code needs to put si_signo on the stack even without

### DIFF
--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -375,7 +375,10 @@ sysreturn rt_sigreturn(void)
     /* sigframe sits at %rsp minus the return address word (pretcode) */
     frame = (struct rt_sigframe *)(t->sigframe[FRAME_RSP] - sizeof(u64));
     sig_debug("rt_sigreturn: frame:0x%lx\n", (unsigned long)frame);
-    sa = get_sigaction(frame->info.si_signo);
+
+    /* safer to query via thread variable */
+    sa = get_sigaction(t->active_signo);
+    t->active_signo = 0;
 
     /* restore signal mask and saved context, if applicable */
     reset_sigmask(t);
@@ -694,7 +697,6 @@ static void setup_sigframe(thread t, int signum, struct siginfo *si)
         t->sigframe[FRAME_RSI] = u64_from_pointer(&frame->info);
         t->sigframe[FRAME_RDX] = u64_from_pointer(&frame->uc);
     } else {
-        frame->info.si_signo = si->si_signo;
         t->sigframe[FRAME_RSI] = 0;
         t->sigframe[FRAME_RDX] = 0;
     }
@@ -702,6 +704,9 @@ static void setup_sigframe(thread t, int signum, struct siginfo *si)
     /* setup regs for signal handler */
     t->sigframe[FRAME_RIP] = u64_from_pointer(sa->sa_handler);
     t->sigframe[FRAME_RDI] = signum;
+
+    /* save signo for safer sigreturn */
+    t->active_signo = signum;
 
     sig_debug("sigframe tid %d, sig %d, rip 0x%lx, rsp 0x%lx, "
               "rdi 0x%lx, rsi 0x%lx, rdx 0x%lx, r8 0x%lx\n", t->tid, signum,

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -692,6 +692,7 @@ static void setup_sigframe(thread t, int signum, struct siginfo *si)
         t->sigframe[FRAME_RSI] = u64_from_pointer(&frame->info);
         t->sigframe[FRAME_RDX] = u64_from_pointer(&frame->uc);
     } else {
+        frame->info.si_signo = si->si_signo;
         t->sigframe[FRAME_RSI] = 0;
         t->sigframe[FRAME_RDX] = 0;
     }

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -201,6 +201,7 @@ thread create_thread(process p)
     t->blocked_on = 0;
     init_sigstate(&t->signals);
     t->dispatch_sigstate = 0;
+    t->active_signo = 0;
 
     // XXX sigframe
     return t;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -181,6 +181,7 @@ typedef struct thread {
     struct sigstate signals;
     sigstate dispatch_sigstate; /* saved sigstate while signal handler in flight */
     u64 sigframe[FRAME_MAX];
+    u16 active_signo;
 } *thread;
 
 typedef closure_type(io, sysreturn, void *buf, u64 length, u64 offset, thread t,


### PR DESCRIPTION
SA_SIGINFO, since we use it in rt_sigreturn