### PR TITLE
minor fixes

### DIFF
--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -25,9 +25,12 @@ static boolean timer_compare(void *za, void *zb)
     return(a->w > b->w);
 }
 
-void remove_timer(timer t)
+/* returns time remaining or 0 if elapsed */
+timestamp remove_timer(timer t)
 {
     t->disable = true;
+    timestamp n = now();
+    return t->w > n ? t->w - n : 0;
 }
 
 static timer __register_timer(timestamp interval, thunk n, boolean periodic)

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -4,7 +4,7 @@ typedef struct timer *timer;
 
 timer register_timer(timestamp, thunk n);
 timer register_periodic_timer(timestamp interval, thunk n);
-void remove_timer(timer t);
+timestamp remove_timer(timer t);
 void initialize_timers(kernel_heaps kh);
 timestamp parse_time();
 void print_timestamp(buffer, timestamp);

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -313,9 +313,9 @@ int blockq_transfer_waiters(blockq dest, blockq src, int n)
             break;
         blockq_item bi = struct_from_list(l, blockq_item, l);
         if (bi->timeout) {
-            /* XXX cancelling timer for now, but it should be restarted on new bq */
-            remove_timer(bi->timeout);
-            bi->timeout = 0;
+            timestamp remain = remove_timer(bi->timeout);
+            bi->timeout = remain == 0 ? 0 :
+                register_timer(remain, closure(dest->h, blockq_item_timeout, dest, bi));
         }
         list_delete(&bi->l);
         assert(bi->t->blocked_on == src);

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -318,6 +318,8 @@ int blockq_transfer_waiters(blockq dest, blockq src, int n)
             bi->timeout = 0;
         }
         list_delete(&bi->l);
+        assert(bi->t->blocked_on == src);
+        bi->t->blocked_on = dest;
         list_insert_before(&dest->waiters_head, &bi->l);
         transferred++;
     }

--- a/src/x86_64/x86_64.h
+++ b/src/x86_64/x86_64.h
@@ -119,14 +119,14 @@ static inline void set_page_write_protect(boolean enable)
 
 extern u8 platform_has_rdtscp;
 
-static inline u64 __rdtscp(void)
+static inline u64 _rdtscp(void)
 {
     u32 a, d;
     asm volatile("rdtscp" : "=a" (a), "=d" (d));
     return (((u64)a) | (((u64)d) << 32));
 }
 
-static inline u64 __rdtsc(void)
+static inline u64 _rdtsc(void)
 {
     u32 a, d;
     asm volatile("rdtsc" : "=a" (a), "=d" (d));
@@ -136,17 +136,17 @@ static inline u64 __rdtsc(void)
 static inline u64 rdtsc(void)
 {
     if (platform_has_rdtscp)
-        return __rdtscp();
-    return __rdtsc();
+        return _rdtscp();
+    return _rdtsc();
 }
 
 static inline u64 rdtsc_precise(void)
 {
     if (platform_has_rdtscp)
-        return __rdtscp();
+        return _rdtscp();
 
     asm volatile("cpuid" ::: "%rax", "%rbx", "%rcx", "%rdx"); /* serialize execution */
-    return __rdtsc();
+    return _rdtsc();
 }
 
 typedef closure_type(clock_now, timestamp);


### PR DESCRIPTION
- fix clang build (__rdtsc is reserved word)
- blockq_transfer_waiters: update t->blocked_on, re-register any outstanding, unexpired timers