### PR TITLE
pci_bar_init: fix mapping when offset exceeds PAGESIZE

### DIFF
--- a/src/x86_64/pci.c
+++ b/src/x86_64/pci.c
@@ -133,8 +133,9 @@ void pci_bar_init(pci_dev dev, struct pci_bar *b, int bar, bytes offset, bytes l
         bytes len = pad(length, PAGESIZE);
         b->vaddr = allocate(virtual_page, len);
         pci_debug("%s: %p[0x%x] -> 0x%lx[0x%lx]+0x%x\n", __func__, b->vaddr, len, b->addr, b->size, offset);
-        map(u64_from_pointer(b->vaddr), b->addr, len, PAGE_DEV_FLAGS, pages);
-        b->vaddr += offset;
+        u64 pa = b->addr + offset;
+        map(u64_from_pointer(b->vaddr), pa & ~PAGEMASK, len, PAGE_DEV_FLAGS, pages);
+        b->vaddr += pa & PAGEMASK;
     }
 }
 


### PR DESCRIPTION
A change introduced in #1098 was causing nanos to crash if a call to pci_bar_init was made with an offset > PAGESIZE. Assuming that the correct fix is to map starting the first page boundary at or after the offset (as opposed to further padding the map length).

May have triggered (but not be the root cause of) #1099.
