### PR TITLE
convert uninterruptible waits to blockq where possible

### DIFF
--- a/contgen/contgen.c
+++ b/contgen/contgen.c
@@ -86,11 +86,13 @@ void cblock()
 
     p("#define CLOSURE_DEFINE_%_%(_rettype, _name^~)|", nleft, nright, ", _lt%, _ln%", ", _rt%, _rn%");
     p("static _rettype (**_fill_##_name(heap h, struct _closure_##_name* n, bytes s^))(void *~) {|", ", _lt% l%", ", _rt%");
-    p("  n->__apply = _name;|");
-    p("  n->__c.name = #_name;|");
-    p("  n->__c.h = h;|");
-    p("  n->__c.size = s;|");
+    p("  if (n != INVALID_ADDRESS) {|");
+    p("    n->__apply = _name;|");
+    p("    n->__c.name = #_name;|");
+    p("    n->__c.h = h;|");
+    p("    n->__c.size = s;|");
     for (int i = 0; i < nleft ; i++)  p("  n->_ln% = l%;|", i, i);
+    p("  }|");
     p("  return (_rettype (**)(void *~))n;|", ", _rt%");
     p("}|");
     p("static _rettype _name(struct _closure_##_name *__self~)\n\n\n", ", _rt% _rn%");

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -10,6 +10,13 @@
 #include <lwip/udp.h>
 #include <net_system_structs.h>
 
+//#define NETSYSCALL_DEBUG
+#ifdef NETSYSCALL_DEBUG
+#define net_debug(x, ...) do {log_printf(" NET", "%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#else
+#define net_debug(x, ...)
+#endif
+
 #define SIOCGIFCONF 0x8912
 #define SIOCGIFADDR 0x8915
 
@@ -93,16 +100,15 @@ enum tcp_socket_state {
     TCP_SOCK_UNDEFINED = 0,
     TCP_SOCK_CREATED = 1,
     TCP_SOCK_IN_CONNECTION = 2,
-    TCP_SOCK_OPEN = 3,
-    TCP_SOCK_LISTENING = 4,
+    TCP_SOCK_ABORTING_CONNECTION = 3,
+    TCP_SOCK_OPEN = 4,
+    TCP_SOCK_LISTENING = 5,
 };
 
 enum udp_socket_state {
     UDP_SOCK_UNDEFINED = 0,
     UDP_SOCK_CREATED = 1,
 };
-
-typedef closure_type(lwip_status_handler, void, err_t);
 
 typedef struct sock {
     struct fdesc f;              /* must be first */
@@ -119,7 +125,6 @@ typedef struct sock {
 	struct {
 	    struct tcp_pcb *lw;
 	    enum tcp_socket_state state; // half open?
-            lwip_status_handler connect_bh;
 	} tcp;
 	struct {
 	    struct udp_pcb *lw;
@@ -127,14 +132,6 @@ typedef struct sock {
 	} udp;
     } info;
 } *sock;
-
-//#define NETSYSCALL_DEBUG
-
-#ifdef NETSYSCALL_DEBUG
-#define net_debug(x, ...) do {log_printf(" NET", "%s: " x, __func__, ##__VA_ARGS__);} while(0)
-#else
-#define net_debug(x, ...)
-#endif
 
 closure_function(1, 0, u32, socket_events,
                  sock, s)
@@ -242,9 +239,9 @@ static inline s64 lwip_to_errno(s8 err)
     case ERR_VAL: return -EINVAL;
     case ERR_WOULDBLOCK: return -EAGAIN;
     case ERR_USE: return -EBUSY;
-    case ERR_ALREADY: return -EBUSY;
-    case ERR_ISCONN: return -EINVAL;
-    case ERR_CONN: return -EINVAL;
+    case ERR_ALREADY: return -EALREADY;
+    case ERR_ISCONN: return -EISCONN;
+    case ERR_CONN: return -ENOTCONN;
     case ERR_IF: return -EINVAL;
     case ERR_ABRT: return -EINVAL;
     case ERR_RST: return -EINVAL;
@@ -824,7 +821,6 @@ static int allocate_tcp_sock(process p, struct tcp_pcb *pcb, u32 flags)
     if (fd >= 0) {
 	s->info.tcp.lw = pcb;
 	s->info.tcp.state = TCP_SOCK_CREATED;
-        s->info.tcp.connect_bh = 0;
     }
     return fd;
 }
@@ -991,36 +987,68 @@ static err_t lwip_tcp_sent(void * arg, struct tcp_pcb * pcb, u16 len)
     return ERR_OK;
 }
 
-closure_function(1, 1, void, connect_tcp_bh,
-                 thread, t,
-                 err_t, lwip_status)
+closure_function(2, 3, sysreturn, connect_tcp_bh,
+                 sock, s, thread, t,
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
+    sysreturn rv = 0;
+    sock s = bound(s);
     thread t = bound(t);
-    net_debug("thread %ld, lwip_status %d\n", t->tid, lwip_status);
-    set_syscall_return(t, lwip_to_errno(lwip_status));
-    thread_wakeup(t);
+    err_t err = get_lwip_error(s);
+
+    net_debug("sock %d, tcp state %d, thread %ld, lwip_status %d, blocked %d, nullify %d, timedout %d\n",
+              s->fd, s->info.tcp.state, t->tid, err, blocked, nullify, timedout);
+
+    if (nullify) {
+        /* XXX spinlock */
+        s->info.tcp.state = TCP_SOCK_ABORTING_CONNECTION;
+        rv = -EINTR;
+        goto out;
+    }
+
+    if (s->info.tcp.state == TCP_SOCK_IN_CONNECTION)
+        return infinity;
+    assert(s->info.tcp.state == TCP_SOCK_OPEN);
+    rv = lwip_to_errno(err);
+  out:
+    if (blocked)
+        thread_wakeup(t);
     closure_finish();
+    return set_syscall_return(t, rv);
 }
 
 static err_t connect_tcp_complete(void* arg, struct tcp_pcb* tpcb, err_t err)
 {
-   if (!arg) {
+   if (!arg)
       return ERR_OK;
-   }
    sock s = (sock)arg;
-   net_debug("sock %d, pcb %p, err %d\n", s->fd, tpcb, err);
+   net_debug("sock %d, tcp state %d, pcb %p, err %d\n", s->fd, s->info.tcp.state, tpcb, err);
+   if (s->info.tcp.state == TCP_SOCK_ABORTING_CONNECTION) {
+       s->info.tcp.state = TCP_SOCK_CREATED;
+       return ERR_ABRT;
+   }
    assert(s->info.tcp.state == TCP_SOCK_IN_CONNECTION);
-   assert(s->info.tcp.connect_bh);
-   s->info.tcp.state = TCP_SOCK_OPEN;
-   apply(s->info.tcp.connect_bh, err);
-   s->info.tcp.connect_bh = 0;
+   s->info.tcp.state = TCP_SOCK_OPEN; /* XXX state handling needs fixing; this could indicate an error as well */
+   set_lwip_error(s, err);
+   blockq_wake_one(s->rxbq);
    return ERR_OK;
 }
 
