### PR TITLE
implement timerfd(2)

### DIFF
--- a/src/net/net.c
+++ b/src/net/net.c
@@ -41,8 +41,9 @@ void sys_timeouts_init(void)
     int n = sizeof(net_lwip_timers) / sizeof(struct net_lwip_timer);
     for (int i = 0; i < n; i++) {
         struct net_lwip_timer * t = (struct net_lwip_timer *)&net_lwip_timers[i];
-        register_periodic_timer(milliseconds(t->interval_ms), CLOCK_ID_MONOTONIC,
-                                closure(lwip_heap, dispatch_lwip_timer, t->handler, t->name));
+        timestamp interval = milliseconds(t->interval_ms);
+        register_timer(CLOCK_ID_MONOTONIC, interval, false, interval,
+                       closure(lwip_heap, dispatch_lwip_timer, t->handler, t->name));
 #ifdef LWIP_DEBUG
         lwip_debug("registered %s timer with period of %ld ms\n", t->name, t->interval_ms);
 #endif

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -25,10 +25,9 @@ static struct net_lwip_timer net_lwip_timers[] = {
     {DHCP_FINE_TIMER_MSECS, dhcp_fine_tmr, "dhcp fine"},
 };
 
-/* We could dispatch lwip timer callbacks as thunks, but breaking it
-   out here gives us a single point of entry for debugging. */
-closure_function(2, 0, void, dispatch_lwip_timer,
-                 lwip_cyclic_timer_handler, handler, const char *, name)
+closure_function(2, 1, void, dispatch_lwip_timer,
+                 lwip_cyclic_timer_handler, handler, const char *, name,
+                 u64, overruns /* ignored */)
 {
 #ifdef LWIP_DEBUG
     lwip_debug("dispatching timer for %s\n", bound(name));

--- a/src/runtime/refcount.h
+++ b/src/runtime/refcount.h
@@ -4,9 +4,9 @@ typedef struct refcount {
     thunk completion;
 } *refcount;
 
-static inline void init_refcount(refcount r, thunk completion)
+static inline void init_refcount(refcount r, int c, thunk completion)
 {
-    r->c = 1;
+    r->c = c;
     r->completion = completion;
 }
 

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -159,6 +159,7 @@ typedef closure_type(thunk, void);
 #include <status.h>
 #include <pqueue.h>
 #include <clock.h>
+#include <refcount.h>
 #include <timer.h>
 #include <range.h>
 
@@ -208,8 +209,6 @@ typedef struct merge *merge;
 
 merge allocate_merge(heap h, status_handler completion);
 status_handler apply_merge(merge m);
-
-#include <refcount.h>
 
 void __stack_chk_guard_init();
 

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -39,7 +39,7 @@ timer register_timer(clock_id id, timestamp val, boolean absolute, timestamp int
     /* one ref for consumer, one for pqueue */
     init_refcount(&t->refcount, 2, init_closure(&t->free, timer_free, t));
     pqueue_insert(timers, t);
-    timer_debug("register timer: %p, expiry %T, interval %T, thunk %p\n", t->expiry, interval, t);
+    timer_debug("register timer: %p, expiry %T, interval %T, thunk %p\n", t, t->expiry, interval, t);
     return t;
 }
 

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -36,8 +36,7 @@ timer register_timer(clock_id id, timestamp val, boolean absolute, timestamp int
     t->disabled = false;
     t->t = n;
 
-    /* one ref for consumer, one for pqueue */
-    init_refcount(&t->refcount, 2, init_closure(&t->free, timer_free, t));
+    init_refcount(&t->refcount, 1, init_closure(&t->free, timer_free, t));
     pqueue_insert(timers, t);
     timer_debug("register timer: %p, expiry %T, interval %T, thunk %p\n", t, t->expiry, interval, t);
     return t;

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -1,6 +1,7 @@
 #pragma once
 typedef u64 timestamp;
 typedef struct timer *timer;
+typedef closure_type(timer_handler, void, u64);
 
 declare_closure_struct(1, 0, void, timer_free,
                        timer, t);
@@ -10,7 +11,7 @@ struct timer {
     timestamp expiry;
     timestamp interval;
     boolean disabled;
-    thunk t;
+    timer_handler t;
     struct refcount refcount;
     closure_struct(timer_free, free);
 };
@@ -29,7 +30,7 @@ static inline void runloop_timer(timestamp duration)
     apply(platform_timer, duration);
 }
 
-timer register_timer(clock_id id, timestamp val, boolean absolute, timestamp interval, thunk n);
+timer register_timer(clock_id id, timestamp val, boolean absolute, timestamp interval, timer_handler n);
 
 #if defined(STAGE3) || defined(BUILD_VDSO)
 #include <vdso.h>

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -67,7 +67,6 @@ static inline void remove_timer(timer t, timestamp *remain)
         timestamp n = now(t->id);
         *remain = x > n ? x - n : 0;
     }
-    refcount_release(&t->refcount);
 }
 
 void initialize_timers(kernel_heaps kh);

