### PR TITLE
Filesystem: add support for symlinks

### DIFF
--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -153,6 +153,14 @@ void buffer_append(buffer b,
                    const void *body,
                    bytes length);
 
+static inline buffer buffer_cstring(heap h, const char *x)
+{
+    int len = runtime_strlen(x);
+    buffer b = allocate_buffer(h, len);
+    buffer_append(b, x, len);
+    return b;
+}
+
 // little endian variants
 #define WRITE_BE(bits)                                          \
     static inline void buffer_write_be##bits(buffer b, u64 x)   \

--- a/src/runtime/text.h
+++ b/src/runtime/text.h
@@ -134,3 +134,26 @@ static inline boolean parse_int(buffer b, u32 base, u64 *result)
   }
   return st;
 }
+
+static inline const u8 *utf8_find(const u8 *x, character c)
+{
+    int nbytes;
+
+    while (x && *x) {
+        if (utf8_decode(x, &nbytes) == c) return x;
+        x += nbytes;
+    }
+    return false;
+}
+
+static inline const u8 *utf8_find_r(const u8 *x, character c)
+{
+    int nbytes;
+    const u8 *found = false;
+
+    while (x && *x) {
+        if (utf8_decode(x, &nbytes) == c) found = x;
+        x += nbytes;
+    }
+    return found;
+}

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -903,6 +903,15 @@ tuple filesystem_creat(filesystem fs, tuple parent, const char *name,
     return dir;
 }
 
