### PR TITLE
revised iovec (readv, writev) and sendfile implementations

### DIFF
--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -326,8 +326,7 @@ int blockq_transfer_waiters(blockq dest, blockq src, int n)
     return transferred;
 }
 
-void blockq_set_completion(blockq bq, io_completion completion, thread t,
-        sysreturn rv)
+void blockq_set_completion(blockq bq, io_completion completion, thread t, sysreturn rv)
 {
     bq->completion = completion;
     bq->completion_thread = t;

--- a/src/unix/eventfd.c
+++ b/src/unix/eventfd.c
@@ -42,8 +42,7 @@ closure_function(5, 1, sysreturn, efd_read_bh,
     blockq_wake_one(efd->write_bq);
     notify_dispatch(efd->f.ns, EPOLLOUT);
 out:
-    if (flags & BLOCKQ_ACTION_BLOCKED)
-        blockq_set_completion(efd->read_bq, bound(completion), bound(t), rv);
+    blockq_handle_completion(efd->read_bq, flags, bound(completion), bound(t), rv);
     closure_finish();
     return rv;
 }
@@ -86,8 +85,7 @@ closure_function(5, 1, sysreturn, efd_write_bh,
     blockq_wake_one(efd->read_bq);
     notify_dispatch(efd->f.ns, EPOLLIN);
 out:
-    if (flags & BLOCKQ_ACTION_BLOCKED)
-        blockq_set_completion(efd->write_bq, bound(completion), bound(t), rv);
+    blockq_handle_completion(efd->write_bq, flags, bound(completion), bound(t), rv);
     closure_finish();
     return rv;
 }

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -171,8 +171,7 @@ closure_function(5, 1, sysreturn, pipe_read_bh,
         notify_dispatch(pf->f.ns, 0); /* for edge trigger */
     }
   out:
-    if (flags & BLOCKQ_ACTION_BLOCKED)
-        blockq_set_completion(pf->bq, bound(completion), bound(t), rv);
+    blockq_handle_completion(pf->bq, flags, bound(completion), bound(t), rv);
     closure_finish();
     return rv;
 }
@@ -229,8 +228,7 @@ closure_function(5, 1, sysreturn, pipe_write_bh,
 
     rv = real_length;
   out:
-    if (flags & BLOCKQ_ACTION_BLOCKED)
-        blockq_set_completion(pf->bq, bound(completion), bound(t), rv);
+    blockq_handle_completion(pf->bq, flags, bound(completion), bound(t), rv);
     closure_finish();
     return rv;
 }

--- a/src/unix/socketpair.c
+++ b/src/unix/socketpair.c
@@ -160,9 +160,7 @@ closure_function(5, 1, sysreturn, sockpair_read_bh,
         }
     }
 out:
-    if (flags & BLOCKQ_ACTION_BLOCKED) {
-        blockq_set_completion(s->read_bq, bound(completion), t, real_length);
-    }
+    blockq_handle_completion(s->read_bq, flags, bound(completion), t, real_length);
     closure_finish();
     return real_length;
 }
@@ -220,9 +218,7 @@ closure_function(5, 1, sysreturn, sockpair_write_bh,
     sockpair_notify_reader(s->peer, EPOLLIN);
     rv = real_length;
 out:
-    if (flags & BLOCKQ_ACTION_BLOCKED)
-        blockq_set_completion(s->write_bq, bound(completion), bound(t), rv);
-
+    blockq_handle_completion(s->write_bq, flags, bound(completion), bound(t), rv);
     closure_finish();
     return rv;
 }

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -25,11 +25,6 @@
     cwd; \
 })
 
-struct iov_progress {
-    int count;
-    u64 total_len;
-};
-
 sysreturn close(int fd);
 
 io_completion syscall_io_complete;
@@ -414,64 +409,85 @@ static inline boolean filepath_is_ancestor(tuple wd1, const char *fp1,
     return false;
 }
 
