### PR TITLE
syscalls: implement asynchronous I/O functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test test-noaccel: mkfs boot stage3
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	creat epoll eventfd fallocate fcntl fst getdents getrandom hw hws mkdir mmap pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
+RUNTIME_TESTS=	aio creat epoll eventfd fallocate fcntl fst getdents getrandom hw hws mkdir mmap pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/src/unix/aio.c
+++ b/src/unix/aio.c
@@ -1,0 +1,372 @@
+#include "unix_internal.h"
+#include <page.h>
+
+#define AIO_RING_MAGIC  0xa10a10a1
+
+#define AIO_KNOWN_FLAGS IOCB_FLAG_RESFD
+
+#define AIO_RESFD_INVALID   -1U
+
+#define aio_lock(aio)   u64 _irqflags = spin_lock_irq(&(aio)->lock)
+#define aio_unlock(aio) spin_unlock_irq(&(aio)->lock, _irqflags)
+
+typedef struct aio_ring {
+    unsigned int id;
+    unsigned int nr;
+    unsigned int head;
+    unsigned int tail;
+    unsigned int magic;
+    unsigned int compat_features;
+    unsigned int incompat_features;
+    unsigned int header_length;
+    struct io_event events[0];
+} *aio_ring;
+
+struct aio {
+    struct list elem;  /* must be first */
+    heap vh;
+    kernel_heaps kh;
+    aio_ring ring;
+    struct spinlock lock;
+    blockq bq;
+    unsigned int nr;
+    unsigned int ongoing_ops;
+    unsigned int copied_evts;
+};
+
+static struct aio *aio_alloc(process p, kernel_heaps kh, unsigned int *id)
+{
+    struct aio *aio = allocate(heap_general(get_kernel_heaps()),
+            sizeof(*aio));
+    if (aio == INVALID_ADDRESS) {
+        return 0;
+    }
+    u64 aio_id = allocate_u64((heap)p->aio_ids, 1);
+    if (aio_id == INVALID_PHYSICAL) {
+        deallocate(heap_general(kh), aio, sizeof(*aio));
+        return 0;
+    }
+    vector_set(p->aio, aio_id, aio);
+    *id = (unsigned int) aio_id;
+    aio->kh = kh;
+    return aio;
+}
+
+static void aio_dealloc(process p, struct aio *aio, unsigned int id)
+{
+    vector_set(p->aio, id, 0);
+    deallocate_u64((heap) p->aio_ids, id, 1);
+    deallocate(heap_general(aio->kh), aio, sizeof(*aio));
+}
+
+static inline struct aio *aio_from_ring(process p, aio_ring ring)
+{
+    return (struct aio *) vector_get(p->aio, ring->id);
+}
+
+sysreturn io_setup(unsigned int nr_events, aio_context_t *ctx_idp)
+{
+    if (!ctx_idp) {
+        return -EFAULT;
+    }
+    if (nr_events == 0) {
+        return -EINVAL;
+    }
+
+    /* Allocate AIO ring structure and add it to process memory map.*/
+    kernel_heaps kh = get_kernel_heaps();
+    heap vh = (heap) current->p->virtual_page;
+    aio_ring ctx;
+    nr_events += 1; /* needed because of head/tail management in ring buffer */
+    u64 alloc_size = pad(sizeof(*ctx) + nr_events * sizeof(struct io_event),
+            PAGESIZE);
+    ctx = (aio_ring) allocate_u64(vh, alloc_size);
+    if (ctx == INVALID_ADDRESS) {
+        return -ENOMEM;
+    }
+    u64 phys = allocate_u64((heap) heap_physical(kh), alloc_size);
+    if (phys == INVALID_PHYSICAL) {
+        deallocate(vh, ctx, alloc_size);
+        return -ENOMEM;
+    }
+    map(u64_from_pointer(ctx), phys, alloc_size,
+            PAGE_WRITABLE | PAGE_NO_EXEC | PAGE_USER, heap_pages(kh));
+
+    struct aio *aio = aio_alloc(current->p, kh, &ctx->id);
+    assert(aio);
+    aio->vh = vh;
+    aio->ring = ctx;
+    spin_lock_init(&aio->lock);
+    aio->bq = 0;
+    aio->nr = nr_events;
+    aio->ongoing_ops = 0;
+
+    ctx->nr = nr_events;
+    ctx->head = ctx->tail = 0;
+    ctx->magic = AIO_RING_MAGIC;
+    ctx->compat_features = 1;   /* same as Linux kernel */
+    ctx->incompat_features = 0; /* same as Linux kernel */
+    ctx->header_length = sizeof(*ctx);
+    *ctx_idp = ctx;
+    return 0;
+}
+
+closure_function(2, 2, void, aio_eventfd_complete,
+                 heap, h, u64 *, efd_val,
+                 thread, t, sysreturn, rv)
+{
+    u64 *efd_val = bound(efd_val);
+    deallocate(bound(h), efd_val, sizeof(*efd_val));
+    closure_finish();
+}
+
+closure_function(4, 2, void, aio_complete,
+                 struct aio *, aio, u64, data, u64, obj, int, res_fd,
+                 thread, t, sysreturn, rv)
+{
+    struct aio *aio = bound(aio);
+    int res_fd = bound(res_fd);
+    aio_ring ring = aio->ring;
+    aio_lock(aio);
+    aio->ongoing_ops--;
+    unsigned int tail = ring->tail;
+    if (tail >= aio->nr) {
+        tail = 0;
+    }
+    ring->events[tail].data = bound(data);
+    ring->events[tail].obj = bound(obj);
+    ring->events[tail].res = rv;
+    if (++tail == aio->nr) {
+        tail = 0;
+    }
+    ring->tail = tail;
+    aio_unlock(aio);
+    if (res_fd != AIO_RESFD_INVALID) {
+        fdesc res = resolve_fd_noret(t->p, res_fd);
+        if (res && res->write) {
+            heap h = heap_general(aio->kh);
+            u64 *efd_val = allocate(h, sizeof(*efd_val));
+            *efd_val = 1;
+            io_completion completion = closure(h, aio_eventfd_complete, h,
+                    efd_val);
+            apply(res->write, efd_val, sizeof(*efd_val), 0, t, true,
+                completion);
+        }
+    }
+    if (aio->bq) {
+        blockq_wake_one(aio->bq);
+    }
+    closure_finish();
+}
+
+static unsigned int aio_avail_events(struct aio *aio)
+{
+    aio_lock(aio);
+    int avail = aio->ring->head - aio->ring->tail;
+    aio_unlock(aio);
+    if (avail <= 0) {
+        avail += aio->nr;
+    }
+    return avail;
+}
+
+static sysreturn iocb_enqueue(struct aio *aio, struct iocb *iocb)
+{
+    if (!iocb) {
+        return -EFAULT;
+    }
+    thread_log(current, "%s: fd %d, op %d", __func__, iocb->aio_fildes,
+            iocb->aio_lio_opcode);
+
+    fdesc f = resolve_fd(current->p, iocb->aio_fildes);
+    if (aio->ongoing_ops >= aio_avail_events(aio) - 1) {
+        return -EAGAIN;
+    }
+    if (iocb->aio_reserved1 || iocb->aio_reserved2 || !iocb->aio_buf ||
+            (iocb->aio_flags & ~AIO_KNOWN_FLAGS)) {
+        return -EINVAL;
+    }
+
+    int res_fd;
+    if (iocb->aio_flags & IOCB_FLAG_RESFD) {
+        res_fd = iocb->aio_resfd;
+    } else {
+        res_fd = AIO_RESFD_INVALID;
+    }
+    io_completion completion = closure(heap_general(aio->kh), aio_complete, aio,
+            iocb->aio_data, (u64) iocb, res_fd);
+    switch (iocb->aio_lio_opcode) {
+    case IOCB_CMD_PREAD:
+        if (!f->read) {
+            goto inval;
+        }
+        apply(f->read, (void *) iocb->aio_buf, iocb->aio_nbytes,
+                iocb->aio_offset, current, true, completion);
+        break;
+    case IOCB_CMD_PWRITE:
+        if (!f->write) {
+            goto inval;
+        }
+        apply(f->write, (void *) iocb->aio_buf, iocb->aio_nbytes,
+                iocb->aio_offset, current, true, completion);
+        break;
+    default:
+        goto inval;
+    }
+    aio_lock(aio);
+    aio->ongoing_ops++;
+    aio_unlock(aio);
+    return 0;
+inval:
+    deallocate_closure(completion);
+    return -EINVAL;
+}
+
+sysreturn io_submit(aio_context_t ctx_id, long nr, struct iocb **iocbpp)
+{
+    struct aio *aio;
+    if (!ctx_id) {
+        return -EFAULT;
+    }
+    if (!(aio = aio_from_ring(current->p, ctx_id))) {
+        return -EINVAL;
+    }
+    int io_ops;
+    for (io_ops = 0; io_ops < nr; io_ops++) {
+        sysreturn rv = iocb_enqueue(aio, iocbpp[io_ops]);
+        if (rv) {
+            if (io_ops == 0) {
+                return rv;
+            } else {
+                break;
+            }
+        }
+    }
+    return io_ops;
+}
+
+closure_function(6, 1, sysreturn, io_getevents_bh,
+                 struct aio *, aio, long, min_nr, long, nr, struct io_event *, events, thread, t, io_completion, completion,
+                 u64, flags)
+{
+    struct aio *aio = bound(aio);
+    struct io_event *events = bound(events);
+    thread t = bound(t);
+    aio_ring ring = aio->ring;
+    sysreturn rv;
+    if (flags & BLOCKQ_ACTION_NULLIFY) {
+        rv = -EINTR;
+        goto out;
+    }
+
+    aio_lock(aio);
+    unsigned int head = ring->head;
+    unsigned int tail = ring->tail;
+    if (head >= aio->nr) {
+        head = 0;
+    }
+    if (tail >= aio->nr) {
+        tail = 0;
+    }
+    while (head != tail) {
+        if (events) {
+            runtime_memcpy(&events[aio->copied_evts], &ring->events[head],
+                    sizeof(struct io_event));
+        }
+        if (++head == aio->nr) {
+            head = 0;
+        }
+        if (++aio->copied_evts == bound(nr)) {
+            break;
+        }
+    }
+    ring->head = head;
+    ring->tail = tail;
+    aio_unlock(aio);
+    if ((aio->copied_evts < bound(min_nr)) &&
+            !(flags & BLOCKQ_ACTION_TIMEDOUT)) {
+        return BLOCKQ_BLOCK_REQUIRED;
+    }
+    rv = aio->copied_evts;
+out:
+    blockq_handle_completion(aio->bq, flags, bound(completion), t, rv);
+    aio->bq = 0;
+    closure_finish();
+    return rv;
+}
+
+sysreturn io_getevents(aio_context_t ctx_id, long min_nr, long nr,
+        struct io_event *events, struct timespec *timeout)
+{
+    if (!ctx_id || !events) {
+        return -EFAULT;
+    }
+    struct aio *aio;
+    if ((nr <= 0) || (nr < min_nr) ||
+            !(aio = aio_from_ring(current->p, ctx_id))) {
+        return -EINVAL;
+    }
+    aio->copied_evts = 0;
+    aio->bq = current->thread_bq;
+    return blockq_check_timeout(aio->bq, current,
+            closure(heap_general(aio->kh), io_getevents_bh, aio, min_nr, nr,
+                    events, current, syscall_io_complete), false,
+            CLOCK_ID_MONOTONIC, timeout ? time_from_timespec(timeout) : 0,
+            false);
+}
+
+static sysreturn io_destroy_internal(struct aio *aio, thread t, boolean in_bh);
+
+closure_function(1, 2, void, io_destroy_complete,
+                 struct aio *, aio,
+                 thread, t, sysreturn, rv)
+{
+    struct aio *aio = bound(aio);
+    if (aio->ongoing_ops) {
+        /* This can happen if io_getevents has been interrupted by a signal: try
+         * again. */
+        io_destroy_internal(aio, t, true);
+    } else {
+        aio_ring ring = aio->ring;
+        unsigned int aio_id = ring->id;
+        u64 phys = physical_from_virtual(ring);
+        u64 alloc_size = pad(sizeof(*ring) + aio->nr * sizeof(struct io_event),
+                PAGESIZE);
+        unmap(u64_from_pointer(ring), alloc_size, heap_pages(aio->kh));
+        deallocate_u64((heap) heap_physical(aio->kh), phys, alloc_size);
+        deallocate(aio->vh, ring, alloc_size);
+        aio_dealloc(current->p, aio, aio_id);
+        apply(syscall_io_complete, t, 0);
+    }
+    closure_finish();
+}
+
+static sysreturn io_destroy_internal(struct aio *aio, thread t, boolean in_bh)
+{
+    io_completion completion = closure(heap_general(aio->kh),
+            io_destroy_complete, aio);
+    assert(completion != INVALID_ADDRESS);
+    unsigned int ongoing_ops = aio->ongoing_ops;
+    if (ongoing_ops) {
+        aio->copied_evts = 0;
+        aio->bq = t->thread_bq;
+        return blockq_check(aio->bq, t,
+                closure(heap_general(aio->kh), io_getevents_bh, aio,
+                        ongoing_ops, ongoing_ops, 0, t, completion), in_bh);
+    } else {
+        apply(completion, t, 0);
+        return 0;
+    }
+}
+
+sysreturn io_destroy(aio_context_t ctx_id)
+{
+    if (!ctx_id) {
+        return -EFAULT;
+    }
+    struct aio *aio;
+    if (!(aio = aio_from_ring(current->p, ctx_id))) {
+        return -EINVAL;
+    }
+    return io_destroy_internal(aio, current, false);
+}

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -123,10 +123,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, lremovexattr, 0);
     register_syscall(map, fremovexattr, 0);
     register_syscall(map, set_thread_area, 0);
