### PR TITLE
cpuid check for rdseed/rdrand on init only

### DIFF
--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -203,8 +203,8 @@ static void read_kernel_syms()
 
 extern void install_gdt64_and_tss();
 
-static boolean have_rdseed;
-static boolean have_rdrand;
+static boolean have_rdseed = false;
+static boolean have_rdrand = false;
 
 static boolean hw_seed(u64 * seed, boolean rdseed)
 {


### PR DESCRIPTION
try_hw_seed was unnecessarily checking for rdseed/rdrand availability on each call. This trivial fix should confine all (costly) uses of cpuid to initialization.
