### PR TITLE
unix timers

### DIFF
--- a/src/net/net.c
+++ b/src/net/net.c
@@ -41,8 +41,9 @@ void sys_timeouts_init(void)
     int n = sizeof(net_lwip_timers) / sizeof(struct net_lwip_timer);
     for (int i = 0; i < n; i++) {
         struct net_lwip_timer * t = (struct net_lwip_timer *)&net_lwip_timers[i];
-        register_periodic_timer(milliseconds(t->interval_ms), CLOCK_ID_MONOTONIC,
-                                closure(lwip_heap, dispatch_lwip_timer, t->handler, t->name));
+        timestamp interval = milliseconds(t->interval_ms);
+        register_timer(CLOCK_ID_MONOTONIC, interval, false, interval,
+                       closure(lwip_heap, dispatch_lwip_timer, t->handler, t->name));
 #ifdef LWIP_DEBUG
         lwip_debug("registered %s timer with period of %ld ms\n", t->name, t->interval_ms);
 #endif

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -25,10 +25,9 @@ static struct net_lwip_timer net_lwip_timers[] = {
     {DHCP_FINE_TIMER_MSECS, dhcp_fine_tmr, "dhcp fine"},
 };
 
-/* We could dispatch lwip timer callbacks as thunks, but breaking it
-   out here gives us a single point of entry for debugging. */
-closure_function(2, 0, void, dispatch_lwip_timer,
-                 lwip_cyclic_timer_handler, handler, const char *, name)
+closure_function(2, 1, void, dispatch_lwip_timer,
+                 lwip_cyclic_timer_handler, handler, const char *, name,
+                 u64, overruns /* ignored */)
 {
 #ifdef LWIP_DEBUG
     lwip_debug("dispatching timer for %s\n", bound(name));

--- a/src/runtime/refcount.h
+++ b/src/runtime/refcount.h
@@ -4,9 +4,9 @@ typedef struct refcount {
     thunk completion;
 } *refcount;
 
-static inline void init_refcount(refcount r, thunk completion)
+static inline void init_refcount(refcount r, int c, thunk completion)
 {
-    r->c = 1;
+    r->c = c;
     r->completion = completion;
 }
 

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -159,6 +159,7 @@ typedef closure_type(thunk, void);
 #include <status.h>
 #include <pqueue.h>
 #include <clock.h>
+#include <refcount.h>
 #include <timer.h>
 #include <range.h>
 
@@ -208,8 +209,6 @@ typedef struct merge *merge;
 
 merge allocate_merge(heap h, status_handler completion);
 status_handler apply_merge(merge m);
-
-#include <refcount.h>
 
 void __stack_chk_guard_init();
 

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -39,7 +39,7 @@ timer register_timer(clock_id id, timestamp val, boolean absolute, timestamp int
     /* one ref for consumer, one for pqueue */
     init_refcount(&t->refcount, 2, init_closure(&t->free, timer_free, t));
     pqueue_insert(timers, t);
-    timer_debug("register timer: %p, expiry %T, interval %T, thunk %p\n", t->expiry, interval, t);
+    timer_debug("register timer: %p, expiry %T, interval %T, thunk %p\n", t, t->expiry, interval, t);
     return t;
 }
 

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -52,9 +52,7 @@ timestamp timer_check()
         pqueue_pop(timers);
         if (!t->disabled) {
             if (t->interval) {
-                u64 overruns = 1;
-                if (delta > t->interval)
-                    overruns += delta / t->interval;
+                u64 overruns = delta > t->interval ? delta / t->interval + 1 : 1;
                 apply(t->t, overruns);
                 if (!t->disabled) {
                     t->expiry += t->interval * overruns;

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -36,8 +36,7 @@ timer register_timer(clock_id id, timestamp val, boolean absolute, timestamp int
     t->disabled = false;
     t->t = n;
 
-    /* one ref for consumer, one for pqueue */
-    init_refcount(&t->refcount, 2, init_closure(&t->free, timer_free, t));
+    init_refcount(&t->refcount, 1, init_closure(&t->free, timer_free, t));
     pqueue_insert(timers, t);
     timer_debug("register timer: %p, expiry %T, interval %T, thunk %p\n", t, t->expiry, interval, t);
     return t;

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -42,7 +42,7 @@ timer register_timer(clock_id id, timestamp val, boolean absolute, timestamp int
     return t;
 }
 
-timestamp timer_check()
+timestamp timer_check(void)
 {
     timer t;
     s64 delta;
@@ -72,26 +72,6 @@ timestamp timer_check()
     	return dt;
     }
     return infinity;
-}
-
-timestamp parse_time(string b)
-{
-    u64 s = 0, frac = 0, fracnorm = 0;
-
-    foreach_character (_, c, b) {
-        if (c == '.')  {
-            fracnorm = 1;
-        } else {
-            if (fracnorm) {
-                frac = frac*10 + digit_of(c);
-                fracnorm *= 10;
-            } else s = s *10 + digit_of(c);
-        }
-    }
-    timestamp result = s << 32;
-
-    if (fracnorm) result |= (frac<<32)/fracnorm;
-    return(result);
 }
 
 void print_timestamp(string b, timestamp t)

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -58,6 +58,13 @@ static inline timestamp timer_expiry(timer t)
 }
 #undef __rtc_offset
 
+static inline void timer_get_remaining(timer t, timestamp *remain, timestamp *interval)
+{
+    timestamp tnow = now(t->id);
+    *remain = t->expiry > tnow ? t->expiry - tnow : 0;
+    *interval = t->interval;
+}
+
 /* returns time remaining or 0 if elapsed */
 static inline void remove_timer(timer t, timestamp *remain)
 {

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -1,6 +1,7 @@
 #pragma once
 typedef u64 timestamp;
 typedef struct timer *timer;
+typedef closure_type(timer_handler, void, u64);
 
 declare_closure_struct(1, 0, void, timer_free,
                        timer, t);
@@ -10,7 +11,7 @@ struct timer {
     timestamp expiry;
     timestamp interval;
     boolean disabled;
-    thunk t;
+    timer_handler t;
     struct refcount refcount;
     closure_struct(timer_free, free);
 };
@@ -29,7 +30,7 @@ static inline void runloop_timer(timestamp duration)
     apply(platform_timer, duration);
 }
 
-timer register_timer(clock_id id, timestamp val, boolean absolute, timestamp interval, thunk n);
+timer register_timer(clock_id id, timestamp val, boolean absolute, timestamp interval, timer_handler n);
 
 #if defined(STAGE3) || defined(BUILD_VDSO)
 #include <vdso.h>

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -67,7 +67,6 @@ static inline void remove_timer(timer t, timestamp *remain)
         timestamp n = now(t->id);
         *remain = x > n ? x - n : 0;
     }
-    refcount_release(&t->refcount);
 }
 
 void initialize_timers(kernel_heaps kh);

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -71,9 +71,8 @@ static inline void remove_timer(timer t, timestamp *remain)
 }
 
 void initialize_timers(kernel_heaps kh);
-timestamp parse_time();
 void print_timestamp(buffer, timestamp);
-timestamp timer_check();
+timestamp timer_check(void);
 
 #define THOUSAND         (1000ull)
 #define MILLION          (1000000ull)

--- a/src/runtime/uniboot.h
+++ b/src/runtime/uniboot.h
@@ -46,4 +46,8 @@ static inline u16 tagof(void* v) {
 /* maximum buckets that can fit within a PAGESIZE_2M mcache */
 #define TABLE_MAX_BUCKETS 131072
 
+/* runloop timer minimum and maximum */
+#define RUNLOOP_TIMER_MAX_PERIOD_US     100000
+#define RUNLOOP_TIMER_MIN_PERIOD_US     10
+
 #include <x86.h>

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -110,7 +110,7 @@ static void blockq_item_finish(blockq bq, blockq_item bi)
         /* XXX acquire spinlock */
     }
 
-    refcount_release(&bi->t->refcount);
+    thread_release(bi->t);
     free_blockq_item(bq, bi);
 }
 
@@ -241,7 +241,7 @@ sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_
 
     bi->a = a;
     bi->t = t;