-/* Seems this could be implemented using a merge? */
-static void iov_transfer_internal(heap h, fdesc f, io op, struct iovec * iov, int iovcnt, struct iov_progress * progress, boolean bh, thread t, sysreturn rv);
-closure_function(7, 2, void, iov_transfer,
-                 heap, h, fdesc, f, io, op, struct iovec *, iov, int, iovcnt, struct iov_progress *, progress, boolean, bh,
+struct iov_progress {
+    boolean initialized;
+    int curr;
+    u64 curr_offset;
+    u64 total_len;
+    io_completion completion;
+};
+
+closure_function(4, 2, void, iov_op_each_complete,
+                 io, op, struct iovec *, iov, int, iovcnt, struct iov_progress, progress,
                  thread, t, sysreturn, rv)
 {
-    iov_transfer_internal(bound(h), bound(f), bound(op), bound(iov), bound(iovcnt), bound(progress), bound(bh), t, rv);
+    io_completion c;
+    int iovcnt = bound(iovcnt);
+    struct iov_progress * p = &bound(progress);
+    struct iovec * iov = bound(iov);
+    thread_log(t, "%s: rv %ld, curr %d, iovcnt %d", __func__, rv, p->curr, iovcnt);
+
+    /* If these ops were truly atomic, we would have to rewind file
+       state on failure... */
+    if (rv < 0) {
+        goto out_complete;
+    }
+
+    /* Increment offset and total by io op retval, advancing to next
+       (non-zero-len) buffer if needed. */
+    p->total_len += rv;
+    p->curr_offset += rv;
+    if (p->curr_offset == bound(iov)[p->curr].iov_len) {
+        p->curr_offset = 0;
+        do {
+            p->curr++;
+        } while (p->curr < iovcnt && iov[p->curr].iov_len == 0);
+    } else {
+        assert(p->curr_offset < iov[p->curr].iov_len);
+    }
+
+    /* If we're done, return the total length... */
+    if (p->curr == iovcnt) {
+        rv = p->total_len;
+        goto out_complete;
+    }
+
+    boolean initialized = p->initialized;
+    p->initialized = true;
+
+    /* ...else issue the next request. */
+    thread_log(t, "   op: curr %d, offset %ld, @ %p, len %ld, init %d",
+               p->curr, p->curr_offset,
+               iov[p->curr].iov_base + p->curr_offset,
+               iov[p->curr].iov_len - p->curr_offset, initialized);
+    apply(bound(op), iov[p->curr].iov_base + p->curr_offset,
+          iov[p->curr].iov_len - p->curr_offset,
+          infinity /* file offset */, t, initialized,
+          (io_completion)closure_self());
+    return;
+  out_complete:
+    c = p->completion;
+    closure_finish();
+    apply(c, t, rv);
 }
 
-/* borrow this value from blockq - something that won't clobber a legitimate syscall return value */
-#define SYSRETURN_KEEP_BLOCKING BLOCKQ_BLOCK_REQUIRED
-
-static void iov_transfer_internal(heap h, fdesc f, io op, struct iovec * iov, int iovcnt, struct iov_progress * progress, boolean bh, thread t, sysreturn rv)
+static sysreturn iov_op(fdesc f, io op, struct iovec *iov, int iovcnt, io_completion completion)
 {
-    boolean do_io = !bh;
-    io_completion completion = closure(h, iov_transfer, h, f, op, iov, iovcnt,
-            progress, true);
-    for (; progress->count < iovcnt; progress->count++) {
-        u64 len = iov[progress->count].iov_len;
-        if (len == 0) {
-            continue;
-        }
-        if (do_io) {
-            thread_log(t, "%s %d/%d%s", __func__, progress->count + 1, iovcnt,
-                    bh ? " BH" : "");
-            rv = apply(op, iov[progress->count].iov_base, len, infinity /* file offset, if applicable */,
-                       t, bh, completion);
-            if (rv == SYSRETURN_KEEP_BLOCKING) {
-                return;
-            }
-        }
-        if (rv > 0) {
-            progress->total_len += rv;
-        }
-        if (rv != len) {
-            break;
-        }
-        do_io = true;
-    }
-    if (progress->total_len > 0) {
-        rv = progress->total_len;
-    }
-    deallocate(h, progress, sizeof(*progress));
-    set_syscall_return(t, rv);
-    if (bh)
-        file_op_maybe_wake(t);
-}
-
-static sysreturn iov_internal(fdesc f, io op, struct iovec *iov, int iovcnt)
-{
-    if (!op || iovcnt < 0) {
+    if (iovcnt < 0 || iovcnt > IOV_MAX)
         return set_syscall_error(current, EINVAL);
-    }
+    if (iovcnt == 0)
+        return 0;
+
     heap h = heap_general(get_kernel_heaps());
-    struct iov_progress *progress = allocate(h, sizeof(struct iov_progress));
-    runtime_memset((void *)progress, 0, sizeof(*progress));
-    iov_transfer_internal(h, f, op, iov, iovcnt, progress, false, current, 0);
-    return sysreturn_value(current);
+    struct iov_progress p;
+    p.initialized = false;
+    p.curr = 0;
+    p.curr_offset = 0;
+    p.total_len = 0;
+    p.completion = completion;
+    io_completion each = closure(h, iov_op_each_complete, op, iov, iovcnt, p);
+    apply(each, current, 0);
+    return get_syscall_return(current);
 }
 
 sysreturn read(int fd, u8 *dest, bytes length)
@@ -497,7 +513,7 @@ sysreturn pread(int fd, u8 *dest, bytes length, s64 offset)
 sysreturn readv(int fd, struct iovec *iov, int iovcnt)
 {
     fdesc f = resolve_fd(current->p, fd);
-    return iov_internal(f, f->read, iov, iovcnt);
+    return iov_op(f, f->read, iov, iovcnt, syscall_io_complete);
 }
 
 sysreturn write(int fd, u8 *body, bytes length)
@@ -522,7 +538,7 @@ sysreturn pwrite(int fd, u8 *body, bytes length, s64 offset)
 sysreturn writev(int fd, struct iovec *iov, int iovcnt)
 {
     fdesc f = resolve_fd(current->p, fd);
-    return iov_internal(f, f->write, iov, iovcnt);
+    return iov_op(f, f->write, iov, iovcnt, syscall_io_complete);
 }
 
 sysreturn sysreturn_from_fs_status(fs_status s)
@@ -607,7 +623,7 @@ static void sendfile_read_complete_internal(heap h, fdesc out, int * offset, voi
                 length, true);
         rv = apply(out->write, buf, rv, 0, t, bh, completion);
     }
