### PR TITLE
some fixes for badger

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -55,7 +55,7 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, msgsnd, 0);
     register_syscall(map, msgrcv, 0);
     register_syscall(map, msgctl, 0);
-    register_syscall(map, flock, 0);
+    register_syscall(map, flock, syscall_ignore);
     register_syscall(map, fdatasync, 0);
     register_syscall(map, link, 0);
     register_syscall(map, symlink, 0);


### PR DESCRIPTION
- stub out flock (just returns 0)
- A file-backed mmap(2) was leading to a buffer allocation equal to the given mmap length, even if the file length itself is much less. This caused an issue in badger whereby a request for a large amount of address space (2gb in this case) was leading to a buffer alloc failure. Going forward, treat the map as two parts: the file-backed portion, sized at the minimum of the file size or given length, and an anonymous portion if the given length is greater than the file size.

Keep in mind that we do not yet support writing to files through a backed mmap, and any program which does this will not see persistence across reboots (or maps, for that matter).

With these changes, the badger test in #829 gives:

```
assigned: 10.0.2.15                                                                                                                                                                                                                            
badger 2019/11/20 14:42:39 INFO: All 0 tables opened in 1ms                                                                                                                                                                                    
The answer is: 42                                                                                                                                                                                                                              
badger 2019/11/20 14:42:39 DEBUG: Storing value log head: {Fid:0 Len:29 Offset:45}                                                                                                                                                             
badger 2019/11/20 14:42:39 INFO: Got compaction priority: {level:0 score:1.73 dropPrefix:[]}                                                                                                                                                   
badger 2019/11/20 14:42:39 INFO: Running for level: 0                                                                                                                                                                                          
badger 2019/11/20 14:42:39 DEBUG: LOG Compact. Added 2 keys. Skipped 0 keys. Iteration took: 1.585ms                                                                                                                                           
badger 2019/11/20 14:42:40 DEBUG: Discard stats: map[]                                                                                                                                                                                         
badger 2019/11/20 14:42:40 INFO: LOG Compact 0->1, del 1 tables, add 1 tables, took 49.518ms                                                                                                                                                   
badger 2019/11/20 14:42:40 INFO: Compaction for level: 0 DONE                                                                                                                                                                                  
badger 2019/11/20 14:42:40 INFO: Force compaction on level 0 done                                                                                                                                                                              
exit status 1
```