-    register_syscall(map, io_setup, 0);
-    register_syscall(map, io_destroy, 0);
-    register_syscall(map, io_getevents, 0);
-    register_syscall(map, io_submit, 0);
     register_syscall(map, io_cancel, 0);
     register_syscall(map, get_thread_area, 0);
     register_syscall(map, lookup_dcookie, 0);
@@ -1926,6 +1922,10 @@ void register_file_syscalls(struct syscall *map)
     register_syscall(map, ftruncate, ftruncate);
     register_syscall(map, fdatasync, fdatasync);
     register_syscall(map, fsync, fsync);
+    register_syscall(map, io_setup, io_setup);
+    register_syscall(map, io_submit, io_submit);
+    register_syscall(map, io_getevents, io_getevents);
+    register_syscall(map, io_destroy, io_destroy);
     register_syscall(map, access, access);
     register_syscall(map, lseek, lseek);
     register_syscall(map, fcntl, fcntl);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -761,6 +761,36 @@ struct statfs {
 typedef u32 uid_t;
 typedef u32 gid_t;
 
+enum {
+    IOCB_CMD_PREAD = 0,
+    IOCB_CMD_PWRITE = 1,
+};
+
+#define IOCB_FLAG_RESFD (1 << 0)
+
+struct iocb {
+    u64 aio_data;
+    u32 aio_key;
+    u32 aio_reserved1;
+    u16 aio_lio_opcode;
+    s16 aio_reqprio;
+    u32 aio_fildes;
+    u64 aio_buf;
+    u64 aio_nbytes;
+    s64 aio_offset;
+    u64 aio_reserved2;
+    u32 aio_flags;
+    u32 aio_resfd;
+};
+
+struct io_event {
+    u64 data;
+    u64 obj;
+    s64 res;
+    s64 res2;
+};
+
+typedef struct aio_ring *aio_context_t;
 
 /* set/getsockopt optnames */
 #define SO_DEBUG     1

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -279,6 +279,8 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     p->posix_timer_ids = create_id_heap(h, h, 0, U32_MAX, 1);
     p->posix_timers = allocate_vector(h, 8);
     p->itimers = allocate_vector(h, 3);
+    p->aio_ids = create_id_heap(h, h, 0, S32_MAX, 1);
+    p->aio = allocate_vector(h, 8);
     return p;
 }
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -344,6 +344,8 @@ typedef struct process {
     id_heap           posix_timer_ids;
     vector            posix_timers; /* unix_timer by timerid */
     vector            itimers;      /* unix_timer by ITIMER_ type */
+    id_heap           aio_ids;
+    vector            aio;
 } *process;
 
 typedef struct sigaction *sigaction;