-    if (rv == SYSRETURN_KEEP_BLOCKING) {
+    if (rv == SYSRETURN_CONTINUE_BLOCKING) {
         return;
     }
     sendfile_complete_internal(h, offset, buf, length, bh, t, rv);
@@ -670,13 +686,8 @@ closure_function(2, 6, sysreturn, file_read,
                                 file_op_complete, t, f, fsf, is_file_offset,
                                 completion));
 
-        /* XXX Presently only support blocking file reads... */
-        if (!bh) {
-            /* no return on sleep, else direct return rax */
-            return file_op_maybe_sleep(t);
-        } else {
-            return SYSRETURN_KEEP_BLOCKING;
-        }
+        /* possible direct return in top half */
+        return bh ? SYSRETURN_CONTINUE_BLOCKING : file_op_maybe_sleep(t);
     } else {
         /* XXX special handling for holes will need to go here */
         return 0;
@@ -724,13 +735,8 @@ closure_function(2, 6, sysreturn, file_write,
                      closure(h, file_op_complete, t, f, fsf, is_file_offset,
                      completion));
 
-    /* XXX Presently only support blocking file writes... */
-    if (!bh) {
-        /* no return on sleep, else direct return rax */
-        return file_op_maybe_sleep(t);
-    } else {
-        return SYSRETURN_KEEP_BLOCKING;
-    }
+    /* possible direct return in top half */
+    return bh ? SYSRETURN_CONTINUE_BLOCKING : file_op_maybe_sleep(t);
 }
 
 closure_function(2, 0, sysreturn, file_close,

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -619,7 +619,7 @@ closure_function(8, 2, void, sendfile_bh,
         goto out_complete;
     }
 
-    /* partial written; issue next */
+    /* partially written; issue next */
     s64 remain = bound(readlen) - bound(written);
     assert(remain > 0);
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -87,6 +87,8 @@ closure_function(0, 6, sysreturn, dummy_read,
 {
     thread_log(t, "%s: dest %p, length %ld, offset_arg %ld",
 	       __func__, dest, length, offset_arg);
+    if (completion)
+        apply(completion, t, 0);
     return 0;
 }
 
@@ -101,6 +103,8 @@ closure_function(0, 6, sysreturn, stdout,
                  void*, d, u64, length, u64, offset, thread, t, boolean, bh, io_completion, completion)
 {
     console_write(d, length);
+    if (completion)
+        apply(completion, t, length);
     return length;
 }
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -119,11 +119,10 @@ typedef struct unix_heaps {
 #define BLOCKQ_ACTION_NULLIFY  2
 #define BLOCKQ_ACTION_TIMEDOUT 4
 
-/* indicate that the blocked thread requires further blocking
-
-   note that this value must not alias any legitimate syscall return
-   value (i.e. -errno) */
-#define BLOCKQ_BLOCK_REQUIRED (0xffffffff00000000ull) /* outside the range of int errno */
+/* This value must not alias any legitimate syscall return value (i.e. -errno). */
+#define SYSRETURN_INVALID           (0xffffffff00000000ull) /* outside the range of int errno */
+#define SYSRETURN_CONTINUE_BLOCKING SYSRETURN_INVALID
+#define BLOCKQ_BLOCK_REQUIRED       SYSRETURN_INVALID
 
 typedef closure_type(io_completion, void, thread t, sysreturn rv);
 typedef closure_type(blockq_action, sysreturn, u64 flags);
@@ -143,11 +142,21 @@ void blockq_set_completion(blockq bq, io_completion completion, thread t,
                            sysreturn rv);
 sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_bh, 
                                timestamp timeout);
+int blockq_transfer_waiters(blockq dest, blockq src, int n);
+
 static inline sysreturn blockq_check(blockq bq, thread t, blockq_action a, boolean in_bh)
 {
     return blockq_check_timeout(bq, t, a, in_bh, 0);
 }
-int blockq_transfer_waiters(blockq dest, blockq src, int n);
+
+static inline void blockq_handle_completion(blockq bq, u64 bq_flags, io_completion completion, thread t, sysreturn rv)
+{
+    if (bq_flags & BLOCKQ_ACTION_BLOCKED) {
+        blockq_set_completion(bq, completion, t, rv);
+    } else {
+        apply(completion, t, rv);
+    }
+}
 
 /* pending and masked signals for a given thread or process */
 typedef struct sigstate {
@@ -237,6 +246,8 @@ typedef struct fdesc {
     int flags;                  /* F_GETFD/F_SETFD flags */
     notify_set ns;
 } *fdesc;
+
+#define IOV_MAX 1024
 
 struct file {
     struct fdesc f;             /* must be first */

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -151,6 +151,8 @@ static inline sysreturn blockq_check(blockq bq, thread t, blockq_action a, boole
 
 static inline void blockq_handle_completion(blockq bq, u64 bq_flags, io_completion completion, thread t, sysreturn rv)
 {
+    if (!completion)
+        return;
     if (bq_flags & BLOCKQ_ACTION_BLOCKED) {
         blockq_set_completion(bq, completion, t, rv);
     } else {


### PR DESCRIPTION
The poll-and-wait ATA driver exposed flaws in the way io_completions were being handled in the iovec and sendfile syscalls. Previously, these completions were applied for blocking operations, but internal versions of those completions were called directly after a direct return from an I/O op. It's likely that this logic was never really tested when using the virtio storage devices - which always block on a read or write. Additionally, certain cases were not being handled, such as partial buffer reads/writes in iovec operations and partial writes in sendfile(2). readv, writev and sendfile runtime tests were all failing when testing with the ATA driver.

These routines have been re-written to eliminate the multiple completion paths. They also take advantage of the new-style closures, which allow a closure to re-use itself as an io_completion. Said routines now only create a single closure in the top half and release it after the entire operation has completed. Note that the now-writable environment (enclosed variables) are used for state-keeping across completion applications. I/O operations for all fdesc types now apply any passed completion, whether the operation requires blocking or returns directly (most done via blockq_handle_completion helper). Previously, completions were only applied when waking up from blocking in a bottom-half call.

All runtime tests now pass with the ATA driver, and webg and node have been verified on t2.
