### PR TITLE
use PCI_SLOTMAX + 1 for msi_map size

### DIFF
--- a/src/x86_64/pci.c
+++ b/src/x86_64/pci.c
@@ -44,7 +44,7 @@ static heap virtual_huge;
 static heap pages;
 
 // assume the single bus layout
-static u32 *msi_map[PCI_SLOTMAX];
+static u32 *msi_map[PCI_SLOTMAX + 1];
 
 struct pci_driver {
     pci_probe probe;


### PR DESCRIPTION
trivial fix from @cdosoftei: use PCI_SLOTMAX + 1 for msi_map size