### PR TITLE
tfs log extensions

### DIFF
--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -8,6 +8,9 @@
 #include <serial.h>
 #include <drivers/ata.h>
 
+//#define STAGE2_DEBUG
+//#define DEBUG_STAGE2_ALLOC
+
 #ifdef STAGE2_DEBUG
 # define stage2_debug rprintf
 #else
@@ -28,7 +31,7 @@ extern void run64(u32 entry);
  */
 
 #define EARLY_WORKING_SIZE   KB
-#define STACKLEN             (8 * PAGESIZE)
+#define STACKLEN             (STAGE2_STACK_PAGES * PAGESIZE)
 
 #define REAL_MODE_STACK_SIZE 0x1000
 #define SCRATCH_BASE         0x500
@@ -182,9 +185,13 @@ static u64 working_saved_base;
 closure_function(0, 4, void, kernel_elf_map,
                  u64, vaddr, u64, paddr, u64, size, u64, flags)
 {
+    stage2_debug("%s: vaddr 0x%lx, paddr 0x%lx, size 0x%lx, flags 0x%lx\n",
+                 __func__, vaddr, paddr, size, flags);
+
     if (paddr == INVALID_PHYSICAL) {
         /* bss */
         paddr = allocate_u64(heap_physical(&kh), size);
+        stage2_debug("bss paddr 0x%lx, end 0x%lx\n", paddr, paddr + size);
         assert(paddr != INVALID_PHYSICAL);
         zero(pointer_from_u64(paddr), size);
     }
@@ -199,6 +206,7 @@ closure_function(0, 1, status, kernel_read_complete,
     /* save kernel elf image for use in stage3 (for symbol data) */
     create_region(u64_from_pointer(buffer_ref(kb, 0)), pad(buffer_length(kb), PAGESIZE), REGION_KERNIMAGE);
 
+    stage2_debug("%s: load_elf\n", __func__);
     void *k = load_elf(kb, 0, stack_closure(kernel_elf_map));
     if (!k) {
         halt("kernel elf parse failed\n");
@@ -208,6 +216,7 @@ closure_function(0, 1, status, kernel_read_complete,
     assert(working_saved_base);
     create_region(working_saved_base, STAGE2_WORKING_HEAP_SIZE, REGION_PHYSICAL);
 
+    stage2_debug("%s: run64, start address %p\n", __func__, k);
     run64(u64_from_pointer(k));
     halt("failed to start long mode\n");
 }
@@ -255,6 +264,8 @@ closure_function(4, 2, void, filesystem_initialized,
                  heap, h, heap, physical, tuple, root, buffer_handler, complete,
                  filesystem, fs, status, s)
 {
+    if (!is_ok(s))
+        halt("unable to open filesystem: %v\n", s);
     filesystem_read_entire(fs, lookup(bound(root), sym(kernel)),
                            bound(physical),
                            bound(complete),

--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -274,6 +274,7 @@ void newstack()
 
     create_filesystem(h,
                       SECTOR_SIZE,
+                      SECTOR_SIZE,
                       infinity,
                       0,         /* ignored in boot */
                       get_stage2_disk_read(h, fs_offset),

--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -291,6 +291,7 @@ void newstack()
                       get_stage2_disk_read(h, fs_offset),
                       closure(h, stage2_empty_write),
                       root,
+                      false,
                       closure(h, filesystem_initialized, h, physical, root, bh));
     
     halt("kernel failed to execute\n");

--- a/mkfs/dump.c
+++ b/mkfs/dump.c
@@ -142,6 +142,7 @@ int main(int argc, char **argv)
     tuple root = allocate_tuple();
     create_filesystem(h,
                       SECTOR_SIZE,
+                      SECTOR_SIZE,
                       infinity,
                       h,
                       closure(h, bread, fd, get_fs_offset(fd)),

--- a/mkfs/dump.c
+++ b/mkfs/dump.c
@@ -148,6 +148,7 @@ int main(int argc, char **argv)
                       closure(h, bread, fd, get_fs_offset(fd)),
                       closure(h, bwrite, fd),
                       root,
+                      false,
                       closure(h, fsc, h, alloca_wrap_buffer(argv[2], runtime_strlen(argv[2])), root));
     return EXIT_SUCCESS;
 }

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -377,6 +377,7 @@ int main(int argc, char **argv)
                       0, /* no read -> new fs */
                       closure(h, bwrite, out, offset),
                       allocate_tuple(),
+                      true,
                       closure(h, fsc, h, out, target_root));
 
     if (bootimg_path != NULL)

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -371,6 +371,7 @@ int main(int argc, char **argv)
     // fixing the size doesn't make sense in this context?
     create_filesystem(h,
                       SECTOR_SIZE,
+                      SECTOR_SIZE,
                       infinity,
                       h,
                       0, /* no read -> new fs */

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -146,13 +146,6 @@ closure_function(2, 3, void, bwrite,
     apply(c, STATUS_OK);
 }
 
-closure_function(1, 3, void, bread,
-                 descriptor, d,
-                 void *, source, range, blocks, status_handler, completion)
-{
-    apply(completion, timm("error", "empty file"));
-}
-
 closure_function(0, 1, void, err,
                  status, s)
 {
@@ -380,7 +373,7 @@ int main(int argc, char **argv)
                       SECTOR_SIZE,
                       infinity,
                       h,
-                      closure(h, bread, out),
+                      0, /* no read -> new fs */
                       closure(h, bwrite, out, offset),
                       allocate_tuple(),
                       closure(h, fsc, h, out, target_root));

--- a/src/runtime/uniboot.h
+++ b/src/runtime/uniboot.h
@@ -49,6 +49,13 @@ extern void * AP_BOOT_PAGE;
    recycled in stage3, so be generous */
 #define STAGE2_WORKING_HEAP_SIZE (128 * MB)
 
+#define STAGE2_STACK_PAGES  32  /* stage2 stack is recycled, too */
+#define KERNEL_STACK_PAGES  32
+#define FAULT_STACK_PAGES   8
+#define INT_STACK_PAGES     8
+#define BH_STACK_PAGES      8
+#define SYSCALL_STACK_PAGES 8
+
 /* maximum buckets that can fit within a PAGESIZE_2M mcache */
 #define TABLE_MAX_BUCKETS 131072
 

--- a/src/runtime/uniboot.h
+++ b/src/runtime/uniboot.h
@@ -62,4 +62,6 @@ extern void * AP_BOOT_PAGE;
 /* could probably find progammatically via cpuid... */
 #define DEFAULT_CACHELINE_SIZE 64
 
+#define TFS_LOG_DEFAULT_EXTENSION_SIZE (512*KB)
+
 #include <x86.h>

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -1006,7 +1006,6 @@ void create_filesystem(heap h,
 #ifndef BOOT
     fs->storage = create_id_heap(h, h, 0, size, SECTOR_SIZE);
     assert(fs->storage != INVALID_ADDRESS);
-    assert(id_heap_set_area(fs->storage, 0, TFS_LOG_DEFAULT_EXTENSION_SIZE, true, true));
 #endif
     fs->tl = log_create(h, fs, closure(h, log_complete, complete, fs));
 }

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -129,7 +129,7 @@ static fs_dma_buf fs_allocate_dma_buffer(filesystem fs, extent e, range i)
     fs_dma_buf db = allocate(fs->h, sizeof(struct fs_dma_buf));
     if (db == INVALID_ADDRESS)
         return db;
-    bytes blocksize = fs->blocksize;
+    bytes blocksize = fs_blocksize(fs);
     bytes absolute = e->block_start + i.start - e->node.r.start;
     db->start_offset = absolute & (blocksize - 1);
     db->data_length = range_span(i);
@@ -207,7 +207,7 @@ closure_function(4, 1, void, fs_read_extent,
     tfs_debug("fs_read_extent: q %R, ex %R, blocks %R, start_offset %ld, i %R, "
               "target_offset %ld, target_start %p, length %ld, blocksize %ld\n",
               q, node->r, db->blocks, db->start_offset, i,
-              target_offset, target_start, db->data_length, (u64)fs->blocksize);
+              target_offset, target_start, db->data_length, fs_blocksize(fs));
 
     status_handler f = apply_merge(bound(m));
     fetch_and_add(&target->end, db->data_length);
@@ -313,7 +313,7 @@ void filesystem_read_entire(filesystem fs, tuple t, heap bufheap, buffer_handler
         return;
     }
 
-    u64 length = pad(fsfile_get_length(f), fs->blocksize);
+    u64 length = pad(fsfile_get_length(f), fs_blocksize(fs));
     buffer b = allocate_buffer(bufheap, pad(length, bufheap->pagesize));
     filesystem_read_internal(fs, f, b, length, 0, closure(fs->h, read_entire_complete, c, b, sh));
 }
@@ -366,7 +366,7 @@ closure_function(4, 1, void, fs_write_extent_aligned_closure,
 static void fs_write_extent_read_block(filesystem fs, fs_dma_buf db, u64 offset_block, status_handler sh)
 {
     u64 absolute_block = db->blocks.start + offset_block;
-    void * buf = db->buf + (offset_block * fs->blocksize);
+    void * buf = db->buf + bytes_from_sectors(fs, offset_block);
     range r = irange(absolute_block, absolute_block + 1);
     tfs_debug("fs_write_extent_read_block: sector range %R, buf %p\n", r, buf);
     apply(fs->r, buf, r, sh);
@@ -397,7 +397,7 @@ static void fs_write_extent(filesystem fs, buffer source, merge m, range q, rmno
 
     /* Check for unaligned block writes and initiate reads for them.
        This would all be obviated by a diskcache. */
-    boolean tail_rmw = ((db->data_length + db->start_offset) & (fs->blocksize - 1)) != 0 &&
+    boolean tail_rmw = ((db->data_length + db->start_offset) & (fs_blocksize(fs) - 1)) != 0 &&
         (i.end != node->r.end); /* no need to rmw tail if we're at the end of the extent */
     boolean plural = range_span(db->blocks) > 1;
 
@@ -984,6 +984,7 @@ closure_function(0, 2, void, ignore_io,
 
 void create_filesystem(heap h,
                        u64 alignment,
+                       u64 blocksize,
                        u64 size,
                        heap dma,
                        block_io read,
@@ -1002,9 +1003,10 @@ void create_filesystem(heap h,
     fs->w = write;
     fs->root = root;
     fs->alignment = alignment;
-    fs->blocksize = SECTOR_SIZE;
+    assert((blocksize & (blocksize - 1)) == 0); /* power of 2 */
+    fs->blocksize_order = find_order(blocksize);
 #ifndef BOOT
-    fs->storage = create_id_heap(h, h, 0, size, SECTOR_SIZE);
+    fs->storage = create_id_heap(h, h, 0, size, fs_blocksize(fs));
     assert(fs->storage != INVALID_ADDRESS);
 #endif
     fs->tl = log_create(h, fs, closure(h, log_complete, complete, fs));

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -990,6 +990,7 @@ void create_filesystem(heap h,
                        block_io read,
                        block_io write,
                        tuple root,
+                       boolean initialize,
                        filesystem_complete complete)
 {
     tfs_debug("create_filesystem: ...\n");
@@ -1009,7 +1010,7 @@ void create_filesystem(heap h,
     fs->storage = create_id_heap(h, h, 0, size, fs_blocksize(fs));
     assert(fs->storage != INVALID_ADDRESS);
 #endif
-    fs->tl = log_create(h, fs, closure(h, log_complete, complete, fs));
+    fs->tl = log_create(h, fs, initialize, closure(h, log_complete, complete, fs));
 }
 
 tuple filesystem_getroot(filesystem fs)

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -730,14 +730,14 @@ boolean filesystem_truncate(filesystem fs, fsfile f, u64 len,
     return false;
 }
 
-boolean filesystem_flush(filesystem fs, tuple t, status_handler completion)
+void filesystem_flush(filesystem fs, tuple t, status_handler completion)
 {
     /* A write() call returns after everything is sent to disk, so nothing to
      * do here. The only work that might be pending is when directory entries
      * are modified, see do_mkentry(); to deal with that, flush the filesystem
      * log.
      */
-    return log_flush_complete(fs->tl, completion);
+    log_flush_complete(fs->tl, completion);
 }
 
 fsfile allocate_fsfile(filesystem fs, tuple md)

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -1006,7 +1006,7 @@ void create_filesystem(heap h,
 #ifndef BOOT
     fs->storage = create_id_heap(h, h, 0, size, SECTOR_SIZE);
     assert(fs->storage != INVALID_ADDRESS);
-    assert(id_heap_set_area(fs->storage, 0, INITIAL_LOG_SIZE, true, true));
+    assert(id_heap_set_area(fs->storage, 0, TFS_LOG_DEFAULT_EXTENSION_SIZE, true, true));
 #endif
     fs->tl = log_create(h, fs, closure(h, log_complete, complete, fs));
 }

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -27,7 +27,7 @@ void filesystem_read(filesystem fs, tuple t, void *dest, u64 offset, u64 length,
 void filesystem_write(filesystem fs, tuple t, buffer b, u64 offset, io_status_handler completion);
 boolean filesystem_truncate(filesystem fs, fsfile f, u64 len,
         status_handler completion);
-boolean filesystem_flush(filesystem fs, tuple t, status_handler completion);
+void filesystem_flush(filesystem fs, tuple t, status_handler completion);
 u64 fsfile_get_length(fsfile f);
 void fsfile_set_length(fsfile f, u64);
 fsfile fsfile_from_node(filesystem fs, tuple n);

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -17,9 +17,10 @@ void create_filesystem(heap h,
                        u64 blocksize,
                        u64 size,
                        heap dma,
-                       block_io read,
+                       block_io read, /* read and write are optional */
                        block_io write,
                        tuple root,
+                       boolean initialize,
                        filesystem_complete complete);
 
 // there is a question as to whether tuple->fs file should be mapped inside out outside the filesystem

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -14,6 +14,7 @@ extern io_status_handler ignore_io_status;
 
 void create_filesystem(heap h,
                        u64 alignment,
+                       u64 blocksize,
                        u64 size,
                        heap dma,
                        block_io read,

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -36,7 +36,7 @@ void log_write(log tl, tuple t, status_handler sh);
 void log_write_eav(log tl, tuple e, symbol a, value v, status_handler sh);
 
 #define INITIAL_LOG_SIZE (512*KB)
-void read_log(log tl, u64 offset, u64 size, status_handler sh);
+void read_log(log tl, status_handler sh);
 void log_flush(log tl);
 boolean log_flush_complete(log tl, status_handler completion);
 void flush(filesystem fs, status_handler);

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -36,7 +36,7 @@ void log_write(log tl, tuple t, status_handler sh);
 void log_write_eav(log tl, tuple e, symbol a, value v, status_handler sh);
 void read_log(log tl, status_handler sh);
 void log_flush(log tl);
-boolean log_flush_complete(log tl, status_handler completion);
+void log_flush_complete(log tl, status_handler completion);
 void flush(filesystem fs, status_handler);
     
 typedef closure_type(buffer_status, buffer, status);

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -33,7 +33,7 @@ typedef struct filesystem {
 
 void ingest_extent(fsfile f, symbol foff, tuple value);
 
-log log_create(heap h, filesystem fs, status_handler sh);
+log log_create(heap h, filesystem fs, boolean initialize, status_handler sh);
 void log_write(log tl, tuple t, status_handler sh);
 void log_write_eav(log tl, tuple e, symbol a, value v, status_handler sh);
 void read_log(log tl, status_handler sh);

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -40,6 +40,7 @@ void read_log(log tl, status_handler sh);
 void log_flush(log tl);
 void log_flush_complete(log tl, status_handler completion);
 void flush(filesystem fs, status_handler);
+boolean filesystem_reserve_storage(filesystem fs, u64 start, u64 length);
     
 typedef closure_type(buffer_status, buffer, status);
 fsfile allocate_fsfile(filesystem fs, tuple md);

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -34,8 +34,6 @@ void ingest_extent(fsfile f, symbol foff, tuple value);
 log log_create(heap h, filesystem fs, status_handler sh);
 void log_write(log tl, tuple t, status_handler sh);
 void log_write_eav(log tl, tuple e, symbol a, value v, status_handler sh);
-
-#define INITIAL_LOG_SIZE (512*KB)
 void read_log(log tl, status_handler sh);
 void log_flush(log tl);
 boolean log_flush_complete(log tl, status_handler completion);

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -2,6 +2,8 @@
 #include <runtime.h>
 #include <tfs.h>
 
+#define TFS_VERSION 0x00000001
+
 // ok, we wanted to make the inode number extensional, but holes
 // and random access writes make that difficult, so this is stateful
 // with an inode

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -28,7 +28,7 @@ typedef struct filesystem {
     block_io w;
     log tl;
     tuple root;
-    bytes blocksize;
+    int blocksize_order;
 } *filesystem;
 
 void ingest_extent(fsfile f, symbol foff, tuple value);
@@ -43,3 +43,18 @@ void flush(filesystem fs, status_handler);
     
 typedef closure_type(buffer_status, buffer, status);
 fsfile allocate_fsfile(filesystem fs, tuple md);
+
+static inline u64 fs_blocksize(filesystem fs)
+{
+    return U64_FROM_BIT(fs->blocksize_order);
+}
+
+static inline u64 bytes_from_sectors(filesystem fs, u64 sectors)
+{
+    return sectors << fs->blocksize_order;
+}
+
+static inline u64 sector_from_offset(filesystem fs, bytes b)
+{
+    return b >> fs->blocksize_order;
+}

--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -10,67 +10,84 @@
 #define END_OF_LOG 1
 #define TUPLE_AVAILABLE 2
 #define END_OF_SEGMENT 3
+#define LOG_EXTENSION_LINK 4
+#define LOG_EXTENSION_HEADER 5
 
+#define COMPLETION_QUEUE_SIZE 10
 typedef struct log {
     filesystem fs;
-    u64 remainder;
-    buffer staging;
-    vector completions;
+    vector completions;         /* XXX change to queue */
     table dictionary;
-    u64 offset;
+
+    /* sector offset, length and staging buffer of current extension */
+    range sectors;
+    buffer staging;
+
     int dirty;              /* cas boolean */
     heap h;
 } *log;
 
-closure_function(1, 1, void, log_write_completion,
-                 vector, v,
+closure_function(3, 1, void, log_write_completion,
+                 buffer, b,
+                 value, completions,
+                 boolean, release,
                  status, s)
 {
     // reclaim the buffer now and the vector...make it a whole thing
     status_handler i;
-    int len = vector_length(bound(v));
+    vector v = bound(completions);
+    int len = vector_length(v);
     for (int count = 0; count < len; count++) {
-        i = vector_delete(bound(v), 0);
+        i = vector_delete(v, 0);
         apply(i, s);
+    }
+    if (bound(release)) {
+        deallocate_buffer(bound(b));
+        deallocate_vector(v);
     }
     closure_finish();
 }
 
 // xxx  currently we cant take writes during the flush
 
-/* XXX it's not right to just stick SECTOR_{SIZE,OFFSET} everywhere...
-   and add block_log2 to fs */
-range log_block_range(log tl, u64 length)
+/* Avoid references to log, which may be in transition to a new extension. */
+static void log_flush_internal(heap h, filesystem fs, buffer b, range log_range,
+                               vector completions, boolean release)
 {
-    return irange(tl->offset >> SECTOR_OFFSET,
-                  (tl->offset + pad(length, tl->fs->blocksize)) >> SECTOR_OFFSET);
+    push_u8(b, END_OF_LOG);
+
+#ifdef TLOG_DEBUG
+    u64 z = b->end;
+    b->start = 0;
+    b->end = 1024;
+    rprintf("staging contains:\n%X\n", b);
+    b->end = z;
+#endif
+
+    u64 sector_start = b->start;
+    assert(sector_start < b->end); /* END_OF_LOG, at least */
+    assert((sector_start & MASK(SECTOR_OFFSET)) == 0);
+    sector_start = log_range.start + (sector_start >> SECTOR_OFFSET);
+    u64 sectors = (buffer_length(b) + (SECTOR_SIZE - 1)) >> SECTOR_OFFSET;
+    range write_range = irange(sector_start, sector_start + sectors);
+    assert(range_contains(log_range, write_range));
+
+    apply(fs->w, buffer_ref(b, 0), write_range,
+          closure(h, log_write_completion, b, completions, release));
+    if (!release) {
+        b->end -= 1;                /* next write removes END_OF_LOG */
+        tlog_debug("log ext offset was %d now %d\n", b->start, b->end);
+        b->start += (sectors - 1) << SECTOR_OFFSET;        /* pick up next write here */
+    }
 }
 
-/* XXX we're just writing the whole log - instead write only from
-   block of buffer start forward */
 void log_flush(log tl)
 {
     if (!__sync_bool_compare_and_swap(&tl->dirty, 1, 0))
         return;
 
     tlog_debug("log_flush: log %p dirty\n", tl);
-    buffer b = tl->staging;
-    push_u8(b, END_OF_LOG);
-#ifdef TLOG_DEBUG
-    u64 z = tl->staging->end;
-    tl->staging->start = 0;
-    tl->staging->end = 1024;
-    rprintf("staging contains:\n%X\n", b);
-    tl->staging->end = z;
-#endif
-
-    void * buf = b->contents;
-    u64 length = b->end;
-    range r = log_block_range(tl, length);
-    apply(tl->fs->w, buf, r, closure(tl->h, log_write_completion, tl->completions));
-    b->end -= 1;                /* next write removes END_OF_LOG */
-//    rprintf("was %d now %d\n", b->start, b->end);
-//    b->start = b->end;          /* pick up next write here */
+    log_flush_internal(tl->h, tl->fs, tl->staging, tl->sectors, tl->completions, false);
 }
 
 boolean log_flush_complete(log tl, status_handler completion)
@@ -83,12 +100,69 @@ boolean log_flush_complete(log tl, status_handler completion)
     return false;
 }
 
+closure_function(7, 1, void, log_extend_link,
+                 u64, offset,
+                 u64, sectors,
+                 heap, h,
+                 filesystem, fs,
+                 buffer, b,
+                 range, r,
+                 vector, c,
+                 status, s)
+{
+    /* add link to close out old extension and commit */
+    buffer b = bound(b);
+    push_u8(b, LOG_EXTENSION_LINK);
+    push_varint(b, bound(offset));
+    push_varint(b, bound(sectors));
+
+    /* flush and dispose */
+    log_flush_internal(bound(h), bound(fs), b, bound(r), bound(c), true);
+}
+
+boolean log_extend(log tl) {
+    tlog_debug("log_extend: tl %p\n", tl);
+
+    /* allocate new log and write with end of log */
+    u64 offset = allocate_u64(tl->fs->storage, INITIAL_LOG_SIZE);
+    if (offset == INVALID_PHYSICAL)
+        return false;
+    offset >>= SECTOR_OFFSET;
+    u64 sectors = INITIAL_LOG_SIZE >> SECTOR_OFFSET;
+    range r = irange(offset, offset + sectors);
+    buffer nb = allocate_buffer(tl->h, INITIAL_LOG_SIZE);
+
+    /* new log extension */
+    tlog_debug("new log extension sector range %R, sectors %d staging %p\n", r, sectors, nb);
+    push_u8(nb, LOG_EXTENSION_HEADER);
+    push_varint(nb, sectors);
+    push_u8(nb, END_OF_LOG);
+    assert(buffer_length(nb) < SECTOR_SIZE);
+    range wr = irange(offset, offset + 1);
+
+    /* Somewhat dicey assumption that, as with other writes, this
+       buffer is not touched after return... */
+    tlog_debug("link old extension to new and switch over\n");
+    apply(tl->fs->w, buffer_ref(nb, 0), wr,
+          closure(tl->h, log_extend_link, offset, sectors, tl->h, tl->fs,
+                  tl->staging, tl->sectors, tl->completions));
+    nb->end -= 1;
+    tl->staging = nb;
+    tl->sectors = r;
+    tl->completions = allocate_vector(tl->h, COMPLETION_QUEUE_SIZE);
+    tl->dirty = false;
+    return true;
+}
+
 void log_write_eav(log tl, tuple e, symbol a, value v, status_handler sh)
 {
     tlog_debug("log_write_eav: tl %p, e %p (%t), a \"%b\", v %v\n", tl, e, e, symbol_string(a), v);
-    /* XXX make log extendable */
-    if (tl->staging->end > INITIAL_LOG_SIZE - 32)
-        halt("log full\n");
+    if (tl->staging->end > INITIAL_LOG_SIZE - 32) {
+        if (!log_extend(tl)) {
+            apply(sh, timm("result", "log_write_eav failed to extend log: out of storage"));
+            return;
+        }
+    }
     push_u8(tl->staging, TUPLE_AVAILABLE);
     encode_eav(tl->staging, tl->dictionary, e, a, v);
     vector_push(tl->completions, sh);
@@ -98,8 +172,12 @@ void log_write_eav(log tl, tuple e, symbol a, value v, status_handler sh)
 void log_write(log tl, tuple t, status_handler sh)
 {
     tlog_debug("log_write: tl %p, t %p (%t)\n", tl, t, t);
-    if (tl->staging->end > INITIAL_LOG_SIZE - 32)
-        halt("log full\n");
+    if (tl->staging->end > INITIAL_LOG_SIZE - 32) {
+        if (!log_extend(tl)) {
+            apply(sh, timm("result", "log_write failed to extend log: out of storage"));
+            return;
+        }
+    }
     push_u8(tl->staging, TUPLE_AVAILABLE);
     // this should be incremental on root!
     encode_tuple(tl->staging, tl->dictionary, t);
@@ -115,6 +193,7 @@ closure_function(2, 1, void, log_read_complete,
     status_handler sh = bound(sh);
     buffer b = tl->staging;
     u8 frame = 0;
+    u64 sector, length;
 
     tlog_debug("log_read_complete: buffer len %d, status %v\n", buffer_length(b), s);
     if (!is_ok(s)) {
@@ -123,13 +202,45 @@ closure_function(2, 1, void, log_read_complete,
         return;
     }
 
-    /* this is crap, but just fix for now due to time */
-
-    // log extension - length at the beginnin and pointer at the end
-    for (; frame = pop_u8(b), frame == TUPLE_AVAILABLE || frame == END_OF_SEGMENT;) {
-        if (frame == END_OF_SEGMENT) {
+    /* need to check bounds */
+    while ((frame = pop_u8(b)) != END_OF_LOG) {
+        switch (frame) {
+        case END_OF_SEGMENT:
             tlog_debug("-> segment boundary\n");
             continue;
+        case LOG_EXTENSION_HEADER:
+            tlog_debug("-> extend header\n");
+            /* XXX the length is really for validation...so hook it up */
+            length = pop_varint(b);
+            tlog_debug("%ld sectors\n", length);
+            continue;
+        case LOG_EXTENSION_LINK:
+            tlog_debug("-> extend link\n");
+            sector = pop_varint(b); /* XXX need to complete the error handling here */
+            length = pop_varint(b);
+            if (length == 0) {
+                apply(sh, timm("result", "zero-length extension\n"));
+                closure_finish();
+                return;
+            }
+            range r = irange(sector, sector + length);
+
+            /* XXX validate against device */
+            assert(tl->staging);
+            buffer_clear(tl->staging);
+            extend_total(tl->staging, length << SECTOR_OFFSET);
+            tl->sectors = r;
+
+            /* chain to next log extension, carrying status handler to end */
+            read_log(tl, sh);
+            closure_finish();
+            return;
+        case TUPLE_AVAILABLE:
+            break;
+        default:
+            apply(sh, timm("result", "unknown frame identifier 0x%x\n", frame));
+            closure_finish();
+            return;
         }
         tuple dv = decode_value(tl->h, tl->dictionary, b);
         tlog_debug("   decoded %p\n", dv);
@@ -162,9 +273,11 @@ closure_function(2, 1, void, log_read_complete,
         }
     }
 
+    /* the log must go on */
     if (frame == END_OF_LOG) {
         *(u8*)(b->contents + b->start - 1) = END_OF_SEGMENT;
     }
+
     /* mark end of log */
     b->end = b->start;
     b->start = 0;
@@ -206,13 +319,13 @@ closure_function(2, 1, void, log_read_complete,
     closure_finish();
 }
 
-void read_log(log tl, u64 offset, u64 size, status_handler sh)
+void read_log(log tl, status_handler sh)
 {
+    u64 size = range_span(tl->sectors) << SECTOR_OFFSET;
     tl->staging = allocate_buffer(tl->h, size);
+    tlog_debug("reading log extension, sectors %R, staging %p\n", tl->sectors, tl->staging);
     status_handler tlc = closure(tl->h, log_read_complete, tl, sh);
-    range r = log_block_range(tl, tl->staging->length);
-//    rprintf("blocks %R\n", r);
-    apply(tl->fs->r, tl->staging->contents, r, tlc);
+    apply(tl->fs->r, tl->staging->contents, tl->sectors, tlc);
 }
 
 log log_create(heap h, filesystem fs, status_handler sh)
@@ -220,13 +333,13 @@ log log_create(heap h, filesystem fs, status_handler sh)
     tlog_debug("log_create: heap %p, fs %p, sh %p\n", h, fs, sh);
     log tl = allocate(h, sizeof(struct log));
     tl->h = h;
-    tl->offset = 0;
+    tl->sectors = irange(0, INITIAL_LOG_SIZE >> SECTOR_OFFSET);
     tl->fs = fs;
-    tl->completions = allocate_vector(h, 10);
+    tl->completions = allocate_vector(h, COMPLETION_QUEUE_SIZE);
     tl->dictionary = allocate_table(h, identity_key, pointer_equal);
     tl->dirty = false;
     tl->staging = 0;
     fs->tl = tl;
-    read_log(tl, 0, INITIAL_LOG_SIZE, sh);
+    read_log(tl, sh);
     return tl;
 }

--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -486,7 +486,7 @@ void read_log(log tl, status_handler sh)
     apply(tl->fs->r, tl->staging->contents, tl->sectors, tlc);
 }
 
-log log_create(heap h, filesystem fs, status_handler sh)
+log log_create(heap h, filesystem fs, boolean initialize, status_handler sh)
 {
     tlog_debug("log_create: heap %p, fs %p, sh %p\n", h, fs, sh);
     log tl = allocate(h, sizeof(struct log));
@@ -507,14 +507,14 @@ log log_create(heap h, filesystem fs, status_handler sh)
     tl->tuple_bytes_remain = 0;
     tl->extension_open = false;
     fs->tl = tl;
-    if (fs->r) {
-        read_log(tl, sh);
-    } else {
+    if (initialize) {
         /* mkfs */
         if (!init_staging(tl, sh))
             goto fail_dealloc;
         init_log_extension(tl->staging, range_span(tl->sectors));
         apply(sh, STATUS_OK);
+    } else {
+        read_log(tl, sh);
     }
     return tl;
   fail_dealloc:

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1171,12 +1171,9 @@ sysreturn fsync(int fd)
     file f = resolve_fd(current->p, fd);
 
     file_op_begin(current);
-    if (filesystem_flush(current->p->fs, f->n,
-            closure(heap_general(get_kernel_heaps()), fsync_complete, current,
-            f))) {
-        /* Nothing to sync. */
-        return set_syscall_return(current, 0);
-    }
+    filesystem_flush(current->p->fs, f->n,
+                     closure(heap_general(get_kernel_heaps()),
+                             fsync_complete, current, f));
     return file_op_maybe_sleep(current);
 }
 

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -321,10 +321,6 @@ void unregister_interrupt(int vector)
     handlers[vector] = 0;
 }
 
-#define FAULT_STACK_PAGES       8
-#define SYSCALL_STACK_PAGES     8
-#define TSS_SIZE                0x68
-
 extern volatile void * TSS;
 static inline void write_tss_u64(int cpu, int offset, u64 val)
 {

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -169,7 +169,9 @@ closure_function(1, 2, void, fsstarted,
                  tuple, root,
                  filesystem, fs, status, s)
 {
-    assert(s == STATUS_OK);
+    if (!is_ok(s))
+        halt("unable to open filesystem: %v\n", s);
+
     enqueue(runqueue, create_init(&heaps, bound(root), fs));
     closure_finish();
 }

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -190,6 +190,7 @@ closure_function(2, 3, void, attach_storage,
                       closure(h, offset_block_io, bound(fs_offset), r),
                       closure(h, offset_block_io, bound(fs_offset), w),
                       bound(root),
+                      false,
                       closure(h, fsstarted, bound(root)));
     closure_finish();
 }

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -182,6 +182,7 @@ closure_function(2, 3, void, attach_storage,
     heap h = heap_general(&heaps);
     create_filesystem(h,
                       SECTOR_SIZE,
+                      SECTOR_SIZE,
                       length,
                       heap_backed(&heaps),
                       closure(h, offset_block_io, bound(fs_offset), r),

--- a/src/x86_64/x86_64.h
+++ b/src/x86_64/x86_64.h
@@ -1,11 +1,6 @@
 #pragma once
 
 #define STACK_ALIGNMENT     16
-#define KERNEL_STACK_PAGES  32
-#define FAULT_STACK_PAGES   8
-#define INT_STACK_PAGES     8
-#define BH_STACK_PAGES      8
-#define SYSCALL_STACK_PAGES 8
 
 #define VIRTUAL_ADDRESS_BITS 48
 
@@ -34,6 +29,8 @@
 #define C0_WP   0x00010000
 
 #define FLAG_INTERRUPT 9
+
+#define TSS_SIZE 0x68
 
 static inline void compiler_barrier(void)
 {


### PR DESCRIPTION
This change makes the tfs log extensible. Fixed-size log extensions are allocated from fs storage as needed. Tuple encodings can now be arbitrarily large, spanning log extension boundaries where necessary.

This will hopefully allow manifests of any size, given available storage.

Note that tlog is not backward-compatible with older images, and any local copies of mkfs will need to be updated.
