### PR TITLE
add optional reboot on exit

### DIFF
--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -4,6 +4,7 @@
 #include <page.h>
 #include <region.h>
 #include <x86_64.h>
+#include <kvm_platform.h>
 #include <serial.h>
 #include <drivers/ata.h>
 
@@ -250,7 +251,6 @@ region fsregion()
     halt("invalid filesystem offset\n");
 }
 
-
 closure_function(4, 2, void, filesystem_initialized,
                  heap, h, heap, physical, tuple, root, buffer_handler, complete,
                  filesystem, fs, status, s)
@@ -282,6 +282,11 @@ void newstack()
                       closure(h, filesystem_initialized, h, physical, root, bh));
     
     halt("kernel failed to execute\n");
+}
+
+void vm_exit(u8 code)
+{
+    QEMU_HALT(code);
 }
 
 static struct heap working_heap;

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -384,3 +384,13 @@ void start_interrupts(kernel_heaps kh)
     /* APIC initialization */
     init_apic(kh);
 }
+
+void triple_fault(void)
+{
+    disable_interrupts();
+    /* zero table limit to induce triple fault */
+    void *idt_desc = idt_from_interrupt(n_interrupt_vectors);
+    *(u16*)idt_desc = 0;
+    asm volatile("lidt %0; int3": : "m"(*(u64*)idt_desc));
+    while (1);
+}

--- a/src/x86_64/kvm_platform.c
+++ b/src/x86_64/kvm_platform.c
@@ -20,11 +20,6 @@
 #define KVM_MSR_SYSTEM_TIME 0x4b564d01
 #define KVM_MSR_WALL_CLOCK  0x4b564d00
 
-void vm_exit(u8 code)
-{
-    QEMU_HALT(code);
-}
-
 void halt(char *format, ...)
 {
     vlist a;

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -270,6 +270,24 @@ static void init_runloop_timer(void)
     runloop_timer_max = microseconds(RUNLOOP_TIMER_MAX_PERIOD_US);
 }
 
+static tuple root;
+
+void vm_exit(u8 code)
+{
+    /* TODO MP: coordinate via IPIs */
+    if (root && table_find(root, sym(reboot_on_exit))) {
+        triple_fault();
+    } else {
+        QEMU_HALT(code);
+    }
+}
+
+closure_function(0, 1, void, bail,
+                 u64, overruns /* ignore */)
+{
+    halt("later!\n");
+}
+
 static void __attribute__((noinline)) init_service_new_stack()
 {
     kernel_heaps kh = &heaps;
@@ -334,7 +352,7 @@ static void __attribute__((noinline)) init_service_new_stack()
     init_net(kh);
 
     init_debug("probe fs, register storage drivers");
-    tuple root = allocate_tuple();
+    root = allocate_tuple();
     u64 fs_offset = 0;
     for_regions(e) {
         if (e->type == REGION_FILESYSTEM)
@@ -365,6 +383,8 @@ static void __attribute__((noinline)) init_service_new_stack()
     install_gdt64_and_tss();
     unmap(PAGESIZE, INITIAL_MAP_SIZE - PAGESIZE, pages);
 
+    register_timer(CLOCK_ID_MONOTONIC, seconds(60), false, 0,
+                   closure(misc, bail));
     init_debug("starting runloop");
     runloop();
 }

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -282,12 +282,6 @@ void vm_exit(u8 code)
     }
 }
 
-closure_function(0, 1, void, bail,
-                 u64, overruns /* ignore */)
-{
-    halt("later!\n");
-}
-
 static void __attribute__((noinline)) init_service_new_stack()
 {
     kernel_heaps kh = &heaps;
@@ -383,8 +377,6 @@ static void __attribute__((noinline)) init_service_new_stack()
     install_gdt64_and_tss();
     unmap(PAGESIZE, INITIAL_MAP_SIZE - PAGESIZE, pages);
 
-    register_timer(CLOCK_ID_MONOTONIC, seconds(60), false, 0,
-                   closure(misc, bail));
     init_debug("starting runloop");
     runloop();
 }

--- a/src/x86_64/x86_64.h
+++ b/src/x86_64/x86_64.h
@@ -227,6 +227,7 @@ static inline void frame_pop(void)
 void runloop() __attribute__((noreturn));
 void kernel_sleep();
 void kernel_delay(timestamp delta);
+
 void init_clock(void);
 boolean init_hpet(kernel_heaps kh);
 
@@ -249,3 +250,4 @@ u64 allocate_interrupt(void);
 void deallocate_interrupt(u64 irq);
 void register_interrupt(int vector, thunk t);
 void unregister_interrupt(int vector);
+void triple_fault(void) __attribute__((noreturn));

--- a/test/runtime/webg.manifest
+++ b/test/runtime/webg.manifest
@@ -15,6 +15,7 @@
 #    telnet:t
 #    http:t
 #    fault:t
+    reboot_on_exit:t
     arguments:[webg longargument]
     environment:(USER:bobby PWD:password)
 )

--- a/test/runtime/webg.manifest
+++ b/test/runtime/webg.manifest
@@ -15,7 +15,7 @@
 #    telnet:t
 #    http:t
 #    fault:t
-    reboot_on_exit:t
+#    reboot_on_exit:t
     arguments:[webg longargument]
     environment:(USER:bobby PWD:password)
 )


### PR DESCRIPTION
If the flag reboot_on_exit is specified in the build manifest, nanos will reboot (using an induced triple fault) on vm_exit (as a result of exit_group(2), an assertion failure, halt or unrecoverable fault) - as opposed to the default qemu exit with code.

Tested on GCE with a webg image which induces halt after a timeout (not included here). The server restarts and continues serving requests as expected.

(CI failure appears to occur in lepton go build:)
```
go get github.com/nanovms/ops/lepton
# google.golang.org/api/option
/go/src/google.golang.org/api/option/option.go:153:14: undefined: grpc.RoundRobin
/go/src/google.golang.org/api/option/option.go:154:42: undefined: grpc.WithBalancer
make[2]: *** [Makefile:29: deps] Error 2
make[2]: Leaving directory '/home/circleci/project/test/go'
make[1]: *** [Makefile:7: all] Error 2
make[1]: Leaving directory '/home/circleci/project/test'
make: *** [Makefile:86: test-noaccel] Error 2

Exited with code exit status 2
```