### PR TITLE
in-kernel tcp connection / http interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ $(error Unsupported STORAGE=$(STORAGE))
 endif
 QEMU_TAP=	-netdev tap,id=n0,ifname=tap0,script=no,downscript=no
 QEMU_NET=	-device virtio-net,mac=7e:b8:7e:87:4a:ea,netdev=n0 $(QEMU_TAP)
-QEMU_USERNET=	-device virtio-net,netdev=n0 -netdev user,id=n0,hostfwd=tcp::8080-:8080,hostfwd=tcp::8079-:8079,hostfwd=tcp::9090-:9090,hostfwd=udp::5309-:5309
+QEMU_USERNET=	-device virtio-net,netdev=n0 -netdev user,id=n0,hostfwd=tcp::8080-:8080,hostfwd=tcp::9090-:9090,hostfwd=udp::5309-:5309
 QEMU_FLAGS=
 
 QEMU_COMMON=	$(QEMU_MEMORY) $(QEMU_DISPLAY) $(QEMU_SERIAL) $(QEMU_STORAGE) -device isa-debug-exit -no-reboot $(QEMU_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ $(error Unsupported STORAGE=$(STORAGE))
 endif
 QEMU_TAP=	-netdev tap,id=n0,ifname=tap0,script=no,downscript=no
 QEMU_NET=	-device virtio-net,mac=7e:b8:7e:87:4a:ea,netdev=n0 $(QEMU_TAP)
-QEMU_USERNET=	-device virtio-net,netdev=n0 -netdev user,id=n0,hostfwd=tcp::8080-:8080,hostfwd=tcp::9090-:9090,hostfwd=udp::5309-:5309
+QEMU_USERNET=	-device virtio-net,netdev=n0 -netdev user,id=n0,hostfwd=tcp::8080-:8080,hostfwd=tcp::8079-:8079,hostfwd=tcp::9090-:9090,hostfwd=udp::5309-:5309
 QEMU_FLAGS=
 
 QEMU_COMMON=	$(QEMU_MEMORY) $(QEMU_DISPLAY) $(QEMU_SERIAL) $(QEMU_STORAGE) -device isa-debug-exit -no-reboot $(QEMU_FLAGS)

--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -170,7 +170,7 @@ closure_function(0, 4, void, kernel_elf_map,
     map(vaddr, paddr, size, flags, heap_pages(&kh));
 }
 
-closure_function(0, 1, void, kernel_read_complete,
+closure_function(0, 1, status, kernel_read_complete,
                  buffer, kb)
 {
     stage2_debug("%s\n", __func__);
@@ -188,6 +188,7 @@ closure_function(0, 1, void, kernel_read_complete,
     create_region(working_saved_base, STAGE2_WORKING_HEAP_SIZE, REGION_PHYSICAL);
 
     run64(u64_from_pointer(k));
+    halt("failed to start long mode\n");
 }
 
 typedef struct tagged_allocator {

--- a/mkfs/dump.c
+++ b/mkfs/dump.c
@@ -36,7 +36,7 @@ closure_function(2, 3, void, bread,
     apply(c, STATUS_OK);
 }
 
-closure_function(1, 1, void, write_file,
+closure_function(1, 1, status, write_file,
                  buffer, path,
                  buffer, b)
 {
@@ -56,6 +56,7 @@ closure_function(1, 1, void, write_file,
         buffer_consume(b, xfer);
     }
     close(fd);
+    return STATUS_OK;
 }
 
 // h just for extending path

--- a/src/gdb/gdbstub.c
+++ b/src/gdb/gdbstub.c
@@ -308,7 +308,7 @@ static boolean handle_request(gdb g, buffer b, buffer output)
 
 #define ASCII_CONTROL_C 0x03
 // not completely reassembling (meaning we dont handle fragments?)
-closure_function(1, 1, void, gdbserver_input,
+closure_function(1, 1, status, gdbserver_input,
                  gdb, g,
                  buffer, b)
 {
@@ -319,7 +319,7 @@ closure_function(1, 1, void, gdbserver_input,
         if (ch == ASCII_CONTROL_C) { //wth?
         //        gdb_handle_exception(g, 1, g->registers);
             rprintf ("control-c\n");
-            return;
+            return STATUS_OK;
         }
     }
  retry:
@@ -357,8 +357,9 @@ closure_function(1, 1, void, gdbserver_input,
 
         }
         reset_parser(g);            
-        return;
+        return STATUS_OK;
     }
+    return STATUS_OK;
 }
 
 buffer_handler init_gdb(heap h,

--- a/src/gdb/gdbtcp.c
+++ b/src/gdb/gdbtcp.c
@@ -5,14 +5,17 @@ typedef struct tcpgdb{
     struct tcp_pcb *p;
 } *tcpgdb;
     
-closure_function(1, 1, void, gdb_send,
+closure_function(1, 1, status, gdb_send,
                  tcpgdb, g,
                  buffer, b)
 {
     //    u64 len = tcp_sndbuf(g->pcb);
     // flags can force a stack copy or toggle push
     // pool?
-    tcp_write(bound(g)->p, buffer_ref(b, 0), buffer_length(b), TCP_WRITE_FLAG_COPY);
+    err_t err = tcp_write(bound(g)->p, buffer_ref(b, 0), buffer_length(b), TCP_WRITE_FLAG_COPY);
+    if (err != ERR_OK)
+        return timm("result", "%s: tcp_write returned with error %d", __func__, err);
+    return STATUS_OK;
 }
 
 err_t gdb_input(void *z, struct tcp_pcb *pcb, struct pbuf *p, err_t err)

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -48,13 +48,15 @@ void send_http_response(buffer_handler out,
 
     // status from t
     buffer d = allocate_buffer(transient, 1000);
-    bprintf (d, "HTTP/1.1 200 OK\r\n");
+    bprintf(d, "HTTP/1.1 200 OK\r\n");
     table_foreach(t, k, v) each_header(d, k, v);
-    each_header(d, sym(Content-Length), aprintf(transient, "%d", c->end));
+    if (c)
+        each_header(d, sym(Content-Length), aprintf(transient, "%d", c->end));
     bprintf(d, "\r\n");
     apply(out, d);
-    apply(out, c);
-    
+    if (c)
+        apply(out, c);
+    deallocate_buffer(d);
 }
 
 static void reset_parser(http_parser p)

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -65,7 +65,6 @@ status send_http_response(buffer_handler out,
         if (!is_ok(s))
             goto out_fail;
     }
-    deallocate_buffer(d);
     return STATUS_OK;
   out_fail:
     return timm_up(s, "%s failed to send", __func__);

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -1,6 +1,7 @@
 #include <runtime.h>
 #include <http.h>
 
+#define STATE_INIT 0
 #define STATE_START_LINE 1
 #define STATE_HEADER 2
 #define STATE_VALUE 3
@@ -72,7 +73,7 @@ status send_http_response(buffer_handler out,
 
 static void reset_parser(http_parser p)
 {
-    p->state = STATE_START_LINE;
+    p->state = STATE_INIT;
     p->header = allocate_tuple();
     p->word = allocate_buffer(p->h, 10);
     p->start_line = allocate_vector(p->h, 3);
@@ -87,19 +88,22 @@ closure_function(1, 1, status, http_recv,
                  buffer, b)
 {
     http_parser p = bound(p);
-    int i;
     tuple start_line;
 
     /* content may be delimited by close rather than content length */
     if (!b) {
         if (p->state == STATE_BODY)
             goto content_finish;
-        return timm("result", "http_recv: connection closed before finished parsing");
+        if (p->state == STATE_INIT)
+            return STATUS_OK;   /* XXX teardown */
+        return timm("result", "http_recv: connection closed before finished parsing (state %d)", p->state);
     }
     
-    for (i = b->start ; i < b->end; i ++) {
+    for (bytes i = b->start; i < b->end; i++) {
         char x = ((unsigned char *)b->contents)[i];
         switch (p->state) {
+        case STATE_INIT:
+            p->state = STATE_START_LINE;
         case STATE_START_LINE:
             switch (x){
             case '\r':
@@ -136,10 +140,7 @@ closure_function(1, 1, status, http_recv,
                 if (p->s == sym(Content-Length)) {
                     if (!parse_int(p->word, 10, &p->content_length))
                         msg_err("failed to parse content length\n");
-                    else
-                        rprintf("content length %ld\n", p->content_length);
                 }
-                rprintf("setting %v -> %v\n", p->s, p->word);
                 table_set(p->header, p->s, p->word);
                 p->word = allocate_buffer(p->h, 0);                
                 p->state = STATE_HEADER;
@@ -162,18 +163,12 @@ closure_function(1, 1, status, http_recv,
     start_line = allocate_tuple();
     for (u64 i = 0; i < vector_length(p->start_line); i++) {
         buffer a = vector_get(p->start_line, i);
-        rprintf("adding %d: %b\n", i, a);
         table_set(start_line, intern_u64(i), a);
     }
-    rprintf("setting startline -> %v\n", start_line);
-    table_set(p->header, sym(startline), start_line);
-    rprintf("setting content -> %v\n", p->word);
-    // XXX wrap?
-    //    table_set(p->header, sym(content), wrap_buffer(p->h, buffer_ref(p->word, 0), buffer_length(p->word)));
+    table_set(p->header, sym(start_line), start_line);
     table_set(p->header, sym(content), p->word);
     apply(p->each, p->header);
     reset_parser(p);
-    rprintf("done\n");
     return STATUS_OK;
 }
 
@@ -184,4 +179,131 @@ buffer_handler allocate_http_parser(heap h, value_handler each)
     p->each = each;
     reset_parser(p);
     return closure(h, http_recv, p);
+}
+
+const char *http_request_methods[] = {
+    [HTTP_REQUEST_METHOD_GET] = "GET",
+    [HTTP_REQUEST_METHOD_HEAD] = "HEAD",
+    [HTTP_REQUEST_METHOD_POST] = "POST",
+    [HTTP_REQUEST_METHOD_PUT] = "PUT",
+    [HTTP_REQUEST_METHOD_DELETE] = "DELETE",
+    [HTTP_REQUEST_METHOD_TRACE] = "TRACE",
+    [HTTP_REQUEST_METHOD_OPTIONS] = "OPTIONS",
+    [HTTP_REQUEST_METHOD_CONNECT] = "CONNECT",
+    [HTTP_REQUEST_METHOD_PATCH] = "PATCH"
+};
+
+typedef struct http_listener_registrant {
+    struct list l;
+    const char *uri;
+    http_request_handler each;
+} *http_listener_registrant;
+
+typedef struct http_listener {
+    heap h;
+    http_request_handler default_handler;
+    struct list registrants;
+} *http_listener;
+
+closure_function(2, 1, void, each_http_request,
+                 http_listener, hl, buffer_handler, out,
+                 value, v)
+{
+    http_method method;
+    http_listener hl = bound(hl);
+    vector vsl = vector_from_tuple(hl->h, table_find(v, sym(start_line)));
+    if (!vsl || vsl == INVALID_ADDRESS)
+        goto not_found;
+
+    buffer mb = vector_get(vsl, 0);
+    for (method = 0; method < HTTP_REQUEST_METHODS; method++) {
+        if (buffer_compare(mb, alloca_wrap_buffer(http_request_methods[method],
+                                                  runtime_strlen(http_request_methods[method]))))
+            break;
+    }
+
+    if (method == HTTP_REQUEST_METHODS)
+        goto not_found;
+
+    /* support absoluteURI? */
+    buffer uri = vector_get(vsl, 1);
+    if (!uri || buffer_length(uri) < 1 || *(u8*)buffer_ref(uri, 0) != '/')
+        goto not_found;
+    buffer_consume(uri, 1);
+
+    /* whatever test for default page */
+    if (buffer_length(uri) == 0) {
+        if (!hl->default_handler)
+            goto not_found;
+        apply(hl->default_handler, method, bound(out), v);
+        return;
+    }
+
+    int total_len = buffer_length(uri);
+    int top_len = 0;
+    char * top = buffer_ref(uri, 0);
+    for (int i = 0; i < total_len; i++) {
+        if (top[i] == '/') {
+            buffer_consume(uri, 1);
+            break;
+        }
+        top_len++;
+    }
+    buffer_consume(uri, top_len);
+
+    if (buffer_length(uri) > 0)
+        table_set(v, sym(relative_uri), uri);
+
+    list_foreach(&hl->registrants, l) {
+        http_listener_registrant r = struct_from_list(l, http_listener_registrant, l);
+        if (top_len == runtime_strlen(r->uri) &&
+            runtime_memcmp(top, r->uri, top_len) == 0) {
+            apply(r->each, method, bound(out), v);
+            return;
+        }
+    }
+  not_found:
+    // XXX send 404
+    rprintf("not found\n");
+}
+
+closure_function(1, 1, buffer_handler, each_http_connection,
+                 http_listener, hl,
+                 buffer_handler, out)
+{
+    http_listener hl = bound(hl);
+    return allocate_http_parser(hl->h, closure(hl->h, each_http_request, hl, out));
+}
+
+/* just top level of abs_path */
+void http_register_uri_handler(http_listener hl, const char *uri, http_request_handler each)
+{
+    http_listener_registrant r = allocate(hl->h, sizeof(struct http_listener_registrant));
+    assert(r != INVALID_ADDRESS); /* no error path, this is pretty much init only */
+    r->uri = uri;
+    r->each = each;
+    list_insert_before(&hl->registrants, &r->l);
+}
+
+void http_register_default_handler(http_listener hl, http_request_handler each)
+{
+    hl->default_handler = each;
+}
+
+connection_handler connection_handler_from_http_listener(http_listener hl)
+{
+    return closure(hl->h, each_http_connection, hl);
+}
+
+/* should take address? */
+http_listener allocate_http_listener(heap h, u16 port)
+{
+    http_listener hl = allocate(h, sizeof(struct http_listener));
+    if (hl == INVALID_ADDRESS)
+        return hl;
+
+    hl->h = h;
+    hl->default_handler = 0;
+    list_init(&hl->registrants);
+    return hl;
 }

--- a/src/http/http.h
+++ b/src/http/http.h
@@ -3,7 +3,7 @@ typedef closure_type(value_handler, void, value);
 
 buffer_handler allocate_http_parser(heap h, value_handler each);
 // just format the buffer?
-void http_request(heap h, buffer_handler bh, tuple headers);
-void send_http_response(buffer_handler out,
-                        tuple t,
-                        buffer c);
+status http_request(heap h, buffer_handler bh, tuple headers);
+status send_http_response(buffer_handler out,
+                          tuple t,
+                          buffer c);

--- a/src/http/http.h
+++ b/src/http/http.h
@@ -1,3 +1,16 @@
+typedef enum {
+    HTTP_REQUEST_METHOD_GET = 0,
+    HTTP_REQUEST_METHOD_HEAD,
+    HTTP_REQUEST_METHOD_POST,
+    HTTP_REQUEST_METHOD_PUT,
+    HTTP_REQUEST_METHOD_DELETE,
+    HTTP_REQUEST_METHOD_TRACE,
+    HTTP_REQUEST_METHOD_OPTIONS,
+    HTTP_REQUEST_METHOD_CONNECT,
+    HTTP_REQUEST_METHOD_PATCH,
+    HTTP_REQUEST_METHODS
+} http_method;
+
 typedef closure_type(http_response, void, tuple);
 typedef closure_type(value_handler, void, value);
 
@@ -7,3 +20,13 @@ status http_request(heap h, buffer_handler bh, tuple headers);
 status send_http_response(buffer_handler out,
                           tuple t,
                           buffer c);
+
+extern const char *http_request_methods[];
+
+typedef struct http_listener *http_listener;
+typedef closure_type(http_request_handler, void, http_method, buffer_handler, value);
+
+void http_register_uri_handler(http_listener hl, const char *uri, http_request_handler each);
+void http_register_default_handler(http_listener hl, http_request_handler each);
+connection_handler connection_handler_from_http_listener(http_listener hl);
+http_listener allocate_http_listener(heap h, u16 port);

--- a/src/http/http.h
+++ b/src/http/http.h
@@ -1,7 +1,5 @@
-#pragma once
 typedef closure_type(http_response, void, tuple);
 typedef closure_type(value_handler, void, value);
-typedef closure_type(buffer_handler, void, buffer);
 
 buffer_handler allocate_http_parser(heap h, value_handler each);
 // just format the buffer?

--- a/src/net/direct.c
+++ b/src/net/direct.c
@@ -1,6 +1,6 @@
 #include <runtime.h>
 #include <lwip.h>
-#include <tfs.h> // XXX fix 
+#include <tfs.h> // XXX fix
 #include <unix.h>
 #include <net.h>
 

--- a/src/net/direct.c
+++ b/src/net/direct.c
@@ -1,0 +1,81 @@
+#include <runtime.h>
+#include <lwip.h>
+#include <tfs.h> // XXX fix 
+#include <unix.h>
+#include <net.h>
+
+typedef struct direct {
+    connection_handler new;
+    struct tcp_pcb *p;
+    heap h;
+} *direct;
+
+/* XXX need status */
+closure_function(1, 1, void, direct_send,
+                 struct tcp_pcb *, pcb,
+                 buffer, b)
+{
+    err_t err;
+    if (!b) {
+        /* close connection */
+        err = tcp_close(bound(pcb));
+        if (err != ERR_OK)
+            rprintf("%s: tcp_close returned with error %d\n", __func__, err);
+        return;
+    }
+    /* Fix interface: can send with PSH flag clear
+       (TCP_WRITE_FLAG_MORE) if we know more data is on the way... */
+    err = tcp_write(bound(pcb), buffer_ref(b, 0), buffer_length(b), TCP_WRITE_FLAG_COPY);
+    if (err != ERR_OK)
+        rprintf("%s: tcp_write returned with error %d\n", __func__, err);
+}
+
+err_t direct_input(void *z, struct tcp_pcb *pcb, struct pbuf *p, err_t err)
+{
+    buffer_handler bh = z;
+    if (p) {
+        /* handler must consume entire buffer */
+        apply(bh, alloca_wrap_buffer(p->payload, p->len));
+        tcp_recved(pcb, p->len);
+    } else {
+        /* connection closed */
+        apply(bh, 0);
+    }
+    return ERR_OK;
+}
+
+static void direct_conn_err(void *z, err_t err)
+{
+    buffer_handler bh = z;
+    rprintf("%s: bh %p, err %d\n", __func__, bh, err);
+}
+
+static void direct_listen_err(void *z, err_t err)
+{
+    direct g = z;
+    rprintf("%s: g %p, err %d\n", __func__, g, err);
+}
+
+/* XXX per-connection descriptor as tcp arg? */
+static err_t direct_accept(void *z, struct tcp_pcb *pcb, err_t b)
+{
+    direct g = z;
+    buffer_handler bh = apply(g->new, closure(g->h, direct_send, pcb));
+    tcp_arg(pcb, bh);
+    tcp_err(pcb, direct_conn_err);
+    tcp_recv(pcb, direct_input);
+    return ERR_OK;
+}
+
+void listen_port(heap h, u16 port, connection_handler c)
+{
+    direct g = allocate(h, sizeof(struct direct));
+    g->p = tcp_new_ip_type(IPADDR_TYPE_ANY);
+    g->h = h;
+    g->new = c;
+    tcp_bind(g->p, IP_ANY_TYPE, port);
+    g->p = tcp_listen(g->p);
+    tcp_arg(g->p, g);
+    tcp_err(g->p, direct_listen_err);
+    tcp_accept(g->p, direct_accept);    
+}

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -3,5 +3,4 @@
 #define NET_SYSCALLS 1
 
 boolean netsyscall_init(unix_heaps uh);
-typedef closure_type(connection_handler, buffer_handler, buffer_handler);
-void listen_port(heap h, u16 port, connection_handler c);
+status listen_port(heap h, u16 port, connection_handler c);

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -3,3 +3,5 @@
 #define NET_SYSCALLS 1
 
 boolean netsyscall_init(unix_heaps uh);
+typedef closure_type(connection_handler, buffer_handler, buffer_handler);
+void listen_port(heap h, u16 port, connection_handler c);

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -227,7 +227,8 @@ static inline void deallocate_buffer(buffer b)
 {
     heap h = b->h;
     deallocate(h, b->contents, b->length);
-    deallocate(h, b, sizeof(struct buffer));
+    if (!b->wrapped)
+        deallocate(h, b, sizeof(struct buffer));
 }
 
 static inline void copy_descriptor(buffer d, buffer s)

--- a/src/runtime/metadata.h
+++ b/src/runtime/metadata.h
@@ -9,8 +9,10 @@ static inline vector vector_from_tuple(heap h, tuple n)
         return 0;
 
     vector r = allocate_vector(h, 100); //table_elements(n));
+    if (r == INVALID_ADDRESS)
+        return r;
+
     void *x;
-    
     for (int i = 0; (x = table_find(n, intern_u64(i))); i++)
         vector_push(r, x);
     
@@ -20,9 +22,11 @@ static inline vector vector_from_tuple(heap h, tuple n)
 // destructive
 static inline tuple tuple_from_vector(vector v)
 {
-    tuple t = allocate_tuple();
     void *p;
     int i = 0;
+    tuple t = allocate_tuple();
+    if (t == INVALID_ADDRESS)
+        return t;
 
     // reversal?
     while ((p = vector_pop(v))) 

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -164,7 +164,7 @@ typedef closure_type(thunk, void);
 #define PAGELOG_2M 21
 #define PAGESIZE_2M U64_FROM_BIT(PAGELOG_2M)
 
-typedef closure_type(buffer_handler, void, buffer);
+typedef closure_type(buffer_handler, status, buffer);
 typedef closure_type(block_io, void, void *, range, status_handler);
 
 // should be  (parser, parser, character)
@@ -186,7 +186,6 @@ typedef struct signature {
 
 void init_runtime(kernel_heaps kh);
 heap allocate_tagged_region(kernel_heaps kh, u64 tag);
-typedef closure_type(buffer_promise, void, buffer_handler);
 
 extern thunk ignore;
 extern status_handler ignore_status;

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -165,6 +165,7 @@ typedef closure_type(thunk, void);
 #define PAGESIZE_2M U64_FROM_BIT(PAGELOG_2M)
 
 typedef closure_type(buffer_handler, status, buffer);
+typedef closure_type(connection_handler, buffer_handler, buffer_handler);
 typedef closure_type(block_io, void, void *, range, status_handler);
 
 // should be  (parser, parser, character)

--- a/src/runtime/status.h
+++ b/src/runtime/status.h
@@ -15,11 +15,11 @@ static inline void timm_term(table t, char *n, vlist *a)
 }
 
 // if the format strings and subsequent arguments dont line up, this whole thing goes sideways
-static inline tuple timm_internal(char *first, ...)
+static inline tuple timm_internal(tuple t, char *first, ...)
 {
     vlist e;
     vstart(e, first);
-    tuple t = allocate_tuple();
+    assert(t != INVALID_ADDRESS);
 
     // deal with the mandatory first argument
     if (first != INVALID_ADDRESS) {
@@ -32,7 +32,9 @@ static inline tuple timm_internal(char *first, ...)
 }
 
 // fix for zero argument case
-#define timm(first, ...)  timm_internal(first, __VA_ARGS__, INVALID_ADDRESS)
+#define timm(first, ...)  timm_internal(allocate_tuple(), first, __VA_ARGS__, INVALID_ADDRESS)
+
+#define timm_append(s, first, ...)  timm_internal(s, first, __VA_ARGS__, INVALID_ADDRESS)
 
 // build up status chain
 #define timm_up(sd, first, ...)                     \

--- a/src/runtime/status.h
+++ b/src/runtime/status.h
@@ -1,4 +1,5 @@
-#pragma once
+#define STATUS_OK ((tuple)0)
+
 typedef tuple status;
 typedef closure_type(status_handler, void, status);
 
@@ -19,6 +20,8 @@ static inline tuple timm_internal(tuple t, char *first, ...)
 {
     vlist e;
     vstart(e, first);
+    if (t == STATUS_OK)
+        t = allocate_tuple();
     assert(t != INVALID_ADDRESS);
 
     // deal with the mandatory first argument
@@ -32,8 +35,7 @@ static inline tuple timm_internal(tuple t, char *first, ...)
 }
 
 // fix for zero argument case
-#define timm(first, ...)  timm_internal(allocate_tuple(), first, __VA_ARGS__, INVALID_ADDRESS)
-
+#define timm(first, ...)  timm_internal(STATUS_OK, first, __VA_ARGS__, INVALID_ADDRESS)
 #define timm_append(s, first, ...)  timm_internal(s, first, __VA_ARGS__, INVALID_ADDRESS)
 
 // build up status chain
@@ -44,7 +46,6 @@ static inline tuple timm_internal(tuple t, char *first, ...)
         __up;                                       \
     })
 
-#define STATUS_OK ((tuple)0)
 static inline boolean is_ok(status s)
 {
     return (s == STATUS_OK);

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -165,7 +165,7 @@ closure_function(2, 4, void, exec_elf_map,
     }
 }
 
-closure_function(2, 1, void, load_interp_complete,
+closure_function(2, 1, status, load_interp_complete,
                  thread, t, kernel_heaps, kh,
                  buffer, b)
 {
@@ -178,6 +178,7 @@ closure_function(2, 1, void, load_interp_complete,
     exec_debug("starting process tid %d, start %p\n", t->tid, start);
     start_process(t, start);
     closure_finish();
+    return STATUS_OK;
 }
 
 process exec_elf(buffer ex, process kp)

--- a/src/unix_process/socket_user.c
+++ b/src/unix_process/socket_user.c
@@ -449,7 +449,7 @@ closure_function(4, 0, void, connection_input,
 }
 
 
-closure_function(2, 1, void, connection_output,
+closure_function(2, 1, status, connection_output,
                  descriptor, c, notifier, n,
                  buffer, b)
 {
@@ -460,6 +460,7 @@ closure_function(2, 1, void, connection_output,
 	notifier_reset_fd(bound(n), c);
         close(c);
     }
+    return STATUS_OK;           /* pff */
 }
 
 closure_function(4, 0, void, accepting,

--- a/src/x86_64/x86_64.h
+++ b/src/x86_64/x86_64.h
@@ -164,6 +164,7 @@ static inline void kern_pause(void)
 typedef struct queue *queue;
 extern queue runqueue;
 extern queue bhqueue;
+extern queue deferqueue;
 
 heap physically_backed(heap meta, heap virtual, heap physical, heap pages, u64 pagesize);
 void physically_backed_dealloc_virtual(heap h, u64 x, bytes length);

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -12,6 +12,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/gdb/gdbstub.c \
 	$(SRCDIR)/gdb/gdbtcp.c \
 	$(SRCDIR)/gdb/gdbutil.c \
+	$(SRCDIR)/http/http.c \
 	$(SRCDIR)/net/direct.c \
 	$(SRCDIR)/net/net.c \
 	$(SRCDIR)/net/netsyscall.c \
@@ -109,6 +110,7 @@ CFLAGS+=	$(KERNCFLAGS) -DSTAGE3
 CFLAGS+= \
 	-I$(SRCDIR) \
 	-I$(SRCDIR)/gdb \
+	-I$(SRCDIR)/http \
 	-I$(SRCDIR)/net \
 	-I$(SRCDIR)/runtime \
 	-I$(SRCDIR)/tfs \

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -12,6 +12,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/gdb/gdbstub.c \
 	$(SRCDIR)/gdb/gdbtcp.c \
 	$(SRCDIR)/gdb/gdbutil.c \
+	$(SRCDIR)/net/direct.c \
 	$(SRCDIR)/net/net.c \
 	$(SRCDIR)/net/netsyscall.c \
 	$(SRCDIR)/runtime/bitmap.c \

--- a/stage3/stage3.c
+++ b/stage3/stage3.c
@@ -71,9 +71,29 @@ closure_function(2, 1, void, each_http_request,
                  heap, h, buffer_handler, out,
                  value, v)
 {
-    send_http_response(bound(out),
-                       timm("ContentType", "text/html"),
-                       aprintf(bound(h), "value: %v\r\n", v));
+    /* later make this generic in http */
+    tuple start_line = table_find(v, sym(startline));
+    if (!start_line)
+        goto not_found;
+    value method = table_find(start_line, sym(0));
+    if (!method)
+        goto not_found;
+    /* XXX type */
+    rprintf("method: %b\n", method);
+    if (buffer_compare((buffer)method, wrap_buffer_cstring(bound(h), "GET"))) {
+        // resolve request-uri to tuple, or some registered handler?
+        send_http_response(bound(out),
+                           timm("ContentType", "text/html"),
+                           aprintf(bound(h), "value: %v\r\n", v));
+    } else {
+        goto not_found;
+    }
+
+    return;
+  not_found:
+    // XXX 404
+    rprintf("not found\n");
+    return;
 }
 
 /* http debug test */

--- a/stage3/stage3.c
+++ b/stage3/stage3.c
@@ -1,6 +1,7 @@
 #include <runtime.h>
 #include <tfs.h>
 #include <unix.h>
+#include <net.h>
 #include <gdb.h>
 #include <virtio/virtio.h>
 
@@ -35,6 +36,35 @@ closure_function(0, 1, void, read_program_fail,
     halt("read program failed %v\n", s);
 }
 
+closure_function(2, 1, void, test_recv,
+                 heap, h,
+                 buffer_handler, out,
+                 buffer, b)
+{
+    buffer response = allocate_buffer(bound(h), 1024);
+    buffer_handler out = bound(out);
+    if (!b) {
+        rprintf("remote closed\n");
+        return;
+    }
+    bprintf(response, "read: %b", b);
+    apply(out, response);
+    if (*((u8*)buffer_ref(b, 0)) == 'q')
+        apply(out, 0);
+}
+
+closure_function(1, 1, buffer_handler, each_connection,
+                 heap, h,
+                 buffer_handler, out)
+{
+    heap h = bound(h);
+//    return allocate_http_parser(h, closure(h, each_request, h, out);
+    buffer response = allocate_buffer(h, 1024);
+    bprintf(response, "hi thanks for coming\r\n");
+    apply(out, response);
+    return closure(h, test_recv, h, out);
+}
+
 closure_function(3, 0, void, startup,
                  kernel_heaps, kh, tuple, root, filesystem, fs)
 {
@@ -49,6 +79,12 @@ closure_function(3, 0, void, startup,
     }
     heap general = heap_general(kh);
     buffer_handler pg = closure(general, read_program_complete, kp, root);
+
+    if (table_find(root, sym(socktest))) {
+        listen_port(general, 8079, closure(general, each_connection, general));
+        rprintf("socktest start 8079\n");
+    }
+
     value p = table_find(root, sym(program));
     assert(p);
     tuple pro = resolve_path(root, split(general, p, '/'));

--- a/stage3/stage3.c
+++ b/stage3/stage3.c
@@ -62,18 +62,18 @@ closure_function(2, 1, status, test_recv,
     buffer response = allocate_buffer(bound(h), 1024);
     buffer_handler out = bound(out);
     if (!b) {
-        rprintf("remote closed\n");
+        rprintf("telnet: remote closed\n");
         return STATUS_OK;
     }
     bprintf(response, "read: %b", b);
     apply(out, response);
     switch (*((u8*)buffer_ref(b, 0))) {
     case 'q':
-        rprintf("remote sent quit\n");
+        rprintf("telnet: remote sent quit\n");
         apply(out, 0);
         break;
     case 'b':
-        rprintf("remote requested bulk buffer\n");
+        rprintf("telnet: remote requested bulk buffer\n");
         apply(out, bulk_test_buffer(bound(h)));
         break;
     }
@@ -86,7 +86,8 @@ closure_function(1, 1, buffer_handler, each_socktest_connection,
 {
     heap h = bound(h);
     buffer response = allocate_buffer(h, 1024);
-    bprintf(response, "hi thanks for coming\r\n");
+    rprintf("telnet: connection\n");
+    bprintf(response, "nanos telnet test interface\r\n");
     apply(out, response);
     return closure(h, test_recv, h, out);
 }
@@ -97,7 +98,7 @@ closure_function(1, 3, void, each_test_request,
                  http_method, m, buffer_handler, out, value, v)
 {
     heap h = bound(h);
-    rprintf("test %s request via http: %v\n", http_request_methods[m], v);
+    rprintf("http: %s request via http: %v\n", http_request_methods[m], v);
     /* XXX alloc issues - confirm that handlers fully consume (and deallocate) buffers */
     status s = send_http_response(out, timm("ContentType", "text/html"),
                                   bulk_test_buffer(h));
@@ -122,7 +123,7 @@ closure_function(3, 0, void, startup,
 
     if (table_find(root, sym(socktest))) {
         listen_port(general, 9090, closure(general, each_socktest_connection, general));
-        rprintf("socktest start 9090\n");
+        rprintf("Debug telnet server started on port 9090\n");
     }
 
     http_listener hl = allocate_http_listener(general, 9090);
@@ -133,7 +134,7 @@ closure_function(3, 0, void, startup,
         status s = listen_port(general, 9090, connection_handler_from_http_listener(hl));
         if (!is_ok(s))
             halt("listen_port failed for http listener: %v\n", s);
-        rprintf("Debug server started on port 9090\n");
+        rprintf("Debug http server started on port 9090\n");
     }
 
     value p = table_find(root, sym(program));

--- a/stage3/stage3.c
+++ b/stage3/stage3.c
@@ -80,7 +80,7 @@ closure_function(2, 1, status, test_recv,
     return STATUS_OK;
 }
 
-closure_function(1, 1, buffer_handler, each_socktest_connection,
+closure_function(1, 1, buffer_handler, each_telnet_connection,
                  heap, h,
                  buffer_handler, out)
 {
@@ -121,8 +121,8 @@ closure_function(3, 0, void, startup,
     heap general = heap_general(kh);
     buffer_handler pg = closure(general, read_program_complete, kp, root);
 
-    if (table_find(root, sym(socktest))) {
-        listen_port(general, 9090, closure(general, each_socktest_connection, general));
+    if (table_find(root, sym(telnet))) {
+        listen_port(general, 9090, closure(general, each_telnet_connection, general));
         rprintf("Debug telnet server started on port 9090\n");
     }
 

--- a/stage3/stage3.c
+++ b/stage3/stage3.c
@@ -6,7 +6,7 @@
 #include <gdb.h>
 #include <virtio/virtio.h>
 
-closure_function(2, 1, void, read_program_complete,
+closure_function(2, 1, status, read_program_complete,
                  process, kp, tuple, root,
                  buffer, b)
 {
@@ -28,6 +28,7 @@ closure_function(2, 1, void, read_program_complete,
     }
     exec_elf(b, bound(kp));
     closure_finish();
+    return STATUS_OK;
 }
 
 closure_function(0, 1, void, read_program_fail,
@@ -38,7 +39,7 @@ closure_function(0, 1, void, read_program_fail,
 }
 
 /* raw tcp socket test */
-closure_function(2, 1, void, test_recv,
+closure_function(2, 1, status, test_recv,
                  heap, h,
                  buffer_handler, out,
                  buffer, b)
@@ -47,12 +48,13 @@ closure_function(2, 1, void, test_recv,
     buffer_handler out = bound(out);
     if (!b) {
         rprintf("remote closed\n");
-        return;
+        return STATUS_OK;
     }
     bprintf(response, "read: %b", b);
     apply(out, response);
     if (*((u8*)buffer_ref(b, 0)) == 'q')
         apply(out, 0);
+    return STATUS_OK;
 }
 
 closure_function(1, 1, buffer_handler, each_socktest_connection,
@@ -93,7 +95,6 @@ closure_function(2, 1, void, each_http_request,
   not_found:
     // XXX 404
     rprintf("not found\n");
-    return;
 }
 
 /* http debug test */

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -157,9 +157,9 @@ LDFLAGS-time=		-static
 
 SRCS-udploop= \
 	$(CURDIR)/udploop.c \
+	$(SRCDIR)/http/http.c \
 	$(SRCDIR)/unix_process/unix_process_runtime.c \
 	$(SRCDIR)/unix_process/mmap_heap.c \
-	$(SRCDIR)/unix_process/http.c \
 	$(SRCDIR)/unix_process/socket_user.c \
 	$(SRCDIR)/unix_process/tiny_heap.c \
 	$(SRCDIR)/runtime/bitmap.c \
@@ -200,9 +200,9 @@ LDFLAGS-vsyscall=	 -static
 
 SRCS-web= \
 	$(CURDIR)/web.c \
+	$(SRCDIR)/http/http.c \
 	$(SRCDIR)/unix_process/unix_process_runtime.c \
 	$(SRCDIR)/unix_process/mmap_heap.c \
-	$(SRCDIR)/unix_process/http.c \
 	$(SRCDIR)/unix_process/socket_user.c \
 	$(SRCDIR)/unix_process/tiny_heap.c \
 	$(SRCDIR)/runtime/bitmap.c \
@@ -249,7 +249,8 @@ SRCS-readv = \
 LDFLAGS-readv=		-static
 
 CFLAGS+=	-DENABLE_MSG_DEBUG
-CFLAGS+=	-I$(SRCDIR)/runtime \
+CFLAGS+=	-I$(SRCDIR)/http \
+		-I$(SRCDIR)/runtime \
 		-I$(SRCDIR)/unix \
 		-I$(SRCDIR)/unix_process \
 		-I$(SRCDIR)/x86_64

--- a/test/runtime/webg.manifest
+++ b/test/runtime/webg.manifest
@@ -11,7 +11,8 @@
     # put all the tracing arguments in subtree
 #    trace:t
 #    debugsyscalls:t
-#    futex_trace:t    
+#    futex_trace:t
+    socktest:t
     fault:t
     arguments:[webg longargument]
     environment:(USER:bobby PWD:password)

--- a/test/runtime/webg.manifest
+++ b/test/runtime/webg.manifest
@@ -12,7 +12,7 @@
 #    trace:t
 #    debugsyscalls:t
 #    futex_trace:t
-#    socktest:t
+#    telnet:t
 #    http:t
 #    fault:t
     arguments:[webg longargument]

--- a/test/runtime/webg.manifest
+++ b/test/runtime/webg.manifest
@@ -14,7 +14,7 @@
 #    futex_trace:t
     socktest:t
     http:t
-    fault:t
+#    fault:t
     arguments:[webg longargument]
     environment:(USER:bobby PWD:password)
 )

--- a/test/runtime/webg.manifest
+++ b/test/runtime/webg.manifest
@@ -12,8 +12,8 @@
 #    trace:t
 #    debugsyscalls:t
 #    futex_trace:t
-    socktest:t
-    http:t
+#    socktest:t
+#    http:t
 #    fault:t
     arguments:[webg longargument]
     environment:(USER:bobby PWD:password)

--- a/test/runtime/webg.manifest
+++ b/test/runtime/webg.manifest
@@ -13,6 +13,7 @@
 #    debugsyscalls:t
 #    futex_trace:t
     socktest:t
+    http:t
     fault:t
     arguments:[webg longargument]
     environment:(USER:bobby PWD:password)

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -101,6 +101,7 @@ SRCS-memops_test= \
 
 SRCS-network_test= \
 	$(CURDIR)/network_test.c \
+	$(SRCDIR)/http/http.c \
 	$(SRCDIR)/runtime/bitmap.c \
 	$(SRCDIR)/runtime/buffer.c \
 	$(SRCDIR)/runtime/extra_prints.c \
@@ -122,7 +123,6 @@ SRCS-network_test= \
 	$(SRCDIR)/tfs/tlog.c \
 	$(SRCDIR)/unix_process/unix_process_runtime.c \
 	$(SRCDIR)/unix_process/mmap_heap.c \
-	$(SRCDIR)/unix_process/http.c \
 	$(SRCDIR)/unix_process/socket_user.c \
 	$(SRCDIR)/unix_process/tiny_heap.c
 
@@ -281,6 +281,7 @@ SRCS-tuple_test= \
 
 SRCS-udp_test= \
 	$(CURDIR)/udp_test.c \
+	$(SRCDIR)/http/http.c \
 	$(SRCDIR)/runtime/bitmap.c \
 	$(SRCDIR)/runtime/buffer.c \
 	$(SRCDIR)/runtime/extra_prints.c \
@@ -302,7 +303,6 @@ SRCS-udp_test= \
 	$(SRCDIR)/tfs/tlog.c \
 	$(SRCDIR)/unix_process/unix_process_runtime.c \
 	$(SRCDIR)/unix_process/mmap_heap.c \
-	$(SRCDIR)/unix_process/http.c \
 	$(SRCDIR)/unix_process/socket_user.c \
 	$(SRCDIR)/unix_process/tiny_heap.c
 
@@ -328,7 +328,8 @@ SRCS-vector_test= \
 	$(SRCDIR)/unix_process/unix_process_runtime.c
 
 
-CFLAGS+=	-I$(SRCDIR)/runtime \
+CFLAGS+=	-I$(SRCDIR)/http \
+		-I$(SRCDIR)/runtime \
 		-I$(SRCDIR)/tfs \
 		-I$(SRCDIR)/unix_process \
 		-I$(SRCDIR)/unix \


### PR DESCRIPTION
This introduces net/direct.c for handling TCP connections within the kernel. http handling code is moved from src/unix_process to src/http and also built into the kernel. As a (temporary) test, stage3.c contains optional telnet and http test drivers (enabled by setting telnet and http flags in manifest, respectively). We can delete these once we've wired up ftrace and other debug services.

A few general changes are also included:
- A "deferqueue" has been added to service.c to allow bottom half code to re-schedule thunks for execution in the following call to process_bhqueue. This is used, for instance, to allow queued data in a direct_conn to spool out to lwIP as space becomes available in the TCP send window. It also becomes possible to approximate a kernel thread by continuously re-scheduling a run method via 'enqueue(deferqueue, closure_self())'.
- buffer_handlers now return a status. Status handling in the connection code isn't thoroughly sorted out, but this is a start.

Obviously, this connection interface is meant to be used for debugging, with ftrace control/trace download and tuple r/w in mind. As such, it is quite rudimentary and designed for handling request-response transactions by exchanging buffers (using buffer_handlers on either end). We can build this out as needed, e.g. passing 'from' sockaddr info to connection_handlers, etc., but don't expect the flexibility of unix sockets here...
