### PR TITLE
assert(): Don't use %s to print assertion condition

### DIFF
--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -40,7 +40,7 @@ void print_stack_from_here();
     do {                                            \
         if (!(x)) {                                 \
             print_stack_from_here();                \
-            halt("assertion %s failed in " __FILE__ ": %s() on line %d; halt\n", #x, __func__, __LINE__); \
+            halt("assertion " #x " failed in " __FILE__ ": %s() on line %d; halt\n", __func__, __LINE__); \
         }                                           \
     } while(0)
 #endif


### PR DESCRIPTION
This allows to see failed assertion condition when runtime is not initialized yet