### PR TITLE
ftrace 

### DIFF
--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -10,7 +10,7 @@
    added to the blockq's waiters queue, an optional timeout is set,
    the lock is released and the thread is finally blocked.
 
-   blockq_wake(), meant to be safe for calling from interrupt context,
+   blockq_wake_one(), meant to be safe for calling from interrupt context,
    takes the blockq lock (really a no-op until SMP support) and
    attempts to apply the action at the head of the waiters queue. If
    it returns infinity, it is left at the head of the queue, the lock is

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -1,0 +1,1103 @@
+#include <runtime.h>
+#include <unix_internal.h>
+#include <ftrace.h>
+#include <x86_64.h>
+#include <symtab.h>
+
+#ifdef CONFIG_FTRACE
+
+/* 1MB default size for the user's trace array */
+#define DEFAULT_TRACE_ARRAY_SIZE        (1ULL << 20)
+#define DEFAULT_TRACE_ARRAY_SIZE_KB     (DEFAULT_TRACE_ARRAY_SIZE >> 10)
+
+#define TRACE_TASK_WIDTH                15
+#define TRACE_PID_WIDTH                 5
+
+/* prevent buffers from growing to unbounded sizes */
+#define TRACE_PRINTER_INIT_SIZE         (1ULL << 12) /* 4KB */
+#define TRACE_PRINTER_FLUSH_SIZE        (1ULL << 18) /* 256KB */
+
+static heap ftrace_heap;
+
+/* whether or not to write into the ring buffer */
+static boolean tracing_on = false;
+
+struct rbuf_entry {
+    unsigned long ip;
+    unsigned long parent_ip;
+    unsigned long tsc;
+    unsigned short cpu;
+    int tid;
+    char name[15]; /* unfortunate but safer than accessing a thread pointer */
+};
+
+struct rbuf {
+    struct rbuf_entry * trace_array;
+    unsigned long count; /* current number of unconsumed items */
+    unsigned long total_written; /* total items ever written */
+    unsigned long max_entries; /* size of buffer */
+    unsigned long read_idx;
+    unsigned long write_idx;
+
+    unsigned long disable_cnt;
+    unsigned long wait_cnt;
+    timer trace_timer;
+    blockq bq;
+};
+
+/* This structure is designed to simply the process of efficiently
+ * writing buffers to userspace when the user issues multiple reads
+ * with changing offsets
+ *
+ * This is also needed to persist rbuf contents across calls to read
+ * when destructive reads are issued (e.g., if the user reads 4KB of
+ * data, it's very likely that the last line of text is going to
+ * split an rbuf entry, and we need to maintain at least that half
+ * line of data in the buffer b for the liekly subsequent call to
+ * read with an incremented offset
+ */
+struct ftrace_printer {
+    buffer b;
+    u64 local_offset;
+};
+
+struct ftrace_tracer {
+    /* human readable */
+    const char * name;
+
+    /* trace_fn must be marked as 'no_instrument_function' or else you're gonna
+     * blow up the call stack and crash
+     */
+    void (*trace_fn)(unsigned long, unsigned long);
+    void (*mcount_update)(void);
+
+    /* return number of bytes written to user */
+    u64 (*print_fn)(struct ftrace_printer * p, struct rbuf * rbuf,
+                    boolean header, boolean destructive,
+                    void * buf, u64 length, u64 offset);
+
+    /* XXX what else */
+};
+
+/*
+ * helper to write a buffer to userspace, paying attention
+ * to length and offset conditions
+ *
+ * b: the buffer to write
+ * buf: the user address to write to
+ * length: the length of the user buffer
+ * buffer_offset: how far into b we should start writing from
+ *
+ * return: number of bytes written
+ */
+static inline u64
+write_to_user_offset(buffer b, void * buf, u64 length, u64 buffer_offset)
+{
+    u64 len = (u64)buffer_length(b);
+
+    /* adjust for length */
+    if (len > length)
+        len = length;
+
+    /* if the offset is past the end, nothing to do */
+    if (len <= buffer_offset)
+        return 0;
+
+    runtime_memcpy(buf, buffer_ref(b, buffer_offset), len);
+    return len;
+}
+
+#define printer_offset(p)           (p)->local_offset
+#define printer_set_offset(p, o)    (p)->local_offset = o
+#define printer_buffer(p)           (p)->b
+#define printer_length(p)           (u64)buffer_length(printer_buffer(p))
+
+/*
+ * Set the printer's local offset
+ */
+static inline void
+printer_reset(struct ftrace_printer * p, u64 offset)
+{
+    u64 poff = printer_offset(p);
+
+    if (offset < poff)
+        buffer_clear(printer_buffer(p));
+    else
+        buffer_consume(printer_buffer(p), offset - poff);
+
+    printer_set_offset(p, offset);
+}
+
+/*
+ * helper to flush printer contents to userspace
+ *
+ * if the user offset is higher than anything the printer covers, drop
+ * the data and update the printer's local offset
+ */
+static inline u64
+printer_write_to_user_offset(struct ftrace_printer * p, void * buf, u64 len,
+                             u64 offset)
+{
+    u64 ret;
+    u64 poff, plen, pend;
+
+    poff = printer_offset(p);
+    plen = printer_length(p);
+    pend = poff + plen;
+
+    /* nothing to write */
+    if (pend < offset) {
+        /* "consume" this data by bumping the printer offset up by the length
+         * of the printer
+         */
+        printer_reset(p, poff + plen);
+        return 0;
+    }
+
+    /* printer is now aligned with this offset */
+    printer_reset(p, offset);
+
+    /* write the printer */
+    ret = write_to_user_offset(
+        printer_buffer(p),
+        buf, len,
+        0
+    );
+
+    /* always consume anything written */
+    printer_reset(p, offset + ret);
+
+    return ret;
+}
+
+/*
+ * Write some data into the printer
+ *
+ * p: printer to write to
+ * fmt (...) : formatted string and args
+*/
+#define printer_write(p, fmt, ...) \
+    bprintf(printer_buffer(p), fmt, ##__VA_ARGS__)
+
+/* right-adjust the str within a width of 'width' characters and
+ * print to buffer
+ */
+static inline void
+printer_print_right_adjusted(struct ftrace_printer * p, char * str,
+                             u16 width)
+{
+    int len = runtime_strlen(str);
+
+    if (len > width) {
+        len = width;
+        str[len] = '\0';
+    }
+
+    while (len < width) {
+        printer_write(p, " ");
+        width--;
+    }
+
+    printer_write(p, str);
+}
+
+static inline void
+printer_print_sym(struct ftrace_printer * p, unsigned long ip)
+{
+    char * name;
+    u64 offset, len;
+
+    name = find_elf_sym(ip, &offset, &len);
+    if (name)
+        printer_write(p, name);
+    else
+        printer_write(p, "<< unknown symbol >>");
+}
+
+static inline u64
+printer_print_entry(struct ftrace_printer * p, struct rbuf_entry * entry,
+                    void (*print_entry)(
+                        struct ftrace_printer *,
+                        struct rbuf_entry *
+                    ),
+                    void * buf, u64 length, u64 offset)
+{
+    u64 len;
+
+    print_entry(p, entry);
+
+    /* no need to print every line to userspace individually, but
+     * prevent the buffer from growing overly large with this check
+     */
+    len = printer_length(p);
+    if (len < TRACE_PRINTER_FLUSH_SIZE)
+        return 0;
+
+    /* flush to user and reset the printer to the new offset */
+    return printer_write_to_user_offset(
+        p, buf, length, offset
+    );
+}
+
+#define rbuf_next_idx(r, idx)   (idx == r->max_entries - 1) ? 0 : idx + 1
+#define rbuf_next_write_idx(r)  rbuf_next_idx(r, r->write_idx)
+#define rbuf_next_read_idx(r)   rbuf_next_idx(r, r->read_idx)
+
+/* these are nops for now, as interrupts are always disabled when
+ * we're in kernel
+ */
+static inline void
+rbuf_lock(struct rbuf * rbuf) {}
+static inline void
+rbuf_unlock(struct rbuf * rbuf) {}
+
+static void
+rbuf_reset(struct rbuf * rbuf)
+{
+    rbuf->count = 0;
+    rbuf->read_idx = 0;
+    rbuf->write_idx = 0;
+    rbuf->total_written = 0;
+    rbuf->disable_cnt = 0;
+    rbuf->wait_cnt = 0;
+    rbuf->trace_timer = 0;
+
+    /* wake any waiters */
+    while (blockq_wake_one(rbuf->bq) != INVALID_ADDRESS);
+}
+
+static int
+rbuf_init(struct rbuf * rbuf, unsigned long buffer_size_kb)
+{
+    unsigned long buffer_size = buffer_size_kb << 10;
+
+    rbuf->max_entries = buffer_size / sizeof(struct rbuf_entry);
+    rbuf->trace_array = allocate(ftrace_heap,
+            sizeof(struct rbuf_entry) * rbuf->max_entries);
+    if (rbuf->trace_array == INVALID_ADDRESS) {
+        msg_err("failed to allocate ftrace trace array\n");
+        return -ENOMEM;
+    }
+
+    rbuf->bq = allocate_blockq(ftrace_heap, "ftrace_rbuf");
+    if (rbuf->bq == INVALID_ADDRESS) {
+        msg_err("failed to allocate ftrace blockq\n");
+        deallocate(ftrace_heap, rbuf->trace_array,
+            sizeof(struct rbuf_entry) * rbuf->max_entries);
+        return -ENOMEM;
+    }
+
+    rbuf_reset(rbuf);
+    return 0;
+}
+
+static inline void
+rbuf_disable(struct rbuf * rbuf)
+{
+    rbuf->disable_cnt++;
+}
+
+static inline void
+rbuf_enable(struct rbuf * rbuf)
+{
+    assert(rbuf->disable_cnt);
+    rbuf->disable_cnt--;
+}
+
+static inline boolean
+rbuf_enabled(struct rbuf * rbuf)
+{
+    return (rbuf->disable_cnt == 0);
+}
+
+static inline void
+rbuf_wait(struct rbuf * rbuf)
+{
+    rbuf->wait_cnt++;
+}
+
+static inline void
+rbuf_release(struct rbuf * rbuf)
+{
+    assert(rbuf->wait_cnt);
+    rbuf->wait_cnt--;
+}
+
+static inline boolean
+rbuf_has_waiters(struct rbuf * rbuf)
+{
+    return (rbuf->wait_cnt != 0);
+}
+
+/* must be locked before calling */
+static inline boolean
+__rbuf_acquire_write_entry(struct rbuf * rbuf, struct rbuf_entry ** acquired)
+{
+
+    if (rbuf->count == rbuf->max_entries)
+        return false;
+
+    rbuf->write_idx = rbuf_next_write_idx(rbuf);
+    *acquired = &(rbuf->trace_array[rbuf->write_idx]);
+    rbuf->count++;
+    rbuf->total_written++;
+    return true;
+}
+
+/* must be locked before calling */
+static inline boolean
+__rbuf_acquire_read_entry(struct rbuf * rbuf, struct rbuf_entry ** acquired)
+{
+    if (rbuf->count == 0)
+        return false;
+
+    rbuf->read_idx = rbuf_next_read_idx(rbuf);
+    *acquired = &(rbuf->trace_array[rbuf->read_idx]);
+    rbuf->count--;
+    return true;
+}
+
+/*
+ * These two pointers are queried by mcount() to determine if we've currently
+ * enabled tracing
+ *
+ * They should be set to ftrace_stub to disable tracing, or the associated
+ * trace function if active
+ */
+ftrace_func_t __current_ftrace_trace_fn = ftrace_stub;
+ftrace_func_t __current_ftrace_graph_return = ftrace_stub;
+
+/* just a single rbuf for now, though this might need to be per-cpu once we
+ * have smp
+ */
+static struct rbuf global_rbuf;
+
+
+/*** Start tracer callbacks */
+
+/* nop tracer */
+static void
+nop_set_mcount(void)
+{
+    __current_ftrace_trace_fn = ftrace_stub;
+    __current_ftrace_graph_return = ftrace_stub;
+}
+
+static u64
+nop_print(struct ftrace_printer * p, struct rbuf * rbuf, boolean header,
+          boolean destructive, void * buf, u64 length, u64 offset)
+{
+    u64 written = 0;
+
+    if (header) {
+        printer_write(p, "# tracer: nop\n");
+        printer_write(p, "#\n");
+        printer_write(p,
+            "# entries-in-buffer/entries-written: %ld/%ld    #P:%d\n",
+            global_rbuf.count, global_rbuf.total_written, 1
+        );
+        printer_write(p, "#\n");
+        printer_write(p, "#           TASK-PID   CPU#     TIMESTAMP  FUNCTION\n");
+        printer_write(p, "#              | |       |         |         |\n");
+    }
+
+    /* flush the printer */
+    written = printer_write_to_user_offset(
+        p,
+        buf,
+        length,
+        offset
+    );
+
+    return written;
+}
+
+closure_function(1, 0, void, rbuf_wake_all_fn,
+                 struct rbuf *, rbuf)
+{
+    struct rbuf * rbuf = bound(rbuf);
+
+    blockq_wake_one(rbuf->bq);
+    rbuf->trace_timer = 0;
+    closure_finish();
+}
+
+/*
+ * There must be a better way than this .... 
+ */
+static inline void
+rbuf_wake_all_deferred(struct rbuf * rbuf)
+{
+    if (!rbuf_has_waiters(rbuf) || rbuf->trace_timer != 0)
+        return;
+
+    rbuf->trace_timer = register_timer(
+        0, closure(ftrace_heap, rbuf_wake_all_fn, rbuf)
+    );
+    assert(rbuf->trace_timer != 0);
+}
+
+/*
+ * Be careful modifying this function.
+ *
+ * Anything it calls __must__ be marked no_instrument_function
+ * or inlined
+ */
+__attribute__((no_instrument_function)) static void
+function_trace(unsigned long ip, unsigned long parent_ip)
+{
+    struct rbuf_entry * entry;
+
+    if (!tracing_on || !rbuf_enabled(&global_rbuf))
+        return;
+
+    /* disable any more events while we're in here */
+    rbuf_disable(&global_rbuf);
+
+    rbuf_lock(&global_rbuf);
+    if (!__rbuf_acquire_write_entry(&global_rbuf, &entry))
+        goto drop;
+
+    entry->cpu = 0;
+    entry->tid = current->tid;
+    entry->ip = ip;
+    entry->parent_ip = parent_ip;
+    entry->tsc = rdtsc();
+    runtime_memcpy(entry->name, current->name, 15);
+
+    /* wake any waiters */
+    rbuf_wake_all_deferred(&global_rbuf);
+
+out_enable:
+    rbuf_unlock(&global_rbuf);
+    rbuf_enable(&global_rbuf);
+    return;
+drop:
+    /* XXX count the drop */
+    goto out_enable;
+}
+
+static void
+function_set_mcount(void)
+{
+    __current_ftrace_trace_fn = function_trace;
+}
+
+static inline void
+do_function_print_entry(struct ftrace_printer * p, struct rbuf_entry * entry)
+{
+    printer_write(p, " ");
+    printer_print_right_adjusted(p, entry->name, TRACE_TASK_WIDTH);
+    printer_write(p, "-%d", entry->tid);
+
+    /* pad with spaces as needed */
+    {
+        int tid, blanks;
+
+        for (tid = entry->tid, blanks = TRACE_PID_WIDTH;
+             tid > 0;
+             tid /= 10)
+        {
+            blanks--;
+        }
+
+        while (blanks-- > 0)
+            printer_write(p, " ");
+    }
+
+    /* CPU number */
+    assert(entry->cpu == 0);
+    printer_write(p, " [000] ");
+
+    /* timestamp */
+    printer_write(p, " %ld: ", entry->tsc);
+
+    /* function and parent */
+    printer_print_sym(p, entry->ip);
+    printer_write(p, " <-");
+    printer_print_sym(p, entry->parent_ip);
+
+    printer_write(p, "\n");
+}
+
+static u64
+function_print_nondestructive(struct ftrace_printer * p, struct rbuf * rbuf,
+                              void * buf, u64 length, u64 offset)
+{
+    struct rbuf_entry * entry;
+    unsigned long idx;
+    u64 written, total;
+
+    written = total = 0;
+
+    for (idx  = rbuf->read_idx;
+         idx != rbuf->write_idx;
+         idx  = rbuf_next_idx(rbuf, idx))
+    {
+        entry   = &(rbuf->trace_array[idx]);
+        written = printer_print_entry(p, entry,
+            do_function_print_entry,
+            buf + total,
+            length - total,
+            offset + total
+        );
+
+        total += written;
+        if (total == length)
+            break;
+    }
+
+    return total;
+}
+
+static u64
+function_print_destructive(struct ftrace_printer * p, struct rbuf * rbuf,
+                           void * buf, u64 length, u64 offset)
+{
+    struct rbuf_entry * entry;
+    u64 written, total;
+
+    written = total = 0;
+
+    while (__rbuf_acquire_read_entry(rbuf, &entry)) {
+        written = printer_print_entry(p, entry,
+            do_function_print_entry,
+            buf + total,
+            length - total,
+            offset + total
+        );
+
+        total += written;
+        if (total == length)
+            break;
+    }
+
+    return total;
+}
+
+static u64
+function_print(struct ftrace_printer * p, struct rbuf * rbuf, boolean header,
+               boolean destructive, void * buf, u64 length, u64 offset)
+
+{
+    u64 written;
+
+    if (header) {
+        printer_write(p, "# tracer: function\n");
+        printer_write(p, "#\n");
+        printer_write(p,
+            "# entries-in-buffer/entries-written: %ld/%ld    #P:%d\n",
+            global_rbuf.count, global_rbuf.total_written, 1
+        );
+        printer_write(p, "#\n");
+        printer_write(p, "#           TASK-PID   CPU#     TIMESTAMP  FUNCTION\n");
+        printer_write(p, "#              | |       |         |         |\n");
+    }
+
+    if (destructive)
+        written = function_print_destructive(p, rbuf, buf, length, offset);
+    else
+        written = function_print_nondestructive(p, rbuf, buf, length, offset);
+
+    /* if we've already written the length, we're done */
+    assert(written <= length);
+    if (written == length)
+        return written;
+
+    /* flush the printer */
+    written += printer_write_to_user_offset(
+        p,
+        buf + written,
+        length - written,
+        offset + written
+    );
+
+    return written;
+}
+
+/*
+ * Be careful modifying this function.
+ *
+ * Anything it calls __must__ be marked no_instrument_function
+ * or inlined
+ */
+__attribute__((no_instrument_function)) static void
+function_graph_trace(unsigned long ip, unsigned long parent_ip)
+{
+    if (!tracing_on)
+        return;
+}
+
+static void
+function_graph_set_mcount(void)
+{
+    __current_ftrace_trace_fn = ftrace_stub;
+    __current_ftrace_graph_return = function_graph_trace;
+}
+
+static u64
+function_graph_print(struct ftrace_printer * p, struct rbuf * rbuf,
+                     boolean header, boolean destructive, void * buf, u64 length,
+                     u64 offset)
+{
+    if (header) {
+        printer_write(p, "# tracer: function_graph\n");
+        printer_write(p, "#\n");
+        printer_write(p, "# CPU  DURATION                  FUNCTION CALLS\n");
+        printer_write(p, "# |     |   |                     |   |   |   |\n");
+    }
+
+    /* TODO */
+
+    return printer_write_to_user_offset(
+        p, buf, length, offset
+    );
+}
+
+#define FTRACE_TRACER(_name, _trace_fn, _mcount_update, _print_fn)\
+{\
+    .name = _name,\
+    .trace_fn = _trace_fn,\
+    .mcount_update = _mcount_update,\
+    .print_fn = _print_fn\
+}
+static struct ftrace_tracer
+tracer_list[] = {
+    /* nop must be first */
+    FTRACE_TRACER("nop", ftrace_stub, nop_set_mcount, nop_print
+    ),
+    FTRACE_TRACER("function", function_trace, function_set_mcount,
+            function_print
+    ),
+    FTRACE_TRACER("function_graph", function_graph_trace,
+            function_graph_set_mcount, function_graph_print
+    )
+};
+#define FTRACE_NR_TRACERS (sizeof(tracer_list) / sizeof(struct ftrace_tracer))
+
+/* currently running tracer */
+struct ftrace_tracer * current_tracer = &(tracer_list[0]);
+
+
+/**** Start file operations ****/
+
+/*
+ * available_tracers callbacks
+ */
+
+/* write space-delimited list of tracer names */
+sysreturn
+FTRACE_FN(available_tracers, read)(file f, void * buf, u64 length, u64 offset)
+{
+    int i;
+    u64 len;
+    buffer b;
+
+    b = allocate_buffer(ftrace_heap, 0);
+    if (b == INVALID_ADDRESS)
+        return -ENOMEM;
+
+    for (i = 0; i < FTRACE_NR_TRACERS; i++) {
+        struct ftrace_tracer * tracer = &(tracer_list[i]);
+
+        if (i)
+            bprintf(b , " ");
+        bprintf(b, tracer->name);
+    }
+
+    bprintf(b, "\n");
+
+    len = write_to_user_offset(b, buf, length, offset);
+    deallocate_buffer(b);
+    return len;
+}
+
+sysreturn
+FTRACE_FN(available_tracers, write)(file f, void * buf, u64 length, u64 offset)
+{
+    return 0;
+}
+
+u32
+FTRACE_FN(available_tracers, events)(file f)
+{
+    return EPOLLIN;
+}
+
+/*
+ * current_tracer callbacks
+ */
+
+/* write name of current tracer */
+sysreturn
+FTRACE_FN(current_tracer, read)(file f, void * buf, u64 length, u64 offset)
+{
+    u64 len;
+    buffer b;
+
+    b = allocate_buffer(ftrace_heap, 0);
+    if (b == INVALID_ADDRESS)
+        return -ENOMEM;
+
+    bprintf(b, "%s\n", current_tracer->name);
+
+    len = write_to_user_offset(b, buf, length, offset);
+    deallocate_buffer(b);
+    return len;
+}
+
+sysreturn
+FTRACE_FN(current_tracer, write)(file f, void * buf, u64 length, u64 offset)
+{
+    int i;
+    char * str;
+
+    /* write with an offset > 0 doesn't make much sense here */
+    if (offset > 0)
+        return 0;
+
+    str = (char *)buf;
+
+    for (i = 0; i < FTRACE_NR_TRACERS; i++) {
+        struct ftrace_tracer * tracer = &(tracer_list[i]);
+        int len = runtime_strlen(tracer->name);
+
+        if ((length == len) &&
+            (runtime_strcmp(tracer->name, str) == 0))
+        {
+            current_tracer = tracer;
+            current_tracer->mcount_update();
+            return length;
+        }
+    }
+
+    return 0;
+}
+
+u32
+FTRACE_FN(current_tracer, events)(file f)
+{
+    return EPOLLIN | EPOLLOUT;
+}
+
+
+/*
+ * trace callbacks
+ *
+ * trace reads are non-destructive and read the whole buffer; for correct
+ * operation we need to make sure the buffer doesn't update while we're
+ * reading -- the user may even issue multiple reads that we need to
+ * prevent updates across
+ */
+static struct ftrace_printer trace_printer;
+static boolean trace_is_open = false;
+
+sysreturn
+FTRACE_FN(trace, open)(file f)
+{
+    if (trace_is_open)
+        return -EBUSY;
+
+    trace_printer.b = allocate_buffer(ftrace_heap, TRACE_PRINTER_INIT_SIZE);
+    if (trace_printer.b == INVALID_ADDRESS) {
+        msg_err("failed to allocate ftrace buffer\n");
+        return -ENOMEM;
+    }
+
+    rbuf_disable(&global_rbuf);
+    trace_is_open = true;
+    return 0;
+}
+
+sysreturn
+FTRACE_FN(trace, close)(file f)
+{
+    assert(trace_is_open);
+    trace_is_open = false;
+    rbuf_enable(&global_rbuf);
+    deallocate_buffer(trace_printer.b);
+    return 0;
+}
+
+sysreturn
+FTRACE_FN(trace, read)(file f, void * buf, u64 length, u64 offset)
+{
+    u64 len;
+
+    /* trace reads are non-destructive, so we'll regenerate anything that
+     * is still sitting in the printer */
+    printer_reset(&trace_printer, 0);
+
+    rbuf_lock(&global_rbuf);
+    {
+        len = current_tracer->print_fn(&trace_printer, &global_rbuf,
+            true, false, buf, length, offset
+        );
+    }
+    rbuf_unlock(&global_rbuf);
+
+    return len;
+}
+
+sysreturn
+FTRACE_FN(trace, write)(file f, void * buf, u64 length, u64 offset)
+{
+    printer_reset(&trace_printer, 0);
+
+    /* writes clear the trace buffer */
+    rbuf_lock(&global_rbuf);
+    {
+        rbuf_reset(&global_rbuf);
+    }
+    rbuf_unlock(&global_rbuf);
+
+    return length;
+}
+
+u32
+FTRACE_FN(trace, events)(file f)
+{
+    return EPOLLIN | EPOLLOUT;
+}
+
+/*
+ * trace_clock callbacks
+ */
+sysreturn
+FTRACE_FN(trace_clock, read)(file f, void * buf, u64 length, u64 offset)
+{
+    int len;
+    buffer b;
+
+    b = allocate_buffer(ftrace_heap, 0);
+    if (b == INVALID_ADDRESS)
+        return -ENOMEM;
+
+    bprintf(b, "x86-tsc\n");
+
+    len = write_to_user_offset(b, buf, length, offset);
+    deallocate_buffer(b);
+
+    return len;
+}
+
+sysreturn
+FTRACE_FN(trace_clock, write)(file f, void * buf, u64 length, u64 offset)
+{
+    char * str;
+    int len;
+
+    /* write with an offset > 0 doesn't make much sense here */
+    if (offset > 0)
+        return 0;
+
+    str = (char *)buf;
+    len = runtime_strlen("x86-tsc");
+    if ((len == length) &&
+        (runtime_strcmp("x86-tsc", str) == 0))
+    {
+        return length;
+    }
+
+    return -EINVAL;
+}
+
+u32
+FTRACE_FN(trace_clock, events)(file f)
+{
+    return EPOLLIN | EPOLLOUT;
+}
+
+/*
+ * trace_pipe callbacks
+ *
+ * On Linux the differences between trace and trace_pipe are that reads on the
+ * latter are destructive and do not disable tracing while the file is open
+ */
+static struct ftrace_printer trace_pipe_printer;
+static boolean trace_pipe_is_open = false;
+
+sysreturn
+FTRACE_FN(trace_pipe, open)(file f)
+{
+    if (trace_pipe_is_open)
+        return -EBUSY;
+
+    trace_pipe_printer.b = allocate_buffer(ftrace_heap, TRACE_PRINTER_INIT_SIZE);
+    if (trace_pipe_printer.b == INVALID_ADDRESS) {
+        msg_err("failed to allocate ftrace buffer\n");
+        return -ENOMEM;
+    }
+
+    printer_reset(&trace_pipe_printer, 0);
+    trace_pipe_is_open = true;
+    return 0;
+}
+
+sysreturn
+FTRACE_FN(trace_pipe, close)(file f)
+{
+    assert(trace_pipe_is_open);
+    trace_pipe_is_open = false;
+    deallocate_buffer(trace_pipe_printer.b);
+    return 0;
+}
+
+static sysreturn
+do_trace_pipe_read(struct ftrace_printer * p, struct rbuf * rbuf, void * buf,
+                   u64 length, u64 offset)
+{
+    u64 len;
+
+    rbuf_lock(rbuf);
+    {
+        len = current_tracer->print_fn(p, rbuf,
+            false, true, buf, length, offset
+        );
+    }
+    rbuf_unlock(rbuf);
+
+    return len;
+}
+
+closure_function(7, 2, sysreturn, trace_pipe_read_bh,
+                 file, f, struct ftrace_printer *, p, struct rbuf *, rbuf,
+                 void *, buf, u64, length, u64, offset, thread, t,
+                 boolean, blocked, boolean, nullify)
+{
+    thread t = bound(t);
+    file f = bound(f);
+    struct rbuf * rbuf = bound(rbuf);
+    sysreturn rv;
+
+    rbuf_disable(rbuf);
+
+    if (nullify) {
+        rv = -EINTR;
+        goto finish;
+    }
+
+    rv = do_trace_pipe_read(
+        bound(p), rbuf, bound(buf), bound(length), bound(offset)
+    );
+
+    if (rv == 0) {
+        if (!blocked)
+            rbuf_wait(rbuf);
+        rv = infinity;
+        goto out;
+    }
+
+finish:
+    if (blocked) {
+        if (rv > 0) {
+            f->offset += rv; /* XXX major hack, don't know how to do things like
+                              * this without sleepable kernel contexts */
+        }
+        thread_wakeup(t);
+        rbuf_release(rbuf);
+    }
+    closure_finish();
+out:
+    rbuf_enable(rbuf);
+    return set_syscall_return(t, rv);
+}
+
+sysreturn
+FTRACE_FN(trace_pipe, read)(file f, void * buf, u64 length, u64 offset)
+{
+    printer_reset(&trace_pipe_printer, offset);
+
+    return blockq_check(
+        global_rbuf.bq,
+        current,
+        closure(ftrace_heap, trace_pipe_read_bh,
+            f, &trace_pipe_printer, &global_rbuf, buf, length, offset, current
+        ),
+        false
+    );
+}
+
+sysreturn
+FTRACE_FN(trace_pipe, write)(file f, void * buf, u64 length, u64 offset)
+{
+    return -EINVAL;
+}
+
+u32
+FTRACE_FN(trace_pipe, events)(file f)
+{
+    u32 mask = 0;
+    rbuf_lock(&global_rbuf);
+    {
+        if (global_rbuf.count != 0)
+            mask |= EPOLLIN;
+    }
+    rbuf_unlock(&global_rbuf);
+
+    return mask;
+}
+
+/*
+ * tracing_on callbacks
+ */
+sysreturn
+FTRACE_FN(tracing_on, read)(file f, void * buf, u64 length, u64 offset)
+{
+    u64 len;
+    buffer b;
+
+    b = allocate_buffer(ftrace_heap, 0);
+    if (b == INVALID_ADDRESS)
+        return -ENOMEM;
+
+    bprintf(b, "%d\n", (tracing_on) ? 1 : 0);
+
+    len = write_to_user_offset(b, buf, length, offset);
+    deallocate_buffer(b);
+    return len;
+}
+
+sysreturn
+FTRACE_FN(tracing_on, write)(file f, void * buf, u64 length, u64 offset)
+{
+    char * str;
+
+    /* write with an offset > 0 doesn't make much sense here */
+    if (offset > 0)
+        return 0;
+
+    if (length != 1)
+        return -EINVAL;
+
+    str = (char *)buf;
+    if (str[0] == '0')
+        tracing_on = false;
+    else if (str[0]== '1')
+        tracing_on = true;
+    else
+        return -EINVAL;
+
+    return 1;
+}
+
+u32
+FTRACE_FN(tracing_on, events)(file f)
+{
+    return EPOLLIN | EPOLLOUT;
+}
+
+int
+ftrace_init(unix_heaps uh, filesystem fs)
+{
+    ftrace_heap = heap_general(&(uh->kh));
+    rbuf_init(&global_rbuf, DEFAULT_TRACE_ARRAY_SIZE_KB);
+    return 0;
+}
+
+void
+ftrace_deinit(void)
+{
+}
+
+#endif /* CONFIG_FTRACE */

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -4,8 +4,6 @@
 #include <x86_64.h>
 #include <symtab.h>
 
-#ifdef CONFIG_FTRACE
-
 /* 1MB default size for the user's trace array */
 #define DEFAULT_TRACE_ARRAY_SIZE        (1ULL << 20)
 #define DEFAULT_TRACE_ARRAY_SIZE_KB     (DEFAULT_TRACE_ARRAY_SIZE >> 10)
@@ -1099,5 +1097,3 @@ void
 ftrace_deinit(void)
 {
 }
-
-#endif /* CONFIG_FTRACE */

--- a/src/unix/ftrace.h
+++ b/src/unix/ftrace.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#ifdef CONFIG_FTRACE
+
+#include <runtime.h>
+#include <unix_internal.h>
+
+#define FTRACE_TRACE_DIR                "/sys/kernel/debug/tracing"
+#define FTRACE_TRACER_DIR(tracer)       FTRACE_TRACE_DIR "/" #tracer
+
+typedef sysreturn (ftrace_open_fn)(file);
+typedef sysreturn (ftrace_close_fn)(file);
+typedef sysreturn (ftrace_read_fn)(file, void *, u64, u64);
+typedef sysreturn (ftrace_write_fn)(file, void *, u64, u64);
+typedef u32 (ftrace_events_fn)(file);
+
+static inline sysreturn 
+ftrace_open_nop(file f) 
+{
+    return 0;
+}
+
+static inline sysreturn 
+ftrace_close_nop(file f) 
+{
+    return 0;
+}
+
+#define FTRACE_PASTER(a, b) a ## _ ## b
+#define FTRACE_EVALUATOR(a, b) FTRACE_PASTER(a, b)
+#define FTRACE_FN(name, operation)\
+    FTRACE_EVALUATOR( FTRACE_EVALUATOR(ftrace, name), operation)
+
+#define FTRACE_PROTOTYPES(name)\
+    ftrace_open_fn FTRACE_FN(name, open);\
+    ftrace_close_fn FTRACE_FN(name, close);\
+    ftrace_read_fn FTRACE_FN(name, read);\
+    ftrace_write_fn FTRACE_FN(name, write);\
+    ftrace_events_fn FTRACE_FN(name, events);
+
+#define FTRACE_SPECIAL_FILE(name) \
+    {\
+        .path    = FTRACE_TRACER_DIR(name),\
+        .open    = ftrace_open_nop,\
+        .close   = ftrace_close_nop,\
+        .read    = FTRACE_FN(name, read),\
+        .write   = FTRACE_FN(name, write),\
+        .events  = FTRACE_FN(name, events)\
+    }
+
+#define FTRACE_SPECIAL_FILE_OC(name) \
+    {\
+        .path    = FTRACE_TRACER_DIR(name),\
+        .open    = FTRACE_FN(name, open),\
+        .close   = FTRACE_FN(name, close),\
+        .read    = FTRACE_FN(name, read),\
+        .write   = FTRACE_FN(name, write),\
+        .events  = FTRACE_FN(name, events)\
+    }
+
+#define FTRACE_SPECIAL_FILES \
+    /* files without open/close callbacks */\
+    FTRACE_SPECIAL_FILE(available_tracers),\
+    FTRACE_SPECIAL_FILE(current_tracer),\
+    FTRACE_SPECIAL_FILE(trace_clock),\
+    FTRACE_SPECIAL_FILE(tracing_on),\
+    /* files with open/close callbacks */\
+    FTRACE_SPECIAL_FILE_OC(trace),\
+    FTRACE_SPECIAL_FILE_OC(trace_pipe)\
+
+FTRACE_PROTOTYPES(available_tracers);
+FTRACE_PROTOTYPES(current_tracer);
+FTRACE_PROTOTYPES(trace_clock);
+FTRACE_PROTOTYPES(trace_pipe);
+FTRACE_PROTOTYPES(trace);
+FTRACE_PROTOTYPES(tracing_on);
+
+extern void ftrace_stub(unsigned long, unsigned long);
+typedef void (*ftrace_func_t)(unsigned long, unsigned long);
+int ftrace_init(unix_heaps uh, filesystem fs);
+void ftrace_deinit(void);
+
+#else
+
+static inline int 
+ftrace_init(unix_heaps uh, filesystem fs)
+{
+    return 0;
+}
+
+static inline void
+ftrace_deinit(void)
+{}
+
+#define FTRACE_SPECIAL_FILES
+
+#endif

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -2,6 +2,8 @@
 
 typedef struct special_file {
     const char *path;
+    sysreturn (*open)(file f);
+    sysreturn (*close)(file f);
     sysreturn (*read)(file f, void *dest, u64 length, u64 offset);
     sysreturn (*write)(file f, void *dest, u64 length, u64 offset);
     u32 (*events)(file f);
@@ -93,6 +95,32 @@ get_special(file f)
     buffer b = table_find(f->n, sym(special));
     assert(b);
     return (special_file *) buffer_ref(b, 0);
+}
+
+sysreturn
+spec_open(file f)
+{
+    special_file *sf = get_special(f);
+    assert(sf);
+
+    thread_log(current, "spec_open: %s", sf->path);
+    if (sf->open)
+        return sf->open(f);
+
+    return 0;
+}
+
+sysreturn
+spec_close(file f)
+{
+    special_file *sf = get_special(f);
+    assert(sf);
+
+    thread_log(current, "spec_close: %s", sf->path);
+    if (sf->close)
+        return sf->close(f);
+
+    return 0;
 }
 
 sysreturn

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -1,4 +1,5 @@
 #include <unix_internal.h>
+#include <ftrace.h>
 
 typedef struct special_file {
     const char *path;
@@ -70,6 +71,7 @@ static special_file special_files[] = {
     { "/dev/urandom", .read = urandom_read, .write = 0, .events = urandom_events },
     { "/dev/null", .read = null_read, .write = null_write, .events = null_events },
     { "/sys/devices/system/cpu/online", .read = cpu_online_read, .write = null_write, .events = cpu_online_events },
+    FTRACE_SPECIAL_FILES
 };
 
 void register_special_files(process p)

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -711,12 +711,12 @@ closure_function(2, 6, sysreturn, file_write,
     runtime_memset(buf, 0, final_length);
     runtime_memcpy(buf, dest, length);
 
+    if (is_special(f->n)) {
+        return spec_write(f, buf, length, offset, t, bh, completion);
+    }
+
     buffer b = wrap_buffer(h, buf, final_length);
     thread_log(t, "%s: b_ref: %p", __func__, buffer_ref(b, 0));
-
-    if (is_special(f->n)) {
-        return spec_write(f, b, length, offset, t, bh, completion);
-    }
 
     filesystem_write(t->p->fs, f->n, b, offset,
                      closure(h, file_op_complete, t, f, fsf, is_file_offset,

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -1,4 +1,5 @@
 #include <unix_internal.h>
+#include <ftrace.h>
 #include <buffer.h>
 #include <gdb.h>
 
@@ -286,6 +287,10 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
 	goto alloc_fail;
     register_net_syscalls(linux_syscalls);
 #endif
+
+    if (ftrace_init(uh, fs))
+	goto alloc_fail;
+
     register_signal_syscalls(linux_syscalls);
     register_mmap_syscalls(linux_syscalls);
     register_thread_syscalls(linux_syscalls);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -445,6 +445,8 @@ sysreturn socketpair(int domain, int type, int protocol, int sv[2]);
 int do_eventfd2(unsigned int count, int flags);
 
 void register_special_files(process p);
+sysreturn spec_open(file f);
+sysreturn spec_close(file f);
 sysreturn spec_read(file f, void *dest, u64 length, u64 offset_arg, thread t,
         boolean bh, io_completion completion);
 sysreturn spec_write(file f, void *dest, u64 length, u64 offset_arg, thread t,

--- a/src/x86_64/ftrace.s
+++ b/src/x86_64/ftrace.s
@@ -6,8 +6,11 @@
 ;; save callee rip and rbp 
 %define SAVE_FRAME_SIZE (8 + 16)
 
+;; must be an even number larger than the largest GPR in the thread frame
+%define FRAME_REG_CNT 18
+
 ;; size of stack used to save mcount regs in save_mcount_regs
-%define SAVE_REG_SIZE (FRAME_MAX*8 + SAVE_FRAME_SIZE)
+%define SAVE_REG_SIZE (FRAME_REG_CNT*8 + SAVE_FRAME_SIZE)
 
 ;; size of mcount call
 %define MCOUNT_INSN_SIZE 5

--- a/src/x86_64/ftrace.s
+++ b/src/x86_64/ftrace.s
@@ -37,7 +37,7 @@ extern __current_ftrace_graph_return
     mov rbp, rsp
  
     ;; we add enough stack to save all the regs, but only need those
-    ;; needed and potentially clobbered by mcount
+    ;; potentially clobbered by mcount
     sub rsp, (SAVE_REG_SIZE - SAVE_FRAME_SIZE)
 
     mov [rsp+FRAME_RAX*8], rax

--- a/src/x86_64/ftrace.s
+++ b/src/x86_64/ftrace.s
@@ -1,0 +1,98 @@
+;; BK: the logic here is similar to Linux, but much simpler as we don't have
+;; to deal with fentry, dynamic tracing, and other complexities
+
+%include "frame.inc"
+
+;; save callee rip and rbp 
+%define SAVE_FRAME_SIZE (8 + 16)
+
+;; size of stack used to save mcount regs in save_mcount_regs
+%define SAVE_REG_SIZE (FRAME_MAX*8 + SAVE_FRAME_SIZE)
+
+;; size of mcount call
+%define MCOUNT_INSN_SIZE 5
+
+extern __current_ftrace_trace_fn
+extern __current_ftrace_graph_return
+
+;; After this is called, the following registers contain:
+;;  %rdi - holds rip of tracee (address of function being traced)
+;;  %rsi - holds return address of tracee
+;;  %rdx - holds the original %rbp
+;;
+;; and the stack will look like:
+;;  [            |             ]  <--- rsp
+;;  [            |             ]
+;;  [    <saved frame ctx>     ]
+;;  [            |             ]
+;;  [            |             ]
+;;  [           rbp            ]  <--- rbp
+;;  [   tracee function addr   ]  <--- moved into rdi and stored in stack(RIP)
+;;  [           rbp            ]  <--- moved into rdx and stored in stack(RBP)
+;;  [ tracee retaddr in parent ]  <--- moved into rsi 
+%macro save_mcount_regs 0
+    push rbp
+    push qword [rsp+8]
+    push rbp
+    mov rbp, rsp
+ 
+    ;; we add enough stack to save all the regs, but only need those
+    ;; needed and potentially clobbered by mcount
+    sub rsp, (SAVE_REG_SIZE - SAVE_FRAME_SIZE)
+
+    mov [rsp+FRAME_RAX*8], rax
+    mov [rsp+FRAME_RCX*8], rcx
+    mov [rsp+FRAME_RDX*8], rdx
+    mov [rsp+FRAME_RSI*8], rsi
+    mov [rsp+FRAME_RDI*8], rdi
+    mov [rsp+FRAME_R8*8], r8
+    mov [rsp+FRAME_R9*8], r9
+
+    ;; save original rbp
+    ;; XXX: Linux does this but rbp already points to the saved rbp ...
+    ;; mov rdx, [rsp+(SAVE_REG_SIZE-8)]
+    mov rdx, [rbp]
+    mov [rsp+FRAME_RBP*8], rdx
+
+    ;; return address from parent into rsi
+    mov rsi, [rdx+8]
+
+    ;; load rdi with tracee function address and save in rip on stack
+    ;; XXX: Linux does this but rbp points us right underneath it ...
+    ;; mov rdi, [rsp+SAVE_REG_SIZE]
+    mov rdi, [rbp+8]
+    mov [rsp+FRAME_RIP*8], rdi
+
+    ;; adjust rdi by the size of the mcount instruction to get the
+    ;; return address of the original call, not mcount
+    sub rdi, MCOUNT_INSN_SIZE
+%endmacro
+
+%macro restore_mcount_regs 0
+    mov r9,  [rsp+FRAME_R9*8]
+    mov r8,  [rsp+FRAME_R8*8]
+    mov rdi, [rsp+FRAME_RDI*8]
+    mov rsi, [rsp+FRAME_RSI*8]
+    mov rdx, [rsp+FRAME_RDX*8]
+    mov rcx, [rsp+FRAME_RCX*8]
+    mov rax, [rsp+FRAME_RAX*8]
+    mov rbp, [rsp+FRAME_RBP*8]
+
+    add rsp, SAVE_REG_SIZE
+%endmacro
+
+global ftrace_stub
+global mcount
+mcount:
+    cmp qword [__current_ftrace_trace_fn], ftrace_stub
+    jnz trace
+
+ftrace_stub:
+    ret
+
+trace:
+    save_mcount_regs
+    mov r8, [__current_ftrace_trace_fn]
+    call r8
+    restore_mcount_regs
+    jmp ftrace_stub

--- a/src/x86_64/serial.c
+++ b/src/x86_64/serial.c
@@ -18,6 +18,8 @@ static boolean is_transmit_empty() {
     return in8(BASE + 5) & 0x20;
 }
 
+/* This floods the ftrace buffers when user is outputting lots of data */
+__attribute__((no_instrument_function))
 void serial_putchar(char c)
 {
     while (!is_transmit_empty())

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -40,6 +40,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/unix/blockq.c \
 	$(SRCDIR)/unix/exec.c \
 	$(SRCDIR)/unix/eventfd.c \
+	$(SRCDIR)/unix/ftrace.c \
 	$(SRCDIR)/unix/futex.c \
 	$(SRCDIR)/unix/mktime.c \
 	$(SRCDIR)/unix/mmap.c \
@@ -68,6 +69,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/x86_64/clock.c \
 	$(SRCDIR)/x86_64/crt0.s \
 	$(SRCDIR)/x86_64/elf.c \
+	$(SRCDIR)/x86_64/ftrace.s \
 	$(SRCDIR)/x86_64/hpet.c \
 	$(SRCDIR)/x86_64/interrupt.c \
 	$(SRCDIR)/x86_64/kvm_platform.c \
@@ -115,6 +117,12 @@ CFLAGS+= \
 	-I$(SRCDIR)/x86_64 \
 	-I$(SRCDIR)/xen/public \
 	-I$(LWIPDIR)/src/include
+
+# Enable tracing by specifying TRACE=ftrace on command line
+ifeq ($(TRACE),ftrace)
+CFLAGS+= -DCONFIG_FTRACE -pg
+endif
+	
 #CFLAGS+=	-DLWIPDIR_DEBUG -DEPOLL_DEBUG -DNETSYSCALL_DEBUG -DKERNEL_DEBUG
 AFLAGS+=	-felf64 -I$(OBJDIR)/
 LDFLAGS+=	$(KERNLDFLAGS) -T linker_script

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -40,7 +40,6 @@ SRCS-stage3.img= \
 	$(SRCDIR)/unix/blockq.c \
 	$(SRCDIR)/unix/exec.c \
 	$(SRCDIR)/unix/eventfd.c \
-	$(SRCDIR)/unix/ftrace.c \
 	$(SRCDIR)/unix/futex.c \
 	$(SRCDIR)/unix/mktime.c \
 	$(SRCDIR)/unix/mmap.c \
@@ -69,7 +68,6 @@ SRCS-stage3.img= \
 	$(SRCDIR)/x86_64/clock.c \
 	$(SRCDIR)/x86_64/crt0.s \
 	$(SRCDIR)/x86_64/elf.c \
-	$(SRCDIR)/x86_64/ftrace.s \
 	$(SRCDIR)/x86_64/hpet.c \
 	$(SRCDIR)/x86_64/interrupt.c \
 	$(SRCDIR)/x86_64/kvm_platform.c \
@@ -120,6 +118,9 @@ CFLAGS+= \
 
 # Enable tracing by specifying TRACE=ftrace on command line
 ifeq ($(TRACE),ftrace)
+SRCS-stage3.img+= \
+	$(SRCDIR)/unix/ftrace.c \
+	$(SRCDIR)/x86_64/ftrace.s
 CFLAGS+= -DCONFIG_FTRACE -pg
 endif
 	

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -4,6 +4,7 @@ PROGRAMS= \
 	creat \
 	eventfd \
 	fst \
+	ftrace \
 	getdents \
 	getrandom \
 	hw \
@@ -45,6 +46,12 @@ SRCS-eventfd= \
 
 LDFLAGS-eventfd=	-static
 LIBS-eventfd=		-lpthread
+
+SRCS-ftrace= \
+	$(CURDIR)/ftrace.c \
+	$(SRCDIR)/unix_process/ssp.c
+
+LDFLAGS-ftrace=	-static
 
 SRCS-getdents=		$(CURDIR)/getdents.c
 LDFLAGS-getdents=	-static

--- a/test/runtime/ftrace.c
+++ b/test/runtime/ftrace.c
@@ -1,0 +1,152 @@
+/* test for basic ftrace functionality */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
+#include <assert.h>
+
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/prctl.h>
+
+#define TRACE_DIR "/sys/kernel/debug/tracing"
+#define FTRACE_CURRENT          TRACE_DIR "/current_tracer"
+#define FTRACE_AVAILABLE        TRACE_DIR "/available_tracers"
+#define FTRACE_TRACE            TRACE_DIR "/trace"
+#define FTRACE_TRACING_ON       TRACE_DIR "/tracing_on"
+#define FTRACE_TRACE_PIPE       TRACE_DIR "/trace_pipe"
+
+#define BUF_SIZE 4096
+
+static void
+open_and_read_max(const char  * fname,
+                  unsigned long max_reads)
+{
+    char buf[BUF_SIZE];
+    ssize_t bytes;
+    int fd;
+    unsigned long reads = 0;
+
+    fd = open(fname, O_RDONLY);
+    if (fd < 0) {
+        fprintf(stderr, "Failed to open %s: %s\n", fname, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    do {
+        bytes = read(fd, buf, BUF_SIZE-1);
+        if (bytes < 0) {
+            if (errno == EINTR)
+                continue;
+
+            fprintf(stderr, "read %s failed: %s\n", fname, strerror(errno));
+            exit(EXIT_FAILURE);
+        }
+
+        buf[bytes] = '\0';
+        if (bytes > 0)
+            printf("%s", buf);
+    } while (bytes > 0 && ++reads < max_reads);
+
+    close(fd);
+}
+
+#define open_and_read(fname) open_and_read_max(fname, (1ULL << 30))
+
+static void
+open_and_write(const char * fname, const char * str)
+{
+    ssize_t bytes;
+    int fd;
+
+    fd = open(fname, O_RDONLY);
+    if (fd < 0) {
+        fprintf(stderr, "Failed to open %s: %s\n", fname, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    bytes = write(fd, str, strlen(str));
+    if (bytes < 0) {
+        fprintf(stderr, "Failed to write to %s: %s\n", fname, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    close(fd);
+}
+
+#if 0
+static void
+alrm(int signo) {}
+
+static int
+register_alarm(unsigned long sec)
+{
+    int ret = alarm(sec);
+    if (ret != 0) {
+        fprintf(stderr, "alarm failed: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    return 0;
+}
+
+static int
+register_timeout(unsigned long sec)
+{
+    struct sigaction sa;
+    int ret;
+
+    memset(&sa, 0, sizeof(struct sigaction));
+    sa.sa_handler = alrm;
+    sigemptyset(&sa.sa_mask);
+
+    ret = sigaction(SIGALRM, &sa, NULL); 
+    if (ret != 0) {
+        fprintf(stderr, "sigaction failed: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    return register_alarm(sec);
+}
+#endif
+
+int main(int argc, char * argv[])
+{
+    /* flush printfs immediately */
+    setbuf(stdout, NULL);
+
+    prctl(PR_SET_NAME, "ftrace_test");
+
+    printf("available tracers: ");
+    open_and_read(FTRACE_AVAILABLE);
+
+    printf("current tracer: ");
+    open_and_read(FTRACE_CURRENT);
+
+    open_and_write(FTRACE_CURRENT, "function");
+    open_and_write(FTRACE_TRACING_ON, "1");
+
+    printf(">>>> trace data:\n");
+    open_and_read(FTRACE_TRACE);
+    printf("<<<< end trace data\n");
+    printf("\n\n");
+
+    printf(">>>> trace_pipe data:\n");
+    //open_and_read_max(FTRACE_TRACE_PIPE, 100);
+    open_and_read_max(FTRACE_TRACE_PIPE, 10000);
+
+    printf("\n<<<< end trace_pipe data:\n");
+
+    printf("ftrace test passed\n");
+    exit(EXIT_SUCCESS);
+}

--- a/test/runtime/ftrace.manifest
+++ b/test/runtime/ftrace.manifest
@@ -1,0 +1,13 @@
+(
+    #64 bit elf to boot from host
+    children:(
+	kernel:(contents:(host:output/stage3/bin/stage3.img))
+        ftrace:(contents:(host:output/test/runtime/bin/ftrace))
+	infile:(contents:(host:test/runtime/read_contents/hello))
+    )
+    # filesystem path to elf for kernel to run
+    program:/ftrace
+    fault:t
+    arguments:[/ftrace]
+    environment:(USER:bobby PWD:/)
+)


### PR DESCRIPTION
Introduce basic ftrace functionality
 - This relies on the "-pg" flag to build the kernel with tracing. All kernel functions are interposed with a call to mcount(), which is responsible for saving the running register context and collecting information about the function being invoked and storing in a ringbuffer.
 - Currently, a user process has to set itself to be traced and then read the /sys/ files to collect tracing information. A future PR will provide external tracing abilities