### PR TITLE
ftrace: send chunked http response

### DIFF
--- a/src/net/direct.c
+++ b/src/net/direct.c
@@ -54,6 +54,12 @@ static boolean direct_conn_send_internal(direct_conn dc)
         if (err == ERR_MEM)
             return false;
 
+        err = tcp_output(dc->p);
+        if (err != ERR_OK) {
+            msg_err("tcp_output failed with %d\n", err);
+            return false;
+        }
+
         /* should handle some other way */
         if (err != ERR_OK) {
             /* XXX */

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -99,8 +99,8 @@ void runloop()
 {
     thunk t;
 
-    while (1) {
-        while ((t = dequeue(runqueue))) {
+    while(1) {
+        while((t = dequeue(runqueue))) {
             apply(t);
             disable_interrupts();
         }

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -99,10 +99,12 @@ void runloop()
 {
     thunk t;
 
-    while(1) {
-        while((t = dequeue(runqueue))) {
+    while (1) {
+        int waiters = queue_length(runqueue);
+        while (waiters > 0 && (t = dequeue(runqueue))) {
             apply(t);
             disable_interrupts();
+            waiters--;
         }
         if (current) {
             proc_pause(current->p);

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -100,11 +100,9 @@ void runloop()
     thunk t;
 
     while (1) {
-        int waiters = queue_length(runqueue);
-        while (waiters > 0 && (t = dequeue(runqueue))) {
+        while ((t = dequeue(runqueue))) {
             apply(t);
             disable_interrupts();
-            waiters--;
         }
         if (current) {
             proc_pause(current->p);


### PR DESCRIPTION
ftrace printer semantics change somewhat: A local rbuf index is set to read_idx on rbuf init and incremented with each print. If a printer returns true, indicating more data to print, another chunk response is scheduled in the future via a runloop timer. False indicates that printing of the rbuf has completed (whether destructive or not), upon which point the http response is finished and rbuf and printers are reset.

One issue is that queued, asynchronous processing of output buffers gets traced after issuing of output has completed on the ftrace side - thus adding a lot of noise to subsequent trace gets. This should only be a concern for trace_pipe, and can be ameliorated by adding an optional completion (status_handler) to buffer_handlers and then tying buffer responses together with a merge. The merge completion would then perform the rbuf deinit, thus re-enabling tracing.