@@ -616,6 +618,12 @@ static inline boolean futex_wake_one_by_uaddr(process p, int *uaddr)
 {
     return futex_wake_many_by_uaddr(p, uaddr, 1);
 }
+
+sysreturn io_setup(unsigned int nr_events, aio_context_t *ctx_idp);
+sysreturn io_submit(aio_context_t ctx_id, long nr, struct iocb **iocbpp);
+sysreturn io_getevents(aio_context_t ctx_id, long min_nr, long nr,
+        struct io_event *events, struct timespec *timeout);
+sysreturn io_destroy(aio_context_t ctx_id);
 
 int do_pipe2(int fds[2], int flags);
 

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -39,6 +39,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/runtime/crypto/chacha.c \
 	$(SRCDIR)/tfs/tfs.c \
 	$(SRCDIR)/tfs/tlog.c \
+	$(SRCDIR)/unix/aio.c \
 	$(SRCDIR)/unix/blockq.c \
 	$(SRCDIR)/unix/exec.c \
 	$(SRCDIR)/unix/eventfd.c \

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -1,5 +1,6 @@
 # these are built for the target platform (Linux x86_64)
 PROGRAMS= \
+	aio \
 	dup \
 	creat \
 	epoll \
@@ -34,6 +35,11 @@ PROGRAMS= \
 	webs \
 	write \
 	writev
