### PR TITLE
exec: use program name as default argument

### DIFF
--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -46,6 +46,15 @@ static void build_exec_stack(process p, thread t, Elf64_Ehdr * e, void *start, u
 
     // argv ASCIIZ strings
     vector arguments = vector_from_tuple(transient, table_find(process_root, sym(arguments)));
+    if (!arguments)
+        arguments = allocate_vector(transient, 1);
+
+    if (vector_length(arguments) == 0) {
+        value p = table_find(process_root, sym(program));
+        assert(p);
+        vector_push(arguments, p);
+    }
+
     char **argv = stack_allocate(vector_length(arguments) * sizeof(u64));
     buffer a;
     int argv_len = 0;
@@ -62,6 +71,7 @@ static void build_exec_stack(process p, thread t, Elf64_Ehdr * e, void *start, u
         argv[argc++] = sp;
         sp += len + 1;
     }
+    deallocate_vector(arguments);
 
     // envp ASCIIZ strings
     tuple environment = table_find(process_root, sym(environment));

--- a/stage3/stage3.c
+++ b/stage3/stage3.c
@@ -50,6 +50,7 @@ closure_function(3, 0, void, startup,
     heap general = heap_general(kh);
     buffer_handler pg = closure(general, read_program_complete, kp, root);
     value p = table_find(root, sym(program));
+    assert(p);
     tuple pro = resolve_path(root, split(general, p, '/'));
     init_network_iface(root);
     filesystem_read_entire(fs, pro, heap_backed(kh), pg, closure(general, read_program_fail));


### PR DESCRIPTION
Without arguments specified via '-a', ops will pass a null argument list to nanos in the manifest. None the wiser, nanos will pass along a zero argument count to the program, causing failures wherever a program expects to find the executable name in argv[0], e.g.:

https://github.com/nanovms/ops/issues/113#issuecomment-539482989

This PR will default to using the value of 'program' in the root tuple if 'arguments' is either undefined or null.

We still may wish to update the behavior of ops here; I imagine most users will expect '-a' to specify arguments to the program without needing to begin with the program name. (A separate flag could be used to override the program name should this be absolutely necessary - e.g. for something like busybox where program name dictates behavior.)
