### PR TITLE
KVM: use TSC-Deadline timer as runloop timer, if available

### DIFF
--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -71,20 +71,18 @@ timestamp timer_check()
     timestamp here = 0;
     timer t = 0;
 
-    while ((t = pqueue_peek(timers)) &&
-           (here = now(), t->w < here)) {
-            pqueue_pop(timers);
-            if(!t->disable) {
-                apply(t->t);
-                if (t->interval) {
-                    t->w += t->interval;
-                    pqueue_insert(timers, t);
-                }
-            } else {
-                deallocate(theap, t, sizeof(struct timer));
-                t = 0;
+    while ((t = pqueue_peek(timers)) && (here = now(), t->w <= here)) {
+        pqueue_pop(timers);
+        if (!t->disable) {
+            apply(t->t);
+            if (t->interval) {
+                t->w += t->interval;
+                pqueue_insert(timers, t);
+                continue;
             }
         }
+        deallocate(theap, t, sizeof(struct timer));
+    }
     if (t) {
     	timestamp dt = t->w - here;
     	timer_debug("check returning dt: %d\n", dt);

--- a/src/x86_64/apic.h
+++ b/src/x86_64/apic.h
@@ -1,5 +1,4 @@
-clock_timer lapic_runloop_timer;
-
 void lapic_eoi(void);
 void init_apic(kernel_heaps kh);
-void configure_lapic_timer(heap h);
+void lapic_set_tsc_deadline_mode(u32 v);
+clock_timer init_lapic_timer(void);

--- a/src/x86_64/kvm_platform.c
+++ b/src/x86_64/kvm_platform.c
@@ -83,9 +83,16 @@ boolean kvm_detect(kernel_heaps kh)
         msg_err("unable to probe pvclock\n");
         return false;
     }
-    heap h = heap_general(kh);
-    assert(lapic_runloop_timer);
-    register_platform_clock_timer(lapic_runloop_timer);
-    configure_lapic_timer(h);
+
+    clock_timer ct;
+    if ((ct = init_tsc_deadline_timer())) {
+        kvm_debug("TSC Deadline available");
+    } else if ((ct = init_lapic_timer())) {
+        kvm_debug("defaulting to (suboptimal) lapic timer");
+    } else {
+        halt("%s: no timer available\n", __func__);
+    }
+
+    register_platform_clock_timer(ct);
     return true;
 }

--- a/src/x86_64/pvclock.c
+++ b/src/x86_64/pvclock.c
@@ -12,7 +12,8 @@ u64 pvclock_now_ns(void)
     u64 result;
 
     do {
-        version = vclock->version & ~1; /* mask enable */
+        /* mask update-in-progress so we don't match */
+        version = vclock->version & ~1;
         read_barrier();
         u64 delta = rdtsc() - vclock->tsc_timestamp;
         if (vclock->tsc_shift < 0) {
@@ -55,7 +56,8 @@ closure_function(0, 1, void, tsc_deadline_timer,
     u64 count = 0;
 
     do {
-        version = vclock->version & ~1; /* mask enable */
+        /* mask update-in-progress so we don't match */
+        version = vclock->version & ~1;
         read_barrier();
         timestamp subsec = truncate_seconds(interval);
         count = (nsec_from_timestamp(subsec) << 32) / vclock->tsc_to_system_mul;

--- a/src/x86_64/pvclock.c
+++ b/src/x86_64/pvclock.c
@@ -1,8 +1,10 @@
 #include <runtime.h>
 #include <x86_64.h>
 #include <pvclock.h>
+#include <apic.h>
 
-static volatile struct pvclock_vcpu_time_info *vclock;
+static heap pvclock_heap;
+static volatile struct pvclock_vcpu_time_info *vclock = 0;
 
 u64 pvclock_now_ns(void)
 {
@@ -10,7 +12,7 @@ u64 pvclock_now_ns(void)
     u64 result;
 
     do {
-        version = vclock->version & ~1; // XXX why mask?
+        version = vclock->version & ~1; /* mask enable */
         read_barrier();
         u64 delta = rdtsc() - vclock->tsc_timestamp;
         if (vclock->tsc_shift < 0) {
@@ -18,6 +20,9 @@ u64 pvclock_now_ns(void)
         } else {
             delta <<= vclock->tsc_shift;
         }
+        /* when moving to SMP: if monotonicity flag is unset, we will
+           have to check for last reading and insure that time doesn't
+           regress */
         result = vclock->system_time +
             (((u128)delta * vclock->tsc_to_system_mul) >> 32);
         read_barrier();
@@ -34,5 +39,49 @@ void init_pvclock(heap h, struct pvclock_vcpu_time_info *vti)
 {
     assert(vti);
     vclock = vti;
+    pvclock_heap = h;
     register_platform_clock_now(closure(h, pvclock_now));
+}
+
+closure_function(0, 0, void, tsc_deadline_interrupt)
+{
+    /* debug here */
+}
+
+closure_function(0, 1, void, tsc_deadline_timer,
+                 timestamp, interval)
+{
+    u32 version;
+    u64 count = 0;
+
+    do {
+        version = vclock->version & ~1; /* mask enable */
+        read_barrier();
+        timestamp subsec = truncate_seconds(interval);
+        count = (nsec_from_timestamp(subsec) << 32) / vclock->tsc_to_system_mul;
+        count += (nsec_from_timestamp(interval - subsec) / vclock->tsc_to_system_mul) << 32;
+        if (vclock->tsc_shift < 0) {
+            count <<= -vclock->tsc_shift;
+        } else {
+            count >>= vclock->tsc_shift;
+        }
+        read_barrier();
+    } while (version != vclock->version);
+
+    write_msr(TSC_DEADLINE_MSR, rdtsc() + count);
+}
+
+clock_timer init_tsc_deadline_timer(void)
+{
+    u32 v[4];
+    assert(vclock);
+    cpuid(0x1, 0, v);
+    if ((v[2] & (1 << 24)) == 0)
+        return 0;                    /* no TSC-Deadline */
+
+    clock_timer ct = closure(pvclock_heap, tsc_deadline_timer);
+    int irq = allocate_interrupt();
+    register_interrupt(irq, closure(pvclock_heap, tsc_deadline_interrupt));
+    lapic_set_tsc_deadline_mode(irq);
+    return ct;
 }

--- a/src/x86_64/pvclock.h
+++ b/src/x86_64/pvclock.h
@@ -16,4 +16,5 @@ struct pvclock_wall_clock {
 } __attribute__((__packed__));
 
 u64 pvclock_now_ns(void);
+clock_timer init_tsc_deadline_timer(void);
 void init_pvclock(heap h, struct pvclock_vcpu_time_info *pvclock);


### PR DESCRIPTION
Profiling has shown significant latency when programming the local APIC timer. Such writing to the APIC registers is trapped, leading to a vm exit and subsequent device emulation within QEMU. This is quite expensive, taking anywhere from 4 to tens of microseconds in traces of webg performance.

KVM has the capability to emulate the TSC-Deadline timer within the host kernel. This is available in qemu whenever kernel-irqchip is set to on or split (default when KVM is enabled). While an APIC register needs to be written once to enable the timer on initialization, interval updates occur through an MSR which is then handled by the kernel irqchip. Avoiding costly device emulation by qemu in userspace, such updates are measured to take ~1.4us with much less variation.

On my machine, a test run against webg of "ab -n 9000 -c 50" leads to ~11.7k reqs/s with TSC Deadline, as opposed to ~9.8k reqs/s with the local APIC timer - a nearly 20% increase in performance.

There are tricks that we can do to ameliorate the expense of programming the timer, such as adding a small margin to the timer expiry in an attempt to aggregate more timer events together per interrupt. Xen hypervisors achieve this with a configurable "timer_slop" parameter that defaults to 50-100us, depending on the distribution. We can consider adding a similar option to allow the user to trade off accuracy for the sake of improved performance.