-static inline int connect_tcp(sock s, const ip_addr_t* address, unsigned short port)
+static inline err_t connect_tcp(sock s, const ip_addr_t* address, unsigned short port)
 {
-    net_debug("sock %d, addr %x, port %d\n", s->fd, address->addr, port);
-    lwip_status_handler bh = closure(s->h, connect_tcp_bh, current);
+    net_debug("sock %d, tcp state %d, addr %x, port %d\n", s->fd, s->info.tcp.state, address->addr, port);
+    switch (s->info.tcp.state) {
+    case TCP_SOCK_IN_CONNECTION:
+    case TCP_SOCK_ABORTING_CONNECTION:
+        return ERR_ALREADY;
+    case TCP_SOCK_OPEN:
+        return ERR_ISCONN;
+    case TCP_SOCK_CREATED:
+        break;
+    default:
+        msg_err("connect attempt while in state %d\n", s->info.tcp.state);
+        return ERR_VAL;
+    }
     struct tcp_pcb * lw = s->info.tcp.lw;
     tcp_arg(lw, s);
     tcp_recv(lw, tcp_input_lower);
@@ -1028,17 +1056,19 @@ static inline int connect_tcp(sock s, const ip_addr_t* address, unsigned short p
     tcp_sent(lw, lwip_tcp_sent);
     s->info.tcp.state = TCP_SOCK_IN_CONNECTION;
     set_lwip_error(s, ERR_OK);
-    assert(s->info.tcp.connect_bh == 0);
-    s->info.tcp.connect_bh = bh;
-    int err = tcp_connect(lw, address, port, connect_tcp_complete);
-    if (err == ERR_OK)
-	thread_sleep_uninterruptible(); /* XXX move to blockq */
-    return err;
+    err_t err = tcp_connect(lw, address, port, connect_tcp_complete);
+    if (err != ERR_OK)
+        return err;
+
+    sysreturn rv = blockq_check_timeout(s->rxbq, current, closure(s->h, connect_tcp_bh, s, current), false, 0);
+    /* should not return under normal cirucmstances */
+    msg_err("blockq check error: %ld\n", rv);
+    return ERR_OK;
 }
 
 sysreturn connect(int sockfd, struct sockaddr * addr, socklen_t addrlen)
 {
-    int err = ERR_OK;
+    err_t err = ERR_OK;
     sock s = resolve_fd(current->p, sockfd);
     if (!addr || addrlen < sizeof(struct sockaddr_in)) {
         return -EINVAL;

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -367,9 +367,9 @@ static sysreturn sock_read_bh_internal(sock s, thread t, void * dest, u64 length
     return rv;
 }
 
-closure_function(7, 2, sysreturn, sock_read_bh,
+closure_function(7, 3, sysreturn, sock_read_bh,
                  sock, s, thread, t, void *, dest, u64, length, struct sockaddr *, src_addr, socklen_t *, addrlen, io_completion, completion,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     sysreturn rv = sock_read_bh_internal(bound(s), bound(t), bound(dest), bound(length), bound(src_addr), bound(addrlen), bound(completion), blocked, nullify);
     if (rv != infinity)
@@ -406,9 +406,9 @@ closure_function(5, 2, void, recvmsg_complete,
     closure_finish();
 }
 
-closure_function(5, 2, sysreturn, recvmsg_bh,
+closure_function(5, 3, sysreturn, recvmsg_bh,
                  sock, s, thread, t, void *, dest, u64, length, struct msghdr *, msg,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     io_completion completion = closure(bound(s)->h, recvmsg_complete, bound(s), bound(msg), bound(dest),
                                        bound(length), true);
@@ -517,9 +517,9 @@ static sysreturn socket_write_tcp_bh_internal(sock s, thread t, void * buf, u64 
     return rv;
 }
 
-closure_function(5, 2, sysreturn, socket_write_tcp_bh,
+closure_function(5, 3, sysreturn, socket_write_tcp_bh,
                  sock, s, thread, t, void *, buf, u64, remain, io_completion, completion,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     sysreturn rv = socket_write_tcp_bh_internal(bound(s), bound(t), bound(buf), bound(remain), bound(completion),
                                                 blocked, nullify);
@@ -1210,9 +1210,9 @@ closure_function(3, 2, void, sendmmsg_buf_complete,
     closure_finish();
 }
 
-closure_function(7, 2, sysreturn, sendmmsg_tcp_bh,
+closure_function(7, 3, sysreturn, sendmmsg_tcp_bh,
                  sock, s, thread, t, void *, buf, u64, len, int, flags, struct mmsghdr *, msgvec, unsigned int, vlen,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     sock s = bound(s);
     thread t = bound(t);
@@ -1403,9 +1403,9 @@ sysreturn listen(int sockfd, int backlog)
     return 0;    
 }
 
-closure_function(5, 2, sysreturn, accept_bh,
+closure_function(5, 3, sysreturn, accept_bh,
                  sock, s, thread, t, struct sockaddr *, addr, socklen_t *, addrlen, int, flags,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     sock s = bound(s);
     thread t = bound(t);

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -9,11 +9,9 @@
 
 #define closure(__h, __name, ...) ({                                    \
     struct _closure_##__name * __n = allocate(__h, sizeof(struct _closure_##__name)); \
-    (__n == INVALID_ADDRESS ? INVALID_ADDRESS :                         \
-        __closure(__h, __n,                                             \
-                  sizeof(struct _closure_##__name), __name, ##__VA_ARGS__));})
+    __closure(__h, __n, sizeof(struct _closure_##__name), __name, ##__VA_ARGS__);})
 
-#define stack_closure(__name, ...)\
+#define stack_closure(__name, ...)                                 \
     __closure(0, stack_allocate(sizeof(struct _closure_##__name)), \
               sizeof(struct _closure_##__name), __name, ##__VA_ARGS__)
 

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -6,18 +6,20 @@
    while holding the blockq's lock. If it succeeds (rv >= 0), it will
    release the lock and return the result of the action to the
    caller. If rv is negative, an error condition is presumed, the lock
-   is released and rv is returned at once. If rv == infinity, the action gets
-   added to the blockq's waiters queue, an optional timeout is set,
-   the lock is released and the thread is finally blocked.
+   is released and rv is returned at once. If rv ==
+   BLOCKQ_BLOCK_REQUIRED, the action gets added to the blockq's
+   waiters queue, an optional timeout is set, the lock is released and
+   the thread is finally blocked.
 
    blockq_wake(), meant to be safe for calling from interrupt context,
    takes the blockq lock (really a no-op until SMP support) and
    attempts to apply the action at the head of the waiters queue. If
-   it returns infinity, it is left at the head of the queue, the lock is
-   released and waiting resumes, otherwise it causes the action to be removed
-   from the queue, and the lock released. In either case, the call returns to
-   the caller. It is up to the action to apply results to the thread frame and
-   call thread_wakeup() as necessary.
+   it returns BLOCKQ_BLOCK_REQUIRED, it is left at the head of the
+   queue, the lock is released and waiting resumes, otherwise it
+   causes the action to be removed from the queue, and the lock
+   released. In either case, the call returns to the caller. It is up
+   to the action to apply results to the thread frame and call
+   thread_wakeup() as necessary.
 
    The action must adhere to the following:
 
@@ -45,8 +47,9 @@
    In the existing cases right now, the action return value semantics
    mirror those of the syscall itself. Of course, the blocking code
    may interpret this return value as necessary, provided that a value
-   >= 0 represents success (no further blocking required), == infinity
-   indicates blocking required, and < 0 an error condition (and return).
+   >= 0 represents success (no further blocking required), ==
+   BLOCKQ_BLOCK_REQUIRED indicates blocking required, and < 0 an error
+   condition (and return).
 
    Note also that this presently serializes requests and handles them
    in that order alone. The action at the head of the queue must
@@ -128,20 +131,21 @@ static void blockq_apply_bi_locked(blockq bq, blockq_item bi, u64 flags)
     blockq_debug("   - returned %ld\n", rv);
 
    /*
-    *  In the existing cases right now, the action return value semantics
-    *  mirror those of the syscall itself. Of course, the blocking code
-    *  may interpret this return value as necessary, provided that a value
-    *  >= 0 represents success (no further blocking required), == infinity
-    *  indicates blocking required, and < 0 an error condition (and return).
+    *  In the existing cases right now, the action return value
+    *  semantics mirror those of the syscall itself. Of course, the
+    *  blocking code may interpret this return value as necessary,
+    *  provided that a value >= 0 represents success (no further
+    *  blocking required), == BLOCKQ_BLOCK_REQUIRED indicates blocking
+    *  required, and < 0 an error condition (and return).
     */
 
     /* IOW, the bi is done if the user tells us its done (or, on a nullify
      * we'll just force it)
      */
-    if ((flags & BLOCKQ_ACTION_NULLIFY) || (rv != infinity))
+    if ((flags & BLOCKQ_ACTION_NULLIFY) || (rv != BLOCKQ_BLOCK_REQUIRED))
         blockq_item_finish(bq, bi);
 
-    /* XXX - Re-register timer if rv == infinity? */
+    /* XXX - Re-register timer if rv == BLOCKQ_BLOCK_REQUIRED? */
 }
 
 /*
@@ -214,7 +218,7 @@ sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a,
        spinlock.
     */
     sysreturn rv = apply(a, 0);
-    if (rv != infinity) {
+    if (rv != BLOCKQ_BLOCK_REQUIRED) {
         /* XXX release spinlock */
         blockq_debug(" - direct return: %ld\n", rv);
         return rv;
@@ -253,7 +257,7 @@ sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a,
      * return now
      */
     if (in_bh || (current != t))
-        return infinity;
+        return BLOCKQ_BLOCK_REQUIRED;
 
     thread_sleep_interruptible();  /* no return */
     assert(0);

--- a/src/unix/eventfd.c
+++ b/src/unix/eventfd.c
@@ -10,9 +10,9 @@ struct efd {
     u64 counter;
 };
 
-closure_function(5, 2, sysreturn, efd_read_bh,
+closure_function(5, 3, sysreturn, efd_read_bh,
                  struct efd *, efd, thread, t, void *, buf, u64, length, io_completion, completion,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     struct efd *efd = bound(efd);
     sysreturn rv = sizeof(efd->counter);
@@ -61,9 +61,9 @@ closure_function(1, 6, sysreturn, efd_read,
     return blockq_check(bound(efd)->read_bq, t, ba, bh);
 }
 
-closure_function(5, 2, sysreturn, efd_write_bh,
+closure_function(5, 3, sysreturn, efd_write_bh,
                  struct efd *, efd, thread, t, void *, buf, u64, length, io_completion, completion,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     struct efd *efd = bound(efd);
     sysreturn rv = sizeof(efd->counter);

--- a/src/unix/eventfd.c
+++ b/src/unix/eventfd.c
@@ -27,7 +27,7 @@ closure_function(5, 1, sysreturn, efd_read_bh,
             rv = -EAGAIN;
             goto out;
         }
-        return infinity;
+        return BLOCKQ_BLOCK_REQUIRED;
     }
     if (efd->f.flags & EFD_SEMAPHORE) {
         u64 readVal = 1;
@@ -80,7 +80,7 @@ closure_function(5, 1, sysreturn, efd_write_bh,
             rv = -EAGAIN;
             goto out;
         }
-        return infinity;
+        return BLOCKQ_BLOCK_REQUIRED;
     }
     efd->counter += counter;
     blockq_wake_one(efd->read_bq);

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -79,7 +79,7 @@ static int futex_wake_many(struct futex * f, int val)
  * to timeout/signal delivery/etc., or by another thread in sys_futex
  *
  * Return:
- *  infinity: timer still active
+ *  BLOCKQ_BLOCK_REQUIRED: timer still active
  *  -ETIMEDOUT: if we timed out
  *  -EINTR: if we're being nullified
  *  0: thread woken up
@@ -92,7 +92,7 @@ closure_function(2, 1, sysreturn, futex_bh,
     sysreturn rv;
 
     if (current == t)
-        rv = infinity;
+        rv = BLOCKQ_BLOCK_REQUIRED;
     else if (flags & BLOCKQ_ACTION_NULLIFY)
         rv = -EINTR;
     else if (flags & BLOCKQ_ACTION_TIMEDOUT)
@@ -100,7 +100,7 @@ closure_function(2, 1, sysreturn, futex_bh,
     else
         rv = 0; /* no timer expire + not us --> actual wakeup */
 
-    if (rv != infinity) {
+    if (rv != BLOCKQ_BLOCK_REQUIRED) {
         thread_wakeup(t);
         closure_finish();
     }

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -84,18 +84,18 @@ static int futex_wake_many(struct futex * f, int val)
  *  -EINTR: if we're being nullified
  *  0: thread woken up
  */
-closure_function(2, 3, sysreturn, futex_bh,
+closure_function(2, 1, sysreturn, futex_bh,
                  struct futex *, f, thread, t,
-                 boolean, blocked, boolean, nullify, boolean, timedout)
+                 u64, flags)
 {
     thread t = bound(t);
     sysreturn rv;
 
     if (current == t)
         rv = infinity;
-    else if (nullify)
+    else if (flags & BLOCKQ_ACTION_NULLIFY)
         rv = -EINTR;
-    else if (timedout)
+    else if (flags & BLOCKQ_ACTION_TIMEDOUT)
         rv = -ETIMEDOUT;
     else
         rv = 0; /* no timer expire + not us --> actual wakeup */

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -158,7 +158,7 @@ closure_function(5, 1, sysreturn, pipe_read_bh,
             rv = -EAGAIN;
             goto out;
         }
-        return infinity;
+        return BLOCKQ_BLOCK_REQUIRED;
     }
 
     buffer_read(b, bound(dest), rv);
@@ -217,7 +217,7 @@ closure_function(5, 1, sysreturn, pipe_write_bh,
             rv = -EAGAIN;
             goto out;
         }
-        return infinity;
+        return BLOCKQ_BLOCK_REQUIRED;
     }
 
     u64 real_length = MIN(length, avail);

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -137,14 +137,14 @@ closure_function(1, 0, sysreturn, pipe_close,
     return 0;
 }
 
-closure_function(5, 3, sysreturn, pipe_read_bh,
+closure_function(5, 1, sysreturn, pipe_read_bh,
                  pipe_file, pf, thread, t, void *, dest, u64, length, io_completion, completion,
-                 boolean, blocked, boolean, nullify, boolean, timedout)
+                 u64, flags)
 {
     pipe_file pf = bound(pf);
     int rv;
 
-    if (nullify) {
+    if (flags & BLOCKQ_ACTION_NULLIFY) {
         rv = -EINTR;
         goto out;
     }
@@ -171,7 +171,7 @@ closure_function(5, 3, sysreturn, pipe_read_bh,
         notify_dispatch(pf->f.ns, 0); /* for edge trigger */
     }
   out:
-    if (blocked)
+    if (flags & BLOCKQ_ACTION_BLOCKED)
         blockq_set_completion(pf->bq, bound(completion), bound(t), rv);
     closure_finish();
     return rv;
@@ -187,18 +187,18 @@ closure_function(1, 6, sysreturn, pipe_read,
         return 0;
 
     blockq_action ba = closure(pf->pipe->h, pipe_read_bh, pf, t, dest, length,
-            completion);
+                               completion);
     return blockq_check(pf->bq, t, ba, bh);
 }
 
-closure_function(5, 3, sysreturn, pipe_write_bh,
+closure_function(5, 1, sysreturn, pipe_write_bh,
                  pipe_file, pf, thread, t, void *, dest, u64, length, io_completion, completion,
-                 boolean, blocked, boolean, nullify, boolean, timedout)
+                 u64, flags)
 {
     sysreturn rv = 0;
     pipe_file pf = bound(pf);
 
-    if (nullify) {
+    if (flags & BLOCKQ_ACTION_NULLIFY) {
         rv = -EINTR;
         goto out;
     }
@@ -229,7 +229,7 @@ closure_function(5, 3, sysreturn, pipe_write_bh,
 
     rv = real_length;
   out:
-    if (blocked)
+    if (flags & BLOCKQ_ACTION_BLOCKED)
         blockq_set_completion(pf->bq, bound(completion), bound(t), rv);
     closure_finish();
     return rv;

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -137,9 +137,9 @@ closure_function(1, 0, sysreturn, pipe_close,
     return 0;
 }
 
-closure_function(5, 2, sysreturn, pipe_read_bh,
+closure_function(5, 3, sysreturn, pipe_read_bh,
                  pipe_file, pf, thread, t, void *, dest, u64, length, io_completion, completion,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     pipe_file pf = bound(pf);
     int rv;
@@ -191,9 +191,9 @@ closure_function(1, 6, sysreturn, pipe_read,
     return blockq_check(pf->bq, t, ba, bh);
 }
 
-closure_function(5, 2, sysreturn, pipe_write_bh,
+closure_function(5, 3, sysreturn, pipe_write_bh,
                  pipe_file, pf, thread, t, void *, dest, u64, length, io_completion, completion,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     sysreturn rv = 0;
     pipe_file pf = bound(pf);

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -151,6 +151,7 @@ static void unregister_epollfd(epollfd efd)
     notify_remove(f->ns, efd->notify_handle, true);
     efd->registered = false;
     efd->notify_handle = 0;
+    refcount_release(&efd->refcount); /* registration */
 }
 
 static void release_epollfd(epollfd efd)
@@ -164,7 +165,7 @@ static void release_epollfd(epollfd efd)
     efd->zombie = true;
     if (efd->registered)
         unregister_epollfd(efd);
-    refcount_release(&efd->refcount); /* registration and alloc */
+    refcount_release(&efd->refcount); /* alloc */
 }
 
 /* XXX maybe merge alloc and registration */

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -1,5 +1,6 @@
 #include <unix_internal.h>
 
+//#define EPOLL_DEBUG
 #ifdef EPOLL_DEBUG
 #define epoll_debug(x, ...) do {log_printf("POLL", "%s: " x, __func__, ##__VA_ARGS__);} while(0)
 #else
@@ -38,11 +39,9 @@ enum epoll_type {
 struct epoll_blocked {
     epoll e;
     thread t;
-    boolean sleeping;
     enum epoll_type epoll_type;
     struct refcount refcount;
     closure_struct(epoll_blocked_free, free);
-    timer timeout;
     union {
 	buffer user_events;
         struct {
@@ -118,7 +117,7 @@ define_closure_function(1, 0, void, epollfd_free,
 {
     epollfd efd = bound(efd);
     epoll_debug("fd %d\n", efd->fd);
-    refcount_release(&efd->e->refcount);
+    refcount_release(&efd->e->refcount); /* release epoll */
     unix_cache_free(get_unix_heaps(), epollfd, efd);
 }
 
@@ -146,11 +145,9 @@ static epollfd alloc_epollfd(epoll e, int fd, u32 eventmask, u64 data)
 
 static void unregister_epollfd(epollfd efd)
 {
-    epoll_debug("efd %d\n", efd->fd);
-
     fdesc f = resolve_fd_noret(current->p, efd->fd);
     assert(f);
-    epoll_debug("f->ns %p\n", f->ns);
+    epoll_debug("efd %d, pre refcount %ld, f->ns %p\n", efd->fd, efd->refcount.c, f->ns);
     notify_remove(f->ns, efd->notify_handle, true);
     efd->registered = false;
     efd->notify_handle = 0;
@@ -167,10 +164,10 @@ static void release_epollfd(epollfd efd)
     efd->zombie = true;
     if (efd->registered)
         unregister_epollfd(efd);
-    refcount_release(&e->refcount);
-    refcount_release(&efd->refcount);
+    refcount_release(&efd->refcount); /* registration and alloc */
 }
 
+/* XXX maybe merge alloc and registration */
 static boolean register_epollfd(epollfd efd, event_handler eh)
 {
     if (efd->registered)
@@ -182,7 +179,7 @@ static boolean register_epollfd(epollfd efd, event_handler eh)
         return false; // XXX
     fdesc f = resolve_fd(current->p, efd->fd);
     efd->registered = true;
-    refcount_reserve(&efd->refcount);
+    refcount_reserve(&efd->refcount); /* registration */
     epoll_debug("fd %d, eventmask 0x%x, handler %p\n", efd->fd, efd->eventmask, eh);
     efd->notify_handle = notify_add(f->ns, efd->eventmask | (EPOLLERR | EPOLLHUP), eh);
     assert(efd->notify_handle != INVALID_ADDRESS);
@@ -255,83 +252,10 @@ define_closure_function(1, 0, void, epoll_blocked_free,
 static void epoll_blocked_release(epoll_blocked w)
 {
     epoll_debug("w %p\n", w);
-    if (!list_empty(&w->blocked_list)) {
-        list_delete(&w->blocked_list);
-        list_init(&w->blocked_list);
-    }
-}
-
-static void epoll_blocked_finish_internal(epoll_blocked w, boolean timedout)
-{
-#ifdef EPOLL_DEBUG
-    epoll_debug("w %p, refcnt %ld\n", w, w->refcount.c);
-    if (w->sleeping)
-	epoll_debug("   sleeping\n");
-    if (timedout)
-	epoll_debug("   timed out %p\n", w->timeout);
-#endif
-    heap h = w->e->h;
-
-    epoll_blocked_release(w);
-
-    if (w->sleeping) {
-        w->sleeping = false;
-        thread_wakeup(w->t);
-        sysreturn rv = 0;
-
-        switch (w->epoll_type) {
-        case EPOLL_TYPE_SELECT:
-	    if (w->rset)
-		bitmap_unwrap(w->rset);
-	    if (w->wset)
-		bitmap_unwrap(w->wset);
-	    if (w->eset)
-		bitmap_unwrap(w->eset);
-            w->nfds = 0;
-	    w->rset = w->wset = w->eset = 0;
-	    rv = w->retcount;	/* XXX error check */
-            break;
-        case EPOLL_TYPE_POLL:
-            unwrap_buffer(h, w->poll_fds);
-            w->poll_fds = 0;
-            rv = w->poll_retcount;
-            break;
-        case EPOLL_TYPE_EPOLL:
-	    rv = user_event_count(w);
-	    unwrap_buffer(h, w->user_events);
-	    w->user_events = 0;
-            break;
-	}
-
-	epoll_debug("   syscall return %ld\n", rv);
-	set_syscall_return(w->t, rv);
-
-	/* We'll let the timeout run to expiry until we can be sure
-	   that we have a race-free way to disable the timer if waking
-	   on an event.
-
-	   XXX This will have to be revisited, for we'll accumulate a
-	   bunch of zombie epoll_blocked and timer objects until they
-	   start timing out.
-	*/
-#ifdef EPOLL_DEBUG
-	if (w->timeout && !timedout)
-	    epoll_debug("      timer remains; refcount %ld\n", w->refcount.c);
-#endif
-	refcount_release(&w->refcount);
-    } else if (timedout) {
-	epoll_debug("   timer expiry after syscall return; ignored\n");
-	refcount_release(&w->refcount);
-    } else {
-	epoll_debug("   in syscall or zombie event\n");
-    }
-}
-
-closure_function(2, 0, void, epoll_blocked_finish,
-                 epoll_blocked, w, boolean, timedout)
-{
-    epoll_blocked_finish_internal(bound(w), bound(timedout));
-    closure_finish();
+    assert(!list_empty(&w->blocked_list));
+    list_delete(&w->blocked_list);
+    list_init(&w->blocked_list);
+    refcount_release(&w->refcount);
 }
 
 static inline u32 report_from_notify_events(epollfd efd, u32 events)
@@ -390,7 +314,7 @@ closure_function(1, 1, void, epoll_wait_notify,
 	    epoll_debug("   user_events null or full\n");
 	    return;
 	}
-	epoll_blocked_finish_internal(w, false);
+	blockq_wake_one(w->t->thread_bq);
     }
 }
 
@@ -407,8 +331,6 @@ static epoll_blocked alloc_epoll_blocked(epoll e)
     refcount_reserve(&w->t->refcount);
     w->e = e;
     refcount_reserve(&e->refcount);
-    w->sleeping = false;
-    w->timeout = 0;
     list_insert_after(&e->blocked_head, &w->blocked_list); /* push */
     return w;
 }
@@ -416,6 +338,43 @@ static epoll_blocked alloc_epoll_blocked(epoll e)
 static void check_fdesc(fdesc f)
 {
     notify_dispatch(f->ns, apply(f->events));
+}
+
+/* It would be nice to devise a way to allow a poll waiter to continue
+   to collect events between wakeup (first event) and running. */
+
+closure_function(3, 3, sysreturn, epoll_wait_bh,
+                 epoll_blocked, w, thread, t, boolean, blockable,
+                 boolean, blocked, boolean, nullify, boolean, timedout)
+{
+    sysreturn rv;
+    epoll_blocked w = bound(w);
+    int eventcount = user_event_count(w);
+
+    epoll_debug("w %p on tid %d, blockable %d, blocked %d, nullify %d, timedout %d, event count %d\n",
+                w, bound(t)->tid, bound(blockable), blocked, nullify, timedout, eventcount);
+
+    if (!bound(blockable) || timedout || eventcount) {
+        rv = eventcount;
+        goto out_wakeup;
+    }
+
+    if (nullify) {
+        /* XXX verify */
+        rv = -EAGAIN;
+        goto out_wakeup;
+    }
+
+    epoll_debug("  continue blocking\n");
+    return infinity;
+  out_wakeup:
+    if (blocked)
+        thread_wakeup(bound(t));
+    unwrap_buffer(w->e->h, w->user_events);
+    w->user_events = 0;
+    epoll_debug("   pre refcnt %ld, returning %ld\n", w->refcount.c, rv);
+    epoll_blocked_release(w);
+    return set_syscall_return(bound(t), rv);
 }
 
 /* Depending on the epoll flags given, we may:
@@ -436,7 +395,7 @@ sysreturn epoll_wait(int epfd,
     if (w == INVALID_ADDRESS)
 	return -ENOMEM;
 
-    epoll_debug("epoll fd %d, new blocked %p, timeout %d\n", epfd, w, timeout);
+    epoll_debug("tid %d, epoll fd %d, new blocked %p, timeout %d\n", current->tid, epfd, w, timeout);
     w->epoll_type = EPOLL_TYPE_EPOLL;
     w->user_events = wrap_buffer(e->h, events, maxevents * sizeof(struct epoll_event));
     w->user_events->end = 0;
@@ -462,29 +421,9 @@ sysreturn epoll_wait(int epfd,
             check_fdesc(f);
     }
 
-    int eventcount = w->user_events->end/sizeof(struct epoll_event);
-    if (timeout == 0 || w->user_events->end) {
-	epoll_debug("   immediate return; eventcount %d\n", eventcount);
-        epoll_blocked_release(w);
-	refcount_release(&w->refcount);
-        return eventcount;
-    }
-
-    if (timeout > 0) {
-        w->timeout = register_timer(milliseconds(timeout), closure(e->h, epoll_blocked_finish, w, true));
-        if (w->timeout == INVALID_ADDRESS) {
-            epoll_debug("   failed to register timer\n");
-            epoll_blocked_release(w);
-            refcount_release(&w->refcount);
-            return -ENOMEM;
-        }
-        refcount_reserve(&w->refcount);
-        epoll_debug("   registered timer %p\n", w->timeout);
-    }
-    epoll_debug("   sleeping...\n");
-    w->sleeping = true;
-    thread_sleep_uninterruptible(); /* XXX move to blockq */
-    return 0;			/* suppress warning */
+    return blockq_check_timeout(w->t->thread_bq, current,
+                                closure(e->h, epoll_wait_bh, w, current, timeout != 0),
+                                false, timeout > 0 ? milliseconds(timeout) : 0);
 }
 
 static epollfd epollfd_from_fd(epoll e, int fd)
@@ -613,9 +552,46 @@ closure_function(1, 1, void, select_notify,
 	if (count > 0) {
 	    fetch_and_add(&w->retcount, count);
 	    epoll_debug("   event on %d, events 0x%x\n", efd->fd, events);
-	    epoll_blocked_finish_internal(w, false);
+	    blockq_wake_one(w->t->thread_bq);
 	}
     }
+}
+
+closure_function(3, 3, sysreturn, select_bh,
+                 epoll_blocked, w, thread, t, boolean, blockable,
+                 boolean, blocked, boolean, nullify, boolean, timedout)
+{
+    sysreturn rv;
+    epoll_blocked w = bound(w);
+    epoll_debug("w %p on tid %d, blockable %d, blocked %d, nullify %d, timedout %d, retcount %ld\n",
+                w, bound(t)->tid, bound(blockable), blocked, nullify, timedout, w->retcount);
+
+    if (!bound(blockable) || timedout || w->retcount) {
+        /* XXX error checking? */
+        rv = w->retcount;
+        goto out_wakeup;
+    }
+
+    if (nullify) {
+        /* XXX verify */
+        rv = -EAGAIN;
+        goto out_wakeup;
+    }
+
+    return infinity;
+  out_wakeup:
+    if (w->rset)
+        bitmap_unwrap(w->rset);
+    if (w->wset)
+        bitmap_unwrap(w->wset);
+    if (w->eset)
+        bitmap_unwrap(w->eset);
+    w->nfds = 0;
+    w->rset = w->wset = w->eset = 0;
+    epoll_blocked_release(w);
+    if (blocked)
+        thread_wakeup(bound(t));
+    return set_syscall_return(bound(t), rv);
 }
 
 static inline epoll select_get_epoll(void)
@@ -634,6 +610,9 @@ static sysreturn select_internal(int nfds,
 				 timestamp timeout,
 				 const sigset_t * sigmask)
 {
+    if (nfds == 0 && timeout == infinity)
+        return 0;
+
     epoll e = select_get_epoll();
     if (e == INVALID_ADDRESS)
 	return -ENOMEM;
@@ -644,13 +623,12 @@ static sysreturn select_internal(int nfds,
     w->nfds = nfds;
     w->rset = w->wset = w->eset = 0;
     w->retcount = 0;
-    sysreturn rv = 0;
 
     epoll_debug("nfds %d, readfds %p, writefds %p, exceptfds %p\n"
-	    "   epoll_blocked %p, timeout %d\n", nfds, readfds, writefds, exceptfds,
-	    w, timeout);
-    if (nfds == 0)
-	goto check_rv_timeout;
+                "   epoll_blocked %p, timeout %d\n", nfds, readfds, writefds, exceptfds,
+                w, timeout);
+    if (nfds == 0)            /* timeout != infinity */
+        goto check_timeout;
 
     w->rset = readfds ? bitmap_wrap(e->h, readfds, nfds) : 0;
     w->wset = writefds ? bitmap_wrap(e->h, writefds, nfds) : 0;
@@ -685,10 +663,7 @@ static sysreturn select_internal(int nfds,
                 remove_fd(e, fd);
 	    } else {
 		epoll_debug("   + fd %d\n", fd);
-		if (alloc_epollfd(e, fd, 0, 0) == INVALID_ADDRESS) {
-		    rv = -EBADF;
-		    goto check_rv_timeout;
-		}
+		assert(alloc_epollfd(e, fd, 0, 0) != INVALID_ADDRESS);
 	    }
 	}
 
@@ -746,24 +721,10 @@ static sysreturn select_internal(int nfds,
 	if (exceptfds)
 	    ep++;
     }
-    rv = w->retcount;
-  check_rv_timeout:
-    if (timeout == 0 || rv != 0) {
-        epoll_debug("   immediate return; return %ld\n", rv);
-        epoll_blocked_release(w);
-        refcount_release(&w->refcount);
-        return rv;
-    }
-
-    if (timeout != infinity) {
-	w->timeout = register_timer(timeout, closure(e->h, epoll_blocked_finish, w, true));
-        refcount_reserve(&w->refcount);
-	epoll_debug("   registered timer %p\n", w->timeout);
-    }
-    epoll_debug("   sleeping...\n");
-    w->sleeping = true;
-    thread_sleep_uninterruptible(); /* XXX move to blockq */
-    return 0;			/* suppress warning */
+  check_timeout:
+    return blockq_check_timeout(w->t->thread_bq, current,
+                                closure(e->h, select_bh, w, current, timeout != 0),
+                                false, timeout > 0 ? timeout : 0);
 }
 
 
@@ -806,8 +767,39 @@ closure_function(1, 1, void, poll_notify,
         fetch_and_add(&w->poll_retcount, 1);
         pfd->revents = events;
         epoll_debug("   event on %d (%d), events 0x%x\n", efd->fd, pfd->fd, pfd->revents);
-        epoll_blocked_finish_internal(w, false);
+        blockq_wake_one(w->t->thread_bq);
     }
+}
+
+closure_function(3, 3, sysreturn, poll_bh,
+                 epoll_blocked, w, thread, t, boolean, blockable,
+                 boolean, blocked, boolean, nullify, boolean, timedout)
+{
+    sysreturn rv;
+    epoll_blocked w = bound(w);
+    epoll_debug("w %p on tid %d, blockable %d, blocked %d, nullify %d, timedout %d, poll_retcount %d\n",
+                w, bound(t)->tid, bound(blockable), blocked, nullify, timedout, w->poll_retcount);
+
+    if (!bound(blockable) || timedout || w->poll_retcount) {
+        /* XXX error checking? */
+        rv = w->poll_retcount;
+        goto out_wakeup;
+    }
+
+    if (nullify) {
+        /* XXX verify */
+        rv = -EAGAIN;
+        goto out_wakeup;
+    }
+
+    return infinity;
+  out_wakeup:
+    unwrap_buffer(w->e->h, w->poll_fds);
+    w->poll_fds = 0;
+    epoll_blocked_release(w);
+    if (blocked)
+        thread_wakeup(bound(t));
+    return set_syscall_return(bound(t), rv);
 }
 
 static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
@@ -825,7 +817,6 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
     w->epoll_type = EPOLL_TYPE_POLL;
     w->poll_fds = wrap_buffer(e->h, fds, nfds * sizeof(struct pollfd));
     w->poll_retcount = 0;
-    sysreturn rv = 0;
 
     bitmap remove_efds = bitmap_clone(e->fds); /* efds to remove */
     for (int i = 0; i < nfds; i++) {
@@ -865,10 +856,7 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
         } else {
             epoll_debug("   + fd %d\n", pfd->fd);
             efd = alloc_epollfd(e, pfd->fd, pfd->events, i);
-            if (efd == INVALID_ADDRESS) {
-                rv = -EBADF;
-                goto check_rv_timeout;
-            }
+            assert(efd != INVALID_ADDRESS);
             fdesc f = resolve_fd_noret(current->p, efd->fd);
             assert(f);
             register_epollfd(efd, closure(e->h, poll_notify, efd));
@@ -881,7 +869,6 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
             continue;
         }
 
-        refcount_reserve(&efd->refcount);
         epoll_debug("   register fd %d, eventmask 0x%x, applying check\n",
             efd->fd, efd->eventmask);
         check_fdesc(f);
@@ -894,28 +881,11 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
         assert(efd != INVALID_ADDRESS);
         release_epollfd(efd);
     }
-
-    rv = w->poll_retcount;
-
-check_rv_timeout:
     deallocate_bitmap(remove_efds);
 
-    if (timeout == 0 || rv) {
-        epoll_debug("   immediate return; return %d\n", rv);
-        epoll_blocked_release(w);
-        refcount_release(&w->refcount);
-        return rv;
-    }
-
-    if (timeout != infinity) {
-        w->timeout = register_timer(timeout, closure(e->h, epoll_blocked_finish, w, true));
-        refcount_reserve(&w->refcount);
-        epoll_debug("   registered timer %p\n", w->timeout);
-    }
-    epoll_debug("   sleeping...\n");
-    w->sleeping = true;
-    thread_sleep_uninterruptible(); /* XXX move to blockq */
-    return 0; /* suppress warning */
+    return blockq_check_timeout(w->t->thread_bq, current,
+                                closure(e->h, poll_bh, w, current, timeout != 0),
+                                false, timeout > 0 ? timeout : 0);
 }
 
 sysreturn ppoll(struct pollfd *fds, nfds_t nfds, const struct timespec *tmo_p, const sigset_t *sigmask)

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -368,7 +368,7 @@ closure_function(3, 1, sysreturn, epoll_wait_bh,
     }
 
     epoll_debug("  continue blocking\n");
-    return infinity;
+    return BLOCKQ_BLOCK_REQUIRED;
   out_wakeup:
     if (flags & BLOCKQ_ACTION_BLOCKED)
         thread_wakeup(t);
@@ -582,7 +582,7 @@ closure_function(3, 1, sysreturn, select_bh,
         goto out_wakeup;
     }
 
-    return infinity;
+    return BLOCKQ_BLOCK_REQUIRED;
   out_wakeup:
     if (w->rset)
         bitmap_unwrap(w->rset);
@@ -729,7 +729,7 @@ static sysreturn select_internal(int nfds,
   check_timeout:
     return blockq_check_timeout(w->t->thread_bq, current,
                                 closure(e->h, select_bh, w, current, timeout != 0),
-                                false, timeout > 0 ? timeout : 0);
+                                false, timeout != infinity ? timeout : 0);
 }
 
 
@@ -798,7 +798,7 @@ closure_function(3, 1, sysreturn, poll_bh,
         goto out_wakeup;
     }
 
-    return infinity;
+    return BLOCKQ_BLOCK_REQUIRED;
   out_wakeup:
     unwrap_buffer(w->e->h, w->poll_fds);
     w->poll_fds = 0;
@@ -892,7 +892,7 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
 
     return blockq_check_timeout(w->t->thread_bq, current,
                                 closure(e->h, poll_bh, w, current, timeout != 0),
-                                false, timeout > 0 ? timeout : 0);
+                                false, timeout != infinity ? timeout : 0);
 }
 
 sysreturn ppoll(struct pollfd *fds, nfds_t nfds, const struct timespec *tmo_p, const sigset_t *sigmask)

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -479,9 +479,9 @@ sysreturn rt_sigprocmask(int how, const u64 *set, u64 *oldset, u64 sigsetsize)
     return 0;
 }
 
-closure_function(2, 2, sysreturn, rt_sigsuspend_bh,
+closure_function(2, 3, sysreturn, rt_sigsuspend_bh,
                  thread, t, u64, saved_mask,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     thread t = bound(t);
     sig_debug("tid %d, saved_mask 0x%lx blocked %d, nullify %d\n", t->tid, bound(saved_mask), blocked, nullify);
@@ -626,9 +626,9 @@ sysreturn tkill(int tid, int sig)
     return tgkill(1, tid, sig);
 }
 
-closure_function(1, 2, sysreturn, pause_bh,
+closure_function(1, 3, sysreturn, pause_bh,
                  thread, t,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     thread t = bound(t);
     sig_debug("tid %d, blocked %d, nullify %d\n", t->tid, blocked, nullify);

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -512,7 +512,7 @@ sysreturn rt_sigsuspend(const u64 * mask, u64 sigsetsize)
     blockq_action ba = closure(h, rt_sigsuspend_bh, t, orig_mask);
     t->signals.saved = orig_mask;
     sigstate_set_mask(&t->signals, *mask);
-    return blockq_check(t->dummy_blockq, t, ba, false);
+    return blockq_check(t->thread_bq, t, ba, false);
 }
 
 sysreturn sigaltstack(const stack_t *ss, stack_t *oss)
@@ -649,7 +649,7 @@ sysreturn pause(void)
     sig_debug("tid %d, blocking...\n", current->tid);
     heap h = heap_general(get_kernel_heaps());
     blockq_action ba = closure(h, pause_bh, current);
-    return blockq_check(current->dummy_blockq, current, ba, false);
+    return blockq_check(current->thread_bq, current, ba, false);
 }
 
 void register_signal_syscalls(struct syscall *map)

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -495,7 +495,7 @@ closure_function(2, 1, sysreturn, rt_sigsuspend_bh,
     }
 
     sig_debug("-> block\n");
-    return infinity;
+    return BLOCKQ_BLOCK_REQUIRED;
 }
 
 sysreturn rt_sigsuspend(const u64 * mask, u64 sigsetsize)
@@ -642,7 +642,7 @@ closure_function(1, 1, sysreturn, pause_bh,
     }
 
     sig_debug("-> block\n");
-    return infinity;
+    return BLOCKQ_BLOCK_REQUIRED;
 }
 
 sysreturn pause(void)

--- a/src/unix/socketpair.c
+++ b/src/unix/socketpair.c
@@ -142,7 +142,7 @@ closure_function(5, 1, sysreturn, sockpair_read_bh,
             real_length = -EAGAIN;
             goto out;
         }
-        return infinity;
+        return BLOCKQ_BLOCK_REQUIRED;
     }
     if (s->sockpair->type == SOCK_STREAM) {
         buffer_read(b, dest, real_length);
@@ -209,7 +209,7 @@ closure_function(5, 1, sysreturn, sockpair_write_bh,
             rv = -EAGAIN;
             goto out;
         }
-        return infinity;
+        return BLOCKQ_BLOCK_REQUIRED;
     }
 
     u64 real_length = MIN(length, avail);

--- a/src/unix/socketpair.c
+++ b/src/unix/socketpair.c
@@ -109,9 +109,9 @@ static inline void sockpair_notify_writer(sockpair_socket s, int events)
     }
 }
 
-closure_function(5, 2, sysreturn, sockpair_read_bh,
+closure_function(5, 3, sysreturn, sockpair_read_bh,
                  sockpair_socket, s, thread, t, void *, dest, u64, length, io_completion, completion,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     sockpair_socket s = bound(s);
     thread t = bound(t);
@@ -181,9 +181,9 @@ closure_function(1, 6, sysreturn, sockpair_read,
     return blockq_check(s->read_bq, t, ba, bh);
 }
 
-closure_function(5, 2, sysreturn, sockpair_write_bh,
+closure_function(5, 3, sysreturn, sockpair_write_bh,
                  sockpair_socket, s, thread, t, void *, dest, u64, length, io_completion, completion,
-                 boolean, blocked, boolean, nullify)
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
     sockpair_socket s = bound(s);
     u64 length = bound(length);

--- a/src/unix/socketpair.c
+++ b/src/unix/socketpair.c
@@ -109,9 +109,9 @@ static inline void sockpair_notify_writer(sockpair_socket s, int events)
     }
 }
 
-closure_function(5, 3, sysreturn, sockpair_read_bh,
+closure_function(5, 1, sysreturn, sockpair_read_bh,
                  sockpair_socket, s, thread, t, void *, dest, u64, length, io_completion, completion,
-                 boolean, blocked, boolean, nullify, boolean, timedout)
+                 u64, flags)
 {
     sockpair_socket s = bound(s);
     thread t = bound(t);
@@ -122,7 +122,7 @@ closure_function(5, 3, sysreturn, sockpair_read_bh,
     int real_length;
     int dgram_length;
 
-    if (nullify) {
+    if (flags & BLOCKQ_ACTION_NULLIFY) {
         real_length = -EINTR;
         goto out;
     }
@@ -160,7 +160,7 @@ closure_function(5, 3, sysreturn, sockpair_read_bh,
         }
     }
 out:
-    if (blocked) {
+    if (flags & BLOCKQ_ACTION_BLOCKED) {
         blockq_set_completion(s->read_bq, bound(completion), t, real_length);
     }
     closure_finish();
@@ -181,9 +181,9 @@ closure_function(1, 6, sysreturn, sockpair_read,
     return blockq_check(s->read_bq, t, ba, bh);
 }
 
-closure_function(5, 3, sysreturn, sockpair_write_bh,
+closure_function(5, 1, sysreturn, sockpair_write_bh,
                  sockpair_socket, s, thread, t, void *, dest, u64, length, io_completion, completion,
-                 boolean, blocked, boolean, nullify, boolean, timedout)
+                 u64, flags)
 {
     sockpair_socket s = bound(s);
     u64 length = bound(length);
@@ -191,7 +191,7 @@ closure_function(5, 3, sysreturn, sockpair_write_bh,
     sysreturn rv = 0;
     buffer b = s->sockpair->data;
 
-    if (nullify) {
+    if (flags & BLOCKQ_ACTION_NULLIFY) {
         rv = -EINTR;
         goto out;
     }
@@ -220,9 +220,9 @@ closure_function(5, 3, sysreturn, sockpair_write_bh,
     sockpair_notify_reader(s->peer, EPOLLIN);
     rv = real_length;
 out:
-    if (blocked) {
+    if (flags & BLOCKQ_ACTION_BLOCKED)
         blockq_set_completion(s->write_bq, bound(completion), bound(t), rv);
-    }
+
     closure_finish();
     return rv;
 }

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -99,7 +99,11 @@ typedef struct iovec {
 
 #define EDESTADDRREQ    89		/* Destination address required */
 #define EOPNOTSUPP      95		/* Operation not supported */
+#define EISCONN         106
+#define ENOTCONN        107
 #define ETIMEDOUT       110     /* Connection timed out */
+#define EALREADY        114
+#define EINPROGRESS     115
 
 #define O_RDONLY	00000000
 #define O_WRONLY	00000001

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -149,8 +149,9 @@ void thread_yield(void)
 
 void thread_wakeup(thread t)
 {
-    thread_log(current, "%s: %ld->%ld blocked_on %p, RIP=0x%lx", __func__, current->tid, t->tid,
-               t->blocked_on, t->frame[FRAME_RIP]);
+    thread_log(current, "%s: %ld->%ld blocked_on %s, RIP=0x%lx", __func__, current->tid, t->tid,
+               t->blocked_on ? (t->blocked_on != INVALID_ADDRESS ? blockq_name(t->blocked_on) : "uninterruptible") :
+               "(null)", t->frame[FRAME_RIP]);
     thread_make_runnable(t);
 }
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -187,8 +187,8 @@ thread create_thread(process p)
         return INVALID_ADDRESS;
     }
 
-    t->dummy_blockq = allocate_blockq(h, "dummy");
-    if (t->dummy_blockq == INVALID_ADDRESS) {
+    t->thread_bq = allocate_blockq(h, "thread");
+    if (t->thread_bq == INVALID_ADDRESS) {
         msg_err("failed to allocate blockq\n");
         deallocate(h, t, sizeof(struct thread));
         return INVALID_ADDRESS;
@@ -245,9 +245,9 @@ void exit_thread(thread t)
 
     /* XXX futex robust list needs implementing - wake up robust futexes here */
 
-    blockq_flush(t->dummy_blockq);
-    deallocate_blockq(t->dummy_blockq);
-    t->dummy_blockq = INVALID_ADDRESS;
+    blockq_flush(t->thread_bq);
+    deallocate_blockq(t->thread_bq);
+    t->thread_bq = INVALID_ADDRESS;
 
     deallocate_closure(t->run);
     t->run = INVALID_ADDRESS;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -156,14 +156,14 @@ void thread_wakeup(thread t)
 
 boolean thread_attempt_interrupt(thread t)
 {
-    thread_log(current, "%s: tid %d\n", __func__, t->tid);
+    thread_log(current, "%s: tid %d", __func__, t->tid);
     if (!thread_in_interruptible_sleep(t)) {
         thread_log(current, "uninterruptible or already running");
         return false;
     }
 
     /* flush pending blockq */
-    thread_log(current, "... interrupting blocked thread %d\n", t->tid);
+    thread_log(current, "... interrupting blocked thread %d", t->tid);
     assert(blockq_flush_thread(t->blocked_on, t));
     assert(thread_is_runnable(t));
     return true;
@@ -217,6 +217,8 @@ thread create_thread(process p)
 
 void exit_thread(thread t)
 {
+    thread_log(current, "exit_thread");
+
     assert(vector_length(t->p->threads) > t->tid);
     vector_set(t->p->threads, t->tid, 0);
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -63,13 +63,10 @@ closure_function(1, 1, context, default_fault_handler,
             return frame;
     }
 
-    console("Unhandled: ");
-    print_u64(frame[FRAME_VECTOR]);
-    console("\n");
     print_frame(frame);
     print_stack(frame);
 
-    if (table_find (current->p->process_root, sym(fault))) {
+    if (table_find(current->p->process_root, sym(fault))) {
         console("starting gdb\n");
         init_tcp_gdb(heap_general(get_kernel_heaps()), current->p, 9090);
         thread_sleep_uninterruptible();

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -7,23 +7,40 @@ sysreturn gettimeofday(struct timeval *tv, void *tz)
     return 0;
 }
 
-closure_function(2, 0, void, nanosleep_timeout,
-                 thread, t, boolean *, dead)
+closure_function(4, 3, sysreturn, nanosleep_bh,
+                 thread, t, timestamp, start, timestamp, interval, struct timespec*, rem,
+                 boolean, blocked, boolean, nullify, boolean, timedout)
 {
-    set_syscall_return(bound(t), 0);
-    thread_wakeup(bound(t));
+    thread t = bound(t);
+    timestamp elapsed = now() - bound(start); /* XXX parameterize */
+    thread_log(t, "%s: start %T, interval %T, rem %p, elapsed %T, blocked %d, nullify %d, timedout %d",
+               __func__, bound(start), bound(interval), bound(rem), elapsed, blocked, nullify, timedout);
+    sysreturn rv = 0;
+    if (nullify) {
+        if (bound(rem)) {
+            timespec_from_time(bound(rem), elapsed);
+            rv = -EINTR;
+            goto out;
+        }
+    }
+
+    if (!timedout && elapsed < bound(interval))
+        return infinity;
+  out:
+    if (blocked)
+        thread_wakeup(t);
     closure_finish();
+    return set_syscall_return(t, rv);
 }
 
 sysreturn nanosleep(const struct timespec* req, struct timespec* rem)
 {
-    // nanosleep is interpretable and the remaining
-    // time is put in rem, but for now this is non interpretable
-    // and we sleep for the whole duration before waking up.
-    register_timer(time_from_timespec(req),
-		closure(heap_general(get_kernel_heaps()), nanosleep_timeout, current, 0));
-    thread_sleep_uninterruptible(); /* XXX move to blockq */
-    return 0;
+    timestamp start = now(); /* XXX parameterize later for clock_nanosleep */
+    timestamp interval = time_from_timespec(req);
+    thread_log(current, "nanosleep: req %p (%T) rem %p, now %T", req, interval, rem, start);
+    return blockq_check_timeout(current->thread_bq, current,
+                                closure(heap_general(get_kernel_heaps()), nanosleep_bh, current, start, interval, rem),
+                                false, time_from_timespec(req));
 }
 
 sysreturn sys_time(time_t *tloc)

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -18,7 +18,8 @@ closure_function(4, 3, sysreturn, nanosleep_bh,
     sysreturn rv = 0;
     if (nullify) {
         if (bound(rem)) {
-            timespec_from_time(bound(rem), elapsed);
+            timestamp remain = elapsed < bound(interval) ? bound(interval) - elapsed : 0;
+            timespec_from_time(bound(rem), remain);
             rv = -EINTR;
             goto out;
         }

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -26,7 +26,7 @@ closure_function(4, 1, sysreturn, nanosleep_bh,
     }
 
     if (!(flags & BLOCKQ_ACTION_TIMEDOUT) && elapsed < bound(interval))
-        return infinity;
+        return BLOCKQ_BLOCK_REQUIRED;
   out:
     if (flags & BLOCKQ_ACTION_BLOCKED)
         thread_wakeup(t);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -119,6 +119,12 @@ typedef struct unix_heaps {
 #define BLOCKQ_ACTION_NULLIFY  2
 #define BLOCKQ_ACTION_TIMEDOUT 4
 
+/* indicate that the blocked thread requires further blocking
+
+   note that this value must not alias any legitimate syscall return
+   value (i.e. -errno) */
+#define BLOCKQ_BLOCK_REQUIRED (0xffffffff00000000ull) /* outside the range of int errno */
+
 typedef closure_type(io_completion, void, thread t, sysreturn rv);
 typedef closure_type(blockq_action, sysreturn, u64 flags);
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -115,9 +115,12 @@ typedef struct unix_heaps {
     heap processes;
 } *unix_heaps;
 
+#define BLOCKQ_ACTION_BLOCKED  1
+#define BLOCKQ_ACTION_NULLIFY  2
+#define BLOCKQ_ACTION_TIMEDOUT 4
+
 typedef closure_type(io_completion, void, thread t, sysreturn rv);
-typedef closure_type(blockq_action, sysreturn, boolean /* blocking */,
-                     boolean /* nullify */, boolean /* timedout */);
+typedef closure_type(blockq_action, sysreturn, u64 flags);
 
 struct blockq;
 typedef struct blockq * blockq;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -179,7 +179,9 @@ typedef struct thread {
 
     /* blockq thread is waiting on, INVALID_ADDRESS for uninterruptible */
     blockq blocked_on;
-    blockq dummy_blockq; /* for pause(2) */
+
+    /* for waiting on thread-specific conditions rather than a resource */
+    blockq thread_bq;
 
     struct sigstate signals;
     sigstate dispatch_sigstate; /* saved sigstate while signal handler in flight */

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -116,7 +116,8 @@ typedef struct unix_heaps {
 } *unix_heaps;
 
 typedef closure_type(io_completion, void, thread t, sysreturn rv);
-typedef closure_type(blockq_action, sysreturn, boolean /* blocking */, boolean /* nullify */);
+typedef closure_type(blockq_action, sysreturn, boolean /* blocking */,
+                     boolean /* nullify */, boolean /* timedout */);
 
 struct blockq;
 typedef struct blockq * blockq;


### PR DESCRIPTION
This rounds out conversion of the remaining cases of uninterruptible blocks that should instead be on a blockq, including the poll waiters (epoll_wait, *select, *poll), nanosleep(2) and TCP connect. The only uninterruptible blocking that remains are filesystem I/O and file-backed mmaps - which are uninterruptible by design.

The blockq actions now take a 'timedout' flag to indicate timer expiry so that the blocking actions don't need to unnecessarily store timestamps and manually check for expiry.

nanosleep(2) implementation should now be complete, and signal interruption will cause the remaining time to be stored in *rem.

The socket code will attempt to abort a TCP connection if a signal was received before lwIP reported connection complete. This could use an explicit test.

Some more exhaustive testing of the poll waiters is in order to verify correct behavior on interruption, so I may either tack on another runtime test(s) before merging or follow up with another PR of tests. A unit test for interrupting nanosleep(2) is in order as well.
