### PR TITLE
http: add chunked transfer encoding

### DIFF
--- a/src/http/http.h
+++ b/src/http/http.h
@@ -20,6 +20,9 @@ status http_request(heap h, buffer_handler bh, tuple headers);
 status send_http_response(buffer_handler out,
                           tuple t,
                           buffer c);
+status send_http_chunk(buffer_handler out, buffer c);
+status send_http_chunked_response(buffer_handler out, tuple t);
+status send_http_response(buffer_handler out, tuple t, buffer c);
 
 extern const char *http_request_methods[];
 

--- a/src/net/direct.c
+++ b/src/net/direct.c
@@ -135,7 +135,18 @@ err_t direct_conn_input(void *z, struct tcp_pcb *pcb, struct pbuf *p, err_t err)
 
 static void direct_conn_err(void *z, err_t err)
 {
+    status s;
     direct_conn dc = z;
+    switch (err) {
+    case ERR_ABRT:
+    case ERR_RST:
+    case ERR_CLSD:
+        /* connection closed */
+        s = apply(dc->receive_bh, 0);
+        if (!is_ok(s))
+            rprintf("%s: failed to close: %v\n", __func__, s);
+        return;
+    }
     rprintf("%s: dc %p, err %d\n", __func__, dc, err);
     dc->pending_err = err;
 }

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -33,6 +33,8 @@ static inline char peek_char(buffer b)
             b;                                                  \
         })
 
+#define alloca_wrap_cstring(__x) alloca_wrap_buffer((__x), runtime_strlen(__x))
+
 #define alloca_wrap(__z) alloca_wrap_buffer(buffer_ref((__z), 0), buffer_length(__z))
 
 #define byte(__b, __i) *(u8 *)((__b)->contents + (__b)->start + (__i))
@@ -253,6 +255,17 @@ static inline boolean buffer_compare(void *za, void *zb)
     return true;
 }
 
+static inline boolean buffer_compare_with_cstring(buffer b, const char *x)
+{
+    int len = buffer_length(b);
+    for (int i = 0; i < len; i++) {
+        if (byte(b, i) != x[i])
+            return false;
+        if (x[i] == '\0')       /* must terminate */
+            return i == len - 1;
+    }
+    return x[len] == '\0';
+}
 
 // the ascii subset..utf8 me
 #define foreach_character(__i, __c, __s)                                \


### PR DESCRIPTION
We can use chunked transfer encoding to form http responses that exceed the maximum buffer size and/or are comprised of multiple buffers.
