### PR TITLE
Fix boot on VMware ESXi

### DIFF
--- a/boot/stage1.s
+++ b/boot/stage1.s
@@ -88,7 +88,7 @@ readsectors:
 fsentry:
         dq stage2
         dq STAGE2SIZE
-        dd 0x5    ; REGION_FILESYSTEM - defined in src/x86_64/region.h
+        dd 12    ; REGION_FILESYSTEM - defined in src/x86_64/region.h
 .end:
 
 

--- a/boot/stage1.s
+++ b/boot/stage1.s
@@ -44,6 +44,9 @@ e820:	xor ebx, ebx
 	int 0x15
         test ebx, ebx
         jne .each
+	; zero out last entry type
+	sub edi, fsentry.end - fsentry
+	mov [edi + fsentry.type - fsentry], ebx
 	ret
         
 
@@ -86,9 +89,9 @@ readsectors:
 
 ;; tell stage2 what its size on disk is so we can find the filesystem
 fsentry:
-        dq stage2
-        dq STAGE2SIZE
-        dd 12    ; REGION_FILESYSTEM - defined in src/x86_64/region.h
+        .base	dq stage2
+        .length	dq STAGE2SIZE
+        .type	dd 12    ; REGION_FILESYSTEM - defined in src/x86_64/region.h
 .end:
 
 

--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -59,7 +59,7 @@ u64 random_u64()
 
 // defined in service32.s
 extern void bios_tty_write(char *s, bytes count);
-extern void bios_read_sectors(void *buffer, int start_sector, int sector_count);
+extern int bios_read_sectors(void *buffer, int start_sector, int sector_count);
 
 void console_write(char *s, bytes count)
 {
@@ -87,7 +87,9 @@ closure_function(1, 3, void, stage2_bios_read,
     while (nsectors > 0) {
         int read_sectors = MIN(nsectors, SCRATCH_LEN >> SECTOR_OFFSET);
         stage2_debug("bios_read_sectors: %p <- 0x%lx (0x%x)\n", dest, start_sector, read_sectors);
-        bios_read_sectors(read_buffer, start_sector, read_sectors);
+        int ret = bios_read_sectors(read_buffer, start_sector, read_sectors);
+        if (ret != 0)
+            halt("bios_read_sectors: error 0x%x\n", ret);
         runtime_memcpy(dest, read_buffer, read_sectors << SECTOR_OFFSET);
         dest += read_sectors << SECTOR_OFFSET;
         start_sector += read_sectors;

--- a/src/x86_64/region.h
+++ b/src/x86_64/region.h
@@ -12,11 +12,11 @@ typedef struct region *region;
 
 #define REGION_PHYSICAL          1 /* available physical memory */
 #define REGION_DEVICE            2 /* e820 physical region configured for i/o */
-#define REGION_IDENTITY          3 /* for page table allocations in stage2 and stage3 */
-#define REGION_IDENTITY_RESERVED 4 /* entire identity area which must be preserved in stage3 */
-#define REGION_FILESYSTEM        5 /* offset on disk for the filesystem, see if we can get disk info from the bios */
-#define REGION_KERNIMAGE         6 /* location of kernel elf image loaded by stage2 */
-#define REGION_RECLAIM           7 /* areas to be unmapped and reclaimed in stage3 (only stage2 stack presently) */
+#define REGION_IDENTITY          10 /* for page table allocations in stage2 and stage3 */
+#define REGION_IDENTITY_RESERVED 11 /* entire identity area which must be preserved in stage3 */
+#define REGION_FILESYSTEM        12 /* offset on disk for the filesystem, see if we can get disk info from the bios */
+#define REGION_KERNIMAGE         13 /* location of kernel elf image loaded by stage2 */
+#define REGION_RECLAIM           14 /* areas to be unmapped and reclaimed in stage3 (only stage2 stack presently) */
 
 static inline region create_region(u64 base, u64 length, int type)
 {
@@ -41,16 +41,16 @@ static inline u64 allocate_region(heap h, bytes size)
     u64 base = 0;
     region r;
 
-    /* Select the highest physical region that's within 32-bit space. */
+    /* Select the lowest physical region that's within 32-bit space. */
     for_regions(e) {
         if ((e->type != rh->type) ||
             ((e->length & ~MASK(PAGELOG)) < len) ||
             (e->base + e->length > U64_FROM_BIT(32)))
             continue;
-        if (e->base > base) {
-            base = e->base;
-            r = e;
-        }
+
+        base = e->base;
+        r = e;
+        break;
     }
 
     if (base == 0)

--- a/src/x86_64/region.h
+++ b/src/x86_64/region.h
@@ -26,6 +26,7 @@ static inline region create_region(u64 base, u64 length, int type)
     r->base = base;
     r->length = length;
     r->type = type;
+    (r-1)->type = 0;
     return r;
 }
 


### PR DESCRIPTION
- allocate first available (lowest) physical region instead of highest:
VMware ESXi has second high memory region that intersects with the kernel map
- BIOS E820 memory map: type 3 and 4 are ACPI reclaimable memory and
ACPI NVS memory but they were used for IDENTITY and IDENTITY_RESERVED
region types in nanos
- create_region() and BIOS e820: make sure last region (list terminator) has type == 0
VMware has more regions initially so regions created by boot2 spill over boot0 code
- halt early if bios_read_sectors() failed

This allows nanos on VMware ESXi boot to succeed.

ESXi VIOS E820 memory regions are:

![Screen Shot 2020-04-07 at 18 05 46 ](https://user-images.githubusercontent.com/3022749/78695981-06a02500-7929-11ea-8625-697b46a5c79d.png)
