### PR TITLE
syscalls: implement fallocate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test test-noaccel: mkfs boot stage3
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	creat epoll eventfd fcntl fst getdents getrandom hw hws mkdir mmap pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
+RUNTIME_TESTS=	creat epoll eventfd fallocate fcntl fst getdents getrandom hw hws mkdir mmap pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/src/runtime/tuple.c
+++ b/src/runtime/tuple.c
@@ -9,6 +9,8 @@
 
 static heap theap;
 
+static value tnullval;
+
 // use runtime tags directly?
 #define type_tuple 1
 #define type_buffer 0
@@ -215,5 +217,10 @@ void encode_tuple(buffer dest, table dictionary, tuple t)
 void init_tuples(heap h)
 {
     theap = h;
+    tnullval = wrap_buffer_cstring(h, "");
 }
 
+value null_value(void)
+{
+    return tnullval;
+}

--- a/src/runtime/tuple.h
+++ b/src/runtime/tuple.h
@@ -32,3 +32,5 @@ static inline value value_from_u64(heap h, u64 v)
     print_number((buffer)result, v, 10, 0);
     return result;
 }
+
+value null_value(void);

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -53,10 +53,19 @@ fsfile allocate_fsfile(filesystem fs, tuple md);
 
 typedef enum {
     FS_STATUS_OK = 0,
+    FS_STATUS_NOSPACE,
+    FS_STATUS_IOERR,
     FS_STATUS_NOENT,
     FS_STATUS_EXIST,
     FS_STATUS_NOTDIR,
 } fs_status;
+
+typedef closure_type(fs_status_handler, void, fsfile, fs_status);
+
+void filesystem_alloc(filesystem fs, tuple t, long offset, long len,
+        boolean keep_size, fs_status_handler completion);
+void filesystem_dealloc(filesystem fs, tuple t, long offset, long len,
+        fs_status_handler completion);
 
 void do_mkentry(filesystem fs, tuple parent, const char *name, tuple entry,
         boolean persistent);

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -76,3 +76,5 @@ sysreturn utimes(const char *filename, const struct timeval times[2]);
 
 sysreturn statfs(const char *path, struct statfs *buf);
 sysreturn fstatfs(int fd, struct statfs *buf);
+
+sysreturn fallocate(int fd, int mode, long offset, long len);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -173,7 +173,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, vmsplice, 0);
     register_syscall(map, move_pages, 0);
     register_syscall(map, utimensat, 0);
-    register_syscall(map, fallocate, 0);
     register_syscall(map, inotify_init1, 0);
     register_syscall(map, preadv, 0);
     register_syscall(map, pwritev, 0);
@@ -1929,6 +1928,7 @@ void register_file_syscalls(struct syscall *map)
     register_syscall(map, dup2, dup2);
     register_syscall(map, dup3, dup3);
     register_syscall(map, fstat, fstat);
+    register_syscall(map, fallocate, fallocate);
     register_syscall(map, sendfile, sendfile);
     register_syscall(map, stat, stat);
     register_syscall(map, lstat, lstat);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -788,3 +788,10 @@ typedef u32 gid_t;
 /* signalfd flags */
 #define SFD_NONBLOCK O_NONBLOCK
 #define SFD_CLOEXEC  O_CLOEXEC
+
+/* fallocate flags */
+#define FALLOC_FL_KEEP_SIZE         0x01
+#define FALLOC_FL_PUNCH_HOLE        0x02
+#define FALLOC_FL_COLLAPSE_RANGE    0x08
+#define FALLOC_FL_ZERO_RANGE        0x10
+#define FALLOC_FL_INSERT_RANGE      0x20

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -4,6 +4,7 @@ PROGRAMS= \
 	creat \
 	epoll \
 	eventfd \
+	fallocate \
 	fcntl \
 	fst \
 	ftrace \
@@ -55,6 +56,12 @@ SRCS-eventfd= \
 
 LDFLAGS-eventfd=	-static
 LIBS-eventfd=		-lpthread
+
+SRCS-fallocate= \
+	$(CURDIR)/fallocate.c \
+	$(SRCDIR)/unix_process/ssp.c
+
+LDFLAGS-fallocate=	-static
 
 SRCS-fcntl= \
 	$(CURDIR)/fcntl.c \

