### PR TITLE
Unix domain sockets: add ioctl implementation

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -574,7 +574,7 @@ closure_function(1, 6, sysreturn, socket_write,
     return socket_write_internal(s, source, length, t, bh, completion);
 }
 
-closure_function(1, 2, sysreturn, socket_ioctl,
+closure_function(1, 2, sysreturn, netsock_ioctl,
                  netsock, s,
                  unsigned long, request, vlist, ap)
 {
@@ -632,18 +632,8 @@ closure_function(1, 2, sysreturn, socket_ioctl,
                 sizeof(ip4_addr_t));
         return 0;
     }
-    case FIONBIO: {
-        int opt = varg(ap, int);
-        if (opt) {
-            s->sock.f.flags |= SOCK_NONBLOCK;
-        }
-        else {
-            s->sock.f.flags &= ~SOCK_NONBLOCK;
-        }
-        return 0;
-    }
     default:
-        return -ENOSYS;
+        return socket_ioctl(&s->sock, request, ap);
     }
 }
 
@@ -775,7 +765,7 @@ static int allocate_sock(process p, int type, u32 flags, netsock * rs)
     s->sock.f.write = closure(h, socket_write, s);
     s->sock.f.close = closure(h, socket_close, s);
     s->sock.f.events = closure(h, socket_events, s);
-    s->sock.f.ioctl = closure(h, socket_ioctl, s);
+    s->sock.f.ioctl = closure(h, netsock_ioctl, s);
     s->p = p;
 
     s->incoming = allocate_queue(h, SOCK_QUEUE_LEN);

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -235,6 +235,14 @@ closure_function(1, 1, u32, unixsock_events,
     return events;
 }
 
+closure_function(1, 2, sysreturn, unixsock_ioctl,
+                 unixsock, s,
+                 unsigned long, request, vlist, ap)
+{
+    unixsock s = bound(s);
+    return socket_ioctl(&s->sock, request, ap);
+}
+
 closure_function(1, 0, sysreturn, unixsock_close,
                  unixsock, s)
 {
@@ -512,6 +520,7 @@ static unixsock unixsock_alloc(heap h, int type, u32 flags)
     s->sock.f.read = closure(h, unixsock_read, s);
     s->sock.f.write = closure(h, unixsock_write, s);
     s->sock.f.events = closure(h, unixsock_events, s);
+    s->sock.f.ioctl = closure(h, unixsock_ioctl, s);
     s->sock.f.close = closure(h, unixsock_close, s);
     s->sock.bind = unixsock_bind;
     s->sock.listen = unixsock_listen;

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -74,4 +74,23 @@ static inline void socket_flush_q(struct sock *s)
     blockq_flush(s->txbq);
 }
 
+static inline sysreturn socket_ioctl(struct sock *s, unsigned long request,
+        vlist ap)
+{
+    switch (request) {
+    case FIONBIO: {
+        int *opt = varg(ap, int *);
+        if (*opt) {
+            s->f.flags |= SOCK_NONBLOCK;
+        }
+        else {
+            s->f.flags &= ~SOCK_NONBLOCK;
+        }
+        return 0;
+    }
+    default:
+        return -ENOSYS;
+    }
+}
+
 sysreturn unixsock_open(int type, int protocol);


### PR DESCRIPTION
Needed by MongoDB (#579) to configure a socket as non-blocking.