### PR TITLE
fix iov_transfer / readv / writev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test test-noaccel: mkfs boot stage3
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	creat fst getdents getrandom hw hws mkdir mmap pipe signal vsyscall write
+RUNTIME_TESTS=	creat eventfd fst getdents getrandom hw hws mkdir mmap pipe readv rename sendfile signal socketpair time unlink vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -217,7 +217,7 @@ thread create_thread(process p)
     t->frame[FRAME_FAULT_HANDLER] = u64_from_pointer(create_fault_handler(h, t));
     t->run = closure(h, run_thread, t);
     t->blocked_on = 0;
-    t->file_op_complete = false;
+    t->file_op_is_complete = false;
     init_sigstate(&t->signals);
     t->dispatch_sigstate = 0;
     t->active_signo = 0;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -193,7 +193,7 @@ typedef struct thread {
     blockq blocked_on;
 
     /* set by file op completion; used to detect if blocking is necessary */
-    boolean file_op_complete;
+    boolean file_op_is_complete;
 
     /* for waiting on thread-specific conditions rather than a resource */
     blockq thread_bq;

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -8,13 +8,13 @@ PROGRAMS= \
 	getdents \
 	getrandom \
 	hw \
-	hwg \
 	hws \
 	mkdir \
 	mmap \
 	nullpage \
 	paging \
 	pipe \
+	readv \
 	rename \
 	sendfile \
 	signal \
@@ -27,8 +27,7 @@ PROGRAMS= \
 	webg \
 	webs \
 	write \
-	writev \
-	readv
+	writev
 
 SRCS-dup= \
 	$(CURDIR)/dup.c \


### PR DESCRIPTION
iov_transfer* functions were blindly casting fdescs as files, causing corruption to socket descriptors when used with readv(2) and writev(2). Normalize them to use fdescs and, instead of trying to pass the file offset to the op and update afterwards, leave it to the file ops (if applicable) by specifying magic (infinity) as the offset parameter to the op.

Also add missing runtime tests to the runtime-tests* targets.

Rename thread boolean file_op_complete (to file_op_is_complete) to avoid confusion with function of same name.
