### PR TITLE
add clock ID parameter to now, timers and blockq; implement clock_nanosleep(2)

### DIFF
--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -120,7 +120,7 @@ static inline u64 stage2_rdtsc(void)
    with CPU clock) would mean we are over-shooting the given interval,
    but that's fine for stage2.
 */
-void kern_sleep(timestamp delta)
+void kernel_delay(timestamp delta)
 {
     u64 end = stage2_rdtsc() + delta;
     while (stage2_rdtsc() < end)

--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -40,6 +40,8 @@ static u64 identity_base;
 
 static u64 s[2] = { 0xa5a5beefa5a5cafe, 0xbeef55aaface55aa };
 
+timestamp rtc_offset = 0;
+
 u64 random_u64()
 {
     u64 s0 = s[0];

--- a/src/drivers/ata.c
+++ b/src/drivers/ata.c
@@ -113,7 +113,7 @@ static int ata_wait(struct ata *dev, u8 mask)
     u8 status;
     int timeout = 0;
 
-    kern_sleep(microseconds(1));
+    kernel_delay(microseconds(1));
 
     /* wait at max 1 second for device to get !BUSY */
     while (timeout < 1000000) {
@@ -123,7 +123,7 @@ static int ata_wait(struct ata *dev, u8 mask)
         if (status == 0xff) {
             ata_out8(dev, ATA_DRIVE, ATA_D_IBM | ATA_DEV(dev->unit));
             timeout += 1000;
-            kern_sleep(microseconds(1000));
+            kernel_delay(microseconds(1000));
             continue;
         }
 
@@ -133,10 +133,10 @@ static int ata_wait(struct ata *dev, u8 mask)
 
         if (timeout > 1000) {
             timeout += 1000;
-            kern_sleep(microseconds(1000));
+            kernel_delay(microseconds(1000));
         } else {
             timeout += 10;
-            kern_sleep(microseconds(10));
+            kernel_delay(microseconds(10));
         }
     }
     if (timeout >= 1000000)
@@ -149,7 +149,7 @@ static int ata_wait(struct ata *dev, u8 mask)
     do {
         if ((status & mask) == mask)
             return (status & ATA_S_ERROR);
-        kern_sleep(microseconds(10));
+        kernel_delay(microseconds(10));
         status = ata_in8(dev, ATA_ALTSTAT);
     } while (timeout--);
     return -3;
@@ -271,9 +271,9 @@ boolean ata_probe(struct ata *dev)
 
     // reset controller (master is selected)
     ata_out8(dev, ATA_CONTROL, ATA_A_RESET);
-    kern_sleep(milliseconds(2));
+    kernel_delay(milliseconds(2));
     ata_out8(dev, ATA_CONTROL, 0);
-    kern_sleep(nanoseconds(400));
+    kernel_delay(nanoseconds(400));
 
     // disable interrupts
     ata_out8(dev, ATA_CONTROL, ATA_A_IDS);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -41,7 +41,7 @@ void sys_timeouts_init(void)
     int n = sizeof(net_lwip_timers) / sizeof(struct net_lwip_timer);
     for (int i = 0; i < n; i++) {
         struct net_lwip_timer * t = (struct net_lwip_timer *)&net_lwip_timers[i];
-        register_periodic_timer(milliseconds(t->interval_ms),
+        register_periodic_timer(milliseconds(t->interval_ms), CLOCK_ID_MONOTONIC,
                                 closure(lwip_heap, dispatch_lwip_timer, t->handler, t->name));
 #ifdef LWIP_DEBUG
         lwip_debug("registered %s timer with period of %ld ms\n", t->name, t->interval_ms);

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1019,7 +1019,7 @@ static inline err_t connect_tcp(sock s, const ip_addr_t* address, unsigned short
     if (err != ERR_OK)
         return err;
 
-    sysreturn rv = blockq_check_timeout(s->rxbq, current, closure(s->h, connect_tcp_bh, s, current), false, 0);
+    sysreturn rv = blockq_check(s->rxbq, current, closure(s->h, connect_tcp_bh, s, current), false);
     /* should not return under normal cirucmstances */
     msg_err("blockq check error: %ld\n", rv);
     return ERR_OK;

--- a/src/runtime/clock.h
+++ b/src/runtime/clock.h
@@ -43,9 +43,4 @@ static inline void register_platform_clock_now(clock_now cn)
     platform_monotonic_now = cn;
 }
 
-static inline void register_platform_clock_timer(clock_timer ct)
-{
-    platform_timer = ct;
-}
-
 u64 rtc_gettimeofday(void);

--- a/src/runtime/clock.h
+++ b/src/runtime/clock.h
@@ -1,0 +1,51 @@
+/* these need to map to linux values */
+typedef enum {
+    CLOCK_ID_REALTIME = 0,
+    CLOCK_ID_MONOTONIC,
+    CLOCK_ID_PROCESS_CPUTIME_ID, /* not used for system, included */
+    CLOCK_ID_THREAD_CPUTIME_ID,  /* for parity with unix world */
+    CLOCK_ID_MONOTONIC_RAW,
+    CLOCK_ID_REALTIME_COARSE,
+    CLOCK_ID_MONOTONIC_COARSE,
+    CLOCK_ID_BOOTTIME,
+    CLOCK_ID_REALTIME_ALARM,
+    CLOCK_ID_BOOTTIME_ALARM,
+} clock_id;
+
+typedef closure_type(clock_now, timestamp);
+
+extern timestamp rtc_offset;
+extern clock_now platform_monotonic_now;
+
+static inline timestamp now(clock_id id)
+{
+    switch (id) {
+    case CLOCK_ID_MONOTONIC:
+    case CLOCK_ID_MONOTONIC_RAW:
+    case CLOCK_ID_MONOTONIC_COARSE:
+    case CLOCK_ID_BOOTTIME:
+        return apply(platform_monotonic_now);
+    case CLOCK_ID_REALTIME:
+    case CLOCK_ID_REALTIME_COARSE:
+        return apply(platform_monotonic_now) + rtc_offset;
+    default:
+        halt("now: unsupported clock id %d\n", id);
+    }
+}
+
+static inline timestamp uptime(void)
+{
+    return now(CLOCK_ID_BOOTTIME);
+}
+
+static inline void register_platform_clock_now(clock_now cn)
+{
+    platform_monotonic_now = cn;
+}
+
+static inline void register_platform_clock_timer(clock_timer ct)
+{
+    platform_timer = ct;
+}
+
+u64 rtc_gettimeofday(void);

--- a/src/runtime/format.c
+++ b/src/runtime/format.c
@@ -82,7 +82,7 @@ void log_vprintf(const char *prefix, const char *log_format, vlist *a)
     buffer b = alloca_wrap_buffer(buf, sizeof(buf));
     b->end = 0;
 
-    bprintf(b, "[%T] %s: ", now(), prefix);
+    bprintf(b, "[%T] %s: ", now(CLOCK_ID_BOOTTIME), prefix);
     buffer f = alloca_wrap_buffer(log_format, runtime_strlen(log_format));
     vbprintf(b, f, a);
     buffer_print(b);

--- a/src/runtime/random.c
+++ b/src/runtime/random.c
@@ -80,7 +80,7 @@ static struct chacha20_s chacha20inst;
 void init_random()
 {
     assert(CHACHA20_KEYBYTES*8 >= CHACHA_MINKEYLEN);
-    chacha20_randomstir(&chacha20inst, now());
+    chacha20_randomstir(&chacha20inst, now(CLOCK_ID_MONOTONIC));
 }
 
 void
@@ -90,7 +90,7 @@ arc4rand(void *ptr, bytes len)
     bytes length;
     u8 *p;
 
-    timestamp t = now();
+    timestamp t = now(CLOCK_ID_MONOTONIC);
     u64 now_sec = sec_from_timestamp(t);
     if ((chacha20->numbytes > CHACHA20_RESEED_BYTES) || (now_sec > chacha20->t_reseed))
         chacha20_randomstir(chacha20, t);

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -156,9 +156,9 @@ typedef closure_type(thunk, void);
 #include <tuple.h>
 #include <status.h>
 #include <pqueue.h>
+#include <clock.h>
 #include <timer.h>
 #include <range.h>
-#include <clock.h>
 
 #define PAGELOG 12
 #define PAGESIZE U64_FROM_BIT(PAGELOG)

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -158,6 +158,7 @@ typedef closure_type(thunk, void);
 #include <pqueue.h>
 #include <timer.h>
 #include <range.h>
+#include <clock.h>
 
 #define PAGELOG 12
 #define PAGESIZE U64_FROM_BIT(PAGELOG)

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -57,15 +57,16 @@ static timer __register_timer(timestamp interval, clock_id id, thunk n, boolean 
         return INVALID_ADDRESS;
     }
 
+    timestamp tn = now(id);
     t->t = n;
     t->disable = false;
-    t->expiry = now(id) + interval;
+    t->expiry = tn + interval;
     t->interval = (periodic) ? interval : 0;
     t->id = id;
     pqueue_insert(timers, t);
 
-    timer_debug("register %s timer: %p %p\n", 
-        (periodic) ? "periodic" : "one-shot" : t, t->interval);
+    timer_debug("register %s timer: %p, interval %T, now %T, expiry %T\n",
+                (periodic) ? "periodic" : "one-shot", t, interval, tn, t->expiry);
 
     return(t);
 }

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -29,7 +29,7 @@ static boolean timer_compare(void *za, void *zb)
 timestamp remove_timer(timer t)
 {
     t->disable = true;
-    timestamp n = now();
+    timestamp n = now(CLOCK_ID_MONOTONIC);
     return t->w > n ? t->w - n : 0;
 }
 
@@ -43,7 +43,7 @@ static timer __register_timer(timestamp interval, thunk n, boolean periodic)
 
     t->t = n;
     t->disable = false;
-    t->w = now() + interval;
+    t->w = now(CLOCK_ID_MONOTONIC) + interval;
     t->interval = (periodic) ? interval : 0;
     pqueue_insert(timers, t);
 
@@ -71,7 +71,7 @@ timestamp timer_check()
     timestamp here = 0;
     timer t = 0;
 
-    while ((t = pqueue_peek(timers)) && (here = now(), t->w <= here)) {
+    while ((t = pqueue_peek(timers)) && (here = now(CLOCK_ID_MONOTONIC), t->w <= here)) {
         pqueue_pop(timers);
         if (!t->disable) {
             apply(t->t);

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -1,6 +1,14 @@
 #pragma once
 typedef u64 timestamp;
 typedef struct timer *timer;
+typedef closure_type(clock_timer, void, timestamp);
+
+extern clock_timer platform_timer;
+
+static inline void runloop_timer(timestamp duration)
+{
+    apply(platform_timer, duration);
+}
 
 timer register_timer(timestamp, thunk n);
 timer register_periodic_timer(timestamp interval, thunk n);
@@ -9,9 +17,6 @@ void initialize_timers(kernel_heaps kh);
 timestamp parse_time();
 void print_timestamp(buffer, timestamp);
 timestamp timer_check();
-void runloop_timer(timestamp duration);
-timestamp now();
-timestamp uptime();
 
 #define THOUSAND (1000ull)
 #define MILLION (1000000ull)

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -5,13 +5,18 @@ typedef closure_type(clock_timer, void, timestamp);
 
 extern clock_timer platform_timer;
 
+static inline void register_platform_clock_timer(clock_timer ct)
+{
+    platform_timer = ct;
+}
+
 static inline void runloop_timer(timestamp duration)
 {
     apply(platform_timer, duration);
 }
 
-timer register_timer(timestamp, thunk n);
-timer register_periodic_timer(timestamp interval, thunk n);
+timer register_timer(timestamp interval, clock_id id, thunk n);
+timer register_periodic_timer(timestamp interval, clock_id id, thunk n);
 timestamp remove_timer(timer t);
 void initialize_timers(kernel_heaps kh);
 timestamp parse_time();

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -201,15 +201,15 @@ thread blockq_wake_one(blockq bq)
     return t;
 }
 
-sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, 
-                               boolean in_bh, timestamp timeout)
+sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_bh,
+                               timestamp timeout, clock_id id)
 {
     assert(t);
     assert(a);
     assert(!(in_bh && timeout)); /* no timeout checks in bh */
 
-    blockq_debug("%p \"%s\", tid %ld, action %p, timeout %ld\n", 
-        bq, blockq_name(bq), t->tid, a, timeout);
+    blockq_debug("%p \"%s\", tid %ld, action %p, timeout %ld, clock_id %d\n",
+                 bq, blockq_name(bq), t->tid, a, timeout, clock_id);
 
     /* XXX irqsafe mutex/spinlock
 
@@ -238,8 +238,8 @@ sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a,
     refcount_reserve(&t->refcount);
 
     if (timeout > 0) {
-        bi->timeout = register_timer(timeout, CLOCK_ID_MONOTONIC,
-                closure(bq->h, blockq_item_timeout, bq, bi));
+        bi->timeout = register_timer(timeout, id,
+                                     closure(bq->h, blockq_item_timeout, bq, bi));
         if (bi->timeout == INVALID_ADDRESS) {
             msg_err("failed to allocate blockq timer\n");
             deallocate(bq->h, bi, sizeof(struct blockq_item));

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -238,7 +238,7 @@ sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a,
     refcount_reserve(&t->refcount);
 
     if (timeout > 0) {
-        bi->timeout = register_timer(timeout,
+        bi->timeout = register_timer(timeout, CLOCK_ID_MONOTONIC,
                 closure(bq->h, blockq_item_timeout, bq, bi));
         if (bi->timeout == INVALID_ADDRESS) {
             msg_err("failed to allocate blockq timer\n");
@@ -315,7 +315,7 @@ int blockq_transfer_waiters(blockq dest, blockq src, int n)
         if (bi->timeout) {
             timestamp remain = remove_timer(bi->timeout);
             bi->timeout = remain == 0 ? 0 :
-                register_timer(remain, closure(dest->h, blockq_item_timeout, dest, bi));
+                register_timer(remain, CLOCK_ID_MONOTONIC, closure(dest->h, blockq_item_timeout, dest, bi));
         }
         list_delete(&bi->l);
         assert(bi->t->blocked_on == src);

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -1875,7 +1875,7 @@ ftrace_thread_switch(thread out, thread in)
     while (in->graph_idx > 0) {
         struct ftrace_graph_entry * stack_ent =
                 &(in->graph_stack[--in->graph_idx]);
-        stack_ent->return_ts = now();
+        stack_ent->return_ts = now(CLOCK_ID_MONOTONIC);
         stack_ent->flush = (out != in); /* just controls a printing option */
         function_graph_trace_return(stack_ent);
     }
@@ -1941,7 +1941,7 @@ prepare_ftrace_return(unsigned long self, unsigned long * parent,
     stack_ent = &(current->graph_stack[depth]);
     stack_ent->retaddr = old;
     stack_ent->func = self;
-    stack_ent->entry_ts = now();
+    stack_ent->entry_ts = now(CLOCK_ID_MONOTONIC);
     stack_ent->fp = frame_pointer;
     stack_ent->depth = depth;
     stack_ent->has_child = 0;
@@ -1986,7 +1986,7 @@ ftrace_return_to_handler(unsigned long frame_pointer)
     if (stack_ent->fp != frame_pointer)
         frame_halt(stack_ent, frame_pointer);
 
-    stack_ent->return_ts = now();
+    stack_ent->return_ts = now(CLOCK_ID_MONOTONIC);
     stack_ent->flush = 0;
     retaddr = stack_ent->retaddr;
 

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -1628,7 +1628,7 @@ closure_function(4, 0, void, __ftrace_send_http_chunk,
     if (__ftrace_send_http_chunk_internal(bound(routine), bound(p),
             bound(local_printer), bound(out)))
     {
-        register_timer(SEND_HTTP_CHUNK_INTERVAL_MS, (thunk)closure_self());
+        register_timer(SEND_HTTP_CHUNK_INTERVAL_MS, CLOCK_ID_MONOTONIC, (thunk)closure_self());
     } else {
         closure_finish();
     }
@@ -1693,7 +1693,7 @@ __ftrace_do_http_method(buffer_handler out, struct ftrace_routine * routine,
         {
             thunk t = closure(ftrace_heap, __ftrace_send_http_chunk, routine,
                 p, local_printer, out);
-            register_timer(SEND_HTTP_CHUNK_INTERVAL_MS, t);
+            register_timer(SEND_HTTP_CHUNK_INTERVAL_MS, CLOCK_ID_MONOTONIC, t);
         }
     }
 

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -165,9 +165,8 @@ sysreturn futex(int *uaddr, int futex_op, int val,
         set_syscall_return(current, 0);
 
         return blockq_check_timeout(f->bq, current, 
-            closure(f->h, futex_bh, f, current),
-            false, ts
-        );
+                                    closure(f->h, futex_bh, f, current),
+                                    false, ts, CLOCK_ID_MONOTONIC);
     }
 
     case FUTEX_WAKE: {
@@ -260,9 +259,8 @@ sysreturn futex(int *uaddr, int futex_op, int val,
         set_syscall_return(current, 0);
         // TODO: timeout should be absolute based on CLOCK_REALTIME
         return blockq_check_timeout(f->bq, current, 
-            closure(f->h, futex_bh, f, current),
-            false, ts
-        );
+                                    closure(f->h, futex_bh, f, current),
+                                    false, ts, CLOCK_ID_MONOTONIC);
     }
 
     case FUTEX_REQUEUE: rprintf("futex_requeue not implemented\n"); break;

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -426,7 +426,8 @@ sysreturn epoll_wait(int epfd,
 
     return blockq_check_timeout(w->t->thread_bq, current,
                                 closure(e->h, epoll_wait_bh, w, current, timeout != 0),
-                                false, timeout > 0 ? milliseconds(timeout) : 0);
+                                false, timeout > 0 ? milliseconds(timeout) : 0,
+                                CLOCK_ID_MONOTONIC);
 }
 
 static epollfd epollfd_from_fd(epoll e, int fd)
@@ -729,7 +730,8 @@ static sysreturn select_internal(int nfds,
   check_timeout:
     return blockq_check_timeout(w->t->thread_bq, current,
                                 closure(e->h, select_bh, w, current, timeout != 0),
-                                false, timeout != infinity ? timeout : 0);
+                                false, timeout != infinity ? timeout : 0,
+                                CLOCK_ID_MONOTONIC);
 }
 
 
@@ -892,7 +894,8 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
 
     return blockq_check_timeout(w->t->thread_bq, current,
                                 closure(e->h, poll_bh, w, current, timeout != 0),
-                                false, timeout != infinity ? timeout : 0);
+                                false, timeout != infinity ? timeout : 0,
+                                CLOCK_ID_MONOTONIC);
 }
 
 sysreturn ppoll(struct pollfd *fds, nfds_t nfds, const struct timespec *tmo_p, const sigset_t *sigmask)

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -737,7 +737,7 @@ sysreturn rt_sigtimedwait(const u64 * set, siginfo_t * info, const struct timesp
     heap h = heap_general(get_kernel_heaps());
     blockq_action ba = closure(h, rt_sigtimedwait_bh, current, *set, info, timeout);
     timestamp t = timeout ? time_from_timespec(timeout) : 0;
-    return blockq_check_timeout(current->thread_bq, current, ba, false, t);
+    return blockq_check_timeout(current->thread_bq, current, ba, false, t, CLOCK_ID_MONOTONIC);
 }
 
 static void setup_sigframe(thread t, int signum, struct siginfo *si)

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -201,7 +201,8 @@ typedef int clockid_t;
 #define CLOCK_BOOTTIME              7
 #define CLOCK_REALTIME_ALARM        8
 #define CLOCK_BOOTTIME_ALARM        9
