### PR TITLE
Detect hypervisor support for rdtscp instruction and use it by default when user invokes rdtsc()

### DIFF
--- a/src/x86_64/clock.c
+++ b/src/x86_64/clock.c
@@ -10,6 +10,8 @@ typedef __uint128_t u128;
 static clock_now platform_now;
 static clock_timer platform_timer;
 
+u8 platform_has_rdtscp = 0;
+
 void register_platform_clock_now(clock_now cn)
 {
     platform_now = cn;
@@ -47,5 +49,11 @@ void runloop_timer(timestamp duration)
 
 void init_clock(void)
 {
+    /* detect rdtscp */
+    u32 regs[4];
+    cpuid(0x80000001, 0, regs);
+    if (regs[3] & U64_FROM_BIT(27))
+        platform_has_rdtscp = 1;
+
     rtc_offset = rtc_gettimeofday() << 32;
 }

--- a/src/x86_64/x86_64.h
+++ b/src/x86_64/x86_64.h
@@ -145,7 +145,7 @@ static inline u64 rdtsc_precise(void)
     if (platform_has_rdtscp)
         return __rdtscp();
 
-    asm volatile("cpuid" ::: "%rax", "%rbx", "%rcx", "%rdx"); /* serialize execution */\
+    asm volatile("cpuid" ::: "%rax", "%rbx", "%rcx", "%rdx"); /* serialize execution */
     return __rdtsc();
 }
 

--- a/src/x86_64/x86_64.h
+++ b/src/x86_64/x86_64.h
@@ -117,12 +117,36 @@ static inline void set_page_write_protect(boolean enable)
     mov_to_cr("cr0", cr0);
 }
 
-static inline u64 rdtsc(void)
+extern u8 platform_has_rdtscp;
+
+static inline u64 __rdtscp(void)
 {
     u32 a, d;
-    asm volatile("cpuid" ::: "%rax", "%rbx", "%rcx", "%rdx"); /* serialize execution */
+    asm volatile("rdtscp" : "=a" (a), "=d" (d));
+    return (((u64)a) | (((u64)d) << 32));
+}
+
+static inline u64 __rdtsc(void)
+{
+    u32 a, d;
     asm volatile("rdtsc" : "=a" (a), "=d" (d));
     return (((u64)a) | (((u64)d) << 32));
+}
+
+static inline u64 rdtsc(void)
+{
+    if (platform_has_rdtscp)
+        return __rdtscp();
+    return __rdtsc();
+}
+
+static inline u64 rdtsc_precise(void)
+{
+    if (platform_has_rdtscp)
+        return __rdtscp();
+
+    asm volatile("cpuid" ::: "%rax", "%rbx", "%rcx", "%rdx"); /* serialize execution */\
+    return __rdtsc();
 }
 
 typedef closure_type(clock_now, timestamp);


### PR DESCRIPTION
This is somewhere between 100x and 1000x faster than cpuid+rdtsc

Also, by default disable the use of cpuid when invoking rdtsc even when rdtscp is not present. Users can still have the precision benefit of cpuid+rdtsc by invoking rdtsc_precise() if they really want it