### PR TITLE
syscalls: add statfs and fstatfs

### DIFF
--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -994,3 +994,18 @@ tuple filesystem_getroot(filesystem fs)
 {
     return fs->root;
 }
+
+u64 fs_blocksize(filesystem fs)
+{
+    return U64_FROM_BIT(fs->blocksize_order);
+}
+
+u64 fs_totalblocks(filesystem fs)
+{
+    return fs->storage->total >> fs->blocksize_order;
+}
+
+u64 fs_freeblocks(filesystem fs)
+{
+    return (fs->storage->total - fs->storage->allocated) >> fs->blocksize_order;
+}

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -65,4 +65,9 @@ void filesystem_exchange(filesystem fs, tuple parent1, symbol sym1,
         tuple parent2, symbol sym2, status_handler completion);
 
 tuple filesystem_getroot(filesystem fs);
+
+u64 fs_blocksize(filesystem fs);
+u64 fs_totalblocks(filesystem fs);
+u64 fs_freeblocks(filesystem fs);
+
 extern const char *gitversion;

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -44,11 +44,6 @@ boolean filesystem_reserve_storage(filesystem fs, u64 start, u64 length);
 typedef closure_type(buffer_status, buffer, status);
 fsfile allocate_fsfile(filesystem fs, tuple md);
 
-static inline u64 fs_blocksize(filesystem fs)
-{
-    return U64_FROM_BIT(fs->blocksize_order);
-}
-
 static inline u64 bytes_from_sectors(filesystem fs, u64 sectors)
 {
     return sectors << fs->blocksize_order;

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -58,3 +58,6 @@ int filesystem_follow_links(tuple link, tuple parent, tuple *target);
 
 sysreturn symlink(const char *target, const char *linkpath);
 sysreturn symlinkat(const char *target, int dirfd, const char *linkpath);
+
+sysreturn statfs(const char *path, struct statfs *buf);
+sysreturn fstatfs(int fd, struct statfs *buf);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -66,8 +66,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, uselib, 0);
     register_syscall(map, personality, 0);
     register_syscall(map, ustat, 0);
-    register_syscall(map, statfs, 0);
-    register_syscall(map, fstatfs, 0);
     register_syscall(map, sysfs, 0);
     register_syscall(map, getpriority, 0);
     register_syscall(map, setpriority, 0);
@@ -1927,6 +1925,8 @@ void register_file_syscalls(struct syscall *map)
     register_syscall(map, prctl, prctl);
     register_syscall(map, sysinfo, sysinfo);
     register_syscall(map, umask, umask);
+    register_syscall(map, statfs, statfs);
+    register_syscall(map, fstatfs, fstatfs);
 }
 
 #define SYSCALL_F_NOTRACE 0x1

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -733,6 +733,23 @@ struct epoll_event {
 
 typedef struct aux {u64 tag; u64 val;} *aux;
 
+struct statfs {
+    long f_type;
+    long f_bsize;
+    long f_blocks;
+    long f_bfree;
+    long f_bavail;
+    long f_files;
+    long f_ffree;
+    struct {
+        int val[2];
+    } f_fsid;
+    long f_namelen;
+    long f_frsize;
+    long f_flags;
+    long f_spare[4];
+};
+
 typedef u32 uid_t;
 typedef u32 gid_t;
 


### PR DESCRIPTION
To retrieve filesystem statistics, fs_blocksize() has been moved from tfs_internal.h and declared in tfs.h, and the 2 new functions fs_totalblocks() and fs_freeblocks() have been implemented.