--- a/test/runtime/fallocate.c
+++ b/test/runtime/fallocate.c
@@ -1,0 +1,91 @@
+#include <errno.h>
+#define _GNU_SOURCE
+#define __USE_GNU
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define test_assert(expr) do { \
+    if (!(expr)) { \
+        printf("Error: %s -- failed at %s:%d\n", #expr, __FILE__, __LINE__); \
+        exit(EXIT_FAILURE); \
+    } \
+} while (0)
+
+int main(int argc, char **argv)
+{
+    int fd;
+    uint8_t buf[8192];
+    unsigned long alloc_size, file_size;
+    int ret;
+
+    setbuf(stdout, NULL);
+
+    test_assert((fallocate(0, 0, 0, 1) == -1) && (errno == ESPIPE));
+
+    fd = open("my_file", O_RDWR | O_CREAT, S_IRWXU);
+    test_assert(fd > 0);
+    test_assert(fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, 1) == 0);
+    test_assert(read(fd, buf, sizeof(buf)) == 0);
+
+    test_assert(fallocate(fd, 0, 0, 1) == 0);
+    buf[0] = 0xff;
+    test_assert((read(fd, buf, sizeof(buf)) == 1) && (buf[0] == 0));
+
+    test_assert(fallocate(fd, 0, 0, sizeof(buf)) == 0);
+    memset(buf, 0xff, sizeof(buf));
+    test_assert(lseek(fd, 4095, SEEK_SET) == 4095);
+    test_assert(write(fd, &buf[4095], 2) == 2);
+    test_assert(lseek(fd, 0, SEEK_SET) == 0);
+    test_assert(read(fd, buf, sizeof(buf)) == sizeof(buf));
+    for (int i = 0; i < 4095; i++) {
+        test_assert(buf[i] == 0);
+    }
+    test_assert((buf[4095] == 0xff) && (buf[4096] == 0xff));
+    for (int i = 4097; i < 8192; i++) {
+        test_assert(buf[i] == 0);
+    }
+
+    alloc_size = 1;
+    do {
+        alloc_size *= 3;
+        ret = fallocate(fd, 0, alloc_size, alloc_size);
+        test_assert((ret == 0) || ((ret == -1) && (errno == ENOSPC)));
+    } while (ret == 0);
+    file_size = lseek(fd, 0, SEEK_END);
+    test_assert(file_size == 2 * alloc_size / 3);
+
+    memset(buf, 0xff, sizeof(buf));
+    test_assert(lseek(fd, 0, SEEK_SET) == 0);
+    test_assert(write(fd, buf, sizeof(buf)) == sizeof(buf));
+    for (int hole = 1; hole <= sizeof(buf) - 2; hole *= 3) {
+        ret = fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, hole,
+                hole);
+        test_assert(ret == 0);
+        test_assert(lseek(fd, hole - 1, SEEK_SET) == hole - 1);
+        test_assert(read(fd, buf, hole + 2) == hole + 2);
+        test_assert(buf[0] == 0xff);
+        for (int i = 1; i <= hole; i++) {
+            test_assert(buf[i] == 0);
+        }
+        test_assert(buf[hole + 1] == ((hole < sizeof(buf) / 2) ? 0xff : 0x00));
+    }
+
+    ret = fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, 0,
+            file_size);
+    test_assert(ret == 0);
+    test_assert(read(fd, buf, sizeof(buf)) == sizeof(buf));
+    for (int i = 0; i < sizeof(buf); i++) {
+        test_assert(buf[i] == 0);
+    }
+
+    test_assert(lseek(fd, 0, SEEK_END) == file_size);
+
+    test_assert(close(fd) == 0);
+
+    printf("fallocate test OK\n");
+    return EXIT_SUCCESS;
+}

--- a/test/runtime/fallocate.manifest
+++ b/test/runtime/fallocate.manifest
@@ -1,0 +1,15 @@
+(
+    #64 bit elf to boot from host
+    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+              #user program
+	      fallocate:(contents:(host:output/test/runtime/bin/fallocate))
+	      )
+    # filesystem path to elf for kernel to run
+    program:/fallocate
+#    trace:t
+#    debugsyscalls:t
+#    futex_trace:t
+    fault:t
+    arguments:[fallocate]
+    environment:()
+)


### PR DESCRIPTION
Supported operations are allocating disk space (with or without keeping the file size) and deallocating disk space. These are the only operations used by MongoDB and MySQL server.

#1101.