### PR TITLE
signed arg for fcntl(2)

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1674,7 +1674,7 @@ sysreturn close(int fd)
     return 0;
 }
 
-sysreturn fcntl(int fd, int cmd, u64 arg)
+sysreturn fcntl(int fd, int cmd, s64 arg)
 {
     fdesc f = resolve_fd(current->p, fd);
 


### PR DESCRIPTION
Some fcntl(2) commands expect arg to be signed. The change to u64 caused a failure in the mac nightly build (arg < 0 check for F_DUPFD_CLOEXEC would always be false).