+tuple filesystem_symlink(filesystem fs, tuple parent, const char *name,
+        const char *target, status_handler completion)
+{
+    tuple link = allocate_tuple();
+    table_set(link, sym(linktarget), buffer_cstring(fs->h, target));
+    fs_set_dir_entry(fs, parent, sym_this(name), link, completion);
+    return link;
+}
+
 void filesystem_delete(filesystem fs, tuple parent, symbol sym,
         status_handler completion)
 {

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -51,12 +51,12 @@ fs_status filesystem_mkentry(filesystem fs, tuple cwd, const char *fp, tuple ent
     boolean persistent, boolean recursive);
 fs_status filesystem_mkdir(filesystem fs, tuple cwd, const char *fp, boolean persistent);
 fs_status filesystem_creat(filesystem fs, tuple cwd, const char *fp, boolean persistent);
-void filesystem_delete(filesystem fs, tuple cwd, const char *fp,
+void filesystem_delete(filesystem fs, tuple parent, symbol sym,
     status_handler completion);
-void filesystem_rename(filesystem fs, tuple oldwd, const char *oldfp,
-        tuple newwd, const char *newfp, status_handler completion);
-void filesystem_exchange(filesystem fs, tuple wd1, const char *fp1,
-        tuple wd2, const char *fp2, status_handler completion);
+void filesystem_rename(filesystem fs, tuple oldparent, symbol oldsym,
+        tuple newparent, const char *newname, status_handler completion);
+void filesystem_exchange(filesystem fs, tuple parent1, symbol sym1,
+        tuple parent2, symbol sym2, status_handler completion);
 
 tuple filesystem_getroot(filesystem fs);
 extern const char *gitversion;

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -49,8 +49,12 @@ typedef enum {
 
 fs_status filesystem_mkentry(filesystem fs, tuple cwd, const char *fp, tuple entry,
     boolean persistent, boolean recursive);
-fs_status filesystem_mkdir(filesystem fs, tuple cwd, const char *fp, boolean persistent);
-fs_status filesystem_creat(filesystem fs, tuple cwd, const char *fp, boolean persistent);
+fs_status filesystem_mkdirpath(filesystem fs, tuple cwd, const char *fp,
+        boolean persistent);
+tuple filesystem_mkdir(filesystem fs, tuple parent, const char *name,
+        status_handler completion);
+tuple filesystem_creat(filesystem fs, tuple parent, const char *name,
+        status_handler completion);
 void filesystem_delete(filesystem fs, tuple parent, symbol sym,
     status_handler completion);
 void filesystem_rename(filesystem fs, tuple oldparent, symbol oldsym,

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -55,6 +55,8 @@ tuple filesystem_mkdir(filesystem fs, tuple parent, const char *name,
         status_handler completion);
 tuple filesystem_creat(filesystem fs, tuple parent, const char *name,
         status_handler completion);
+tuple filesystem_symlink(filesystem fs, tuple parent, const char *name,
+        const char *target, status_handler completion);
 void filesystem_delete(filesystem fs, tuple parent, symbol sym,
     status_handler completion);
 void filesystem_rename(filesystem fs, tuple oldparent, symbol oldsym,

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -1,0 +1,53 @@
+#include <unix_internal.h>
+#include <filesystem.h>
+
+// fused buffer wrap, split, and resolve
+int resolve_cstring(tuple cwd, const char *f, tuple *entry, tuple *parent)
+{
+    if (!f)
+        return -EFAULT;
+
+    tuple t = *f == '/' ? filesystem_getroot(current->p->fs) : cwd;
+    tuple p = t;
+    buffer a = little_stack_buffer(NAME_MAX);
+    char y;
+    int nbytes;
+
+    while ((y = *f)) {
+        if (y == '/') {
+            if (buffer_length(a)) {
+                p = t;
+                t = lookup(t, intern(a));
+                if (!t)
+                    goto done;
+                if (!children(t))
+                    return -ENOTDIR;
+                buffer_clear(a);
+            }
+            f++;
+        } else {
+            nbytes = push_utf8_character(a, f);
+            if (!nbytes) {
+                thread_log(current, "Invalid UTF-8 sequence.\n");
+                p = false;
+                goto done;
+            }
+            f += nbytes;
+        }
+    }
+
+    if (buffer_length(a)) {
+        p = t;
+        t = lookup(t, intern(a));
+    }
+done:
+    if (!t && (*f == '/') && (*(f + 1)))
+        /* The path being resolved contains entries under a non-existent
+         * directory. */
+        p = false;
+    if (parent)
+        *parent = p;
+    if (entry)
+        *entry = t;
+    return (t ? 0 : -ENOENT);
+}

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -1,6 +1,8 @@
 #include <unix_internal.h>
 #include <filesystem.h>
 
+#define SYMLINK_HOPS_MAX    8
+
 // fused buffer wrap, split, and resolve
 int resolve_cstring(tuple cwd, const char *f, tuple *entry, tuple *parent)
 {
@@ -12,14 +14,22 @@ int resolve_cstring(tuple cwd, const char *f, tuple *entry, tuple *parent)
     buffer a = little_stack_buffer(NAME_MAX);
     char y;
     int nbytes;
+    int err;
 
     while ((y = *f)) {
         if (y == '/') {
             if (buffer_length(a)) {
                 p = t;
                 t = lookup(t, intern(a));
-                if (!t)
+                if (!t) {
+                    err = -ENOENT;
                     goto done;
+                }
+                err = filesystem_follow_links(t, p, &t);
+                if (err) {
+                    t = false;
+                    goto done;
+                }
                 if (!children(t))
                     return -ENOTDIR;
                 buffer_clear(a);
@@ -29,6 +39,7 @@ int resolve_cstring(tuple cwd, const char *f, tuple *entry, tuple *parent)
             nbytes = push_utf8_character(a, f);
             if (!nbytes) {
                 thread_log(current, "Invalid UTF-8 sequence.\n");
+                err = -ENOENT;
                 p = false;
                 goto done;
             }
@@ -40,6 +51,7 @@ int resolve_cstring(tuple cwd, const char *f, tuple *entry, tuple *parent)
         p = t;
         t = lookup(t, intern(a));
     }
+    err = -ENOENT;
 done:
     if (!t && (*f == '/') && (*(f + 1)))
         /* The path being resolved contains entries under a non-existent
@@ -49,5 +61,94 @@ done:
         *parent = p;
     if (entry)
         *entry = t;
-    return (t ? 0 : -ENOENT);
+    return (t ? 0 : err);
+}
+
+int resolve_cstring_follow(tuple cwd, const char *f, tuple *entry,
+        tuple *parent)
+{
+    tuple t, p;
+    int ret = resolve_cstring(cwd, f, &t, &p);
+    if (!ret) {
+        ret = filesystem_follow_links(t, p, &t);
+    }
+    if ((ret == 0) && entry) {
+        *entry = t;
+    }
+    if (parent) {
+        *parent = p;
+    }
+    return ret;
+}
+
+int filesystem_follow_links(tuple link, tuple parent, tuple *target)
+{
+    if (!is_symlink(link)) {
+        return 0;
+    }
+
+    tuple target_t;
+    buffer buf = little_stack_buffer(NAME_MAX + 1);
+    int hop_count = 0;
+    while (true) {
+        buffer target_b = linktarget(link);
+        if (!target_b) {
+            *target = link;
+            return 0;
+        }
+        int ret = resolve_cstring(parent, cstring(target_b, buf), &target_t,
+                &parent);
+        if (ret) {
+            return ret;
+        }
+        if (is_symlink(target_t)) {
+            if (hop_count++ == SYMLINK_HOPS_MAX) {
+                return -ELOOP;
+            }
+        }
+        link = target_t;
+    }
+}
+
+closure_function(1, 1, void, symlink_complete,
+                 thread, t,
+                 status, s)
+{
+    thread t = bound(t);
+    thread_log(current, "%s: status %v (%s)", __func__, s,
+            is_ok(s) ? "OK" : "NOTOK");
+    set_syscall_return(t, is_ok(s) ? 0 : -EIO);
+    file_op_maybe_wake(t);
+    closure_finish();
+}
+
+static sysreturn symlink_internal(tuple cwd, const char *path,
+        const char *target)
+{
+    if (!target) {
+        set_syscall_error(current, EFAULT);
+    }
+    tuple parent;
+    int ret = resolve_cstring(cwd, path, 0, &parent);
+    if ((ret != -ENOENT) || !parent) {
+        return set_syscall_return(current, ret);
+    }
+    file_op_begin(current);
+    filesystem_symlink(current->p->fs, parent, filename_from_path(path), target,
+            closure(heap_general(get_kernel_heaps()), symlink_complete,
+            current));
+    return file_op_maybe_sleep(current);
+}
+
+sysreturn symlink(const char *target, const char *linkpath)
+{
+    thread_log(current, "symlink %s -> %s", linkpath, target);
+    return symlink_internal(current->p->cwd, linkpath, target);
+}
+
+sysreturn symlinkat(const char *target, int dirfd, const char *linkpath)
+{
+    thread_log(current, "symlinkat %d %s -> %s", dirfd, linkpath, target);
+    tuple cwd = resolve_dir(dirfd, linkpath);
+    return symlink_internal(cwd, linkpath, target);
 }

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -1,1 +1,23 @@
+static inline symbol lookup_sym(tuple parent, tuple t)
+{
+    void *c = children(parent);
+    if (!c) return false;
+    table_foreach(c, k, v) {
+        if (v == t)
+            return k;
+    }
+    return false;
+}
+
+static inline const char *filename_from_path(const char *path)
+{
+    const char *filename = (char *) utf8_find_r((u8 *) path, '/');
+    if (!filename) {
+        filename = path;
+    } else {
+        filename++;
+    }
+    return filename;
+}
+
 int resolve_cstring(tuple cwd, const char *f, tuple *entry, tuple *parent);

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -1,3 +1,30 @@
+#define resolve_dir(__dirfd, __path) ({ \
+    tuple cwd; \
+    if (*(__path) == '/') cwd = filesystem_getroot(current->p->fs); \
+    else if (__dirfd == AT_FDCWD) cwd = current->p->cwd; \
+    else { \
+        file f = resolve_fd(current->p, __dirfd); \
+        if (!is_dir(f->n)) return set_syscall_error(current, ENOTDIR); \
+        cwd = f->n; \
+    } \
+    cwd; \
+})
+
+static inline buffer linktarget(table x)
+{
+    return table_find(x, sym(linktarget));
+}
+
+static inline boolean is_dir(tuple n)
+{
+    return children(n) ? true : false;
+}
+
+static inline boolean is_symlink(tuple n)
+{
+    return linktarget(n) ? true : false;
+}
+
 static inline symbol lookup_sym(tuple parent, tuple t)
 {
     void *c = children(parent);
@@ -21,3 +48,13 @@ static inline const char *filename_from_path(const char *path)
 }
 
 int resolve_cstring(tuple cwd, const char *f, tuple *entry, tuple *parent);
+
+/* Same as resolve_cstring(), except that if the entry is a symbolic link this
+ * function follows the link (recursively). */
+int resolve_cstring_follow(tuple cwd, const char *f, tuple *entry,
+        tuple *parent);
+
+int filesystem_follow_links(tuple link, tuple parent, tuple *target);
+
+sysreturn symlink(const char *target, const char *linkpath);
+sysreturn symlinkat(const char *target, int dirfd, const char *linkpath);

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -1,0 +1,1 @@
+int resolve_cstring(tuple cwd, const char *f, tuple *entry, tuple *parent);

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -88,7 +88,7 @@ void register_special_files(process p)
         filesystem_mkentry(p->fs, 0, sf->path, entry, false, true);
     }
 
-    filesystem_mkdir(p->fs, 0, "/sys/devices/system/cpu/cpu0", false);
+    filesystem_mkdirpath(p->fs, 0, "/sys/devices/system/cpu/cpu0", false);
 }
 
 static special_file *

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -918,6 +918,8 @@ static int try_write_dirent(tuple root, struct linux_dirent *dirp, char *p,
 
 sysreturn getdents(int fd, struct linux_dirent *dirp, unsigned int count)
 {
+    if (!dirp)
+        return set_syscall_error(current, EFAULT);
     file f = resolve_fd(current->p, fd);
     tuple c = children(f->n);
     if (!c)
@@ -981,6 +983,8 @@ static int try_write_dirent64(tuple root, struct linux_dirent64 *dirp, char *p,
 
 sysreturn getdents64(int fd, struct linux_dirent64 *dirp, unsigned int count)
 {
+    if (!dirp)
+        return set_syscall_error(current, EFAULT);
     file f = resolve_fd(current->p, fd);
     tuple c = children(f->n);
     if (!c)

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -95,6 +95,7 @@ typedef struct iovec {
 
 #define ENOSYS          38              /* Invalid system call number */
 #define ENOTEMPTY       39              /* Directory not empty */
+#define ELOOP           40              /* Too many symbolic links */
 #define ENOPROTOOPT     42              /* Protocol not available */
 
 #define EDESTADDRREQ    89		/* Destination address required */
@@ -116,7 +117,9 @@ typedef struct iovec {
 #define O_APPEND	00002000
 #define O_NONBLOCK	00004000
 #define O_DIRECT        00040000
+#define O_NOFOLLOW      00400000
 #define O_CLOEXEC       02000000
+#define O_PATH         010000000
 
 #define F_LINUX_SPECIFIC_BASE   0x400
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -264,6 +264,7 @@ typedef closure_type(io, sysreturn, void *buf, u64 length, u64 offset, thread t,
 #define FDESC_TYPE_EVENTFD      8
 #define FDESC_TYPE_SIGNALFD     9
 #define FDESC_TYPE_TIMERFD     10
+#define FDESC_TYPE_SYMLINK     11
 
 typedef struct fdesc {
     io read, write;

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -42,6 +42,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/unix/blockq.c \
 	$(SRCDIR)/unix/exec.c \
 	$(SRCDIR)/unix/eventfd.c \
+	$(SRCDIR)/unix/filesystem.c \
 	$(SRCDIR)/unix/futex.c \
 	$(SRCDIR)/unix/mktime.c \
 	$(SRCDIR)/unix/mmap.c \

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -21,6 +21,7 @@ PROGRAMS= \
 	sendfile \
 	signal \
 	socketpair \
+	symlink \
 	thread_test \
 	time \
 	udploop \
@@ -161,6 +162,11 @@ SRCS-socketpair= \
 	$(SRCDIR)/unix_process/ssp.c
 LDFLAGS-socketpair=	-static
 LIBS-socketpair=	-lpthread
+
+SRCS-symlink= \
+	$(CURDIR)/symlink.c \
+	$(SRCDIR)/unix_process/ssp.c
+LDFLAGS-symlink=	-static
 
 SRCS-thread_test= \
 	$(SRCDIR)/unix_process/ssp.c\

--- a/test/runtime/symlink.c
+++ b/test/runtime/symlink.c
@@ -1,0 +1,123 @@
+#include <errno.h>
+#define _GNU_SOURCE
+#define __USE_GNU
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define test_assert(expr) do { \
+    if (!(expr)) { \
+        printf("Error: %s -- failed at %s:%d\n", #expr, __FILE__, __LINE__); \
+        exit(EXIT_FAILURE); \
+    } \
+} while (0)
+
+int main(int argc, char **argv)
+{
+    int fd;
+    char buf[8];
+    struct stat s;
+    char *cwd;
+
+    setbuf(stdout, NULL);
+
+    test_assert(readlink("link", buf, sizeof(buf)) == -1);
+    test_assert(errno == ENOENT);
+
+    test_assert(symlink("target", "link") == 0);
+    memset(buf, 0, sizeof(buf));
+    test_assert((readlink("link", buf, 1) == 1) && (buf[0] == 't'));
+    test_assert((readlinkat(AT_FDCWD, "link", buf, 1) == 1) && (buf[0] == 't'));
+    test_assert(readlink("link", buf, sizeof(buf)) == strlen("target"));
+    test_assert(!strcmp(buf, "target"));
+
+    test_assert((access("link", F_OK) == -1) && (errno == ENOENT));
+    test_assert((open("link", O_RDONLY) == -1) && (errno == ENOENT));
+
+    test_assert((open("link", O_RDONLY | O_NOFOLLOW) == -1) &&
+            (errno == ELOOP));
+
+    fd = open("link", O_RDONLY | O_NOFOLLOW | O_PATH);
+    test_assert(fd >= 0);
+    close(fd);
+
+    fd = open("target", O_RDWR | O_CREAT, S_IRWXU);
+    test_assert(fd >= 0);
+    close(fd);
+    test_assert(readlink("target", buf, sizeof(buf)) == -1);
+    test_assert(errno == EINVAL);
+    test_assert((lstat("link", &s) == 0) && ((s.st_mode & S_IFMT) == S_IFLNK));
+    test_assert((stat("link", &s) == 0) && ((s.st_mode & S_IFMT) == S_IFREG));
+    test_assert(fstatat(AT_FDCWD, "link", &s, AT_SYMLINK_NOFOLLOW) == 0);
+    test_assert((s.st_mode & S_IFMT) == S_IFLNK);
+    test_assert(fstatat(AT_FDCWD, "link", &s, 0) == 0);
+    test_assert((s.st_mode & S_IFMT) == S_IFREG);
+    fd = open("link", O_RDONLY);
+    test_assert(fd >= 0);
+    close(fd);
+
+    test_assert(truncate("link", 1) == 0);
+    fd = open("target", O_RDONLY);
+    test_assert(fd >= 0);
+    test_assert(read(fd, buf, sizeof(buf)) == 1);
+    close(fd);
+
+    test_assert(symlink("link", "link1") == 0);
+    fd = open("link1", O_RDONLY);
+    test_assert(fd >= 0);
+    close(fd);
+
+    test_assert(symlinkat("link", AT_FDCWD, "link2") == 0);
+    fd = open("link2", O_RDONLY);
+    test_assert(fd >= 0);
+    close(fd);
+
+    test_assert(symlinkat("link", -1, "/link3") == 0);
+    fd = open("link3", O_RDONLY);
+    test_assert(fd >= 0);
+    close(fd);
+
+    test_assert(mkdir("dir", S_IRWXU) == 0);
+    test_assert(symlink("../link", "/dir/link") == 0);
+    fd = open("/dir/link", O_RDONLY);
+    test_assert(fd >= 0);
+    close(fd);
+
+    test_assert((symlink("target", "nonexistent/link") == -1) &&
+            (errno == ENOENT));
+    test_assert((symlink("target", "target/link") == -1) && (errno == ENOTDIR));
+
+    test_assert(unlink("target") == 0);
+    test_assert((open("link", O_RDONLY) == -1) && (errno == ENOENT));
+    test_assert((open("link1", O_RDONLY) == -1) && (errno == ENOENT));
+    test_assert((open("link2", O_RDONLY) == -1) && (errno == ENOENT));
+    test_assert((open("link3", O_RDONLY) == -1) && (errno == ENOENT));
+    test_assert((open("/dir/link", O_RDONLY) == -1) && (errno == ENOENT));
+
+    test_assert(symlink("link_to_self", "link_to_self") == 0);
+    test_assert((open("link_to_self", O_RDONLY) == -1) && (errno == ELOOP));
+
+    test_assert(symlink("/link_loop0", "link_loop1") == 0);
+    test_assert(symlink("/link_loop1", "link_loop0") == 0);
+    test_assert((open("link_loop0", O_RDONLY) == -1) && (errno == ELOOP));
+
+    test_assert(symlink("/dir/link_loop3", "link_loop2") == 0);
+    test_assert(symlink("../link_loop2", "/dir/link_loop3") == 0);
+    test_assert((open("link_loop2", O_RDONLY) == -1) && (errno == ELOOP));
+
+    test_assert(symlink("dir", "dir_link") == 0);
+    test_assert((rename("dir", "/dir_link/dir") < 0) && (errno == EINVAL));
+
+    test_assert(symlink("nonexistent", "broken_link") == 0);
+    test_assert((rename("dir", "/broken_link/dir") < 0) && (errno == ENOENT));
+
+    test_assert(chdir("/dir_link") == 0);
+    cwd = getcwd(buf, sizeof(buf));
+    test_assert(cwd && !strcmp(cwd, "/dir"));
+
+    printf("Test passed\n");
+    return EXIT_SUCCESS;
+}

--- a/test/runtime/symlink.manifest
+++ b/test/runtime/symlink.manifest
@@ -1,0 +1,15 @@
+(
+    #64 bit elf to boot from host
+    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+              #user program
+	      symlink:(contents:(host:output/test/runtime/bin/symlink))
+	      )
+    # filesystem path to elf for kernel to run
+    program:/symlink
+#    trace:t
+#    debugsyscalls:t
+#    futex_trace:t
+    fault:t
+    arguments:[symlink]
+    environment:()
+)


### PR DESCRIPTION
A symlink is represented by a tuple with a symbol called "linktarget", which contains the path of the filesystem entry being linked to.
A new runtime test is also added to exercise symlink-related code.