### PR TITLE
various bug fixes

### DIFF
--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -112,7 +112,6 @@ static timestamp get_timeout_timestamp(int futex_op, u64 val2)
 {
     switch (futex_op) {
     case FUTEX_WAIT:
-    case FUTEX_CMP_REQUEUE:
     case FUTEX_WAIT_BITSET:
         return (val2) 
             ? time_from_timespec((struct timespec *)pointer_from_u64(val2)) 
@@ -156,14 +155,14 @@ sysreturn futex(int *uaddr, int futex_op, int val,
             false, ts
         );
     }
-            
+
     case FUTEX_WAKE: {
         if (verbose)
             thread_log(current, "futex_wake [%ld %p %d] %d",
                 current->tid, uaddr, *uaddr, val);
         return set_syscall_return(current, futex_wake_many(f, val));
     }
-        
+
     case FUTEX_CMP_REQUEUE: {
         int wake1, wake2;
         struct futex * f2;

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -1,5 +1,10 @@
 #include <unix_internal.h>
 
+struct futex {
+    heap h;
+    blockq bq;
+};
+
 static u64 futex_key_function(void *x)
 {
     return u64_from_pointer(x);
@@ -52,18 +57,6 @@ static thread futex_wake_one(struct futex * f)
     return w;
 }
 
-boolean futex_wake(process p, int *uaddr)
-{
-    struct futex * f;
-
-    f = table_find(p->futices, (void *)uaddr);
-    if (!f)
-        return false;
-
-    futex_wake_one(f);
-    return true;
-}
-
 /*
  * Wake up to 'val' waiters
  * Return the number woken
@@ -79,6 +72,18 @@ static int futex_wake_many(struct futex * f, int val)
     }
 
     return nr_woken;
+}
+
+boolean futex_wake_many_by_uaddr(process p, int *uaddr, int val)
+{
+    struct futex * f;
+
+    f = table_find(p->futices, (void *)uaddr);
+    if (!f)
+        return false;
+
+    futex_wake_many(f, val);
+    return true;
 }
 
 /*

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -670,8 +670,11 @@ typedef u32 gid_t;
 
 
 /* set/getsockopt optnames */
-#define SO_TYPE 3
-#define SO_SNDBUF   7
+#define SO_DEBUG     1
+#define SO_REUSEADDR 2
+#define SO_TYPE      3
+#define SO_ERROR     4
+#define SO_SNDBUF    7
 
 
 /* eventfd flags */

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -124,6 +124,7 @@ closure_function(1, 0, void, run_thread,
 
 void thread_sleep_interruptible(void)
 {
+    disable_interrupts();
     assert(current->blocked_on);
     thread_log(current, "sleep interruptible (on \"%s\")", blockq_name(current->blocked_on));
     runloop();
@@ -131,6 +132,7 @@ void thread_sleep_interruptible(void)
 
 void thread_sleep_uninterruptible(void)
 {
+    disable_interrupts();
     assert(!current->blocked_on);
     current->blocked_on = INVALID_ADDRESS;
     thread_log(current, "sleep uninterruptible");
@@ -139,6 +141,7 @@ void thread_sleep_uninterruptible(void)
 
 void thread_yield(void)
 {
+    disable_interrupts();
     thread_log(current, "yield %d, RIP=0x%lx", current->tid, current->frame[FRAME_RIP]);
     assert(!current->blocked_on);
     current->syscall = -1;
@@ -208,6 +211,7 @@ thread create_thread(process p)
     t->frame[FRAME_FAULT_HANDLER] = u64_from_pointer(create_fault_handler(h, t));
     t->run = closure(h, run_thread, t);
     t->blocked_on = 0;
+    t->file_op_complete = false;
     init_sigstate(&t->signals);
     t->dispatch_sigstate = 0;
     t->active_signo = 0;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -152,6 +152,7 @@ void thread_wakeup(thread t)
     thread_log(current, "%s: %ld->%ld blocked_on %s, RIP=0x%lx", __func__, current->tid, t->tid,
                t->blocked_on ? (t->blocked_on != INVALID_ADDRESS ? blockq_name(t->blocked_on) : "uninterruptible") :
                "(null)", t->frame[FRAME_RIP]);
+    assert(t->blocked_on);
     thread_make_runnable(t);
 }
 
@@ -240,7 +241,7 @@ void exit_thread(thread t)
 
     if (t->clear_tid) {
         *t->clear_tid = 0;
-        futex(t->clear_tid, FUTEX_WAKE, 1, 0, 0, 0);
+        futex_wake(t->p, t->clear_tid); /* ignore errors */
     }
 
     if (t->select_epoll)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -259,7 +259,7 @@ void exit_thread(thread t)
 
     if (t->clear_tid) {
         *t->clear_tid = 0;
-        futex_wake(t->p, t->clear_tid); /* ignore errors */
+        futex_wake_one_by_uaddr(t->p, t->clear_tid); /* ignore errors */
     }
 
     if (t->select_epoll)

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -104,6 +104,16 @@ closure_function(0, 6, sysreturn, stdout,
     return length;
 }
 
+closure_function(0, 0, u32, std_output_events)
+{
+    return EPOLLOUT;
+}
+
+closure_function(0, 0, u32, std_input_events)
+{
+    return 0;
+}
+
 extern struct syscall *linux_syscalls;
 
 static boolean create_stdfiles(unix_heaps uh, process p)
@@ -131,6 +141,8 @@ static boolean create_stdfiles(unix_heaps uh, process p)
     in->f.write = out->f.write = err->f.write = closure(h, stdout);
     in->f.read = out->f.read = err->f.read = closure(h, dummy_read);
     in->f.flags = out->f.flags = err->f.flags = O_RDWR;
+    out->f.events = err->f.events = closure(h, std_output_events);
+    in->f.events = closure(h, std_input_events);
     return true;
 }
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -190,6 +190,9 @@ typedef struct thread {
     /* blockq thread is waiting on, INVALID_ADDRESS for uninterruptible */
     blockq blocked_on;
 
+    /* set by file op completion; used to detect if blocking is necessary */
+    boolean file_op_complete;
+
     /* for waiting on thread-specific conditions rather than a resource */
     blockq thread_bq;
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -293,11 +293,6 @@ typedef struct process {
     struct sigaction  sigactions[NSIG];
 } *process;
 
-struct futex {
-    heap h;
-    blockq bq;
-};
-
 typedef struct sigaction *sigaction;
 
 #define SIGACT_SIGINFO  0x00000001
@@ -464,8 +459,13 @@ void init_syscalls();
 void init_threads(process p);
 void init_futices(process p);
 
-boolean futex_wake(process p, int *uaddr);
 sysreturn futex(int *uaddr, int futex_op, int val, u64 val2, int *uaddr2, int val3);
+boolean futex_wake_many_by_uaddr(process p, int *uaddr, int val);
+
+static inline boolean futex_wake_one_by_uaddr(process p, int *uaddr)
+{
+    return futex_wake_many_by_uaddr(p, uaddr, 1);
+}
 
 int do_pipe2(int fds[2], int flags);
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -147,6 +147,7 @@ static inline sysreturn blockq_check(blockq bq, thread t, blockq_action a, boole
 {
     return blockq_check_timeout(bq, t, a, in_bh, 0);
 }
+int blockq_transfer_waiters(blockq dest, blockq src, int n);
 
 /* pending and masked signals for a given thread or process */
 typedef struct sigstate {
@@ -281,6 +282,11 @@ typedef struct process {
     struct sigstate   signals;
     struct sigaction  sigactions[NSIG];
 } *process;
+
+struct futex {
+    heap h;
+    blockq bq;
+};
 
 typedef struct sigaction *sigaction;
 
@@ -448,6 +454,7 @@ void init_syscalls();
 void init_threads(process p);
 void init_futices(process p);
 
+boolean futex_wake(process p, int *uaddr);
 sysreturn futex(int *uaddr, int futex_op, int val, u64 val2, int *uaddr2, int val3);
 
 int do_pipe2(int fds[2], int flags);


### PR DESCRIPTION
These bugs were found while investigating https://github.com/nanovms/ops/issues/403 and #1003.

- getsockopt needed support for SO_ERROR
- missing poll events method for std files
- futex:
  - FUTEX_CMP_REQUEUE was incorrectly interpreting val2 as a timeout, and was also waking waiters before re-queuing them to the uaddr2 futex when it should only re-queue (use blockq_transfer_waiters to re-queue)
  - on thread exit, don't call futex syscall directly with a wake (causing a soft create); use futex_wake instead - if the futex isn't found, just ignore it
- file syscalls: explicitly check if file operation completed before putting thread to sleep (triggered by a file_read spanning only a file hole in the write runtime test - not related to node)