-#define TIMER_ABSTIME               0x10
+
+#define TIMER_ABSTIME               0x1
 
 struct timespec {
 	u64 ts_sec;

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -198,6 +198,9 @@ typedef int clockid_t;
 #define CLOCK_MONOTONIC_RAW         4
 #define CLOCK_REALTIME_COARSE       5
 #define CLOCK_MONOTONIC_COARSE      6
+#define CLOCK_BOOTTIME              7
+#define CLOCK_REALTIME_ALARM        8
+#define CLOCK_BOOTTIME_ALARM        9
 
 struct timespec {
 	u64 ts_sec;

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -201,6 +201,7 @@ typedef int clockid_t;
 #define CLOCK_BOOTTIME              7
 #define CLOCK_REALTIME_ALARM        8
 #define CLOCK_BOOTTIME_ALARM        9
+#define TIMER_ABSTIME               0x10
 
 struct timespec {
 	u64 ts_sec;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -196,7 +196,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     p->syscalls = linux_syscalls;
     p->sysctx = false;
     p->utime = p->stime = 0;
-    p->start_time = now();
+    p->start_time = now(CLOCK_ID_MONOTONIC);
     init_sigstate(&p->signals);
     zero(p->sigactions, sizeof(p->sigactions));
     return p;
@@ -205,7 +205,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
 void proc_enter_user(process p)
 {
     if (p->sysctx) {
-        timestamp here = now();
+        timestamp here = now(CLOCK_ID_MONOTONIC);
         p->stime += here - p->start_time;
         p->sysctx = false;
         p->start_time = here;
@@ -215,7 +215,7 @@ void proc_enter_user(process p)
 void proc_enter_system(process p)
 {
     if (!p->sysctx) {
-        timestamp here = now();
+        timestamp here = now(CLOCK_ID_MONOTONIC);
         p->utime += here - p->start_time;
         p->sysctx = true;
         p->start_time = here;
@@ -224,7 +224,7 @@ void proc_enter_system(process p)
 
 void proc_pause(process p)
 {
-    timestamp here = now();
+    timestamp here = now(CLOCK_ID_MONOTONIC);
     if (p->sysctx) {
         p->stime += here - p->start_time;
     }
@@ -235,14 +235,14 @@ void proc_pause(process p)
 
 void proc_resume(process p)
 {
-    p->start_time = now();
+    p->start_time = now(CLOCK_ID_MONOTONIC);
 }
 
 timestamp proc_utime(process p)
 {
     timestamp utime = p->utime;
     if (!p->sysctx) {
-        utime += now() - p->start_time;
+        utime += now(CLOCK_ID_MONOTONIC) - p->start_time;
     }
     return utime;
 }
@@ -251,7 +251,7 @@ timestamp proc_stime(process p)
 {
     timestamp stime = p->stime;
     if (p->sysctx) {
-        stime += now() - p->start_time;
+        stime += now(CLOCK_ID_MONOTONIC) - p->start_time;
     }
     return stime;
 }

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -65,13 +65,13 @@ sysreturn clock_nanosleep(clockid_t _clock_id, int flags, const struct timespec 
     timestamp treq = time_from_timespec(req);
     clock_id id = (clock_id)_clock_id;
 
-    /* For improved accuracy, we could send absolute flag down the
-       pike to the timer register - for now just convert to relative. */
     timestamp tnow = now(id);
 
     thread_log(current, "clock_nanosleep: clock id %d, flags 0x%x, req %p (%T) rem %p, now %T",
                id, flags, req, treq, rem, tnow);
 
+    /* For improved accuracy, we could send absolute flag down the
+       pike to the timer register - for now just convert to relative. */
     if (flags & TIMER_ABSTIME) {
         if (tnow >= treq)
             return 0;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -141,12 +141,12 @@ boolean blockq_flush_thread(blockq bq, thread t);
 void blockq_set_completion(blockq bq, io_completion completion, thread t,
                            sysreturn rv);
 sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_bh, 
-                               timestamp timeout);
+                               timestamp timeout, clock_id id);
 int blockq_transfer_waiters(blockq dest, blockq src, int n);
 
 static inline sysreturn blockq_check(blockq bq, thread t, blockq_action a, boolean in_bh)
 {
-    return blockq_check_timeout(bq, t, a, in_bh, 0);
+    return blockq_check_timeout(bq, t, a, in_bh, 0, 0 /* n/a */);
 }
 
 static inline void blockq_handle_completion(blockq bq, u64 bq_flags, io_completion completion, thread t, sysreturn rv)

--- a/src/x86_64/apic.c
+++ b/src/x86_64/apic.c
@@ -61,7 +61,7 @@ static u32 apic_timer_cal_sec;
 static void calibrate_lapic_timer()
 {
     apic_write(APIC_TMRINITCNT, -1u);
-    kern_sleep(milliseconds(10));
+    kernel_delay(milliseconds(10));
     u32 delta = -1u - apic_read(APIC_TMRCURRCNT);
     apic_set(APIC_LVT_TMR, APIC_LVT_INTMASK);
     apic_timer_cal_sec = (1000 / CALIBRATE_DURATION_MS) * delta;

--- a/src/x86_64/rtc.c
+++ b/src/x86_64/rtc.c
@@ -2,7 +2,6 @@
 #include <io.h>
 
 #include "mktime.h"
-#include "rtc.h"
 
 #define RTC_COMMAND 0x70
 #define RTC_DATA 0x71
@@ -39,6 +38,7 @@ u64 rtc_gettimeofday(void) {
     tm.tm_mday = bcd2bin(rtc_read(RTC_DAY_OF_MONTH));
     tm.tm_mon = bcd2bin(rtc_read(RTC_MONTH));
     tm.tm_year = bcd2bin(rtc_read(RTC_YEAR)) + 2000;
+
 
     return mktime(&tm);
 }

--- a/src/x86_64/rtc.h
+++ b/src/x86_64/rtc.h
@@ -1,6 +1,0 @@
-#pragma once
-
-#include <runtime.h>
-
-extern u64 rtc_gettimeofday(void);
-

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -229,7 +229,7 @@ u64 random_seed(void)
         return seed;
     if (have_rdrand && hw_seed(&seed, false))
         return seed;
-    return (u64)now();
+    return (u64)now(CLOCK_ID_MONOTONIC);
 }
 
 static void init_hwrand(void)

--- a/src/x86_64/x86_64.h
+++ b/src/x86_64/x86_64.h
@@ -149,16 +149,6 @@ static inline u64 rdtsc_precise(void)
     return _rdtsc();
 }
 
-typedef closure_type(clock_now, timestamp);
-typedef closure_type(clock_timer, void, timestamp);
-
-void register_platform_clock_now(clock_now cn);
-void register_platform_clock_timer(clock_timer ct);
-
-void init_clock(void);
-boolean init_hpet(kernel_heaps kh);
-void kern_sleep(timestamp delta);
-
 static inline u64 read_flags(void)
 {
     u64 out;
@@ -228,6 +218,10 @@ static inline void frame_pop(void)
 
 void runloop() __attribute__((noreturn));
 void kernel_sleep();
+void kernel_delay(timestamp delta);
+void init_clock(void);
+boolean init_hpet(kernel_heaps kh);
+
 void process_bhqueue();
 void install_fallback_fault_handler(fault_handler h);
 

--- a/test/runtime/time.c
+++ b/test/runtime/time.c
@@ -5,43 +5,181 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <errno.h>
+#include <assert.h>
 
-int
-main()
+#define BILLION 1000000000ull
+
+static void print_timespec(struct timespec * ts)
+{
+    printf("%lld.%.9ld", (long long)ts->tv_sec, ts->tv_nsec);
+}
+
+static void validate_interval(unsigned long long nsec, struct timespec * start, struct timespec * end)
+{
+    if (end->tv_sec < start->tv_sec ||
+        (end->tv_sec == start->tv_sec && end->tv_nsec < start->tv_nsec)) {
+        printf("failure; time went backwards: start ");
+        print_timespec(start);
+        printf(", end ");
+        print_timespec(end);
+        printf("\n");
+        exit(EXIT_FAILURE);
+    }
+
+    long long elapsed = (end->tv_sec - start->tv_sec) * BILLION + (end->tv_nsec - start->tv_nsec);
+    if (elapsed < nsec) {
+        printf("failure; measured interval (%lld) less than requested (%lld)\n", elapsed, nsec);
+        exit(EXIT_FAILURE);
+    }
+    printf("   measured delta +%lld ns\n", elapsed - nsec);
+}
+
+static void test_clock_nanosleep(clockid_t clock_id, unsigned long long nsec)
+{
+    struct timespec start, end, req, rem;
+
+    /* check relative interval */
+    if (clock_gettime(clock_id, &start) < 0)
+        goto out_clock_gettime_fail;
+    printf("%s, clock_id %d, nsec %lld\n   relative test, start: ", __func__, clock_id, nsec);
+    print_timespec(&start);
+
+    req.tv_sec = nsec / BILLION;
+    req.tv_nsec = nsec % BILLION;
+    printf("\n      calling clock_nanosleep with req = ");
+    print_timespec(&req);
+    printf("\n");
+    if (clock_nanosleep(clock_id, 0, &req, &rem) < 0)
+        goto out_clock_nanosleep_fail;
+
+    if (clock_gettime(clock_id, &end) < 0)
+        goto out_clock_gettime_fail;
+
+    validate_interval(nsec, &start, &end);
+
+    /* check absolute interval */
+    if (clock_gettime(clock_id, &start) < 0)
+        goto out_clock_gettime_fail;
+    printf("   absolute test, start: ");
+    print_timespec(&start);
+
+    unsigned long long ti = start.tv_nsec + nsec;
+    req.tv_nsec = ti % BILLION;
+    req.tv_sec = start.tv_sec + (ti / BILLION);
+    printf("\n      calling clock_nanosleep with absolute req = ");
+    print_timespec(&req);
+    printf("\n");
+
+    if (clock_nanosleep(clock_id, TIMER_ABSTIME, &req, &rem) < 0)
+        goto out_clock_nanosleep_fail;
+
+    if (clock_gettime(clock_id, &end) < 0)
+        goto out_clock_gettime_fail;
+
+    validate_interval(nsec, &start, &end);
+    return;
+  out_clock_gettime_fail:
+    printf("   clock_gettime (id %d) failed: %d (%s)\n", clock_id, errno, strerror(errno));
+    exit(EXIT_FAILURE);
+  out_clock_nanosleep_fail:
+    printf("   clock_nanosleep (id %d) failed: %d (%s)\n", clock_id, errno, strerror(errno));
+    exit(EXIT_FAILURE);
+}
+
+static void test_nanosleep(unsigned long long nsec)
+{
+    struct timespec start, end, req, rem;
+
+    /* Linux nanosleep measures against CLOCK_MONOTONIC (see nanosleep(2) man page) */
+    if (clock_gettime(CLOCK_MONOTONIC, &start) < 0)
+        goto out_clock_gettime_fail;
+    printf("%s, nsec %lld\n   relative test, start: ", __func__, nsec);
+    print_timespec(&start);
+
+    req.tv_sec = nsec / BILLION;
+    req.tv_nsec = nsec % BILLION;
+    printf("\n      calling clock_nanosleep with req = ");
+    print_timespec(&req);
+    printf("\n");
+    if (nanosleep(&req, &rem) < 0)
+        goto out_nanosleep_fail;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &end) < 0)
+        goto out_clock_gettime_fail;
+
+    validate_interval(nsec, &start, &end);
+    return;
+  out_clock_gettime_fail:
+    printf("   clock_gettime failed: %d (%s)\n", errno, strerror(errno));
+    exit(EXIT_FAILURE);
+  out_nanosleep_fail:
+    printf("   nanosleep failed: %d (%s)\n", errno, strerror(errno));
+    exit(EXIT_FAILURE);
+
+}
+
+void test_time_and_times(void)
 {
     struct tms tms, tms_prev;
-    clock_t uptime, uptime_prev;
+    clock_t uptime, uptime_prev = 0;
     int i;
-
-    setbuf(stdout, NULL);
     memset(&tms_prev, 0, sizeof(tms_prev));
-    uptime_prev = 0;
-    for (i = 0; i < 10; i++) {
-        struct timeval tv;
-        time_t t, t2;
 
-        gettimeofday(&tv, NULL);
-        printf("gettimeofday: tv_sec = %lu, tv_usec = %lu\n", tv.tv_sec, tv.tv_usec);
+    for (i = 0; i < 3; i++) {
+        time_t t = time(NULL);
+        assert(t != (time_t)-1);
 
-        t = time(NULL);
-        printf("time: retval = %ld\n%s", t, ctime(&t));
-
+        time_t t2;
         t = time(&t2);
-        printf("time: retval = %ld, out = %ld\n", t, t2);
+        assert(t == t2);
+        printf("%s", asctime(localtime(&t)));
+
+        struct timeval tv;
+        gettimeofday(&tv, NULL);
+        printf("   gettimeofday: %lu.%.6lu, ", tv.tv_sec, tv.tv_usec);
 
         uptime = times(&tms);
         if ((tms.tms_utime < tms_prev.tms_utime) ||
-                (tms.tms_stime < tms_prev.tms_stime) ||
-                (tms.tms_cutime < tms_prev.tms_cutime) ||
-                (tms.tms_cstime < tms_prev.tms_cstime) || (uptime < uptime_prev)) {
+            (tms.tms_stime < tms_prev.tms_stime) ||
+            (tms.tms_cutime < tms_prev.tms_cutime) ||
+            (tms.tms_cstime < tms_prev.tms_cstime) || (uptime < uptime_prev)) {
             printf("times: non-monotonic values\n");
-            return EXIT_FAILURE;
+            exit(EXIT_FAILURE);
         }
         memcpy(&tms_prev, &tms, sizeof(tms));
         uptime_prev = uptime;
 
+        struct timespec tp;
+        printf("CLOCK_MONOTONIC: ");
+        if (clock_gettime(CLOCK_MONOTONIC, &tp) < 0)
+            goto out_clock_gettime_fail;
+        print_timespec(&tp);
+
+        printf(", CLOCK_REALTIME: ");
+        if (clock_gettime(CLOCK_REALTIME, &tp) < 0)
+            goto out_clock_gettime_fail;
+        print_timespec(&tp);
+        printf("\n");
         sleep(1);
     }
+    return;
+  out_clock_gettime_fail:
+    printf("clock_gettime (CLOCK_REALTIME) failed: %d (%s)\n", errno, strerror(errno));
+    exit(EXIT_FAILURE);
+}
 
-    return 0;
+int
+main()
+{
+    setbuf(stdout, NULL);
+    test_time_and_times();
+    unsigned long long intervals[] = { 0, BILLION / 2, BILLION, -1 };
+    for (int i = 0; intervals[i] != -1; i++) {
+        test_nanosleep(intervals[i]);
+        test_clock_nanosleep(CLOCK_MONOTONIC, intervals[i]);
+        test_clock_nanosleep(CLOCK_REALTIME, intervals[i]);
+    }
+    printf("time test passed\n");
+    return EXIT_SUCCESS;
 }

--- a/test/unit/network_test.c
+++ b/test/unit/network_test.c
@@ -33,7 +33,7 @@ closure_function(7, 1, void, value_in,
     s->responses++;
 
     static timestamp last;
-    timestamp t = now();
+    timestamp t = now(CLOCK_ID_MONOTONIC);
     u64 *count = bound(count);
 
     if ((t - last) > (1ull<<32)){


### PR DESCRIPTION
Clocksource and timer facilities now accept a clock ID parameter (cloning posix 1b interval timer types). To start, this allows measurements and timer deadlines based on real (wall clock) time in addition to monotonic time. clock_gettime(2) now honors the clk_id parameter (if supported), and clock_nanosleep(2) is implemented (sans support for CLOCK_PROCESS_CPUTIME_ID).
