### PR TITLE
thread exit cleanup

### DIFF
--- a/contgen/contgen.c
+++ b/contgen/contgen.c
@@ -73,16 +73,18 @@ void pi(char *fmt, ...)
 
 void cblock()
 {
-    p("#define CLOSURE_%_%(_rettype, _name^~)|", nleft, nright, ", _lt%, _ln%", ", _rt%, _rn%");
-    p("struct _closure_##_name;|");
-    p("static _rettype _name(struct _closure_##_name *~);|", ", _rt%");
-
+    p("#define CLOSURE_STRUCT_%_%(_rettype, _name^~)|", nleft, nright, ", _lt%, _ln%", ", _rt%, _rn%");
     p("struct _closure_##_name {|");
     p("  _rettype (*__apply)(struct _closure_##_name *~);|", ", _rt%");
     p("  struct _closure_common __c;|");
     for (int i = 0; i < nleft ; i++)  p("  _lt% _ln%;|", i, i);
-    p("};|");
+    p("};\n\n");
 
+    p("#define CLOSURE_DECLARE_FUNCS_%_%(_rettype, _name^~)|", nleft, nright, ", _lt%, _ln%", ", _rt%, _rn%");
+    p("static _rettype (**_fill_##_name(heap h, struct _closure_##_name* n, bytes s^))(void *~);|", ", _lt% l%", ", _rt%");
+    p("static _rettype _name(struct _closure_##_name *~);\n\n", ", _rt%");
+
+    p("#define CLOSURE_DEFINE_%_%(_rettype, _name^~)|", nleft, nright, ", _lt%, _ln%", ", _rt%, _rn%");
     p("static _rettype (**_fill_##_name(heap h, struct _closure_##_name* n, bytes s^))(void *~) {|", ", _lt% l%", ", _rt%");
     p("  n->__apply = _name;|");
     p("  n->__c.name = #_name;|");

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -689,7 +689,7 @@ closure_function(1, 0, sysreturn, socket_close,
     deallocate_closure(s->f.events);
     deallocate_closure(s->f.ioctl);
     release_fdesc(&s->f);
-    unix_cache_free(get_unix_heaps(), socket, s);
+    unix_cache_free(s->p->uh, socket, s);
     return 0;
 }
 
@@ -759,7 +759,7 @@ static int allocate_sock(process p, int type, u32 flags, sock * rs)
     sock s;
     int fd;
 
-    s = unix_cache_alloc(get_unix_heaps(), socket);
+    s = unix_cache_alloc(p->uh, socket);
     if (s == INVALID_ADDRESS) {
 	msg_err("failed to allocate struct sock\n");
         goto err_sock;
@@ -771,7 +771,7 @@ static int allocate_sock(process p, int type, u32 flags, sock * rs)
         goto err_fd;
     }
 
-    heap h = heap_general(get_kernel_heaps());
+    heap h = heap_general((kernel_heaps)p->uh);
     init_fdesc(h, &s->f, FDESC_TYPE_SOCKET);
     s->f.read = closure(h, socket_read, s);
     s->f.write = closure(h, socket_write, s);
@@ -812,7 +812,7 @@ err_rx:
 err_queue:
     deallocate_fd(p, fd);
 err_fd:
-    unix_cache_free(get_unix_heaps(), socket, s);
+    unix_cache_free(p->uh, socket, s);
 err_sock:
     return -ENOMEM;
 }

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -17,7 +17,7 @@
     __closure(0, stack_allocate(sizeof(struct _closure_##__name)), \
               sizeof(struct _closure_##__name), __name, ##__VA_ARGS__)
 
-#define fill_closure(__p, __name, ...)\
+#define init_closure(__p, __name, ...)                                  \
     __closure(0, (__p), sizeof(struct _closure_##__name), __name, ##__VA_ARGS__)
 
 #define closure_struct(__name, __field) struct _closure_##__name __field;

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -17,14 +17,32 @@
     __closure(0, stack_allocate(sizeof(struct _closure_##__name)), \
               sizeof(struct _closure_##__name), __name, ##__VA_ARGS__)
 
+#define fill_closure(__p, __name, ...)\
+    __closure(0, (__p), sizeof(struct _closure_##__name), __name, ##__VA_ARGS__)
+
+#define closure_struct(__name, __field) struct _closure_##__name __field;
+
 struct _closure_common {
     char *name;
     heap h;
     bytes size;
 };
 
-#define __closure_define(nl, nr) CLOSURE_ ## nl ## _ ## nr
-#define closure_function(nl, nr, ...) __closure_define(nl, nr)(__VA_ARGS__)
+#define __closure_struct_declare(nl, nr) CLOSURE_STRUCT_ ## nl ## _ ## nr
+#define __closure_function_declare(nl, nr) CLOSURE_DECLARE_FUNCS_ ## nl ## _ ## nr
+#define __closure_define(nl, nr) CLOSURE_DEFINE_ ## nl ## _ ## nr
+
+#define closure_function(nl, nr, ...)                   \
+    __closure_struct_declare(nl, nr)(__VA_ARGS__)       \
+    __closure_function_declare(nl, nr)(__VA_ARGS__)     \
+    __closure_define(nl, nr)(__VA_ARGS__)
+
+/* use these for closures embedded within structs */
+#define declare_closure_struct(nl, nr, ...) __closure_struct_declare(nl, nr)(__VA_ARGS__)
+#define declare_closure_function(nl, nr, ...) __closure_function_declare(nl, nr)(__VA_ARGS__)
+#define define_closure_function(nl, nr, ...)            \
+    __closure_function_declare(nl, nr)(__VA_ARGS__)     \
+    __closure_define(nl, nr)(__VA_ARGS__)
 
 #define bound(v) (__self->v)
 #define closure_self() (&(__self->__apply))

--- a/src/runtime/refcount.h
+++ b/src/runtime/refcount.h
@@ -1,0 +1,26 @@
+/* a lightweight, inline version of merge without status handling */
+typedef struct refcount {
+    word c;
+    thunk completion;
+} *refcount;
+
+static inline void init_refcount(refcount r, thunk completion)
+{
+    r->c = 1;
+    r->completion = completion;
+}
+
+static inline void refcount_reserve(refcount r)
+{
+    fetch_and_add(&r->c, 1);
+}
+
+static inline void refcount_release(refcount r)
+{
+    word n = fetch_and_add(&r->c, (word)-1);
+    if (n < 1)
+        halt("%s: invalid count %ld\n", __func__, n);
+    if (n == 1) {
+        apply(r->completion);
+    }
+}

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -206,6 +206,8 @@ typedef struct merge *merge;
 merge allocate_merge(heap h, status_handler completion);
 status_handler apply_merge(merge m);
 
+#include <refcount.h>
+
 void __stack_chk_guard_init();
 
 #define _countof(a) (sizeof(a) / sizeof(*(a)))

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -107,6 +107,7 @@ static void blockq_item_finish(blockq bq, blockq_item bi)
         /* XXX acquire spinlock */
     }
 
+    refcount_release(&bi->t->refcount);
     free_blockq_item(bq, bi);
 }
 
@@ -227,6 +228,7 @@ sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a,
 
     bi->a = a;
     bi->t = t;
+    refcount_reserve(&t->refcount);
 
     if (timeout > 0) {
         bi->timeout = register_timer(timeout,

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -1,12 +1,11 @@
 #include <unix_internal.h>
 #include <page.h>
 
-#define PF_INFO
-#ifdef PF_INFO
-#define pf_info(x, ...) do { log_printf("  PF", "thread %d, " x "\n", current->tid, ##__VA_ARGS__); \
-        thread_log(current, x, ##__VA_ARGS__); } while(0)
+#define PF_DEBUG
+#ifdef PF_DEBUG
+#define pf_debug(x, ...) thread_log(current, x, ##__VA_ARGS__);
 #else
-#define pf_info(x, ...)
+#define pf_debug(x, ...)
 #endif
 
 static boolean vmap_attr_equal(vmap a, vmap b)
@@ -37,7 +36,7 @@ deliver_segv(u64 vaddr, s32 si_code)
         }
     };
 
-    pf_info("delivering SIGSEGV; vaddr 0x%lx si_code %s",
+    pf_debug("delivering SIGSEGV; vaddr 0x%lx si_code %s",
         vaddr, (si_code == SEGV_MAPERR) ? "SEGV_MAPPER" : "SEGV_ACCERR"
     );
 
@@ -82,7 +81,7 @@ boolean unix_fault_page(u64 vaddr, context frame)
 
     /* no vmap --> send access violation */
     if (vm == INVALID_ADDRESS) {
-        pf_info("no vmap found for addr 0x%lx, rip 0x%lx", vaddr, frame[FRAME_RIP]);
+        pf_debug("no vmap found for addr 0x%lx, rip 0x%lx", vaddr, frame[FRAME_RIP]);
         deliver_segv(vaddr, SEGV_MAPERR); /* does not return */
         assert(0);
     }
@@ -98,17 +97,16 @@ boolean unix_fault_page(u64 vaddr, context frame)
             return false;
         }
 
-        pf_info("page protection violation\naddr 0x%lx, rip 0x%lx, "
-                "error %s%s%s vm->flags (%s%s%s%s)", 
-                vaddr, frame[FRAME_RIP],
-                (error_code & FRAME_ERROR_PF_RW) ? "W" : "R",
-                (error_code & FRAME_ERROR_PF_US) ? "U" : "S",
-                (error_code & FRAME_ERROR_PF_ID) ? "I" : "D",
-                (vm->flags & VMAP_FLAG_MMAP) ? "mmap " : "",
-                (vm->flags & VMAP_FLAG_ANONYMOUS) ? "anonymous " : "",
-                (vm->flags & VMAP_FLAG_WRITABLE) ? "writable " : "",
-                (vm->flags & VMAP_FLAG_EXEC) ? "executable " : ""
-        );
+        pf_debug("page protection violation\naddr 0x%lx, rip 0x%lx, "
+                 "error %s%s%s vm->flags (%s%s%s%s)", 
+                 vaddr, frame[FRAME_RIP],
+                 (error_code & FRAME_ERROR_PF_RW) ? "W" : "R",
+                 (error_code & FRAME_ERROR_PF_US) ? "U" : "S",
+                 (error_code & FRAME_ERROR_PF_ID) ? "I" : "D",
+                 (vm->flags & VMAP_FLAG_MMAP) ? "mmap " : "",
+                 (vm->flags & VMAP_FLAG_ANONYMOUS) ? "anonymous " : "",
+                 (vm->flags & VMAP_FLAG_WRITABLE) ? "writable " : "",
+                 (vm->flags & VMAP_FLAG_EXEC) ? "executable " : "");
 
         deliver_segv(vaddr, SEGV_ACCERR); /* does not return */
         assert(0);

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -6,14 +6,18 @@
 #define epoll_debug(x, ...)
 #endif
 
-typedef struct epoll *epoll;
+typedef struct epollfd *epollfd;
+
+declare_closure_struct(1, 0, void, epollfd_free,
+                       epollfd, efd);
 
 typedef struct epollfd {
     int fd;
     u32 eventmask;  /* epoll events registered - XXX need lock */
     u32 lastevents; /* retain last received events; for edge trigger */
     u64 data;	    /* may be multiple versions of data? */
-    u64 refcnt;
+    struct refcount refcount;
+    closure_struct(epollfd_free, free);
     epoll e;
     boolean registered;
     boolean zombie;		/* freed or masked by oneshot */
@@ -21,6 +25,9 @@ typedef struct epollfd {
 } *epollfd;
 
 typedef struct epoll_blocked *epoll_blocked;
+
+declare_closure_struct(1, 0, void, epoll_blocked_free,
+                       epoll_blocked, w);
 
 enum epoll_type {
     EPOLL_TYPE_SELECT,
@@ -30,10 +37,11 @@ enum epoll_type {
 
 struct epoll_blocked {
     epoll e;
-    u64 refcnt;
     thread t;
     boolean sleeping;
     enum epoll_type epoll_type;
+    struct refcount refcount;
+    closure_struct(epoll_blocked_free, free);
     timer timeout;
     union {
 	buffer user_events;
@@ -52,17 +60,33 @@ struct epoll_blocked {
     struct list blocked_list;
 };
 
+declare_closure_struct(1, 0, void, epoll_free,
+                       epoll, e);
+
+/* we call it an epoll, but these structs are used for select and poll too */
 struct epoll {
     struct fdesc f;             /* must be first */
-    // xxx - multiple threads can block on the same e with epoll_wait
-    struct list blocked_head;
-    u64 refcnt;
+    struct list blocked_head;   /* an epoll_blocked per thread (in epoll_wait)  */
+    struct refcount refcount;
+    closure_struct(epoll_free, free);
     heap h;
     vector events;		/* epollfds indexed by fd */
     int nfds;
     bitmap fds;			/* fds being watched / epollfd registered */
 };
     
+define_closure_function(1, 0, void, epoll_free,
+                        epoll, e)
+{
+    epoll e = bound(e);
+    epoll_debug("e %p\n", e);
+    deallocate_bitmap(e->fds);
+    deallocate_vector(e->events);
+    if (e->f.close && e->f.close != INVALID_ADDRESS)
+        deallocate_closure(e->f.close);
+    unix_cache_free(get_unix_heaps(), epoll, e);
+}
+
 static epoll epoll_alloc_internal(void)
 {
     epoll e = unix_cache_alloc(get_unix_heaps(), epoll);
@@ -70,7 +94,7 @@ static epoll epoll_alloc_internal(void)
 	return e;
 
     list_init(&e->blocked_head);
-    e->refcnt = 1;
+    init_refcount(&e->refcount, fill_closure(&e->free, epoll_free, e));
     e->h = heap_general(get_kernel_heaps());
     e->events = allocate_vector(e->h, 8);
     if (e->events == INVALID_ADDRESS)
@@ -89,31 +113,13 @@ static epoll epoll_alloc_internal(void)
     return INVALID_ADDRESS;
 }
 
-static void epoll_dealloc_internal(epoll e)
+define_closure_function(1, 0, void, epollfd_free,
+                        epollfd, efd)
 {
-    epoll_debug("e %p\n", e);
-    deallocate_bitmap(e->fds);
-    deallocate_vector(e->events);
-    if (e->f.close && e->f.close != INVALID_ADDRESS)
-        deallocate_closure(e->f.close);
-    unix_cache_free(get_unix_heaps(), epoll, e);
-}
-
-static inline void reserve_epoll(epoll e)
-{
-    u64 r = fetch_and_add(&e->refcnt, 1);
-    (void)r;
-    epoll_debug("e %p, old refcnt %d\n", e, r);
-}
-
-static void release_epoll(epoll e)
-{
-    u64 r = fetch_and_add(&e->refcnt, -1);
-    epoll_debug("e %p, old refcnt %d\n", e, r);
-    assert(r > 0);
-    if (r != 1)
-        return;
-    epoll_dealloc_internal(e);
+    epollfd efd = bound(efd);
+    epoll_debug("fd %d\n", efd->fd);
+    refcount_release(&efd->e->refcount);
+    unix_cache_free(get_unix_heaps(), epollfd, efd);
 }
 
 static epollfd alloc_epollfd(epoll e, int fd, u32 eventmask, u64 data)
@@ -127,26 +133,15 @@ static epollfd alloc_epollfd(epoll e, int fd, u32 eventmask, u64 data)
     efd->lastevents = 0;
     efd->e = e;
     efd->data = data;
-    efd->refcnt = 1;
+    init_refcount(&efd->refcount, fill_closure(&efd->free, epollfd_free, efd));
     efd->registered = false;
     efd->zombie = false;
-    reserve_epoll(e);
     vector_set(e->events, fd, efd);
     bitmap_set(e->fds, fd, 1);
     if (fd >= e->nfds)
 	e->nfds = fd + 1;
+    refcount_reserve(&e->refcount);
     return efd;
-}
-
-static void release_epollfd(epollfd efd)
-{
-    epoll_debug("fd %d, refcnt %ld\n", efd->fd, efd->refcnt);
-    assert(efd->refcnt > 0);
-    if (fetch_and_add(&efd->refcnt, -1) == 1) {
-        epoll_debug("  deallocating efd %p\n", efd);
-        release_epoll(efd->e);
-	unix_cache_free(get_unix_heaps(), epollfd, efd);
-    }
 }
 
 static void unregister_epollfd(epollfd efd)
@@ -161,7 +156,7 @@ static void unregister_epollfd(epollfd efd)
     efd->notify_handle = 0;
 }
 
-static void free_epollfd(epollfd efd)
+static void release_epollfd(epollfd efd)
 {
     epoll e = efd->e;
     int fd = efd->fd;
@@ -169,11 +164,11 @@ static void free_epollfd(epollfd efd)
     assert(vector_get(e->events, fd) == efd);
     vector_set(e->events, fd, 0);
     bitmap_set(e->fds, fd, 0);
-    assert(efd->refcnt > 0);
     efd->zombie = true;
     if (efd->registered)
         unregister_epollfd(efd);
-    release_epollfd(efd);
+    refcount_release(&e->refcount);
+    refcount_release(&efd->refcount);
 }
 
 static boolean register_epollfd(epollfd efd, event_handler eh)
@@ -187,7 +182,7 @@ static boolean register_epollfd(epollfd efd, event_handler eh)
         return false; // XXX
     fdesc f = resolve_fd(current->p, efd->fd);
     efd->registered = true;
-    fetch_and_add(&efd->refcnt, 1);
+    refcount_reserve(&efd->refcount);
     epoll_debug("fd %d, eventmask 0x%x, handler %p\n", efd->fd, efd->eventmask, eh);
     efd->notify_handle = notify_add(f->ns, efd->eventmask | (EPOLLERR | EPOLLHUP), eh);
     assert(efd->notify_handle != INVALID_ADDRESS);
@@ -199,7 +194,7 @@ static void epoll_release_epollfds(epoll e)
     bitmap_foreach_set(e->fds, fd) {
 	epollfd efd = vector_get(e->events, fd);
 	assert(efd != 0 && efd != INVALID_ADDRESS);
-	free_epollfd(efd);
+	release_epollfd(efd);
     }
 }
 
@@ -207,7 +202,7 @@ void epoll_finish(epoll e)
 {
     epoll_debug("e %p\n", e);
     epoll_release_epollfds(e);
-    release_epoll(e);
+    refcount_release(&e->refcount);
 }
 
 closure_function(1, 0, sysreturn, epoll_close,
@@ -242,37 +237,37 @@ sysreturn epoll_create(int flags)
   out_dealloc_fd:
     deallocate_fd(current->p, fd);
   out_dealloc_epoll:
-    epoll_dealloc_internal(e);
+    refcount_release(&e->refcount);
     return rv;
 }
 
 #define user_event_count(__w) (buffer_length(__w->user_events)/sizeof(struct epoll_event))
 
-static void epoll_blocked_release(epoll_blocked w)
+define_closure_function(1, 0, void, epoll_blocked_free,
+                        epoll_blocked, w)
 {
+    epoll_blocked w = bound(w);
     epoll_debug("w %p\n", w);
-    if (!list_empty(&w->blocked_list)) {
-	list_delete(&w->blocked_list);
-        list_init(&w->blocked_list);
-	epoll_debug("   removed from epoll list\n");
-    }
-    if (fetch_and_add(&w->refcnt, -1) == 1) {
-	release_epoll(w->e);
-	unix_cache_free(get_unix_heaps(), epoll_blocked, w);
-	epoll_debug("   deallocated\n");
-    }
+    refcount_release(&w->e->refcount);
+    unix_cache_free(get_unix_heaps(), epoll_blocked, w);
 }
 
 static void epoll_blocked_finish_internal(epoll_blocked w, boolean timedout)
 {
 #ifdef EPOLL_DEBUG
-    epoll_debug("w %p, refcnt %ld\n", w, w->refcnt);
+    epoll_debug("w %p, refcnt %ld\n", w, w->refcount.c);
     if (w->sleeping)
 	epoll_debug("   sleeping\n");
     if (timedout)
 	epoll_debug("   timed out %p\n", w->timeout);
 #endif
     heap h = w->e->h;
+
+    if (!list_empty(&w->blocked_list)) {
+        list_delete(&w->blocked_list);
+        list_init(&w->blocked_list);
+        epoll_debug("   removed from epoll list\n");
+    }
 
     if (w->sleeping) {
         w->sleeping = false;
@@ -316,13 +311,12 @@ static void epoll_blocked_finish_internal(epoll_blocked w, boolean timedout)
 	*/
 #ifdef EPOLL_DEBUG
 	if (w->timeout && !timedout)
-	    epoll_debug("      timer remains; refcount %ld\n", w->refcnt);
+	    epoll_debug("      timer remains; refcount %ld\n", w->refcount.c);
 #endif
-	epoll_blocked_release(w);
+	refcount_release(&w->refcount);
     } else if (timedout) {
 	epoll_debug("   timer expiry after syscall return; ignored\n");
-	assert(w->refcnt == 1);
-	epoll_blocked_release(w);
+	refcount_release(&w->refcount);
     } else {
 	epoll_debug("   in syscall or zombie event\n");
     }
@@ -400,12 +394,14 @@ static epoll_blocked alloc_epoll_blocked(epoll e)
     epoll_blocked w = unix_cache_alloc(get_unix_heaps(), epoll_blocked);
     if (w == INVALID_ADDRESS)
 	return w;
-    w->refcnt = 1;
+    epoll_debug("w %p\n", w);
+    init_refcount(&w->refcount, fill_closure(&w->free, epoll_blocked_free, w));
     w->t = current;
+    refcount_reserve(&w->t->refcount);
     w->e = e;
+    refcount_reserve(&e->refcount);
     w->sleeping = false;
     w->timeout = 0;
-    reserve_epoll(e);
     list_insert_after(&e->blocked_head, &w->blocked_list); /* push */
     return w;
 }
@@ -449,7 +445,7 @@ sysreturn epoll_wait(int epfd,
         fdesc f = resolve_fd_noret(current->p, efd->fd);
         if (!f) {
             epoll_debug("   x fd %d\n", efd->fd);
-            free_epollfd(efd);
+            release_epollfd(efd);
             continue;
         }
 
@@ -462,13 +458,13 @@ sysreturn epoll_wait(int epfd,
     int eventcount = w->user_events->end/sizeof(struct epoll_event);
     if (timeout == 0 || w->user_events->end) {
 	epoll_debug("   immediate return; eventcount %d\n", eventcount);
-	epoll_blocked_release(w);
+	refcount_release(&w->refcount);
         return eventcount;
     }
 
     if (timeout > 0) {
 	w->timeout = register_timer(milliseconds(timeout), closure(e->h, epoll_blocked_finish, w, true));
-	fetch_and_add(&w->refcnt, 1);
+        refcount_reserve(&w->refcount);
 	epoll_debug("   registered timer %p\n", w->timeout);
     }
     epoll_debug("   sleeping...\n");
@@ -519,7 +515,7 @@ static sysreturn remove_fd(epoll e, int fd)
     if (efd == INVALID_ADDRESS) {
         return -ENOENT;
     }
-    free_epollfd(efd);
+    release_epollfd(efd);
     return 0;
 }
 
@@ -692,7 +688,7 @@ static sysreturn select_internal(int nfds,
             fdesc f = resolve_fd_noret(current->p, efd->fd);
             if (!f) {
                 epoll_debug("   x fd %d\n", efd->fd);
-                free_epollfd(efd);
+                release_epollfd(efd);
                 continue;
             }
 
@@ -714,7 +710,7 @@ static sysreturn select_internal(int nfds,
                 if (efd->registered) {
                     epoll_debug("   replacing\n");
                     /* make into zombie; kind of brutal...need removal */
-                    free_epollfd(efd);
+                    release_epollfd(efd);
                     efd = alloc_epollfd(e, fd, eventmask, 0);
                     assert(efd != INVALID_ADDRESS);
 		} else {
@@ -740,13 +736,13 @@ static sysreturn select_internal(int nfds,
   check_rv_timeout:
     if (timeout == 0 || rv != 0) {
 	epoll_debug("   immediate return; return %ld\n", rv);
-	epoll_blocked_release(w);
+	refcount_release(&w->refcount);
 	return rv;
     }
 
     if (timeout != infinity) {
 	w->timeout = register_timer(timeout, closure(e->h, epoll_blocked_finish, w, true));
-	fetch_and_add(&w->refcnt, 1);
+        refcount_reserve(&w->refcount);
 	epoll_debug("   registered timer %p\n", w->timeout);
     }
     epoll_debug("   sleeping...\n");
@@ -839,7 +835,7 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
             } else {
                 if (efd->eventmask != pfd->events || efd->data != i) {
                     epoll_debug("   = fd %d (replacing)\n", pfd->fd);
-                    free_epollfd(efd);
+                    release_epollfd(efd);
                     efd = alloc_epollfd(e, pfd->fd, pfd->events, i);
                     assert(efd != INVALID_ADDRESS);
                     register_epollfd(efd, closure(e->h, poll_notify, efd));
@@ -866,11 +862,11 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
         fdesc f = resolve_fd_noret(current->p, efd->fd);
         if (!f) {
             epoll_debug("   x fd %d\n", pfd->fd);
-            free_epollfd(efd);
+            release_epollfd(efd);
             continue;
         }
 
-        fetch_and_add(&efd->refcnt, 1);
+        refcount_reserve(&efd->refcount);
         epoll_debug("   register fd %d, eventmask 0x%x, applying check\n",
             efd->fd, efd->eventmask);
         check_fdesc(f);
@@ -881,7 +877,7 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
         epoll_debug("   - fd %d\n", fd);
         epollfd efd = epollfd_from_fd(e, fd);
         assert(efd != INVALID_ADDRESS);
-        free_epollfd(efd);
+        release_epollfd(efd);
     }
 
     rv = w->poll_retcount;
@@ -891,13 +887,13 @@ check_rv_timeout:
 
     if (timeout == 0 || rv) {
         epoll_debug("   immediate return; return %d\n", rv);
-        epoll_blocked_release(w);
+        refcount_release(&w->refcount);
         return rv;
     }
 
     if (timeout != infinity) {
         w->timeout = register_timer(timeout, closure(e->h, epoll_blocked_finish, w, true));
-        fetch_and_add(&w->refcnt, 1);
+        refcount_reserve(&w->refcount);
         epoll_debug("   registered timer %p\n", w->timeout);
     }
     epoll_debug("   sleeping...\n");

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -472,6 +472,12 @@ sysreturn epoll_wait(int epfd,
 
     if (timeout > 0) {
         w->timeout = register_timer(milliseconds(timeout), closure(e->h, epoll_blocked_finish, w, true));
+        if (w->timeout == INVALID_ADDRESS) {
+            epoll_debug("   failed to register timer\n");
+            epoll_blocked_release(w);
+            refcount_release(&w->refcount);
+            return -ENOMEM;
+        }
         refcount_reserve(&w->refcount);
         epoll_debug("   registered timer %p\n", w->timeout);
     }

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -94,7 +94,7 @@ static epoll epoll_alloc_internal(void)
 	return e;
 
     list_init(&e->blocked_head);
-    init_refcount(&e->refcount, fill_closure(&e->free, epoll_free, e));
+    init_refcount(&e->refcount, init_closure(&e->free, epoll_free, e));
     e->h = heap_general(get_kernel_heaps());
     e->events = allocate_vector(e->h, 8);
     if (e->events == INVALID_ADDRESS)
@@ -133,7 +133,7 @@ static epollfd alloc_epollfd(epoll e, int fd, u32 eventmask, u64 data)
     efd->lastevents = 0;
     efd->e = e;
     efd->data = data;
-    init_refcount(&efd->refcount, fill_closure(&efd->free, epollfd_free, efd));
+    init_refcount(&efd->refcount, init_closure(&efd->free, epollfd_free, efd));
     efd->registered = false;
     efd->zombie = false;
     vector_set(e->events, fd, efd);
@@ -402,7 +402,7 @@ static epoll_blocked alloc_epoll_blocked(epoll e)
     epoll_debug("w %p\n", w);
 
     /* initial reservation released on thread wakeup (or direct return) */
-    init_refcount(&w->refcount, fill_closure(&w->free, epoll_blocked_free, w));
+    init_refcount(&w->refcount, init_closure(&w->free, epoll_blocked_free, w));
     w->t = current;
     refcount_reserve(&w->t->refcount);
     w->e = e;

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -717,8 +717,6 @@ static void setup_sigframe(thread t, int signum, struct siginfo *si)
 /* XXX lock down / use access fns */
 void dispatch_signals(thread t)
 {
-    sig_debug("tid %d\n", t->tid);
-
     if (t->dispatch_sigstate) {
         /* sorry, no nested handling */
         return;
@@ -730,10 +728,8 @@ void dispatch_signals(thread t)
     if (qs == INVALID_ADDRESS) {
         ss = &t->p->signals;
         qs = sigstate_dequeue_signal(ss, sigstate_get_mask(&t->signals)); /* include thread mask */
-        if (qs == INVALID_ADDRESS) {
-            sig_debug("tid %d: nothing to process\n", t->tid);
+        if (qs == INVALID_ADDRESS)
             return;
-        }
     }
     t->dispatch_sigstate = ss;
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -235,7 +235,8 @@ void exit_thread(thread t)
 
     /* XXX need to handle futex robust list */
 
-    /* XXX release select epoll */
+    if (t->select_epoll)
+        epoll_finish(t->select_epoll);
 
     blockq_flush(t->dummy_blockq);
     deallocate_blockq(t->dummy_blockq);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -197,7 +197,7 @@ thread create_thread(process p)
     t->p = p;
     t->syscall = -1;
     t->uh = *p->uh;
-    init_refcount(&t->refcount, fill_closure(&t->free, free_thread, t));
+    init_refcount(&t->refcount, init_closure(&t->free, free_thread, t));
     t->select_epoll = 0;
     t->tid = tidcount++;
     t->clear_tid = 0;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -262,7 +262,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
 	goto alloc_fail;
     set_syscall_handler(syscall_enter);
     process kernel_process = create_process(uh, root, fs);
-    current = create_thread(kernel_process);
+    current = dummy_thread = create_thread(kernel_process);
     running_frame = current->frame;
 
     /* Install a fault handler for use when anonymous pages are

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -148,11 +148,14 @@ typedef struct sigstate {
     struct list heads[NSIG];
 } *sigstate;
 
+declare_closure_struct(1, 0, void, free_thread,
+                         thread, t);
 typedef struct epoll *epoll;
 typedef struct thread {
     // if we use an array typedef its fragile
     // there are likley assumptions that frame sits at the base of thread
     u64 frame[FRAME_MAX];
+    char name[16]; /* thread name */
     int syscall;
     process p;
 
@@ -164,10 +167,12 @@ typedef struct thread {
     */
     struct unix_heaps uh;
 
+    struct refcount refcount;
+    closure_struct(free_thread, free);
+
     epoll select_epoll;
     int *clear_tid;
     int tid;
-    char name[16]; /* thread name */
 
     thunk run;
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -170,7 +170,6 @@ typedef struct thread {
     char name[16]; /* thread name */
 
     thunk run;
-    queue log[64];
 
     /* blockq thread is waiting on, INVALID_ADDRESS for uninterruptible */
     blockq blocked_on;
@@ -270,16 +269,18 @@ typedef struct sigaction *sigaction;
 #define SIGACT_SIGINFO  0x00000001
 #define SIGACT_SIGNALFD 0x00000002 /* TODO */
 
+extern thread dummy_thread;
 extern thread current;
 
 static inline unix_heaps get_unix_heaps()
 {
+    assert(current);
     return &current->uh;
 }
 
 static inline kernel_heaps get_kernel_heaps()
 {
-    return (kernel_heaps)&current->uh;
+    return (kernel_heaps)get_unix_heaps();
 }
 
 #define unix_cache_alloc(uh, c) ({ heap __c = uh->c ## _cache; allocate(__c, __c->pagesize); })

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -148,8 +148,6 @@ typedef struct sigstate {
     struct list heads[NSIG];
 } *sigstate;
 
-void init_sigstate(sigstate ss);
-
 typedef struct epoll *epoll;
 typedef struct thread {
     // if we use an array typedef its fragile
@@ -333,6 +331,20 @@ static inline void timespec_from_time(struct timespec *ts, timestamp t)
 static inline time_t time_t_from_time(timestamp t)
 {
     return t / TIMESTAMP_SECOND;
+}
+
+void init_sigstate(sigstate ss);
+void sigstate_flush_queue(sigstate ss);
+void sigstate_reset_thread(thread t);
+
+static inline void sigstate_thread_restore(thread t)
+{
+    sigstate ss = t->dispatch_sigstate;
+    if (ss) {
+        t->dispatch_sigstate = 0;
+        ss->mask = ss->saved;
+        ss->saved = 0;
+    }
 }
 
 void dispatch_signals(thread t);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -217,6 +217,8 @@ struct file {
     u64 length;
 };
 
+void epoll_finish(epoll e);
+
 #define VMAP_FLAG_MMAP          1
 #define VMAP_FLAG_ANONYMOUS     2
 #define VMAP_FLAG_WRITABLE      4


### PR DESCRIPTION
This contains a variety of clean up around unix land to allow us to free up structures on thread exit. Mostly this consists of straightening out refcounts in various structures (facilitated by adding a refcount interface - a small improvement over fetch_and_add) and finishing cleanup for various types of objects (particularly with poll waiting). Note that yet more additions have been made to closures - specifically the ability to embed a closure struct within another struct, which I used for the various refcount completions.

See #456 
 