-    refcount_reserve(&t->refcount);
+    thread_reserve(t);
 
     if (timeout > 0) {
         bi->timeout = register_timer(clkid, timeout, absolute, 0,

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -143,8 +143,9 @@ static void blockq_apply_bi_locked(blockq bq, blockq_item bi, u64 flags)
  * Invoke its action and remove it from the list of waiters,
  * if applicable
  */
-closure_function(2, 0, void, blockq_item_timeout,
-                 blockq, bq, blockq_item, bi)
+closure_function(2, 1, void, blockq_item_timeout,
+                 blockq, bq, blockq_item, bi,
+                 u64, overruns /* ignored */)
 {
     blockq bq = bound(bq);
     blockq_item bi = bound(bi);
@@ -319,7 +320,7 @@ int blockq_transfer_waiters(blockq dest, blockq src, int n)
         blockq_item bi = struct_from_list(l, blockq_item, l);
         if (bi->timeout) {
             timestamp remain;
-            thunk t = bi->timeout->t;
+            timer_handler t = bi->timeout->t;
             remove_timer(bi->timeout, &remain);
             bi->timeout = remain == 0 ? 0 :
                 register_timer(CLOCK_ID_MONOTONIC, remain, false, 0,

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -271,6 +271,7 @@ sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_
     assert(0);
 }
 
+/* XXX This deserves another pass; blockq_item should really just be embedded into thread. */
 boolean blockq_flush_thread(blockq bq, thread t)
 {
     boolean unblocked = false;

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -1628,7 +1628,7 @@ closure_function(4, 0, void, __ftrace_send_http_chunk,
     if (__ftrace_send_http_chunk_internal(bound(routine), bound(p),
             bound(local_printer), bound(out)))
     {
-        register_timer(SEND_HTTP_CHUNK_INTERVAL_MS, CLOCK_ID_MONOTONIC, (thunk)closure_self());
+        register_timer(CLOCK_ID_MONOTONIC, SEND_HTTP_CHUNK_INTERVAL_MS, false, 0, (thunk)closure_self());
     } else {
         closure_finish();
     }
@@ -1693,7 +1693,7 @@ __ftrace_do_http_method(buffer_handler out, struct ftrace_routine * routine,
         {
             thunk t = closure(ftrace_heap, __ftrace_send_http_chunk, routine,
                 p, local_printer, out);
-            register_timer(SEND_HTTP_CHUNK_INTERVAL_MS, CLOCK_ID_MONOTONIC, t);
+            register_timer(CLOCK_ID_MONOTONIC, SEND_HTTP_CHUNK_INTERVAL_MS, false, 0, t);
         }
     }
 

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -166,7 +166,7 @@ sysreturn futex(int *uaddr, int futex_op, int val,
 
         return blockq_check_timeout(f->bq, current, 
                                     closure(f->h, futex_bh, f, current),
-                                    false, ts, CLOCK_ID_MONOTONIC);
+                                    false, CLOCK_ID_MONOTONIC, ts, false);
     }
 
     case FUTEX_WAKE: {
@@ -260,7 +260,7 @@ sysreturn futex(int *uaddr, int futex_op, int val,
         // TODO: timeout should be absolute based on CLOCK_REALTIME
         return blockq_check_timeout(f->bq, current, 
                                     closure(f->h, futex_bh, f, current),
-                                    false, ts, CLOCK_ID_MONOTONIC);
+                                    false, CLOCK_ID_MONOTONIC, ts, false);
     }
 
     case FUTEX_REQUEUE: rprintf("futex_requeue not implemented\n"); break;

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -246,6 +246,7 @@ define_closure_function(1, 0, void, epoll_blocked_free,
 {
     epoll_blocked w = bound(w);
     epoll_debug("w %p\n", w);
+    thread_release(w->t);
     refcount_release(&w->e->refcount);
     unix_cache_free(get_unix_heaps(), epoll_blocked, w);
 }
@@ -336,7 +337,7 @@ static epoll_blocked alloc_epoll_blocked(epoll e)
     /* initial reservation released on thread wakeup (or direct return) */
     init_refcount(&w->refcount, 1, init_closure(&w->free, epoll_blocked_free, w));
     w->t = current;
-    refcount_reserve(&w->t->refcount);
+    thread_reserve(w->t);
     w->e = e;
     refcount_reserve(&e->refcount);
     list_insert_after(&e->blocked_head, &w->blocked_list); /* push */

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -796,8 +796,8 @@ static void signalfd_siginfo_fill(struct signalfd_siginfo * si, queued_signal qs
     case SI_TIMER:
         si->ssi_tid = qs->si.sifields.timer.tid;
         si->ssi_overrun = qs->si.sifields.timer.overrun;
-        si->ssi_ptr = (u64)qs->si.sifields.timer.sigval.val_ptr;
-        si->ssi_int = qs->si.sifields.timer.sigval.val_int;
+        si->ssi_ptr = (u64)qs->si.sifields.timer.sigval.sival_ptr;
+        si->ssi_int = qs->si.sifields.timer.sigval.sival_int;
         break;
     case SI_SIGIO:
         si->ssi_band = qs->si.sifields.sigpoll.band;
@@ -810,8 +810,8 @@ static void signalfd_siginfo_fill(struct signalfd_siginfo * si, queued_signal qs
     case SI_ASYNCNL:
         si->ssi_pid = qs->si.sifields.rt.pid;
         si->ssi_uid = qs->si.sifields.rt.uid;
-        si->ssi_ptr = (u64)qs->si.sifields.rt.sigval.val_ptr;
-        si->ssi_int = qs->si.sifields.rt.sigval.val_int;
+        si->ssi_ptr = (u64)qs->si.sifields.rt.sigval.sival_ptr;
+        si->ssi_int = qs->si.sifields.rt.sigval.sival_int;
         break;
     }
 }

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -747,7 +747,7 @@ closure_function(4, 1, sysreturn, rt_sigtimedwait_bh,
     if (qs == INVALID_ADDRESS) {
         if (!blocked) {
             const struct timespec * ts = bound(timeout);
-            if (ts && ts->ts_sec == 0 && ts->ts_nsec == 0) {
+            if (ts && ts->tv_sec == 0 && ts->tv_nsec == 0) {
                 closure_finish();
                 return set_syscall_error(t, EAGAIN); /* poll */
             }

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -232,8 +232,8 @@ static void deliver_signal(sigstate ss, struct siginfo *info)
                     qs->si.sifields.timer.tid == info->sifields.timer.tid) {
                     qs->si.sifields.timer.overrun += info->sifields.timer.overrun;
                     sig_debug("timer update id %d, overrun %d\n",
-                              qs->si->sifields.timer.tid,
-                              qs->si->sifields.timer.overrun);
+                              qs->si.sifields.timer.tid,
+                              qs->si.sifields.timer.overrun);
                     return;
                 }
             }

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -230,7 +230,9 @@ static void deliver_signal(sigstate ss, struct siginfo *info)
                 queued_signal qs = struct_from_list(l, queued_signal, l);
                 if (qs->si.si_code == SI_TIMER &&
                     qs->si.sifields.timer.tid == info->sifields.timer.tid) {
-                    qs->si.sifields.timer.overrun += info->sifields.timer.overrun;
+                    u64 overruns = (u64)qs->si.sifields.timer.overrun +
+                        info->sifields.timer.overrun;
+                    qs->si.sifields.timer.overrun = MIN((u64)S32_MAX, overruns);
                     sig_debug("timer update id %d, overrun %d\n",
                               qs->si.sifields.timer.tid,
                               qs->si.sifields.timer.overrun);

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -598,8 +598,7 @@ sysreturn tgkill(int tgid, int tid, int sig)
         return 0;               /* always permitted */
 
     thread t;
-    if (tid >= vector_length(current->p->threads) ||
-        !(t = vector_get(current->p->threads, tid)))
+    if ((t = thread_from_tid(current->p, tid)) == INVALID_ADDRESS)
         return -ESRCH;
 
     struct siginfo si;
@@ -674,8 +673,7 @@ sysreturn rt_tgsigqueueinfo(int tgid, int tid, int sig, siginfo_t *uinfo)
         return rv;
 
     thread t;
-    if (tid >= vector_length(current->p->threads) ||
-        !(t = vector_get(current->p->threads, tid)))
+    if ((t = thread_from_tid(current->p, tid)) == INVALID_ADDRESS)
         return -ESRCH;
 
     uinfo->si_signo = sig;

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -772,7 +772,7 @@ sysreturn rt_sigtimedwait(const u64 * set, siginfo_t * info, const struct timesp
     heap h = heap_general(get_kernel_heaps());
     blockq_action ba = closure(h, rt_sigtimedwait_bh, current, *set, info, timeout);
     timestamp t = timeout ? time_from_timespec(timeout) : 0;
-    return blockq_check_timeout(current->thread_bq, current, ba, false, t, CLOCK_ID_MONOTONIC);
+    return blockq_check_timeout(current->thread_bq, current, ba, false, CLOCK_ID_MONOTONIC, t, false);
 }
 
 typedef struct signal_fd {

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -230,7 +230,18 @@ static void deliver_signal(sigstate ss, struct siginfo *info)
     if (sigstate_is_pending(ss, sig)) {
         /* If this is a timer event, attempt to find a queued info for
            this timer and update the info (overrun) instead of
-           queueing another entry. */
+           queueing another entry.
+
+           I'm kind of assuming that both 1) this won't happen at any
+           high rate in real-world use, and 2) the depth of queued
+           infos for a given rt signal would ever practically be more
+           than one (or a few if a timer is mixed with other
+           sources). But I could be wrong. If so, we could change over
+           to registering a "siginfo update" closure which will update
+           the overrun count after dequeueing the signal (just before
+           entering the handler or other dispatch method). This would
+           obviate any need to search for and update a queued info.
+        */
         if (info->si_code == SI_TIMER) {
             list_foreach(sigstate_get_sighead(ss, sig), l) {
                 queued_signal qs = struct_from_list(l, queued_signal, l);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -35,9 +35,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, shmget, 0);
     register_syscall(map, shmat, 0);
     register_syscall(map, shmctl, 0);
-    register_syscall(map, getitimer, 0);
-    register_syscall(map, alarm, 0);
-    register_syscall(map, setitimer, 0);
     register_syscall(map, fork, 0);
     register_syscall(map, vfork, 0);
     register_syscall(map, execve, 0);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -200,7 +200,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, move_pages, 0);
     register_syscall(map, utimensat, 0);
     register_syscall(map, fallocate, 0);
-    register_syscall(map, signalfd4, 0);
     register_syscall(map, inotify_init1, 0);
     register_syscall(map, preadv, 0);
     register_syscall(map, pwritev, 0);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -199,10 +199,8 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, vmsplice, 0);
     register_syscall(map, move_pages, 0);
     register_syscall(map, utimensat, 0);
-    register_syscall(map, timerfd_create, 0);
     register_syscall(map, fallocate, 0);
-    register_syscall(map, timerfd_settime, 0);
-    register_syscall(map, timerfd_gettime, 0);
+    register_syscall(map, signalfd4, 0);
     register_syscall(map, inotify_init1, 0);
     register_syscall(map, preadv, 0);
     register_syscall(map, pwritev, 0);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -155,11 +155,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, restart_syscall, 0);
     register_syscall(map, semtimedop, 0);
     register_syscall(map, fadvise64, 0);
-    register_syscall(map, timer_create, 0);
-    register_syscall(map, timer_settime, 0);
-    register_syscall(map, timer_gettime, 0);
-    register_syscall(map, timer_getoverrun, 0);
-    register_syscall(map, timer_delete, 0);
     register_syscall(map, clock_settime, 0);
     register_syscall(map, utimes, 0);
     register_syscall(map, vserver, 0);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -451,6 +451,28 @@ struct signalfd_siginfo {
     u8 pad[SIGNALFD_SIGINFO_SIZE - 100];
 };
 
+#define SIGEV_SIGNAL    0
+#define SIGEV_NONE      1
+#define SIGEV_THREAD    2
+#define SIGEV_THREAD_ID 4
+
+#define SIGEVENT_SIZE 64
+#define SIGEVENT_PAD_BYTES (SIGEVENT_SIZE - (sizeof(s32) * 2 + sizeof(sigval_t)))
+
+typedef struct sigevent {
+    sigval_t sigev_value;
+    s32 sigev_signo;
+    s32 sigev_notify;
+    union {
+        u32 pad[SIGEVENT_PAD_BYTES / sizeof(u32)];
+        u32 tid;
+        struct {
+            void (*function)(sigval_t);
+            void *attribute;
+        } sigev_thread;
+    } sigev_un;
+} sigevent_t;
+
 typedef u64 fd_set;
 
 typedef unsigned long int nfds_t;

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -328,9 +328,9 @@ struct rlimit {
 # define SEGV_PKUERR    4   /* failed protection key checks */
 #define NSIGSEGV    4
 
-typedef struct sigval {
-    s32 val_int;
-    void * val_ptr;
+typedef union sigval {
+    s32 sival_int;
+    void * sival_ptr;
 } sigval_t;
 
 typedef struct siginfo {

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -206,9 +206,13 @@ typedef int clockid_t;
 
 #define TIMER_ABSTIME               0x1
 
+#define ITIMER_REAL    0
+#define ITIMER_VIRTUAL 1
+#define ITIMER_PROF    2
+
 struct timespec {
-    u64 ts_sec;
-    u64 ts_nsec;
+    u64 tv_sec;
+    u64 tv_nsec;
 };
 
 typedef s64 time_t;

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -206,8 +206,25 @@ typedef int clockid_t;
 #define TIMER_ABSTIME               0x1
 
 struct timespec {
-	u64 ts_sec;
-	u64 ts_nsec;
+    u64 ts_sec;
+    u64 ts_nsec;
+};
+
+typedef s64 time_t;
+
+struct timeval {
+    time_t tv_sec;  /* seconds */
+    u64 tv_usec;    /* microseconds */
+};
+
+struct itimerspec {
+    struct timespec it_interval;
+    struct timespec it_value;
+};
+
+struct itimerval {
+    struct timeval it_interval;
+    struct timeval it_value;
 };
 
 // straight from linux
@@ -622,14 +639,6 @@ struct rt_sigframe {
     /* fp state follows here */
 };
 
-
-typedef s64 time_t;
-
-struct timeval {
-    time_t tv_sec;  /* seconds */
-    u64 tv_usec;    /* microseconds */
-};
-
 #define CLOCKS_PER_SEC  100
 
 typedef s64 clock_t;
@@ -710,6 +719,10 @@ typedef u32 gid_t;
 #define EFD_CLOEXEC     02000000
 #define EFD_NONBLOCK    00004000
 #define EFD_SEMAPHORE   00000001
+
+/* timerfd flags */
+#define TFD_CLOEXEC     O_CLOEXEC
+#define TFD_NONBLOCK    O_NONBLOCK
 
 /* renameat2 flags */
 #define RENAME_NOREPLACE    (1 << 0)

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -101,9 +101,10 @@ typedef struct iovec {
 #define EOPNOTSUPP      95		/* Operation not supported */
 #define EISCONN         106
 #define ENOTCONN        107
-#define ETIMEDOUT       110     /* Connection timed out */
+#define ETIMEDOUT       110             /* Connection timed out */
 #define EALREADY        114
 #define EINPROGRESS     115
+#define ECANCELED       125             /* Used for timer cancel on RTC shift */
 
 #define O_RDONLY	00000000
 #define O_WRONLY	00000001
@@ -721,8 +722,10 @@ typedef u32 gid_t;
 #define EFD_SEMAPHORE   00000001
 
 /* timerfd flags */
-#define TFD_CLOEXEC     O_CLOEXEC
-#define TFD_NONBLOCK    O_NONBLOCK
+#define TFD_CLOEXEC             O_CLOEXEC
+#define TFD_NONBLOCK            O_NONBLOCK
+#define TFD_TIMER_ABSTIME       (1 << 0)
+#define TFD_TIMER_CANCEL_ON_SET (1 << 1)
 
 /* renameat2 flags */
 #define RENAME_NOREPLACE    (1 << 0)

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -348,7 +348,7 @@ typedef struct siginfo {
 
         struct {
             u32 tid;
-            u32 overrun;
+            s32 overrun;
             sigval_t sigval;
             int sys_private;
         } timer;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -208,7 +208,7 @@ thread create_thread(process p)
     t->p = p;
     t->syscall = -1;
     t->uh = *p->uh;
-    init_refcount(&t->refcount, init_closure(&t->free, free_thread, t));
+    init_refcount(&t->refcount, 1, init_closure(&t->free, free_thread, t));
     t->select_epoll = 0;
     t->tid = tidcount++;
     t->clear_tid = 0;

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -345,8 +345,9 @@ static void sigev_deliver(unix_timer ut)
         sigev_update_siginfo(ut);
         deliver_signal_to_process(ut->p, &ut->info.posix.si);
         break;
-    case SIGEV_THREAD:
-        halt("SIGEV_THREAD not yet implemented.\n");
+    default:
+        /* SIGEV_THREAD is a glibc thing; we should never see it. */
+        halt("%s: invalid sigev_notify %d\n", __func__, sevp->sigev_notify);
     }
 }
 
@@ -473,10 +474,9 @@ sysreturn timer_create(int clockid, struct sigevent *sevp, u32 *timerid)
                 return -EINVAL;
             break;
         case SIGEV_THREAD:
-            /* XXX ? */
-            msg_err("%s: SIGEV_THREAD not yet supported\n", __func__);
-            return -EOPNOTSUPP;
-            break;
+            /* should never see this, but bark if we do */
+            msg_err("%s: SIGEV_THREAD should be handled by libc / nptl\n", __func__);
+            return -EINVAL;
         default:
             return -EINVAL;
         }

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -1,0 +1,186 @@
+#include <unix_internal.h>
+
+//#define UNIX_TIMER_DEBUG
+#ifdef UNIX_TIMER_DEBUG
+#define timer_debug(x, ...) do {log_printf("UTMR", "%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#else
+#define timer_debug(x, ...)
+#endif
+
+enum unix_timer_type {
+    UNIX_TIMER_TYPE_TIMERFD = 1,
+    UNIX_TIMER_TYPE_TIMER,      /* timer_create */
+    UNIX_TIMER_TYPE_ITIMER
+};
+
+typedef struct unix_timer {
+    struct fdesc f;             /* used for timerfd only; must be first */
+    int type;
+    clock_id cid;
+    timer t;                    /* zero if disarmed */
+
+    union {
+        struct {
+            void *timerid;
+        } timer;
+
+        struct {
+            int itimer_which;
+        } itimer;
+
+        struct {
+            int fd;
+            blockq bq;
+        } timerfd;
+    } info;
+} *unix_timer;
+
+static heap unix_timer_heap;
+
+static unix_timer allocate_unix_timer(int type)
+{
+    unix_timer ut = allocate(unix_timer_heap, sizeof(struct unix_timer));
+    if (ut == INVALID_ADDRESS)
+        return ut;
+    ut->type = type;
+    return ut;
+}
+
+static void deallocate_unix_timer(unix_timer t)
+{
+    deallocate(unix_timer_heap, t, sizeof(struct unix_timer));
+}
+
+static void timerfd_fill_itimerspec(timer t, struct itimerspec *i)
+{
+    if (t->t) {
+        timestamp tnow = now(t->id);
+        timestamp tremain = t->expiry > tnow ? t->expiry - tnow : 0;
+        i->it_value.ts_sec = sec_from_timestamp(tremain);
+        i->it_value.ts_nsec = nsec_from_timestamp(tremain);
+        i->it_interval.ts_sec = sec_from_timestamp(t->interval);
+        i->it_interval.ts_nsec = nsec_from_timestamp(t->interval);
+    } else {
+        i->it_value.ts_sec = 0;
+        i->it_value.ts_nsec = 0;
+        i->it_interval.ts_sec = 0;
+        i->it_interval.ts_nsec = 0;
+    }
+}
+
+sysreturn timerfd_settime(int fd, int flags,
+                          const struct itimerspec *new_value,
+                          struct itimerspec *old_value)
+{
+    unix_timer ut = resolve_fd(current->p, fd); /* macro, may return EBADF */
+    if (ut->f.type != FDESC_TYPE_TIMERFD)
+        return -EINVAL;
+
+    if (!new_value)
+        return -EFAULT;
+
+    if (old_value)
+        timerfd_fill_itimerspec(ut->t, old_value);
+
+    
+    
+    return 0;
+}
+
+sysreturn timerfd_gettime(int fd, struct itimerspec *curr_value)
+{
+    unix_timer ut = resolve_fd(current->p, fd); /* macro, may return EBADF */
+    if (ut->f.type != FDESC_TYPE_TIMERFD)
+        return -EINVAL;
+
+    if (!curr_value)
+        return -EFAULT;
+
+    /* XXX really need a way to take a reference to timer object */
+    timerfd_fill_itimerspec(ut->t, curr_value);
+    return 0;
+}
+
+closure_function(1, 6, sysreturn, timerfd_read,
+                 unix_timer, ut,
+                 void *, dest, u64, length, u64, offset_arg, thread, t, boolean, bh, io_completion, completion)
+{
+//    unix_timer ut = bound(ut);
+    if (length == 0)
+        return 0;
+
+    return 0; // XXX
+}
+
+closure_function(1, 0, u32, timerfd_events,
+                 unix_timer, ut)
+{
+//    unix_timer ut = bound(ut);
+
+    return 0; // XXX
+}
+
+closure_function(1, 0, sysreturn, timerfd_close,
+                 unix_timer, ut)
+{
+    // XXX
+    return 0;
+}
+
+sysreturn timerfd_create(int clockid, int flags)
+{
+    if (clockid != CLOCK_REALTIME &&
+        clockid != CLOCK_MONOTONIC &&
+        clockid != CLOCK_BOOTTIME &&
+        clockid != CLOCK_REALTIME_ALARM &&
+        clockid != CLOCK_BOOTTIME_ALARM)
+        return -EINVAL;
+
+    if (flags & ~(EFD_NONBLOCK | TFD_CLOEXEC))
+        return -EINVAL;
+
+    unix_timer ut = allocate_unix_timer(UNIX_TIMER_TYPE_TIMERFD);
+    if (ut == INVALID_ADDRESS)
+        return -ENOMEM;
+
+    u64 fd = allocate_fd(current->p, ut);
+    if (fd == INVALID_PHYSICAL) {
+        deallocate_unix_timer(ut);
+        return -EMFILE;
+    }
+
+    timer_debug("unix_timer %p, fd %d\n", ut, fd);
+    init_fdesc(unix_timer_heap, &ut->f, FDESC_TYPE_TIMERFD);
+    ut->cid = clockid;
+    ut->t = 0;
+    ut->info.timerfd.fd = fd;
+    ut->info.timerfd.bq = allocate_blockq(unix_timer_heap, "timerfd");
+    if (ut->info.timerfd.bq == INVALID_ADDRESS)
+        goto err_mem_bq;
+    ut->f.flags = flags;
+    ut->f.read = closure(unix_timer_heap, timerfd_read, ut);
+    ut->f.events = closure(unix_timer_heap, timerfd_events, ut);
+    ut->f.close = closure(unix_timer_heap, timerfd_close, ut);
+    return fd;
+  err_mem_bq:
+    deallocate_fd(current->p, fd);
+    deallocate_unix_timer(ut);
+    return -ENOMEM;
+}
+
+#if 0
+sysreturn timer_create(clockid_t clockid, struct sigevent *sevp, void **timerid)
+{
+
+}
+#endif
+
+void register_timer_syscalls(struct syscall *map)
+{
+    
+}
+
+void init_unix_timers(kernel_heaps kh)
+{
+    unix_timer_heap = heap_general(kh);
+}

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -301,7 +301,7 @@ static unix_timer posix_timer_from_timerid(u32 timerid)
 
 static s32 timer_overruns_s32(unix_timer ut)
 {
-    return ut->overruns > (u64)S32_MAX ? S32_MAX : (s32)ut->overruns;
+    return (s32)MIN((u64)S32_MAX, ut->overruns);
 }
 
 /* XXX clear overruns here, or after delivery confirmed? */

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -224,8 +224,9 @@ closure_function(1, 6, sysreturn, timerfd_read,
     return blockq_check(ut->info.timerfd.bq, t, ba, bh);
 }
 
-closure_function(1, 0, u32, timerfd_events,
-                 unix_timer, ut)
+closure_function(1, 1, u32, timerfd_events,
+                 unix_timer, ut,
+                 thread, t /* ignored */)
 {
     return bound(ut)->expirations > 0 ? EPOLLIN : 0;
 }

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -18,6 +18,7 @@ typedef struct unix_timer {
     int type;
     clock_id cid;
     timer t;                    /* zero if disarmed */
+    u64 expirations;
 
     union {
         struct {
@@ -31,18 +32,23 @@ typedef struct unix_timer {
         struct {
             int fd;
             blockq bq;
+            boolean cancel_on_set;
+            boolean canceled;   /* by time set */
         } timerfd;
     } info;
 } *unix_timer;
 
 static heap unix_timer_heap;
 
-static unix_timer allocate_unix_timer(int type)
+static unix_timer allocate_unix_timer(int type, clock_id cid)
 {
     unix_timer ut = allocate(unix_timer_heap, sizeof(struct unix_timer));
     if (ut == INVALID_ADDRESS)
         return ut;
     ut->type = type;
+    ut->cid = cid;
+    ut->t = 0;
+    ut->expirations = 0;
     return ut;
 }
 
@@ -51,39 +57,95 @@ static void deallocate_unix_timer(unix_timer t)
     deallocate(unix_timer_heap, t, sizeof(struct unix_timer));
 }
 
-static void timerfd_fill_itimerspec(timer t, struct itimerspec *i)
+static void itimerspec_from_timer(unix_timer ut, struct itimerspec *i)
 {
-    if (t->t) {
+    timestamp remain = 0, interval = 0;
+    if (ut->t) {
+        timer t = ut->t;
         timestamp tnow = now(t->id);
-        timestamp tremain = t->expiry > tnow ? t->expiry - tnow : 0;
-        i->it_value.ts_sec = sec_from_timestamp(tremain);
-        i->it_value.ts_nsec = nsec_from_timestamp(tremain);
-        i->it_interval.ts_sec = sec_from_timestamp(t->interval);
-        i->it_interval.ts_nsec = nsec_from_timestamp(t->interval);
-    } else {
-        i->it_value.ts_sec = 0;
-        i->it_value.ts_nsec = 0;
-        i->it_interval.ts_sec = 0;
-        i->it_interval.ts_nsec = 0;
+        remain = t->expiry > tnow ? t->expiry - tnow : 0;
+        interval = t->interval;
     }
+    timespec_from_time(&i->it_value, remain);
+    timespec_from_time(&i->it_interval, interval);
+}
+
+/* note that all of this assumes that the various timer operations are
+   performed in the syscall top half, i.e. with interrupts disabled... */
+
+static inline void timerfd_remove_timer(unix_timer ut)
+{
+    if (!ut->t)
+        return;
+    thunk t = ut->t->t;
+    remove_timer(ut->t, 0);
+    ut->t = 0;
+    deallocate_closure(t);
+}
+
+closure_function(1, 0, void, timerfd_timer_expire,
+                 unix_timer, ut)
+{
+    unix_timer ut = bound(ut);
+    assert(ut->t);
+    assert(!ut->t->disabled);
+
+    fetch_and_add(&ut->expirations, 1); /* atomic really necessary? */
+    timer_debug("fd %d -> %d\n", ut->info.timerfd.fd, ut->expirations);
+
+    blockq_wake_one(ut->info.timerfd.bq);
+    notify_dispatch(ut->f.ns, EPOLLIN);
+
+    if (ut->t->interval == 0)
+        timerfd_remove_timer(ut);     /* deallocs closure for us */
+}
+
+void notify_unix_timers_of_rtc_change(void)
+{
+    /* XXX TODO:
+
+       This should be implemented if and when we support explicit
+       setting of wall time via settimeofday(2), clock_settime(2),
+       update detected from hypervisor, etc. Any such setting of the
+       clock should call this function, which in turn should walk
+       through the active unix_timers and cancel them as necessary (if
+       cancel_on_set).
+    */
 }
 
 sysreturn timerfd_settime(int fd, int flags,
                           const struct itimerspec *new_value,
                           struct itimerspec *old_value)
 {
-    unix_timer ut = resolve_fd(current->p, fd); /* macro, may return EBADF */
-    if (ut->f.type != FDESC_TYPE_TIMERFD)
+    if (flags & ~(TFD_TIMER_ABSTIME | TFD_TIMER_CANCEL_ON_SET))
         return -EINVAL;
 
     if (!new_value)
         return -EFAULT;
 
-    if (old_value)
-        timerfd_fill_itimerspec(ut->t, old_value);
+    unix_timer ut = resolve_fd(current->p, fd); /* macro, may return EBADF */
+    if (ut->f.type != FDESC_TYPE_TIMERFD)
+        return -EINVAL;
 
-    
-    
+    if (old_value)
+        itimerspec_from_timer(ut, old_value);
+
+    ut->info.timerfd.cancel_on_set =
+        (ut->cid == CLOCK_REALTIME || ut->cid == CLOCK_REALTIME_ALARM) &&
+        (flags ^ (TFD_TIMER_ABSTIME | TFD_TIMER_CANCEL_ON_SET)) == 0;
+
+    /* runtime timers are partly immutable; so cancel and re-create on set */
+    timerfd_remove_timer(ut);
+
+    timestamp tinit = time_from_timespec(&new_value->it_value);
+    timestamp interval = time_from_timespec(&new_value->it_interval);
+
+    timer t = register_timer(ut->cid, tinit, (flags & TFD_TIMER_ABSTIME) != 0, interval,
+                             closure(unix_timer_heap, timerfd_timer_expire, ut));
+    if (t == INVALID_ADDRESS)
+        return -ENOMEM;
+
+    ut->t = t;
     return 0;
 }
 
@@ -96,34 +158,89 @@ sysreturn timerfd_gettime(int fd, struct itimerspec *curr_value)
     if (!curr_value)
         return -EFAULT;
 
-    /* XXX really need a way to take a reference to timer object */
-    timerfd_fill_itimerspec(ut->t, curr_value);
+    itimerspec_from_timer(ut, curr_value);
     return 0;
+}
+
+closure_function(5, 1, sysreturn, timerfd_read_bh,
+                 unix_timer, ut, void *, dest, u64, length, thread, t, io_completion, completion,
+                 u64, flags)
+{
+    unix_timer ut = bound(ut);
+    thread t = bound(t);
+    boolean blocked = (flags & BLOCKQ_ACTION_BLOCKED) != 0;
+    sysreturn rv = sizeof(u64);
+
+    timer_debug("fd %d, dest %p, length %ld, tid %d, flags 0x%lx\n",
+                ut->info.timerfd.fd, bound(dest), bound(length), t->tid, flags);
+
+    if (bound(length) < sizeof(u64)) {
+        assert(!blocked);
+        rv = -EINVAL;
+        goto out;
+    }
+
+    if (flags & BLOCKQ_ACTION_NULLIFY) {
+        assert(blocked);
+        rv = -EINTR;
+        goto out;
+    }
+
+    if (ut->info.timerfd.canceled) {
+        rv = -ECANCELED;
+        goto out;
+    }
+
+    u64 expirations = ut->expirations;
+    if (expirations == 0) {
+        if (!blocked && (ut->f.flags & TFD_NONBLOCK)) {
+            rv = -EAGAIN;
+            goto out;
+        }
+        timer_debug("   -> block\n");
+        return BLOCKQ_BLOCK_REQUIRED;
+    }
+
+    /* would do atomic swap were it not for ints disabled... */
+    *(u64*)bound(dest) = expirations;
+    ut->expirations = 0;
+  out:
+    timer_debug("   -> returning %ld\n", rv);
+    blockq_handle_completion(ut->info.timerfd.bq, flags, bound(completion), t, rv);
+    closure_finish();
+    return rv;
 }
 
 closure_function(1, 6, sysreturn, timerfd_read,
                  unix_timer, ut,
                  void *, dest, u64, length, u64, offset_arg, thread, t, boolean, bh, io_completion, completion)
 {
-//    unix_timer ut = bound(ut);
     if (length == 0)
         return 0;
-
-    return 0; // XXX
+    unix_timer ut = bound(ut);
+    timer_debug("fd %d, dest %p, length %ld, tid %d, bh %d, completion %p\n", ut->info.timerfd.fd,
+                dest, length, t->tid, bh, completion);
+    blockq_action ba = closure(unix_timer_heap, timerfd_read_bh, ut, dest, length, t, completion);
+    return blockq_check(ut->info.timerfd.bq, t, ba, bh);
 }
 
 closure_function(1, 0, u32, timerfd_events,
                  unix_timer, ut)
 {
-//    unix_timer ut = bound(ut);
-
-    return 0; // XXX
+    return bound(ut)->expirations > 0 ? EPOLLIN : 0;
 }
 
 closure_function(1, 0, sysreturn, timerfd_close,
                  unix_timer, ut)
 {
-    // XXX
+    unix_timer ut = bound(ut);
+    timerfd_remove_timer(ut);
+    deallocate_blockq(ut->info.timerfd.bq);
+    deallocate_closure(ut->f.read);
+    deallocate_closure(ut->f.events);
+    deallocate_closure(ut->f.close);
+    release_fdesc(&ut->f);
+    deallocate_unix_timer(ut);
     return 0;
 }
 
@@ -136,10 +253,10 @@ sysreturn timerfd_create(int clockid, int flags)
         clockid != CLOCK_BOOTTIME_ALARM)
         return -EINVAL;
 
-    if (flags & ~(EFD_NONBLOCK | TFD_CLOEXEC))
+    if (flags & ~(TFD_NONBLOCK | TFD_CLOEXEC))
         return -EINVAL;
 
-    unix_timer ut = allocate_unix_timer(UNIX_TIMER_TYPE_TIMERFD);
+    unix_timer ut = allocate_unix_timer(UNIX_TIMER_TYPE_TIMERFD, clockid);
     if (ut == INVALID_ADDRESS)
         return -ENOMEM;
 
@@ -151,12 +268,11 @@ sysreturn timerfd_create(int clockid, int flags)
 
     timer_debug("unix_timer %p, fd %d\n", ut, fd);
     init_fdesc(unix_timer_heap, &ut->f, FDESC_TYPE_TIMERFD);
-    ut->cid = clockid;
-    ut->t = 0;
     ut->info.timerfd.fd = fd;
     ut->info.timerfd.bq = allocate_blockq(unix_timer_heap, "timerfd");
     if (ut->info.timerfd.bq == INVALID_ADDRESS)
         goto err_mem_bq;
+    ut->info.timerfd.cancel_on_set = false;
     ut->f.flags = flags;
     ut->f.read = closure(unix_timer_heap, timerfd_read, ut);
     ut->f.events = closure(unix_timer_heap, timerfd_events, ut);
@@ -177,10 +293,13 @@ sysreturn timer_create(clockid_t clockid, struct sigevent *sevp, void **timerid)
 
 void register_timer_syscalls(struct syscall *map)
 {
-    
+    register_syscall(map, timerfd_create, timerfd_create);
+    register_syscall(map, timerfd_gettime, timerfd_gettime);
+    register_syscall(map, timerfd_settime, timerfd_settime);
 }
 
-void init_unix_timers(kernel_heaps kh)
+boolean unix_timers_init(unix_heaps uh)
 {
-    unix_timer_heap = heap_general(kh);
+    unix_timer_heap = heap_general((kernel_heaps)uh);
+    return true;
 }

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -347,8 +347,8 @@ closure_function(1, 1, void, posix_timer_expire,
     assert(!ut->t->disabled);
 
     ut->overruns += overruns;
-    timer_debug("interval %ld, id %d +%d -> %d\n", ut->t->interval,
-                ut->info.posix.id, overruns, ut->overruns);
+    timer_debug("id %d, interval %ld, id %d +%d -> %d\n",
+                ut->info.posix.id, ut->t->interval, overruns, ut->overruns);
 
     sigev_deliver(ut);
 

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -4,7 +4,6 @@
 
    - validation of timeval and timespecs parameters across board
    - support for thread and process time(r)s
-   - support for SIGEV_THREAD
 */
 
 //#define UNIX_TIMER_DEBUG

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -245,6 +245,15 @@ timestamp proc_stime(process p)
     return stime;
 }
 
+extern thunk unix_interrupt_checks;
+closure_function(0, 0, void, do_interrupt_checks)
+{
+    /* If we're returning to the standard thread frame, check if we
+       can invoke any signal handlers. */
+    if (running_frame == current->frame)
+        dispatch_signals(current);
+}
+
 process init_unix(kernel_heaps kh, tuple root, filesystem fs)
 {
     heap h = heap_general(kh);
@@ -291,6 +300,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     fault_handler fallback_handler = create_fault_handler(h, current);
     install_fallback_fault_handler(fallback_handler);
 
+    unix_interrupt_checks = closure(h, do_interrupt_checks);
     register_special_files(kernel_process);
     init_syscalls();
     register_file_syscalls(linux_syscalls);

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -187,6 +187,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     zero(p->sigactions, sizeof(p->sigactions));
     p->posix_timer_ids = create_id_heap(h, 0, U32_MAX, 1);
     p->posix_timers = allocate_vector(h, 8);
+    p->itimers = allocate_vector(h, 3);
     return p;
 }
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -185,6 +185,8 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     p->start_time = now(CLOCK_ID_MONOTONIC);
     init_sigstate(&p->signals);
     zero(p->sigactions, sizeof(p->sigactions));
+    p->posix_timer_ids = create_id_heap(h, 0, U32_MAX, 1);
+    p->posix_timers = allocate_vector(h, 8);
     return p;
 }
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -260,7 +260,8 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
 	goto alloc_fail;
     if (!pipe_init(uh))
 	goto alloc_fail;
-
+    if (!unix_timers_init(uh))
+        goto alloc_fail;
     if (ftrace_init(uh, fs))
 	goto alloc_fail;
 
@@ -301,6 +302,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     register_thread_syscalls(linux_syscalls);
     register_poll_syscalls(linux_syscalls);
     register_clock_syscalls(linux_syscalls);
+    register_timer_syscalls(linux_syscalls);
     register_other_syscalls(linux_syscalls);
     configure_syscalls(kernel_process);
     return kernel_process;

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -19,9 +19,9 @@ closure_function(5, 1, sysreturn, nanosleep_bh,
         if (bound(rem)) {
             timestamp remain = elapsed < bound(interval) ? bound(interval) - elapsed : 0;
             timespec_from_time(bound(rem), remain);
-            rv = -EINTR;
-            goto out;
         }
+        rv = -EINTR;
+        goto out;
     }
 
     if (!(flags & BLOCKQ_ACTION_TIMEDOUT) && elapsed < bound(interval))

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -320,6 +320,8 @@ typedef struct process {
     timestamp         start_time;
     struct sigstate   signals;
     struct sigaction  sigactions[NSIG];
+    heap              posix_timer_ids;
+    vector            posix_timers; /* unix_timer by id */
 } *process;
 
 typedef struct sigaction *sigaction;
@@ -329,6 +331,22 @@ typedef struct sigaction *sigaction;
 
 extern thread dummy_thread;
 extern thread current;
+
+static inline thread thread_from_tid(process p, int tid)
+{
+    thread t = vector_get(p->threads, tid);
+    return t ? t : INVALID_ADDRESS;
+}
+
+static inline void thread_reserve(thread t)
+{
+    refcount_reserve(&t->refcount);
+}
+
+static inline void thread_release(thread t)
+{
+    refcount_release(&t->refcount);
+}
 
 static inline unix_heaps get_unix_heaps()
 {

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -321,7 +321,8 @@ typedef struct process {
     struct sigstate   signals;
     struct sigaction  sigactions[NSIG];
     heap              posix_timer_ids;
-    vector            posix_timers; /* unix_timer by id */
+    vector            posix_timers; /* unix_timer by timerid */
+    vector            itimers;      /* unix_timer by ITIMER_ type */
 } *process;
 
 typedef struct sigaction *sigaction;
@@ -417,13 +418,13 @@ static inline void timeval_from_time(struct timeval *d, timestamp t)
 
 static inline timestamp time_from_timespec(const struct timespec *t)
 {
-    return seconds(t->ts_sec) + nanoseconds(t->ts_nsec);
+    return seconds(t->tv_sec) + nanoseconds(t->tv_nsec);
 }
 
 static inline void timespec_from_time(struct timespec *ts, timestamp t)
 {
-    ts->ts_sec = sec_from_timestamp(t);
-    ts->ts_nsec = nsec_from_timestamp(truncate_seconds(t));
+    ts->tv_sec = sec_from_timestamp(t);
+    ts->tv_nsec = nsec_from_timestamp(truncate_seconds(t));
 }
 
 static inline time_t time_t_from_time(timestamp t)

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -149,12 +149,12 @@ boolean blockq_flush_thread(blockq bq, thread t);
 void blockq_set_completion(blockq bq, io_completion completion, thread t,
                            sysreturn rv);
 sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_bh, 
-                               timestamp timeout, clock_id id);
+                               clock_id id, timestamp timeout, boolean absolute);
 int blockq_transfer_waiters(blockq dest, blockq src, int n);
 
 static inline sysreturn blockq_check(blockq bq, thread t, blockq_action a, boolean in_bh)
 {
-    return blockq_check_timeout(bq, t, a, in_bh, 0, 0 /* n/a */);
+    return blockq_check_timeout(bq, t, a, in_bh, 0, 0, false);
 }
 
 static inline void blockq_handle_completion(blockq bq, u64 bq_flags, io_completion completion, thread t, sysreturn rv)

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -404,7 +404,7 @@ static inline timestamp time_from_timespec(const struct timespec *t)
 
 static inline void timespec_from_time(struct timespec *ts, timestamp t)
 {
-    ts->ts_sec = t / TIMESTAMP_SECOND;
+    ts->ts_sec = sec_from_timestamp(t);
     ts->ts_nsec = nsec_from_timestamp(truncate_seconds(t));
 }
 
@@ -446,10 +446,16 @@ void register_mmap_syscalls(struct syscall *);
 void register_thread_syscalls(struct syscall *);
 void register_poll_syscalls(struct syscall *);
 void register_clock_syscalls(struct syscall *);
+void register_timer_syscalls(struct syscall *);
 void register_other_syscalls(struct syscall *);
+
+/* Call this routine if RTC offset should ever shift... */
+void notify_unix_timers_of_rtc_change(void);
 
 boolean poll_init(unix_heaps uh);
 boolean pipe_init(unix_heaps uh);
+boolean unix_timers_init(unix_heaps uh);
+
 #define sysreturn_from_pointer(__x) ((s64)u64_from_pointer(__x));
 
 extern sysreturn syscall_ignore();

--- a/src/x86_64/def64.h
+++ b/src/x86_64/def64.h
@@ -13,6 +13,15 @@ typedef __uint128_t u128;
 typedef u64 word;
 typedef u64 bytes;
 
+// XXX verify
+#define U32_MAX (~0u)
+#define S32_MAX ((s32)(U32_MAX >> 1))
+#define S32_MIN (-S32_MAX - 1)
+
+#define U64_MAX (~0ull)
+#define S64_MAX ((s64)(U64_MAX >> 1))
+#define S64_MIN (-S64_MAX - 1)
+
 #define pointer_from_u64(__a) ((void *)(__a))
 #define u64_from_pointer(__a) ((u64)(__a))
 // a super sad hack to allow us to write to the bss in elf.c as

--- a/src/x86_64/def64.h
+++ b/src/x86_64/def64.h
@@ -13,7 +13,6 @@ typedef __uint128_t u128;
 typedef u64 word;
 typedef u64 bytes;
 
-// XXX verify
 #define U32_MAX (~0u)
 #define S32_MAX ((s32)(U32_MAX >> 1))
 #define S32_MIN (-S32_MAX - 1)

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -74,6 +74,9 @@ static void timer_update(void)
 
 extern void interrupt_exit(void);
 
+/* could make a generic hook/register if more users... */
+thunk unix_interrupt_checks;
+
 NOTRACE
 void process_bhqueue()
 {
@@ -96,6 +99,9 @@ void process_bhqueue()
 
     /* XXX - and disable before frame pop */
     frame_pop();
+
+    if (unix_interrupt_checks)
+        apply(unix_interrupt_checks);
     interrupt_exit();
 }
 
@@ -289,6 +295,7 @@ static void __attribute__((noinline)) init_service_new_stack()
     /* XXX bhqueue is large to accomodate vq completions; explore batch processing on vq side */
     bhqueue = allocate_queue(misc, 2048);
     deferqueue = allocate_queue(misc, 64);
+    unix_interrupt_checks = 0;
 
     /* interrupts */
     init_debug("start_interrupts");

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -51,6 +51,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/unix/special.c \
 	$(SRCDIR)/unix/syscall.c \
 	$(SRCDIR)/unix/thread.c \
+	$(SRCDIR)/unix/timer.c \
 	$(SRCDIR)/unix/unix_clock.c \
 	$(SRCDIR)/unix/unix.c \
 	$(SRCDIR)/unix/vdso.c \

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -165,6 +165,7 @@ SRCS-time= \
 	$(CURDIR)/time.c \
 	$(SRCDIR)/unix_process/ssp.c
 LDFLAGS-time=		-static
+LIBS-time=		-lrt -lpthread
 
 SRCS-udploop= \
 	$(CURDIR)/udploop.c \

--- a/test/runtime/time.c
+++ b/test/runtime/time.c
@@ -1,5 +1,6 @@
 #include <sys/time.h>
 #include <sys/times.h>
+#include <sys/syscall.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -9,6 +10,8 @@
 #include <assert.h>
 #include <sys/timerfd.h>
 #include <sys/epoll.h>
+#include <signal.h>
+#include <sched.h>
 
 //#define TIMETEST_DEBUG
 #ifdef TIMETEST_DEBUG
@@ -213,6 +216,7 @@ static inline void timerfd_set(int fd, unsigned long long value, unsigned long l
         fail_perror("timerfd_settime");
 }
 
+/* XXX test absolute */
 void test_timerfd(clockid_t clkid, unsigned long long nsec)
 {
     printf("%s for clkid %d, %lld nsec\n", __func__, clkid, nsec);
@@ -318,6 +322,80 @@ void test_timerfd(clockid_t clkid, unsigned long long nsec)
     close(fd);
 }
 
+void posix_timer_set(timer_t id, unsigned long long value, unsigned long long interval)
+{
+    struct itimerspec its;
+    timespec_from_nsec(&its.it_interval, interval);
+    timespec_from_nsec(&its.it_value, value);
+    if (timer_settime(id, 0, &its, 0) < 0)
+        fail_perror("timer_settime");
+}
+
+static volatile int test_posix_timers_caught = 0;
+
+static void test_posix_timers_handler(int sig, siginfo_t *si, void *ucontext)
+{
+    assert(si);
+    timetest_debug("sig %d, si->signo %d, si->errno %d, si->code %d, tid %d, overrun %d\n",
+                   sig, si->si_signo, si->si_errno, si->si_code, si->si_timerid, si->si_overrun);
+    assert(sig == SIGRTMIN);
+    assert(sig == si->si_signo);
+    assert(si->si_code == SI_TIMER);
+    test_posix_timers_caught = si->si_value.sival_int;
+}
+
+static void yield_for(volatile int * v)
+{
+    /* XXX add timeout */
+    while (!*v)
+        sched_yield();
+}
+
+void test_posix_timers(clockid_t clkid, unsigned long long nsec)
+{
+    printf("%s for clkid %d, %lld nsec\n", __func__, clkid, nsec);
+    timer_t id;
+
+    test_posix_timers_caught = 0;
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = test_posix_timers_handler;
+    sa.sa_flags |= SA_SIGINFO;
+    int rv = sigaction(SIGRTMIN, &sa, 0);
+    if (rv < 0)
+        fail_perror("test_signal_catch: sigaction");
+
+    sigset_t ss;
+    sigemptyset(&ss);
+    sigaddset(&ss, SIGRTMIN);
+    rv = sigprocmask(SIG_UNBLOCK, &ss, 0);
+    if (rv < 0)
+        fail_perror("sigprocmask");
+
+    rv = syscall(SYS_timer_create, clkid, 0, 0);
+    if (rv >= 0 || errno != EFAULT)
+        fail_error("timer_create with null timerid should have failed with EFAULT (rv %d, errno %d)\n", rv, errno);
+
+    timetest_debug("   process signal test...\n");
+    struct sigevent sev;
+    sev.sigev_notify = SIGEV_SIGNAL;
+    sev.sigev_signo = SIGRTMIN;
+    sev.sigev_value.sival_int = 1;
+    if (timer_create(clkid, &sev, &id) < 0)
+        fail_perror("timer_create");
+
+    posix_timer_set(id, nsec, 0);
+    timetest_debug("   waiting for signal catch...\n");
+    yield_for(&test_posix_timers_caught);
+    timetest_debug("   caught\n");
+    if (test_posix_timers_caught != 1)
+        fail_error("timer sig caught but unexpected value (%d)\n", test_posix_timers_caught);
+
+    /* XXX test default (null) sigevent */
+
+    /* XXX test absolute */
+}
+
 int
 main()
 {
@@ -330,6 +408,9 @@ main()
         test_clock_nanosleep(CLOCK_REALTIME, intervals[i]);
         test_timerfd(CLOCK_MONOTONIC, intervals[i]);
         test_timerfd(CLOCK_REALTIME, intervals[i]);
+        test_timerfd(CLOCK_MONOTONIC, intervals[i]);
+        test_posix_timers(CLOCK_MONOTONIC, intervals[i]);
+        test_posix_timers(CLOCK_REALTIME, intervals[i]);
     }
     printf("time test passed\n");
     return EXIT_SUCCESS;

--- a/test/runtime/time.c
+++ b/test/runtime/time.c
@@ -166,7 +166,7 @@ void test_time_and_times(void)
 
         struct timeval tv;
         gettimeofday(&tv, NULL);
-        timetest_msg("gettimeofday: %lu.%.6lu, ", tv.tv_sec, tv.tv_usec);
+        timetest_msg("gettimeofday: %lu.%.6lu\n", tv.tv_sec, tv.tv_usec);
 
         uptime = times(&tms);
         if ((tms.tms_utime < tms_prev.tms_utime) ||
@@ -193,6 +193,7 @@ void test_time_and_times(void)
     }
 }
 
+#define pertest_msg(x, ...) timetest_msg("test %d: " x, test->test_id, ##__VA_ARGS__);
 #define pertest_debug(x, ...) timetest_debug("test %d: " x, test->test_id, ##__VA_ARGS__);
 #define pertest_fail_perror(x, ...) fail_perror("test %d: " x, test->test_id, ##__VA_ARGS__);
 #define pertest_fail_error(x, ...) fail_error("test %d: " x, test->test_id, ##__VA_ARGS__);
@@ -451,9 +452,9 @@ static void posix_test_finish(struct timer_test *test)
                                         test->total_overruns, test->nsec);
     if (delta < 0)
         pertest_fail_error("interval validation failed\n");
-    timetest_msg("%s clock id %d, nsec %lld, overruns %lld passed "
-                 "with delta %lld nsec\n", test->absolute ? "absolute" : "relative",
-                 test->clock, test->nsec, test->overruns, delta);
+    pertest_msg("%s clock id %d, nsec %lld, overruns %lld passed "
+                "with delta %lld nsec\n", test->absolute ? "absolute" : "relative",
+                test->clock, test->nsec, test->overruns, delta);
 }
 
 static void posix_timers_sighandler(int sig, siginfo_t *si, void *ucontext)
@@ -473,9 +474,9 @@ static void posix_timers_sighandler(int sig, siginfo_t *si, void *ucontext)
     pertest_debug("read %d overruns, total %lld\n", si->si_overrun, test->total_overruns);
     if (test->total_overruns >= test->overruns) {
         posix_test_finish(test);
-        posix_timers_finished++;
         pertest_debug("finished (total finished %d)\n", posix_timers_finished);
         test->total_overruns = -1;
+        posix_timers_finished++;
     }
 }
 
@@ -552,8 +553,7 @@ void test_posix_timers(void)
     while (posix_timers_finished < ntests)
         usleep(500000);
 
-    /* XXX somehow suppress output from spurious signals after test finish... */
-    timetest_debug("signal test passed\n");
+    timetest_msg("signal test passed\n");
 }
 
 /* XXX only ITIMER_REAL right now */
@@ -634,7 +634,7 @@ void test_itimers(void)
                 struct timespec start;
                 timeval_from_nsec(&itv.it_value, test_intervals[j]);
                 timeval_from_nsec(&itv.it_interval, k == 0 ? 0 : test_intervals[j]);
-                timetest_debug("starting: which %d, interval %lld nsec, %s\n",
+                timetest_msg("starting: which %d, interval %lld nsec, %s\n",
                                i, test_intervals[j], k == 0 ? "one-shot" : "periodic");
                 int overruns = k == 0 ? 1 : 3 /* XXX */;
                 itimer_which = i;

--- a/test/runtime/time.c
+++ b/test/runtime/time.c
@@ -237,6 +237,7 @@ void test_timerfd(clockid_t clkid, unsigned long long nsec)
         fail_perror("read");
     if (expirations == 0)
         fail_error("read zero expirations\n");
+    timetest_debug("   + %lld\n", expirations);
 
     timerfd_check_disarmed(fd);
 
@@ -319,7 +320,7 @@ main()
 {
     setbuf(stdout, NULL);
     test_time_and_times();
-    unsigned long long intervals[] = { 1000, 1000000, BILLION, -1 };
+    unsigned long long intervals[] = { 1, 1000, 1000000, BILLION, 2 * BILLION, -1 };
     for (int i = 0; intervals[i] != -1; i++) {
         test_nanosleep(intervals[i]);
         test_clock_nanosleep(CLOCK_MONOTONIC, intervals[i]);

--- a/test/runtime/time.c
+++ b/test/runtime/time.c
@@ -233,8 +233,11 @@ void test_timerfd(clockid_t clkid, unsigned long long nsec)
     timerfd_set(fd, nsec, 0);
 
     rv = read(fd, &expirations, sizeof(expirations));
-    if (rv < sizeof(expirations))
+    printf("rv %d, errno %d\n", rv, errno);
+    if (rv < 0)
         fail_perror("read");
+    if (rv != sizeof(expirations))
+        fail_error("read returned unexpected value: %d\n", rv);
     if (expirations == 0)
         fail_error("read zero expirations\n");
     timetest_debug("   + %lld\n", expirations);


### PR DESCRIPTION
This PR introduces support for itimer, timerfd and posix timer interfaces, implementing the following system calls:

- alarm
- getitimer
- setitimer
- timer_create
- timer_settime
- timer_gettime
- timer_getoverrun
- timer_delete
- timerfd_create
- timerfd_gettime
- timerfd_settime

In the process of implementing these, a number of improvements have been made to the runtime timer facility as well as signal handling:

timers
- Runtime timers accept an initial interval as well as an optional, periodic interval to better match the unix interfaces.
- Timer callbacks (of type timer_handler) now accept a count of overruns. When a periodic timer expiry is more than one interval behind the current time, the next expiry is advanced past the current time and the number of overruns is computed from the delta.
- Timer registration, and in turn other interfaces using it, now accept a flag to indicate if the expiry is absolute.

signals
-  The signal delivery path detects posix timer signals (type SI_TIMER) and accumulates overruns accordingly. As per spec, only one signal is queued at a timer per posix timer - even if the signal is a realtime (queueable) signal.
- A bug / false assumption in setup_sigframe was causing crashes in signal handlers that used SSE instructions (e.g. movaps). Rather than align the stack to 16 bytes, align it to 8 - but not 16. The x86-64 ABI dictates that the stack must be aligned to 16 bytes before a call, however we are entering the handler directly - which is analogous to entering after a call (which saves a return address, causing the 8 byte alignment). A function prologue will re-align to 16 before executing the body.
- Signal dispatching was previously occurring only on return from a syscall or in run_thread, which was clearly insufficient for timely delivery. In order to dispatch signal handlers after interrupt handling, a hook has been added to process_bhqueue back into the unix world to invoke dispatch_signals(current) if it so happens that a running_frame was a thread frame. rt_sigreturn was also missing a dispatch call to pick up any additional signals to process.

misc
- added missing thread release in epoll_blocked_free

TODO:
- Process and thread-based clocks are not yet implemented (itimer: ITIMER_VIRTUAL, ITIMER_PROF; posix: CLOCK_PROCESS_CPUTIME_ID, CLOCK_THREAD_CPUTIME_ID). Runtime timer expiries are made monotonic before adding them to the timer heap, but there isn't really a direct mapping from a process/thread clock to a system monotonic time. However, there are ways around this. TBD
- There is a half-finished hook into the unix timer code for notification of an RTC time change event. This is required to implement TFD_TIMER_CANCEL_ON_SET for timerfds. This isn't presently wired up and needs further work on the RTC side. (See notify_unix_timers_of_rtc_change(), which would probably be better implemented as a generic closure registration.)
- An attempt has been made to make a robust runtime test for all these interfaces, but there are surely some corner cases and error conditions that are not being checked.

supercedes #1050, and resolves #448, #992, and #789