+
+SRCS-aio= \
+	$(CURDIR)/aio.c \
+	$(SRCDIR)/unix_process/ssp.c
+LDFLAGS-aio=	-static
 
 SRCS-dup= \
 	$(CURDIR)/dup.c \

--- a/test/runtime/aio.c
+++ b/test/runtime/aio.c
@@ -1,0 +1,206 @@
+#include <errno.h>
+#define _GNU_SOURCE
+#define __USE_GNU
+#include <fcntl.h>
+#include <linux/aio_abi.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define BUF_SIZE        8192
+#define SMALLBUF_SIZE   256
+
+#define test_assert(expr) do { \
+    if (!(expr)) { \
+        printf("Error: %s -- failed at %s:%d\n", #expr, __FILE__, __LINE__); \
+        exit(EXIT_FAILURE); \
+    } \
+} while (0)
+
+static void iocb_setup_pread(struct iocb *iocb, int fd, void *buf,
+        size_t count, long long offset)
+{
+    memset(iocb, 0, sizeof(*iocb));
+    iocb->aio_fildes = fd;
+    iocb->aio_lio_opcode = IOCB_CMD_PREAD;
+    iocb->aio_buf = (__u64) buf;
+    iocb->aio_nbytes = count;
+    iocb->aio_offset = offset;
+}
+
+static void iocb_setup_pwrite(struct iocb *iocb, int fd, void *buf,
+        size_t count, long long offset)
+{
+    memset(iocb, 0, sizeof(*iocb));
+    iocb->aio_fildes = fd;
+    iocb->aio_lio_opcode = IOCB_CMD_PWRITE;
+    iocb->aio_buf = (__u64) buf;
+    iocb->aio_nbytes = count;
+    iocb->aio_offset = offset;
+}
+
+static void aio_test_readwrite(void)
+{
+    int fd;
+    aio_context_t ioc = 0;
+    uint8_t read_buf[BUF_SIZE], write_buf[BUF_SIZE];
+    struct iocb iocb;
+    struct iocb *iocbp = &iocb;
+    struct io_event evt;
+
+    fd = open("file_rw", O_RDWR | O_CREAT, S_IRWXU);
+    test_assert(fd > 0);
+    test_assert(syscall(SYS_io_setup, 1, &ioc) == 0);
+
+    test_assert(syscall(SYS_io_submit, ioc, 0, &iocbp) == 0);
+
+    iocb_setup_pwrite(&iocb, fd, NULL, BUF_SIZE, 0);
+    test_assert(syscall(SYS_io_submit, ioc, 1, &iocbp) == -1);
+    test_assert(errno == EINVAL);
+
+    iocb_setup_pwrite(&iocb, fd, write_buf, BUF_SIZE, 0);
+    iocb.aio_lio_opcode = -1;
+    test_assert(syscall(SYS_io_submit, ioc, 1, &iocbp) == -1);
+    test_assert(errno == EINVAL);
+
+    iocb_setup_pwrite(&iocb, -fd, write_buf, BUF_SIZE, 0);
+    test_assert(syscall(SYS_io_submit, ioc, 1, &iocbp) == -1);
+    test_assert(errno == EBADF);
+
+    for (int i = 0; i < BUF_SIZE; i++) {
+        write_buf[i] = i & 0xFF;
+    }
+    iocb_setup_pwrite(&iocb, fd, write_buf, BUF_SIZE, 0);
+    iocb.aio_data = (__u64) read_buf;
+    test_assert(syscall(SYS_io_submit, ioc, 1, &iocbp) == 1);
+    test_assert(syscall(SYS_io_getevents, ioc, 1, 1, &evt, NULL) == 1);
+    test_assert((evt.data == (__u64) read_buf) && (evt.obj == (__u64) iocbp));
+    test_assert(evt.res == BUF_SIZE);
+
+    iocb_setup_pread(&iocb, fd, read_buf, BUF_SIZE, 0);
+    iocb.aio_data = (__u64) write_buf;
+    test_assert(syscall(SYS_io_submit, ioc, 1, &iocbp) == 1);
+    test_assert(syscall(SYS_io_getevents, ioc, 1, 1, &evt, NULL) == 1);
+    test_assert((evt.data == (__u64) write_buf) && (evt.obj == (__u64) iocbp));
+    test_assert(evt.res == BUF_SIZE);
+    for (int i = 0; i < BUF_SIZE; i++) {
+        test_assert(read_buf[i] == (i & 0xFF));
+    }
+
+    test_assert(syscall(SYS_io_destroy, ioc) == 0);
+
+    /* Call io_destroy without waiting for I/O completion. */
+    ioc = 0;
+    test_assert(syscall(SYS_io_setup, 1, &ioc) == 0);
+    iocb_setup_pread(&iocb, fd, read_buf, BUF_SIZE, 0);
+    test_assert(syscall(SYS_io_submit, ioc, 1, &iocbp) == 1);
+    test_assert(syscall(SYS_io_destroy, ioc) == 0);
+
+    test_assert(close(fd) == 0);
+}
+
+static void aio_test_eventfd(void)
+{
+    int fd;
+    aio_context_t ioc = 0;
+    struct iocb iocb;
+    struct iocb *iocbp = &iocb;
+    int efd;
+    uint64_t efd_val;
+    struct timespec ts;
+    struct io_event evt;
+
+    fd = open("file_efd", O_RDWR | O_CREAT, S_IRWXU);
+    test_assert(fd > 0);
+    test_assert(syscall(SYS_io_setup, 1, &ioc) == 0);
+
+    iocb_setup_pwrite(&iocb, fd, "test", strlen("test"), 0);
+    efd = eventfd(0, 0);
+    test_assert(efd > 0);
+    iocb.aio_resfd = efd;
+    iocb.aio_flags = IOCB_FLAG_RESFD;
+
+    test_assert(syscall(SYS_io_submit, ioc, 1, &iocbp) == 1);
+    test_assert(read(efd, &efd_val, sizeof(efd_val)) == sizeof(efd_val));
+    test_assert(efd_val == 1);
+
+    /* The I/O event should now be available without blocking. */
+    ts.tv_sec = ts.tv_nsec = 0;
+    test_assert(syscall(SYS_io_getevents, ioc, 1, 1, &evt, &ts) == 1);
+    test_assert((evt.obj == (__u64) iocbp) && (evt.res == strlen("test")));
+
+    ts.tv_nsec = 1000000;
+    test_assert(syscall(SYS_io_getevents, ioc, 1, 1, &evt, &ts) == 0);
+
+    test_assert(close(efd) == 0);
+    test_assert(syscall(SYS_io_destroy, ioc) == 0);
+    test_assert(close(fd) == 0);
+}
+
+static void aio_test_multiple()
+{
+    int fd;
+    aio_context_t ioc = 0;
+    struct iocb iocbs[8];
+    struct iocb *iocb_ptrs[8];
+    uint8_t read_buf[SMALLBUF_SIZE], write_buf[SMALLBUF_SIZE];
+    struct io_event evts[8];
+
+    fd = open("file_mult", O_RDWR | O_CREAT, S_IRWXU);
+    test_assert(fd > 0);
+
+    test_assert(syscall(SYS_io_setup, 8, &ioc) == 0);
+
+    for (int i = 0; i < SMALLBUF_SIZE; i++) {
+        write_buf[i] = i;
+    }
+    for (int i = 0; i < 8; i++) {
+        iocb_ptrs[i] = &iocbs[i];
+        iocb_setup_pwrite(&iocbs[i], fd, write_buf + i * 8, 8, i * 8);
+        iocbs[i].aio_data = (__u64) write_buf;
+    }
+    test_assert(syscall(SYS_io_submit, ioc, 8, iocb_ptrs) == 8);
+    test_assert(syscall(SYS_io_getevents, ioc, 8, 8, evts, NULL) == 8);
+    for (int i = 0; i < 8; i++) {
+        test_assert(evts[i].data == (__u64) write_buf);
+        test_assert(evts[i].res == 8);
+        iocb_setup_pread(&iocbs[i], fd, read_buf + i * 8, 8, i * 8);
+        iocbs[i].aio_data = (__u64) read_buf;
+    }
+    test_assert(syscall(SYS_io_submit, ioc, 18, iocb_ptrs) == 8);
+    test_assert(syscall(SYS_io_getevents, ioc, 8, 8, evts, NULL) == 8);
+    for (int i = 0; i < 8; i++) {
+        test_assert(evts[i].data == (__u64) read_buf);
+        test_assert(evts[i].res == 8);
+    }
+    for (int i = 0; i < SMALLBUF_SIZE; i++) {
+        test_assert(read_buf[i] == i);
+    }
+
+    iocb_setup_pread(&iocbs[0], fd, read_buf, 0, 0);
+    iocb_setup_pread(&iocbs[1], -fd, read_buf, 0, 0);
+    test_assert(syscall(SYS_io_submit, ioc, 2, iocb_ptrs) == 1);
+    test_assert(syscall(SYS_io_getevents, ioc, 1, 8, evts, NULL) == 1);
+
+    test_assert(syscall(SYS_io_destroy, ioc) == 0);
+    test_assert(close(fd) == 0);
+}
+
+int main(int argc, char **argv)
+{
+    aio_context_t ioc = 0;
+
+    setbuf(stdout, NULL);
+
+    test_assert((syscall(SYS_io_setup, 1, NULL) == -1) && (errno == EFAULT));
+    test_assert((syscall(SYS_io_setup, 0, &ioc) == -1) && (errno == EINVAL));
+    aio_test_readwrite();
+    aio_test_eventfd();
+    aio_test_multiple();
+    printf("AIO test OK\n");
+    return EXIT_SUCCESS;
+}

--- a/test/runtime/aio.manifest
+++ b/test/runtime/aio.manifest
@@ -1,0 +1,15 @@
+(
+    #64 bit elf to boot from host
+    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+              #user program
+	      aio:(contents:(host:output/test/runtime/bin/aio))
+	      )
+    # filesystem path to elf for kernel to run
+    program:/aio
+#    trace:t
+#    debugsyscalls:t
+#    futex_trace:t
+    fault:t
+    arguments:[aio]
+    environment:()
+)


### PR DESCRIPTION
Supported operations are pread and pwrite. Canceling an ongoing operation is not supported.

Closes #1102.