--- a/src/runtime/uniboot.h
+++ b/src/runtime/uniboot.h
@@ -46,4 +46,8 @@ static inline u16 tagof(void* v) {
 /* maximum buckets that can fit within a PAGESIZE_2M mcache */
 #define TABLE_MAX_BUCKETS 131072
 
+/* runloop timer minimum and maximum */
+#define RUNLOOP_TIMER_MAX_PERIOD_US     100000
+#define RUNLOOP_TIMER_MIN_PERIOD_US     10
+
 #include <x86.h>

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -143,8 +143,9 @@ static void blockq_apply_bi_locked(blockq bq, blockq_item bi, u64 flags)
  * Invoke its action and remove it from the list of waiters,
  * if applicable
  */
-closure_function(2, 0, void, blockq_item_timeout,
-                 blockq, bq, blockq_item, bi)
+closure_function(2, 1, void, blockq_item_timeout,
+                 blockq, bq, blockq_item, bi,
+                 u64, overruns /* ignored */)
 {
     blockq bq = bound(bq);
     blockq_item bi = bound(bi);
@@ -319,7 +320,7 @@ int blockq_transfer_waiters(blockq dest, blockq src, int n)
         blockq_item bi = struct_from_list(l, blockq_item, l);
         if (bi->timeout) {
             timestamp remain;
-            thunk t = bi->timeout->t;
+            timer_handler t = bi->timeout->t;
             remove_timer(bi->timeout, &remain);
             bi->timeout = remain == 0 ? 0 :
                 register_timer(CLOCK_ID_MONOTONIC, remain, false, 0,

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -1628,7 +1628,7 @@ closure_function(4, 0, void, __ftrace_send_http_chunk,
     if (__ftrace_send_http_chunk_internal(bound(routine), bound(p),
             bound(local_printer), bound(out)))
     {
-        register_timer(SEND_HTTP_CHUNK_INTERVAL_MS, CLOCK_ID_MONOTONIC, (thunk)closure_self());
+        register_timer(CLOCK_ID_MONOTONIC, SEND_HTTP_CHUNK_INTERVAL_MS, false, 0, (thunk)closure_self());
     } else {
         closure_finish();
     }
@@ -1693,7 +1693,7 @@ __ftrace_do_http_method(buffer_handler out, struct ftrace_routine * routine,
         {
             thunk t = closure(ftrace_heap, __ftrace_send_http_chunk, routine,
                 p, local_printer, out);
-            register_timer(SEND_HTTP_CHUNK_INTERVAL_MS, CLOCK_ID_MONOTONIC, t);
+            register_timer(CLOCK_ID_MONOTONIC, SEND_HTTP_CHUNK_INTERVAL_MS, false, 0, t);
         }
     }
 

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -166,7 +166,7 @@ sysreturn futex(int *uaddr, int futex_op, int val,
 
         return blockq_check_timeout(f->bq, current, 
                                     closure(f->h, futex_bh, f, current),
-                                    false, ts, CLOCK_ID_MONOTONIC);
+                                    false, CLOCK_ID_MONOTONIC, ts, false);
     }
 
     case FUTEX_WAKE: {
@@ -260,7 +260,7 @@ sysreturn futex(int *uaddr, int futex_op, int val,
         // TODO: timeout should be absolute based on CLOCK_REALTIME
         return blockq_check_timeout(f->bq, current, 
                                     closure(f->h, futex_bh, f, current),
-                                    false, ts, CLOCK_ID_MONOTONIC);
+                                    false, CLOCK_ID_MONOTONIC, ts, false);
     }
 
     case FUTEX_REQUEUE: rprintf("futex_requeue not implemented\n"); break;

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -772,7 +772,7 @@ sysreturn rt_sigtimedwait(const u64 * set, siginfo_t * info, const struct timesp
     heap h = heap_general(get_kernel_heaps());
     blockq_action ba = closure(h, rt_sigtimedwait_bh, current, *set, info, timeout);
     timestamp t = timeout ? time_from_timespec(timeout) : 0;
-    return blockq_check_timeout(current->thread_bq, current, ba, false, t, CLOCK_ID_MONOTONIC);
+    return blockq_check_timeout(current->thread_bq, current, ba, false, CLOCK_ID_MONOTONIC, t, false);
 }
 
 typedef struct signal_fd {

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -200,7 +200,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, move_pages, 0);
     register_syscall(map, utimensat, 0);
     register_syscall(map, fallocate, 0);
-    register_syscall(map, signalfd4, 0);
     register_syscall(map, inotify_init1, 0);
     register_syscall(map, preadv, 0);
     register_syscall(map, pwritev, 0);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -199,10 +199,8 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, vmsplice, 0);
     register_syscall(map, move_pages, 0);
     register_syscall(map, utimensat, 0);
-    register_syscall(map, timerfd_create, 0);
     register_syscall(map, fallocate, 0);
-    register_syscall(map, timerfd_settime, 0);
-    register_syscall(map, timerfd_gettime, 0);
+    register_syscall(map, signalfd4, 0);
     register_syscall(map, inotify_init1, 0);
     register_syscall(map, preadv, 0);
     register_syscall(map, pwritev, 0);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -206,8 +206,25 @@ typedef int clockid_t;
 #define TIMER_ABSTIME               0x1
 
 struct timespec {
-	u64 ts_sec;
-	u64 ts_nsec;
+    u64 ts_sec;
+    u64 ts_nsec;
+};
+
+typedef s64 time_t;
+
+struct timeval {
+    time_t tv_sec;  /* seconds */
+    u64 tv_usec;    /* microseconds */
+};
+
+struct itimerspec {
+    struct timespec it_interval;
+    struct timespec it_value;
+};
+
+struct itimerval {
+    struct timeval it_interval;
+    struct timeval it_value;
 };
 
 // straight from linux
@@ -622,14 +639,6 @@ struct rt_sigframe {
     /* fp state follows here */
 };
 
-
-typedef s64 time_t;
-
-struct timeval {
-    time_t tv_sec;  /* seconds */
-    u64 tv_usec;    /* microseconds */
-};
-
 #define CLOCKS_PER_SEC  100
 
 typedef s64 clock_t;
@@ -710,6 +719,10 @@ typedef u32 gid_t;
 #define EFD_CLOEXEC     02000000
 #define EFD_NONBLOCK    00004000
 #define EFD_SEMAPHORE   00000001
+
+/* timerfd flags */
+#define TFD_CLOEXEC     O_CLOEXEC
+#define TFD_NONBLOCK    O_NONBLOCK
 
 /* renameat2 flags */
 #define RENAME_NOREPLACE    (1 << 0)

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -101,9 +101,10 @@ typedef struct iovec {
 #define EOPNOTSUPP      95		/* Operation not supported */
 #define EISCONN         106
 #define ENOTCONN        107
-#define ETIMEDOUT       110     /* Connection timed out */
+#define ETIMEDOUT       110             /* Connection timed out */
 #define EALREADY        114
 #define EINPROGRESS     115
+#define ECANCELED       125             /* Used for timer cancel on RTC shift */
 
 #define O_RDONLY	00000000
 #define O_WRONLY	00000001
@@ -721,8 +722,10 @@ typedef u32 gid_t;
 #define EFD_SEMAPHORE   00000001
 
 /* timerfd flags */
-#define TFD_CLOEXEC     O_CLOEXEC
-#define TFD_NONBLOCK    O_NONBLOCK
+#define TFD_CLOEXEC             O_CLOEXEC
+#define TFD_NONBLOCK            O_NONBLOCK
+#define TFD_TIMER_ABSTIME       (1 << 0)
+#define TFD_TIMER_CANCEL_ON_SET (1 << 1)
 
 /* renameat2 flags */
 #define RENAME_NOREPLACE    (1 << 0)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -208,7 +208,7 @@ thread create_thread(process p)
     t->p = p;
     t->syscall = -1;
     t->uh = *p->uh;
-    init_refcount(&t->refcount, init_closure(&t->free, free_thread, t));
+    init_refcount(&t->refcount, 1, init_closure(&t->free, free_thread, t));
     t->select_epoll = 0;
     t->tid = tidcount++;
     t->clear_tid = 0;

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -1,0 +1,186 @@
+#include <unix_internal.h>
+
+//#define UNIX_TIMER_DEBUG
+#ifdef UNIX_TIMER_DEBUG
+#define timer_debug(x, ...) do {log_printf("UTMR", "%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#else
+#define timer_debug(x, ...)
+#endif
+
+enum unix_timer_type {
+    UNIX_TIMER_TYPE_TIMERFD = 1,
+    UNIX_TIMER_TYPE_TIMER,      /* timer_create */
+    UNIX_TIMER_TYPE_ITIMER
+};
+
+typedef struct unix_timer {
+    struct fdesc f;             /* used for timerfd only; must be first */
+    int type;
+    clock_id cid;
+    timer t;                    /* zero if disarmed */
+
+    union {
+        struct {
+            void *timerid;
+        } timer;
+
+        struct {
+            int itimer_which;
+        } itimer;
+
+        struct {
+            int fd;
+            blockq bq;
+        } timerfd;
+    } info;
+} *unix_timer;
+
+static heap unix_timer_heap;
+
+static unix_timer allocate_unix_timer(int type)
+{
+    unix_timer ut = allocate(unix_timer_heap, sizeof(struct unix_timer));
+    if (ut == INVALID_ADDRESS)
+        return ut;
+    ut->type = type;
+    return ut;
+}
+
+static void deallocate_unix_timer(unix_timer t)
+{
+    deallocate(unix_timer_heap, t, sizeof(struct unix_timer));
+}
+
+static void timerfd_fill_itimerspec(timer t, struct itimerspec *i)
+{
+    if (t->t) {
+        timestamp tnow = now(t->id);
+        timestamp tremain = t->expiry > tnow ? t->expiry - tnow : 0;
+        i->it_value.ts_sec = sec_from_timestamp(tremain);
+        i->it_value.ts_nsec = nsec_from_timestamp(tremain);
+        i->it_interval.ts_sec = sec_from_timestamp(t->interval);
+        i->it_interval.ts_nsec = nsec_from_timestamp(t->interval);
+    } else {
+        i->it_value.ts_sec = 0;
+        i->it_value.ts_nsec = 0;
+        i->it_interval.ts_sec = 0;
+        i->it_interval.ts_nsec = 0;
+    }
+}
+
+sysreturn timerfd_settime(int fd, int flags,
+                          const struct itimerspec *new_value,
+                          struct itimerspec *old_value)
+{
+    unix_timer ut = resolve_fd(current->p, fd); /* macro, may return EBADF */
+    if (ut->f.type != FDESC_TYPE_TIMERFD)
+        return -EINVAL;
+
+    if (!new_value)
+        return -EFAULT;
+
+    if (old_value)
+        timerfd_fill_itimerspec(ut->t, old_value);
+
+    
+    
+    return 0;
+}
+
+sysreturn timerfd_gettime(int fd, struct itimerspec *curr_value)
+{
+    unix_timer ut = resolve_fd(current->p, fd); /* macro, may return EBADF */
+    if (ut->f.type != FDESC_TYPE_TIMERFD)
+        return -EINVAL;
+
+    if (!curr_value)
+        return -EFAULT;
+
+    /* XXX really need a way to take a reference to timer object */
+    timerfd_fill_itimerspec(ut->t, curr_value);
+    return 0;
+}
+
+closure_function(1, 6, sysreturn, timerfd_read,
+                 unix_timer, ut,
+                 void *, dest, u64, length, u64, offset_arg, thread, t, boolean, bh, io_completion, completion)
+{
+//    unix_timer ut = bound(ut);
+    if (length == 0)
+        return 0;
+
+    return 0; // XXX
+}
+
+closure_function(1, 0, u32, timerfd_events,
+                 unix_timer, ut)
+{
+//    unix_timer ut = bound(ut);
+
+    return 0; // XXX
+}
+
+closure_function(1, 0, sysreturn, timerfd_close,
+                 unix_timer, ut)
+{
+    // XXX
+    return 0;
+}
+
+sysreturn timerfd_create(int clockid, int flags)
+{
+    if (clockid != CLOCK_REALTIME &&
+        clockid != CLOCK_MONOTONIC &&
+        clockid != CLOCK_BOOTTIME &&
+        clockid != CLOCK_REALTIME_ALARM &&
+        clockid != CLOCK_BOOTTIME_ALARM)
+        return -EINVAL;
+
+    if (flags & ~(EFD_NONBLOCK | TFD_CLOEXEC))
+        return -EINVAL;
+
+    unix_timer ut = allocate_unix_timer(UNIX_TIMER_TYPE_TIMERFD);
+    if (ut == INVALID_ADDRESS)
+        return -ENOMEM;
+
+    u64 fd = allocate_fd(current->p, ut);
+    if (fd == INVALID_PHYSICAL) {
+        deallocate_unix_timer(ut);
+        return -EMFILE;
+    }
+
+    timer_debug("unix_timer %p, fd %d\n", ut, fd);
+    init_fdesc(unix_timer_heap, &ut->f, FDESC_TYPE_TIMERFD);
+    ut->cid = clockid;
+    ut->t = 0;
+    ut->info.timerfd.fd = fd;
+    ut->info.timerfd.bq = allocate_blockq(unix_timer_heap, "timerfd");
+    if (ut->info.timerfd.bq == INVALID_ADDRESS)
+        goto err_mem_bq;
+    ut->f.flags = flags;
+    ut->f.read = closure(unix_timer_heap, timerfd_read, ut);
+    ut->f.events = closure(unix_timer_heap, timerfd_events, ut);
+    ut->f.close = closure(unix_timer_heap, timerfd_close, ut);
+    return fd;
+  err_mem_bq:
+    deallocate_fd(current->p, fd);
+    deallocate_unix_timer(ut);
+    return -ENOMEM;
+}
+
+#if 0
+sysreturn timer_create(clockid_t clockid, struct sigevent *sevp, void **timerid)
+{
+
+}
+#endif
+
+void register_timer_syscalls(struct syscall *map)
+{
+    
+}
+
+void init_unix_timers(kernel_heaps kh)
+{
+    unix_timer_heap = heap_general(kh);
+}

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -224,8 +224,9 @@ closure_function(1, 6, sysreturn, timerfd_read,
     return blockq_check(ut->info.timerfd.bq, t, ba, bh);
 }
 
-closure_function(1, 0, u32, timerfd_events,
-                 unix_timer, ut)
+closure_function(1, 1, u32, timerfd_events,
+                 unix_timer, ut,
+                 thread, t /* ignored */)
 {
     return bound(ut)->expirations > 0 ? EPOLLIN : 0;
 }

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -18,6 +18,7 @@ typedef struct unix_timer {
     int type;
     clock_id cid;
     timer t;                    /* zero if disarmed */
+    u64 expirations;
 
     union {
         struct {
@@ -31,18 +32,23 @@ typedef struct unix_timer {
         struct {
             int fd;
             blockq bq;
+            boolean cancel_on_set;
+            boolean canceled;   /* by time set */
         } timerfd;
     } info;
 } *unix_timer;
 
 static heap unix_timer_heap;
 
-static unix_timer allocate_unix_timer(int type)
+static unix_timer allocate_unix_timer(int type, clock_id cid)
 {
     unix_timer ut = allocate(unix_timer_heap, sizeof(struct unix_timer));
     if (ut == INVALID_ADDRESS)
         return ut;
     ut->type = type;
+    ut->cid = cid;
+    ut->t = 0;
+    ut->expirations = 0;
     return ut;
 }
 
@@ -51,39 +57,95 @@ static void deallocate_unix_timer(unix_timer t)
     deallocate(unix_timer_heap, t, sizeof(struct unix_timer));
 }
 
-static void timerfd_fill_itimerspec(timer t, struct itimerspec *i)
+static void itimerspec_from_timer(unix_timer ut, struct itimerspec *i)
 {
-    if (t->t) {
+    timestamp remain = 0, interval = 0;
+    if (ut->t) {
+        timer t = ut->t;
         timestamp tnow = now(t->id);
-        timestamp tremain = t->expiry > tnow ? t->expiry - tnow : 0;
-        i->it_value.ts_sec = sec_from_timestamp(tremain);
-        i->it_value.ts_nsec = nsec_from_timestamp(tremain);
-        i->it_interval.ts_sec = sec_from_timestamp(t->interval);
-        i->it_interval.ts_nsec = nsec_from_timestamp(t->interval);
-    } else {
-        i->it_value.ts_sec = 0;
-        i->it_value.ts_nsec = 0;
-        i->it_interval.ts_sec = 0;
-        i->it_interval.ts_nsec = 0;
+        remain = t->expiry > tnow ? t->expiry - tnow : 0;
+        interval = t->interval;
     }
+    timespec_from_time(&i->it_value, remain);
+    timespec_from_time(&i->it_interval, interval);
+}
+
+/* note that all of this assumes that the various timer operations are
+   performed in the syscall top half, i.e. with interrupts disabled... */
+
+static inline void timerfd_remove_timer(unix_timer ut)
+{
+    if (!ut->t)
+        return;
+    thunk t = ut->t->t;
+    remove_timer(ut->t, 0);
+    ut->t = 0;
+    deallocate_closure(t);
+}
+
+closure_function(1, 0, void, timerfd_timer_expire,
+                 unix_timer, ut)
+{
+    unix_timer ut = bound(ut);
+    assert(ut->t);
+    assert(!ut->t->disabled);
+
+    fetch_and_add(&ut->expirations, 1); /* atomic really necessary? */
+    timer_debug("fd %d -> %d\n", ut->info.timerfd.fd, ut->expirations);
+
+    blockq_wake_one(ut->info.timerfd.bq);
+    notify_dispatch(ut->f.ns, EPOLLIN);
+
+    if (ut->t->interval == 0)
+        timerfd_remove_timer(ut);     /* deallocs closure for us */
+}
+
+void notify_unix_timers_of_rtc_change(void)
+{
+    /* XXX TODO:
+
+       This should be implemented if and when we support explicit
+       setting of wall time via settimeofday(2), clock_settime(2),
+       update detected from hypervisor, etc. Any such setting of the
+       clock should call this function, which in turn should walk
+       through the active unix_timers and cancel them as necessary (if
+       cancel_on_set).
+    */
 }
 
 sysreturn timerfd_settime(int fd, int flags,
                           const struct itimerspec *new_value,
                           struct itimerspec *old_value)
 {
-    unix_timer ut = resolve_fd(current->p, fd); /* macro, may return EBADF */
-    if (ut->f.type != FDESC_TYPE_TIMERFD)
+    if (flags & ~(TFD_TIMER_ABSTIME | TFD_TIMER_CANCEL_ON_SET))
         return -EINVAL;
 
     if (!new_value)
         return -EFAULT;
 
-    if (old_value)
-        timerfd_fill_itimerspec(ut->t, old_value);
+    unix_timer ut = resolve_fd(current->p, fd); /* macro, may return EBADF */
+    if (ut->f.type != FDESC_TYPE_TIMERFD)
+        return -EINVAL;
 
-    
-    
+    if (old_value)
+        itimerspec_from_timer(ut, old_value);
+
+    ut->info.timerfd.cancel_on_set =
+        (ut->cid == CLOCK_REALTIME || ut->cid == CLOCK_REALTIME_ALARM) &&
+        (flags ^ (TFD_TIMER_ABSTIME | TFD_TIMER_CANCEL_ON_SET)) == 0;
+
+    /* runtime timers are partly immutable; so cancel and re-create on set */
+    timerfd_remove_timer(ut);
+
+    timestamp tinit = time_from_timespec(&new_value->it_value);
+    timestamp interval = time_from_timespec(&new_value->it_interval);
+
+    timer t = register_timer(ut->cid, tinit, (flags & TFD_TIMER_ABSTIME) != 0, interval,
+                             closure(unix_timer_heap, timerfd_timer_expire, ut));
+    if (t == INVALID_ADDRESS)
+        return -ENOMEM;
+
+    ut->t = t;
     return 0;
 }
 
@@ -96,34 +158,89 @@ sysreturn timerfd_gettime(int fd, struct itimerspec *curr_value)
     if (!curr_value)
         return -EFAULT;
 
-    /* XXX really need a way to take a reference to timer object */
-    timerfd_fill_itimerspec(ut->t, curr_value);
+    itimerspec_from_timer(ut, curr_value);
     return 0;
+}
+
+closure_function(5, 1, sysreturn, timerfd_read_bh,
+                 unix_timer, ut, void *, dest, u64, length, thread, t, io_completion, completion,
+                 u64, flags)
+{
+    unix_timer ut = bound(ut);
+    thread t = bound(t);
+    boolean blocked = (flags & BLOCKQ_ACTION_BLOCKED) != 0;
+    sysreturn rv = sizeof(u64);
+
+    timer_debug("fd %d, dest %p, length %ld, tid %d, flags 0x%lx\n",
+                ut->info.timerfd.fd, bound(dest), bound(length), t->tid, flags);
+
+    if (bound(length) < sizeof(u64)) {
+        assert(!blocked);
+        rv = -EINVAL;
+        goto out;
+    }
+
+    if (flags & BLOCKQ_ACTION_NULLIFY) {
+        assert(blocked);
+        rv = -EINTR;
+        goto out;
+    }
+
+    if (ut->info.timerfd.canceled) {
+        rv = -ECANCELED;
+        goto out;
+    }
+
+    u64 expirations = ut->expirations;
+    if (expirations == 0) {
+        if (!blocked && (ut->f.flags & TFD_NONBLOCK)) {
+            rv = -EAGAIN;
+            goto out;
+        }
+        timer_debug("   -> block\n");
+        return BLOCKQ_BLOCK_REQUIRED;
+    }
+
+    /* would do atomic swap were it not for ints disabled... */
+    *(u64*)bound(dest) = expirations;
+    ut->expirations = 0;
+  out:
+    timer_debug("   -> returning %ld\n", rv);
+    blockq_handle_completion(ut->info.timerfd.bq, flags, bound(completion), t, rv);
+    closure_finish();
+    return rv;
 }
 
 closure_function(1, 6, sysreturn, timerfd_read,
                  unix_timer, ut,
                  void *, dest, u64, length, u64, offset_arg, thread, t, boolean, bh, io_completion, completion)
 {
-//    unix_timer ut = bound(ut);
     if (length == 0)
         return 0;
-
-    return 0; // XXX
+    unix_timer ut = bound(ut);
+    timer_debug("fd %d, dest %p, length %ld, tid %d, bh %d, completion %p\n", ut->info.timerfd.fd,
+                dest, length, t->tid, bh, completion);
+    blockq_action ba = closure(unix_timer_heap, timerfd_read_bh, ut, dest, length, t, completion);
+    return blockq_check(ut->info.timerfd.bq, t, ba, bh);
 }
 
 closure_function(1, 0, u32, timerfd_events,
                  unix_timer, ut)
 {
-//    unix_timer ut = bound(ut);
-
-    return 0; // XXX
+    return bound(ut)->expirations > 0 ? EPOLLIN : 0;
 }
 
 closure_function(1, 0, sysreturn, timerfd_close,
                  unix_timer, ut)
 {
-    // XXX
+    unix_timer ut = bound(ut);
+    timerfd_remove_timer(ut);
+    deallocate_blockq(ut->info.timerfd.bq);
+    deallocate_closure(ut->f.read);
+    deallocate_closure(ut->f.events);
+    deallocate_closure(ut->f.close);
+    release_fdesc(&ut->f);
+    deallocate_unix_timer(ut);
     return 0;
 }
 
@@ -136,10 +253,10 @@ sysreturn timerfd_create(int clockid, int flags)
         clockid != CLOCK_BOOTTIME_ALARM)
         return -EINVAL;
 
-    if (flags & ~(EFD_NONBLOCK | TFD_CLOEXEC))
+    if (flags & ~(TFD_NONBLOCK | TFD_CLOEXEC))
         return -EINVAL;
 
-    unix_timer ut = allocate_unix_timer(UNIX_TIMER_TYPE_TIMERFD);
+    unix_timer ut = allocate_unix_timer(UNIX_TIMER_TYPE_TIMERFD, clockid);
     if (ut == INVALID_ADDRESS)
         return -ENOMEM;
 
@@ -151,12 +268,11 @@ sysreturn timerfd_create(int clockid, int flags)
 
     timer_debug("unix_timer %p, fd %d\n", ut, fd);
     init_fdesc(unix_timer_heap, &ut->f, FDESC_TYPE_TIMERFD);
-    ut->cid = clockid;
-    ut->t = 0;
     ut->info.timerfd.fd = fd;
     ut->info.timerfd.bq = allocate_blockq(unix_timer_heap, "timerfd");
     if (ut->info.timerfd.bq == INVALID_ADDRESS)
         goto err_mem_bq;
+    ut->info.timerfd.cancel_on_set = false;
     ut->f.flags = flags;
     ut->f.read = closure(unix_timer_heap, timerfd_read, ut);
     ut->f.events = closure(unix_timer_heap, timerfd_events, ut);
@@ -177,10 +293,13 @@ sysreturn timer_create(clockid_t clockid, struct sigevent *sevp, void **timerid)
 
 void register_timer_syscalls(struct syscall *map)
 {
-    
+    register_syscall(map, timerfd_create, timerfd_create);
+    register_syscall(map, timerfd_gettime, timerfd_gettime);
+    register_syscall(map, timerfd_settime, timerfd_settime);
 }
 
-void init_unix_timers(kernel_heaps kh)
+boolean unix_timers_init(unix_heaps uh)
 {
-    unix_timer_heap = heap_general(kh);
+    unix_timer_heap = heap_general((kernel_heaps)uh);
+    return true;
 }

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -260,7 +260,8 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
 	goto alloc_fail;
     if (!pipe_init(uh))
 	goto alloc_fail;
-
+    if (!unix_timers_init(uh))
+        goto alloc_fail;
     if (ftrace_init(uh, fs))
 	goto alloc_fail;
 
@@ -301,6 +302,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     register_thread_syscalls(linux_syscalls);
     register_poll_syscalls(linux_syscalls);
     register_clock_syscalls(linux_syscalls);
+    register_timer_syscalls(linux_syscalls);
     register_other_syscalls(linux_syscalls);
     configure_syscalls(kernel_process);
     return kernel_process;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -149,12 +149,12 @@ boolean blockq_flush_thread(blockq bq, thread t);
 void blockq_set_completion(blockq bq, io_completion completion, thread t,
                            sysreturn rv);
 sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_bh, 
-                               timestamp timeout, clock_id id);
+                               clock_id id, timestamp timeout, boolean absolute);
 int blockq_transfer_waiters(blockq dest, blockq src, int n);
 
 static inline sysreturn blockq_check(blockq bq, thread t, blockq_action a, boolean in_bh)
 {
-    return blockq_check_timeout(bq, t, a, in_bh, 0, 0 /* n/a */);
+    return blockq_check_timeout(bq, t, a, in_bh, 0, 0, false);
 }
 
 static inline void blockq_handle_completion(blockq bq, u64 bq_flags, io_completion completion, thread t, sysreturn rv)

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -404,7 +404,7 @@ static inline timestamp time_from_timespec(const struct timespec *t)
 
 static inline void timespec_from_time(struct timespec *ts, timestamp t)
 {
-    ts->ts_sec = t / TIMESTAMP_SECOND;
+    ts->ts_sec = sec_from_timestamp(t);
     ts->ts_nsec = nsec_from_timestamp(truncate_seconds(t));
 }
 
@@ -446,10 +446,16 @@ void register_mmap_syscalls(struct syscall *);
 void register_thread_syscalls(struct syscall *);
 void register_poll_syscalls(struct syscall *);
 void register_clock_syscalls(struct syscall *);
+void register_timer_syscalls(struct syscall *);
 void register_other_syscalls(struct syscall *);
+
+/* Call this routine if RTC offset should ever shift... */
+void notify_unix_timers_of_rtc_change(void);
 
 boolean poll_init(unix_heaps uh);
 boolean pipe_init(unix_heaps uh);
+boolean unix_timers_init(unix_heaps uh);
+
 #define sysreturn_from_pointer(__x) ((s64)u64_from_pointer(__x));
 
 extern sysreturn syscall_ignore();

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -51,6 +51,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/unix/special.c \
 	$(SRCDIR)/unix/syscall.c \
 	$(SRCDIR)/unix/thread.c \
+	$(SRCDIR)/unix/timer.c \
 	$(SRCDIR)/unix/unix_clock.c \
 	$(SRCDIR)/unix/unix.c \
 	$(SRCDIR)/unix/vdso.c \

--- a/test/runtime/time.c
+++ b/test/runtime/time.c
@@ -237,6 +237,7 @@ void test_timerfd(clockid_t clkid, unsigned long long nsec)
         fail_perror("read");
     if (expirations == 0)
         fail_error("read zero expirations\n");
+    timetest_debug("   + %lld\n", expirations);
 
     timerfd_check_disarmed(fd);
 
@@ -319,7 +320,7 @@ main()
 {
     setbuf(stdout, NULL);
     test_time_and_times();
-    unsigned long long intervals[] = { 1000, 1000000, BILLION, -1 };
+    unsigned long long intervals[] = { 1, 1000, 1000000, BILLION, 2 * BILLION, -1 };
     for (int i = 0; intervals[i] != -1; i++) {
         test_nanosleep(intervals[i]);
         test_clock_nanosleep(CLOCK_MONOTONIC, intervals[i]);


### PR DESCRIPTION
This introduces support for timerfd(2) as well as some generic timer infrastructure for the unix world. The runtime timer interface has been changed slightly to allow differing start and periodic intervals as well as absolute timestamps.

Resolves #992 
