### PR TITLE
page cache implementation and generic support for scatter-gather I/O

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -11,6 +11,7 @@ SRCS-stage2.elf= \
 	$(SRCDIR)/runtime/range.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/pqueue.c \
+	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/symbol.c \
 	$(SRCDIR)/runtime/table.c \
 	$(SRCDIR)/runtime/timer.c \

--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -302,7 +302,7 @@ void newstack()
                       SECTOR_SIZE,
                       infinity,
                       0,         /* ignored in boot */
-                      get_stage2_disk_read(h, fs_offset),
+                      sg_wrapped_block_reader(get_stage2_disk_read(h, fs_offset), SECTOR_OFFSET, heap_backed(&kh)),
                       closure(h, stage2_empty_write),
                       root,
                       false,
@@ -351,6 +351,7 @@ void centry()
     init_runtime(&working_heap);
     init_tuples(allocate_tagged_region(&working_heap, tag_tuple));
     init_symbols(allocate_tagged_region(&working_heap, tag_symbol), &working_heap);
+    init_sg(&working_heap);
     init_extra_prints();
     stage2_debug("%s\n", __func__);
 

--- a/mkfs/Makefile
+++ b/mkfs/Makefile
@@ -17,6 +17,7 @@ SRCS-mkfs= \
 	$(SRCDIR)/runtime/timer.c \
 	$(SRCDIR)/runtime/tuple_parser.c \
 	$(SRCDIR)/runtime/tuple.c \
+	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/string.c \
 	$(SRCDIR)/runtime/sha256.c \
 	$(SRCDIR)/runtime/crypto/chacha.c \
@@ -40,6 +41,7 @@ SRCS-dump= \
 	$(SRCDIR)/runtime/table.c \
 	$(SRCDIR)/runtime/timer.c \
 	$(SRCDIR)/runtime/tuple.c \
+	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/string.c \
 	$(SRCDIR)/runtime/sha256.c \
 	$(SRCDIR)/runtime/crypto/chacha.c \

--- a/mkfs/dump.c
+++ b/mkfs/dump.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv)
                       SECTOR_SIZE,
                       infinity,
                       h,
-                      closure(h, bread, fd, get_fs_offset(fd)),
+                      sg_wrapped_block_reader(closure(h, bread, fd, get_fs_offset(fd)), SECTOR_OFFSET, h),
                       closure(h, bwrite, fd),
                       root,
                       false,

--- a/src/runtime/range.h
+++ b/src/runtime/range.h
@@ -33,6 +33,16 @@ boolean rangemap_range_find_gaps(rangemap rm, range q, range_handler gap_handler
 rangemap allocate_rangemap(heap h);
 void deallocate_rangemap(rangemap rm);
 
+static inline range range_rshift(range r, int order)
+{
+    return irange(r.start >> order, r.end >> order);
+}
+
+static inline range range_lshift(range r, int order)
+{
+    return irange(r.start << order, r.end << order);
+}
+
 static inline range range_from_rmnode(rmnode n)
 {
     return n->r;

--- a/src/runtime/range.h
+++ b/src/runtime/range.h
@@ -25,8 +25,11 @@ boolean rangemap_reinsert(rangemap rm, rmnode n, range k);
 boolean rangemap_remove_range(rangemap rm, range r);
 rmnode rangemap_lookup(rangemap rm, u64 point);
 rmnode rangemap_lookup_at_or_next(rangemap rm, u64 point);
-boolean rangemap_range_lookup(rangemap rm, range q, rmnode_handler nh);
-boolean rangemap_range_find_gaps(rangemap rm, range q, range_handler rh);
+boolean rangemap_range_intersects(rangemap rm, range q);
+boolean rangemap_range_lookup(rangemap rm, range q, rmnode_handler node_handler);
+boolean rangemap_range_lookup_with_gaps(rangemap rm, range q, rmnode_handler node_handler,
+                                        range_handler gap_handler);
+boolean rangemap_range_find_gaps(rangemap rm, range q, range_handler gap_handler);
 rangemap allocate_rangemap(heap h);
 void deallocate_rangemap(rangemap rm);
 

--- a/src/runtime/refcount.h
+++ b/src/runtime/refcount.h
@@ -21,7 +21,8 @@ static inline boolean refcount_release(refcount r)
     if (n < 1)
         halt("%s: invalid count %ld\n", __func__, n);
     if (n == 1) {
-        apply(r->completion);
+        if (r->completion)
+            apply(r->completion);
         return true;
     }
     return false;

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -180,7 +180,10 @@ typedef closure_type(thunk, void);
 
 typedef closure_type(buffer_handler, status, buffer);
 typedef closure_type(connection_handler, buffer_handler, buffer_handler);
+typedef closure_type(io_status_handler, void, status, bytes);
 typedef closure_type(block_io, void, void *, range, status_handler);
+
+#include <sg.h>
 
 // should be  (parser, parser, character)
 typedef closure_type(parser, void *, character);

--- a/src/runtime/sg.c
+++ b/src/runtime/sg.c
@@ -1,0 +1,119 @@
+#include <runtime.h>
+
+//#define SG_DEBUG
+#if defined(SG_DEBUG)
+#define sg_debug(x, ...) do {rprintf("SG:  " x, ##__VA_ARGS__);} while(0)
+#else
+#define sg_debug(x, ...)
+#endif
+
+#define DEFAULT_SG_FRAGS 8
+
+static heap sg_heap;
+static struct list free_sg_lists; /* TODO spinlock */
+
+/* copy content of sg, up to limit bytes, into target, consuming and
+   deallocating everything */
+u64 sg_copy_to_buf_and_release(void *target, sg_list sg, u64 limit)
+{
+    sg_buf sgb;
+    u64 written = 0;
+
+    sg_debug("%s: target %p, sg %p, limit 0x%lx, count %ld\n", __func__, target, sg, limit, sg->count);
+    while ((sgb = sg_list_head_remove(sg)) != INVALID_ADDRESS) {
+        u64 len = MIN(sgb->length, limit);
+        if (len > 0) {
+            runtime_memcpy(target + written, sgb->buf, len);
+            written += len;
+            limit -= len;
+        }
+        /* release all buffers */
+        sg_buf_release(sgb);
+    }
+    deallocate_sg_list(sg);
+    sg_debug("   total written: %ld\n", written);
+    return written;
+}
+
+sg_list allocate_sg_list(void)
+{
+    list l = list_get_next(&free_sg_lists);
+    if (l) {
+        list_delete(l);
+        return struct_from_list(l, sg_list, l);
+    }
+
+    sg_list sg = allocate(sg_heap, sizeof(struct sg_list));
+    if (!sg)
+        return sg;
+    sg->b = allocate_buffer(sg_heap, sizeof(struct sg_buf) * DEFAULT_SG_FRAGS);
+    if (sg->b == INVALID_ADDRESS) {
+        deallocate(sg_heap, sg, sizeof(struct sg_list));
+        return INVALID_ADDRESS;
+    }
+    list_init(&sg->l);
+    sg->count = 0;
+    return sg;
+}
+
+void deallocate_sg_list(sg_list sg)
+{
+    buffer_clear(sg->b);
+    sg->count = 0;
+    list_insert_after(&free_sg_lists, &sg->l);
+}
+
+closure_function(4, 0, void, sg_wrapped_buf_release,
+                 refcount, refcount, heap, backed, void *, buf, bytes, padlen)
+{
+    deallocate(sg_heap, bound(refcount), sizeof(struct refcount));
+    deallocate(bound(backed), bound(buf), bound(padlen));
+    closure_finish();
+}
+
+/* wrap linear block io into an sg reader - for uses without pagecache (stage2, dump) */
+closure_function(3, 3, void, sg_wrapped_read,
+                 block_io, block_read, int, block_order, heap, backed,
+                 sg_list, sg, range, q, status_handler, sh)
+{
+    int block_order = bound(block_order);
+    bytes length = range_span(q);
+    bytes padlen = pad(length, 1 << block_order);
+    void *buf = allocate(bound(backed), padlen);
+    sg_debug("%s: io %p, order %d, backed %p, sg %p, range %R, sh %p\n",
+             __func__, bound(block_read), block_order, bound(backed), sg, q, sh);
+
+    if (buf == INVALID_ADDRESS) {
+        apply(sh, timm("result", "%s: failed to allocate backed buffer of size %ld",
+                       __func__, padlen));
+        return;
+    }
+    refcount refcount = allocate(sg_heap, sizeof(struct refcount));
+    if (refcount == INVALID_ADDRESS) {
+        apply(sh, timm("result", "%s: alloc failed", __func__));
+        return;
+    }
+    init_refcount(refcount, 1, closure(sg_heap, sg_wrapped_buf_release,
+                                       refcount, bound(backed), buf, padlen));
+    sg_buf sgb = sg_list_tail_add(sg, length);
+    sgb->buf = buf;
+    sgb->length = length;
+    sgb->refcount = refcount;
+    assert((q.start & MASK(block_order)) == 0);
+    range blocks = irange(q.start >> block_order, (q.start + padlen) >> block_order);
+    sg_debug("   reading into sgb %p, buf %p, blocks %R\n", sgb, buf, blocks);
+    apply(bound(block_read), buf, blocks, sh);
+}
+
+sg_block_io sg_wrapped_block_reader(block_io bio, int block_order, heap backed)
+{
+    sg_debug("%s, heap %p, bio %p, order %d, backed %p\n", __func__, sg_heap, bio, block_order, backed);
+    return closure(sg_heap, sg_wrapped_read, bio, block_order, backed);
+}
+
+void init_sg(heap h)
+{
+    sg_debug("%s\n", __func__);
+    sg_heap = h;
+    list_init(&free_sg_lists);
+}

--- a/src/runtime/sg.h
+++ b/src/runtime/sg.h
@@ -1,0 +1,85 @@
+/* want to support:
+
+   1) scatter gather request with the consumer owning/providing the
+      sg_vec but producer owning the frags/pages
+
+      - use of refcount to manage access to frags
+
+   ... but what if the requester passed an sg handler?
+      + release could be per request, not per page
+        - still is per page internally within pagecache
+          + but producer may take more optimal steps
+            1. e.g. allocate larger orders to backed heap and use ranges internally
+      + consumer can use refcount as well when sharing 
+
+      - the consumer supplying the sg list allows for an operation
+        that spans extents and pages neatly synthesizes into one
+        result list
+
+   Another way to look at it: the scatter gather operation is a
+   transaction that is divided into smaller transactions - each with
+   two phases: request and completion. To begin, a transaction
+   activation record is allocated along with an identifier. The front
+   side (consumer) makes a request using a pointer to the record
+   (sg_vec). The request handler takes a reference to the sg_vec 
+
+
+*/
+
+typedef struct sg_buf {
+    void *buf;                  /* beginning of fragment */
+    u32 length;                 /* [buf, buf + length) */
+    u32 misc;                   /* padding, could be used as offset/index */
+    refcount refcount;          /* reference held for source (e.g. page) */
+} *sg_buf;
+
+/* represents a scatter-gather transaction - global kernel object */
+typedef struct sg_list {
+    buffer b;                   /* buffer (array) of sg_bufs */
+    word count;                 /* total bytes accumulated */
+    struct list l;              /* for free list */
+} *sg_list;
+
+typedef closure_type(sg_block_io, void, sg_list, range, status_handler);
+
+static inline sg_buf sg_list_tail_add(sg_list sg, word length)
+{
+    buffer_extend(sg->b, sizeof(struct sg_buf));
+    void *sgf = buffer_ref(sg->b, buffer_length(sg->b));
+    buffer_produce(sg->b, sizeof(struct sg_buf));
+    fetch_and_add(&sg->count, length);
+    return sgf;
+}
+
+/* Once an sg_buf is removed from the list, it must be later released
+   with sg_buf_release. Unremoved items from the list can be released
+   at once with sg_list_finish. */
+
+static inline sg_buf sg_list_head_remove(sg_list sg)
+{
+    if (buffer_length(sg->b) < sizeof(struct sg_buf))
+        return INVALID_ADDRESS;
+    sg_buf sgf = (sg_buf)buffer_ref(sg->b, 0);
+    fetch_and_add(&sg->count, -sgf->length);
+    buffer_consume(sg->b, sizeof(struct sg_buf));
+    return sgf;
+}
+
+static inline void sg_buf_release(sg_buf sgf)
+{
+    refcount_release(sgf->refcount);
+}
+
+static inline void sg_list_release(sg_list sg)
+{
+    sg_buf sgb;
+    while ((sgb = sg_list_head_remove(sg)) != INVALID_ADDRESS) {
+        sg_buf_release(sgb);
+    }
+}
+
+sg_list allocate_sg_list(void);
+void deallocate_sg_list(sg_list sgo);
+void init_sg(heap h);
+u64 sg_copy_to_buf_and_release(void *dest, sg_list src, u64 limit);
+sg_block_io sg_wrapped_block_reader(block_io bio, int block_order, heap backed);

--- a/src/runtime/sg.h
+++ b/src/runtime/sg.h
@@ -67,7 +67,7 @@ static inline void sg_list_release(sg_list sg)
 }
 
 sg_list allocate_sg_list(void);
-void deallocate_sg_list(sg_list sgo);
+void deallocate_sg_list(sg_list sg);
 void init_sg(heap h);
 u64 sg_copy_to_buf_and_release(void *dest, sg_list src, u64 limit);
 sg_block_io sg_wrapped_block_reader(block_io bio, int block_order, heap backed);

--- a/src/runtime/sg.h
+++ b/src/runtime/sg.h
@@ -1,29 +1,17 @@
-/* want to support:
+/* A scatter gather operation is a transaction that is divided into
+   smaller transactions - each with two phases: request and
+   completion. To begin, a transaction activation record and handle is
+   allocated with allocate_sg_list. A consumer makes a request using
+   the empty sg_list. On completion, the sg_list is filled with
+   scatter-gather buffer data. As the consumer consumes buffers
+   (sg_bufs), they are released with sg_buf_release - or the entire
+   list and any unconsumed buffers are released at once with
+   sg_list_release.
 
-   1) scatter gather request with the consumer owning/providing the
-      sg_vec but producer owning the frags/pages
-
-      - use of refcount to manage access to frags
-
-   ... but what if the requester passed an sg handler?
-      + release could be per request, not per page
-        - still is per page internally within pagecache
-          + but producer may take more optimal steps
-            1. e.g. allocate larger orders to backed heap and use ranges internally
-      + consumer can use refcount as well when sharing 
-
-      - the consumer supplying the sg list allows for an operation
-        that spans extents and pages neatly synthesizes into one
-        result list
-
-   Another way to look at it: the scatter gather operation is a
-   transaction that is divided into smaller transactions - each with
-   two phases: request and completion. To begin, a transaction
-   activation record is allocated along with an identifier. The front
-   side (consumer) makes a request using a pointer to the record
-   (sg_vec). The request handler takes a reference to the sg_vec 
-
-
+   A producing requester allocates the sg_list and populates it with
+   scatter-gather buffer data before initiating a request. It must
+   supply a refcount pointer for each buffer (which may all point to a
+   single refcount for the request, essentially acting as a merge).
 */
 
 typedef struct sg_buf {

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -100,7 +100,20 @@ typedef struct fs_dma_buf {
     range blocks;        /* in sectors, not bytes */
     u64 start_offset;    /* offset of query start within first block */
     u64 data_length;
+    struct refcount refcount;
 } *fs_dma_buf;
+
+/* XXX TODO: eliminate extra copy by writing directly to pagecache
+   buffers (and let the pagecache know to do partial sector reads -
+   and not read for full sector writes */
+
+closure_function(2, 0, void, fs_release_dma_buffer,
+                 filesystem, fs, fs_dma_buf, db)
+{
+    fs_dma_buf db = bound(db);
+    deallocate(bound(fs)->dma, db->buf, db->alloc_size);
+    deallocate(bound(fs)->h, db, sizeof(struct fs_dma_buf));
+}
 
 static fs_dma_buf fs_allocate_dma_buffer(filesystem fs, extent e, range i)
 {
@@ -129,107 +142,69 @@ static fs_dma_buf fs_allocate_dma_buffer(filesystem fs, extent e, range i)
 #else
     db->buf = 0;                /* fixed up by caller for stage2 */
 #endif
+    init_refcount(&db->refcount, 1, closure(fs->h, fs_release_dma_buffer, fs, db));
     return db;
 }
 
-static void fs_deallocate_dma_buffer(filesystem fs, fs_dma_buf db)
+static void fs_zero_pad_sg(filesystem fs, sg_list sg, u64 length)
 {
-#ifndef BOOT
-    deallocate(fs->dma, db->buf, db->alloc_size);
-#endif
-    deallocate(fs->h, db, sizeof(struct fs_dma_buf));
-}
+    static void *fs_zero_page;
+    static struct refcount fs_zero_page_refcount;
 
-closure_function(4, 1, void, fs_read_extent_complete,
-                 filesystem, fs, fs_dma_buf, db, void *, target, status_handler, sh,
-                 status, s)
-{
-    fs_dma_buf db = bound(db);
-    tfs_debug("fs_read_extent_complete: dma buf 0x%p, start_offset %ld, length %ld, target %p, status %v\n",
-              db->buf, db->start_offset, db->data_length, bound(target), s);
-#ifndef BOOT
-    if (is_ok(s))
-        runtime_memcpy(bound(target), db->buf + db->start_offset, db->data_length);
-#endif
-    fs_deallocate_dma_buffer(bound(fs), db);
-    apply(bound(sh), s);
-    closure_finish();
+    if (!fs_zero_page) {
+        init_refcount(&fs_zero_page_refcount, 1, 0);
+        assert(fs->dma);
+        fs_zero_page = allocate_zero(fs->dma, PAGESIZE);
+        assert(fs_zero_page != INVALID_ADDRESS);
+    }
+
+    sg_buf sgb;
+    while (length > 0) {
+        u64 n = MIN(length, PAGESIZE);
+        sgb = sg_list_tail_add(sg, n);
+        sgb->buf = fs_zero_page;
+        sgb->length = n;
+        sgb->refcount = &fs_zero_page_refcount;
+        refcount_reserve(&fs_zero_page_refcount);
+        length -= n;
+    }
 }
 
 closure_function(4, 1, void, fs_read_extent,
-                 filesystem, fs, buffer, target, merge, m, range, q,
+                 filesystem, fs, sg_list, sg, merge, m, range, q,
                  rmnode, node)
 {
     filesystem fs = bound(fs);
-    buffer target = bound(target);
     range q = bound(q);
     range i = range_intersection(q, node->r);
-    u64 length = range_span(i);
-    u64 target_offset = i.start - q.start;
-    void *target_start = buffer_ref(target, target_offset);
+    u64 len = range_span(i);
+    assert(len > 0);
     extent e = (extent)node;
-    status_handler f = apply_merge(bound(m));
-
     if (e->uninited) {
-        runtime_memset(target_start, 0, length);
-        fetch_and_add(&target->end, length);
-        apply(f, STATUS_OK);
+        fs_zero_pad_sg(bound(fs), bound(sg), len);
         return;
     }
-
-    /* get and init dma buf */
-    fs_dma_buf db = fs_allocate_dma_buffer(fs, e, i);
-    if (db == INVALID_ADDRESS) {
-        msg_err("failed; unable to allocate dma buffer, i span %ld bytes\n", length);
-        return;
-    }
-#ifdef BOOT
-    /* XXX To skip the copy in stage2, we're banking on the kernel
-       being loaded in its entirety, with no partial-block reads
-       (except the end, but that's fine). */
-    assert(i.start == node->r.start);
-    db->buf = target_start;
-#endif
-
-    tfs_debug("fs_read_extent: q %R, ex %R, blocks %R, start_offset %ld, i %R, "
-              "target_offset %ld, target_start %p, length %ld, blocksize %ld\n",
-              q, node->r, db->blocks, db->start_offset, i,
-              target_offset, target_start, db->data_length, fs_blocksize(fs));
-
-    fetch_and_add(&target->end, db->data_length);
-    status_handler copy = closure(fs->h, fs_read_extent_complete, fs, db, target_start, f);
-    apply(fs->r, db->buf, db->blocks, copy);
+    bytes absolute = e->block_start + i.start - e->node.r.start;
+    range r = irange(absolute, absolute + len); /* XXX check sg partial end block */
+    tfs_debug("fs_read_extent (sg): sg %p, len %ld, q %R, i %R, r %R\n", bound(sg), len, q, i, r);
+    apply(fs->sg_r, bound(sg), r, apply_merge(bound(m)));
 }
 
+
 closure_function(3, 1, void, fs_zero_hole,
-                 filesystem, fs, buffer, target, range, q,
+                 filesystem, fs, sg_list, sg, range, q,
                  range, z)
 {
     range q = bound(q);
     range i = range_intersection(q, z);
-    u64 target_offset = i.start - q.start;
-    void * target_start = buffer_ref(bound(target), target_offset);
     u64 length = range_span(i);
-    tfs_debug("fs_zero_hole: i %R, target_start %p, length %ld\n", i, target_start, length);
-    runtime_memset(target_start, 0, length);
-    fetch_and_add(&bound(target)->end, length);
+    tfs_debug("fs_zero_hole: i %R, length %ld\n", i, length);
+    fs_zero_pad_sg(bound(fs), bound(sg), length);
 }
 
 io_status_handler ignore_io_status;
 
-closure_function(3, 1, void, filesystem_read_complete,
-                 heap, h, io_status_handler, c, buffer, b,
-                 status, s)
-{
-    buffer b = bound(b);
-    tfs_debug("filesystem_read_complete: status %v, length %d\n", s, buffer_length(b));
-    report_sha256(b);
-    apply(bound(c), s, is_ok(s) ? buffer_length(b) : 0);
-    unwrap_buffer(bound(h), b);
-    closure_finish();
-}
-
-static void filesystem_read_internal(filesystem fs, fsfile f, buffer b, u64 length, u64 offset,
+static void filesystem_read_internal(filesystem fs, fsfile f, sg_list sg, u64 length, u64 offset,
                                      status_handler sh)
 {
     merge m = allocate_merge(fs->h, sh);
@@ -242,43 +217,64 @@ static void filesystem_read_internal(filesystem fs, fsfile f, buffer b, u64 leng
     }
     range total = irange(offset, offset + actual_length);
 
-    /* read extent data */
-    rangemap_range_lookup(f->extentmap, total, stack_closure(fs_read_extent, fs, b, m, total));
-
-    /* zero areas corresponding to file holes */
-    rangemap_range_find_gaps(f->extentmap, total, stack_closure(fs_zero_hole, fs, b, total));
+    /* read extent data and zero gaps */
+    rangemap_range_lookup_with_gaps(f->extentmap, total,
+                                    stack_closure(fs_read_extent, fs, sg, m, total),
+                                    stack_closure(fs_zero_hole, fs, sg, total));
 
     apply(k, STATUS_OK);
 }
 
-void filesystem_read(filesystem fs, tuple t, void *dest, u64 length, u64 offset,
-                     io_status_handler io_complete)
+void filesystem_read_sg(filesystem fs, tuple t, sg_list sg,
+                        u64 length, u64 offset,
+                        status_handler sh)
 {
-    tfs_debug("filesystem_read: t %v, dest %p, length %ld, offset %ld, completion %p\n",
-              t, dest, length, offset, io_complete);
+    tfs_debug("%s: t %v, sg %p, length %ld, offset %ld, completion %p\n",
+              __func__, t, sg, length, offset, sh);
     fsfile f;
     if (!(f = table_find(fs->files, t))) {
         tuple e = timm("result", "no such file %t", t);
-        apply(io_complete, e, 0);
+        apply(sh, e);
         return;
     }
-
-    /* b->end will accumulate the read extent and hole lengths, thus
-       effectively handing a read length to the completion. */
-    buffer b = wrap_buffer(fs->h, dest, length);
-    b->end = b->start;
-    status_handler sh = closure(fs->h, filesystem_read_complete, fs->h, io_complete, b);
-    filesystem_read_internal(fs, f, b, length, offset, sh);
+    filesystem_read_internal(fs, f, sg, length, offset, sh);
 }
 
-closure_function(3, 1, void, read_entire_complete,
-                 buffer_handler, bh, buffer, b, status_handler, sh,
+/* TODO moving sg up to syscall level means eliminating this extra step */
+closure_function(4, 1, void, filesystem_read_complete,
+                 void *, dest, u64, limit, io_status_handler, io_complete, sg_list, sg,
+                 status, s)
+{
+    u64 count = 0;
+    if (is_ok(s)) {
+        count = sg_copy_to_buf_and_release(bound(dest), bound(sg), bound(limit));
+    }
+    apply(bound(io_complete), s, count);
+    closure_finish();
+}
+
+void filesystem_read_linear(filesystem fs, tuple t, void *dest,
+                            u64 length, u64 offset,
+                            io_status_handler io_complete)
+{
+    sg_list sg = allocate_sg_list();
+    if (sg == INVALID_ADDRESS) {
+        apply(io_complete, timm("result", "failed to allocate sg list"), 0);
+        return;
+    }
+    filesystem_read_sg(fs, t, sg, length, offset,
+                       closure(fs->h, filesystem_read_complete, dest, length, io_complete, sg));
+}
+
+closure_function(5, 1, void, read_entire_complete,
+                 sg_list, sg, buffer_handler, bh, buffer, b, u64, length, status_handler, sh,
                  status, s)
 {
     buffer b = bound(b);
-    tfs_debug("read_entire_complete: status %v, addr %p, length %d\n",
-              s, buffer_ref(b, 0), buffer_length(b));
+    tfs_debug("read_entire_complete: status %v, addr %p\n", s, buffer_ref(b, 0));
     if (is_ok(s)) {
+        u64 len = sg_copy_to_buf_and_release(buffer_ref(bound(b), 0), bound(sg), bound(length));
+        buffer_produce(b, len);
         report_sha256(b);
         apply(bound(bh), b);
     } else {
@@ -294,14 +290,18 @@ void filesystem_read_entire(filesystem fs, tuple t, heap bufheap, buffer_handler
               t, bufheap, c, sh);
     fsfile f;
     if (!(f = table_find(fs->files, t))) {
-        tuple e = timm("result", "no such file %t", t);
-        apply(sh, e);
+        apply(sh, timm("result", "no such file %t", t));
         return;
     }
 
     u64 length = pad(fsfile_get_length(f), fs_blocksize(fs));
     buffer b = allocate_buffer(bufheap, pad(length, bufheap->pagesize));
-    filesystem_read_internal(fs, f, b, length, 0, closure(fs->h, read_entire_complete, c, b, sh));
+    sg_list sg = allocate_sg_list();
+    if (b == INVALID_ADDRESS || sg == INVALID_ADDRESS) {
+        apply(sh, timm("result", "allocation failure"));
+        return;
+    }
+    filesystem_read_internal(fs, f, sg, length, 0, closure(fs->h, read_entire_complete, sg, c, b, length, sh));
 }
 
 /*
@@ -318,7 +318,7 @@ closure_function(3, 1, void, fs_write_extent_complete,
                  status, s)
 {
     tfs_debug("fs_write_extent_complete: status %v\n", s);
-    fs_deallocate_dma_buffer(bound(fs), bound(db));
+    refcount_release(&bound(db)->refcount);
     apply(bound(sh), s);
     closure_finish();
 }
@@ -349,13 +349,30 @@ closure_function(4, 1, void, fs_write_extent_aligned_closure,
     closure_finish();
 }
 
+closure_function(4, 1, void, fs_write_extent_read_block_sg_complete,
+                 filesystem, fs, void *, buf, sg_list, sg, status_handler, sh,
+                 status, s)
+{
+    if (is_ok(s)) {
+        sg_copy_to_buf_and_release(bound(buf), bound(sg), fs_blocksize(bound(fs)));
+    }
+    apply(bound(sh), s);
+}
+
 static void fs_write_extent_read_block(filesystem fs, fs_dma_buf db, u64 offset_block, status_handler sh)
 {
     u64 absolute_block = db->blocks.start + offset_block;
     void * buf = db->buf + bytes_from_sectors(fs, offset_block);
-    range r = irange(absolute_block, absolute_block + 1);
-    tfs_debug("fs_write_extent_read_block: sector range %R, buf %p\n", r, buf);
-    apply(fs->r, buf, r, sh);
+    range r = irange(bytes_from_sectors(fs, absolute_block),
+                     bytes_from_sectors(fs, absolute_block + fs_blocksize(fs)));
+    tfs_debug("fs_write_extent_read_block (sg): sector range %R, buf %p\n", r, buf);
+    sg_list sg = allocate_sg_list();
+    if (sg == INVALID_ADDRESS) {
+        apply(sh, timm("result", "%s: failed to allocate sg list", __func__));
+        return;
+    }
+    apply(fs->sg_r, sg, r, closure(fs->h, fs_write_extent_read_block_sg_complete,
+                                   fs, buf, sg, sh));
 }
 
 static void fs_write_extent(filesystem fs, buffer source, merge m, range q, rmnode node)
@@ -653,7 +670,7 @@ boolean set_extent_length(fsfile f, extent ex, u64 length, merge m)
     range r = ex->node.r;
     r.end = ex->node.r.start + length;
 
-    if (rangemap_range_lookup(f->extentmap, r, 0)) {
+    if (rangemap_range_intersects(f->extentmap, r)) {
         tfs_debug("failed: collides with existing extent\n");
         return false;
     }
@@ -1264,6 +1281,7 @@ closure_function(2, 1, void, log_complete,
                  filesystem_complete, fc, filesystem, fs,
                  status, s)
 {
+    tfs_debug("%s: complete %p, fs %p, status %v\n", __func__, bound(fc), bound(fs), s);
     filesystem fs = bound(fs);
     fixup_directory(fs->root, fs->root);
     apply(bound(fc), fs, s);
@@ -1278,23 +1296,25 @@ void create_filesystem(heap h,
                        u64 blocksize,
                        u64 size,
                        heap dma,
-                       block_io read,
+                       sg_block_io read,
                        block_io write,
                        tuple root,
                        boolean initialize,
                        filesystem_complete complete)
 {
-    tfs_debug("create_filesystem: ...\n");
+    tfs_debug("%s\n", __func__);
     filesystem fs = allocate(h, sizeof(struct filesystem));
+    assert(fs != INVALID_ADDRESS);
+    fs->h = h;
     ignore_io_status = closure(h, ignore_io);
     fs->files = allocate_table(h, identity_key, pointer_equal);
     fs->extents = allocate_table(h, identity_key, pointer_equal);
     fs->dma = dma;
-    fs->r = read;
-    fs->h = h;
+    fs->sg_r = read;
     fs->w = write;
     fs->root = root;
     fs->alignment = alignment;
+    fs->size = size;
     assert((blocksize & (blocksize - 1)) == 0); /* power of 2 */
     fs->blocksize_order = find_order(blocksize);
 #ifndef BOOT

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -2,7 +2,6 @@ typedef struct filesystem *filesystem;
 typedef struct fsfile *fsfile;
 
 typedef closure_type(filesystem_complete, void, filesystem, status);
-typedef closure_type(io_status_handler, void, status, bytes);
 
 extern io_status_handler ignore_io_status;
 
@@ -16,7 +15,7 @@ void create_filesystem(heap h,
                        u64 blocksize,
                        u64 size,
                        heap dma,
-                       block_io read, /* read and write are optional */
+                       sg_block_io read,
                        block_io write,
                        tuple root,
                        boolean initialize,
@@ -24,7 +23,8 @@ void create_filesystem(heap h,
 
 // there is a question as to whether tuple->fs file should be mapped inside out outside the filesystem
 // status
-void filesystem_read(filesystem fs, tuple t, void *dest, u64 offset, u64 length, io_status_handler completion);
+void filesystem_read_sg(filesystem fs, tuple t, sg_list sg, u64 length, u64 offset, status_handler sh);
+void filesystem_read_linear(filesystem fs, tuple t, void *dest, u64 offset, u64 length, io_status_handler completion);
 void filesystem_write(filesystem fs, tuple t, buffer b, u64 offset, io_status_handler completion);
 boolean filesystem_truncate(filesystem fs, fsfile f, u64 len,
         status_handler completion);

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -9,21 +9,16 @@
 
 typedef struct log *log;
 
-struct cbm {
-    u8 *buffer;
-    u64 capacity_in_bits;
-};
-
 typedef struct filesystem {
     id_heap storage;
-    struct cbm *free;
+    u64 size;
     heap h;
     int alignment;
     table files; // maps tuple to fsfile
     table extents; // maps extents
     closure_type(log, void, tuple);
     heap dma;
-    block_io r;
+    sg_block_io sg_r;
     block_io w;
     log tl;
     tuple root;
@@ -35,7 +30,6 @@ void ingest_extent(fsfile f, symbol foff, tuple value);
 log log_create(heap h, filesystem fs, boolean initialize, status_handler sh);
 void log_write(log tl, tuple t, status_handler sh);
 void log_write_eav(log tl, tuple e, symbol a, value v, status_handler sh);
-void read_log(log tl, status_handler sh);
 void log_flush(log tl);
 void log_flush_complete(log tl, status_handler completion);
 void flush(filesystem fs, status_handler);

--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -486,7 +486,7 @@ static void log_read(log tl, status_handler sh)
         apply(sh, timm("result", "failed to allocate sg list"));
         return;
     }
-    range r = irange(tl->sectors.start << SECTOR_OFFSET, tl->sectors.end << SECTOR_OFFSET);
+    range r = range_lshift(tl->sectors, SECTOR_OFFSET);
     status_handler tlc = closure(tl->h, log_read_complete, tl, sg, range_span(r), sh);
     tlog_debug("%s: issuing sg read, sg %p, r %R, tlc %p\n", __func__, sg, r, tlc);
     apply(tl->fs->sg_r, sg, r, tlc);

--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -284,25 +284,29 @@ static inline void log_tuple_produce(log tl, buffer b, u64 length)
     tl->tuple_bytes_remain -= length;
 }
 
-closure_function(2, 1, void, log_read_complete,
-                 log, tl, status_handler, sh,
+static void log_read(log tl, status_handler sh);
+
+closure_function(4, 1, void, log_read_complete,
+                 log, tl, sg_list, sg, u64, length, status_handler, sh,
                  status, read_status)
 {
     log tl = bound(tl);
     status s = STATUS_OK;
     status_handler sh = bound(sh);
-    buffer b = tl->staging;
     u8 frame = 0;
     u64 sector, length, tuple_length;
 
-    tlog_debug("log_read_complete: buffer len %d, status %v\n", buffer_length(b), read_status);
     if (!is_ok(read_status)) {
-        tlog_debug("read failure: %v\n", read_status);
+        tlog_debug("log_read failure: %v\n", read_status);
         apply(sh, timm_up(read_status, "result", "read failed"));
         closure_finish();
         return;
     }
 
+    sg_copy_to_buf_and_release(buffer_ref(tl->staging, 0), bound(sg), bound(length));
+
+    buffer b = tl->staging;
+    tlog_debug("log_read_complete: buffer len %d, status %v\n", buffer_length(b), read_status);
     tlog_debug("-> new log extension, checking magic and version\n");
     if (!tl->extension_open) {
         if (runtime_memcmp(buffer_ref(b, 0), tfs_magic, TFS_MAGIC_BYTES)) {
@@ -345,7 +349,7 @@ closure_function(2, 1, void, log_read_complete,
             tl->extension_open = false;
 
             /* chain to next log extension, carrying status handler to end */
-            read_log(tl, sh);
+            log_read(tl, sh);
             goto out;
         case TUPLE_AVAILABLE:
             tlog_debug("-> tuple available\n");
@@ -472,13 +476,20 @@ static boolean init_staging(log tl, status_handler sh)
     return false;
 }
 
-void read_log(log tl, status_handler sh)
+static void log_read(log tl, status_handler sh)
 {
     assert(!tl->extension_open);
     if (!init_staging(tl, sh))
         return;
-    status_handler tlc = closure(tl->h, log_read_complete, tl, sh);
-    apply(tl->fs->r, tl->staging->contents, tl->sectors, tlc);
+    sg_list sg = allocate_sg_list();
+    if (sg == INVALID_ADDRESS) {
+        apply(sh, timm("result", "failed to allocate sg list"));
+        return;
+    }
+    range r = irange(tl->sectors.start << SECTOR_OFFSET, tl->sectors.end << SECTOR_OFFSET);
+    status_handler tlc = closure(tl->h, log_read_complete, tl, sg, range_span(r), sh);
+    tlog_debug("%s: issuing sg read, sg %p, r %R, tlc %p\n", __func__, sg, r, tlc);
+    apply(tl->fs->sg_r, sg, r, tlc);
 }
 
 log log_create(heap h, filesystem fs, boolean initialize, status_handler sh)
@@ -509,7 +520,7 @@ log log_create(heap h, filesystem fs, boolean initialize, status_handler sh)
         init_log_extension(tl->staging, range_span(tl->sectors));
         apply(sh, STATUS_OK);
     } else {
-        read_log(tl, sh);
+        log_read(tl, sh);
     }
     return tl;
   fail_dealloc:

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -516,9 +516,9 @@ static void vmap_paint(heap h, rangemap pvmap, vmap q)
     assert((rq.end & MASK(PAGELOG)) == 0);
     assert(range_span(rq) > 0);
 
-    rmnode_handler nh = stack_closure(vmap_paint_intersection, h, pvmap, q);
-    range_handler rh = stack_closure(vmap_paint_gap, h, pvmap, q);
-    rangemap_range_lookup_with_gaps(pvmap, rq, nh, rh);
+    rangemap_range_lookup_with_gaps(pvmap, rq,
+                                    stack_closure(vmap_paint_intersection, h, pvmap, q),
+                                    stack_closure(vmap_paint_gap, h, pvmap, q));
 
     update_map_flags(rq.start, range_span(rq), page_map_flags(q->flags));
 }

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -517,10 +517,8 @@ static void vmap_paint(heap h, rangemap pvmap, vmap q)
     assert(range_span(rq) > 0);
 
     rmnode_handler nh = stack_closure(vmap_paint_intersection, h, pvmap, q);
-    rangemap_range_lookup(pvmap, rq, nh);
-
     range_handler rh = stack_closure(vmap_paint_gap, h, pvmap, q);
-    rangemap_range_find_gaps(pvmap, rq, rh);
+    rangemap_range_lookup_with_gaps(pvmap, rq, nh, rh);
 
     update_map_flags(rq.start, range_span(rq), page_map_flags(q->flags));
 }
@@ -646,8 +644,8 @@ static sysreturn mmap(void *target, u64 size, int prot, int flags, int fd, u64 o
 
     thread_log(current, "  read file at 0x%lx, flen %ld, blocking...", where, flen);
     file_op_begin(current);
-    filesystem_read(p->fs, f->n, buffer_ref(b, 0), flen, offset,
-                    closure(h, mmap_read_complete, current, where, flen, b, page_map_flags(vmflags)));
+    filesystem_read_linear(p->fs, f->n, buffer_ref(b, 0), flen, offset,
+                           closure(h, mmap_read_complete, current, where, flen, b, page_map_flags(vmflags)));
     return file_op_maybe_sleep(current);
 }
 

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -516,9 +516,8 @@ static void vmap_paint(heap h, rangemap pvmap, vmap q)
     assert((rq.end & MASK(PAGELOG)) == 0);
     assert(range_span(rq) > 0);
 
-    rangemap_range_lookup_with_gaps(pvmap, rq,
-                                    stack_closure(vmap_paint_intersection, h, pvmap, q),
-                                    stack_closure(vmap_paint_gap, h, pvmap, q));
+    rangemap_range_lookup(pvmap, rq, stack_closure(vmap_paint_intersection, h, pvmap, q));
+    rangemap_range_find_gaps(pvmap, rq, stack_closure(vmap_paint_gap, h, pvmap, q));
 
     update_map_flags(rq.start, range_span(rq), page_map_flags(q->flags));
 }

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -441,33 +441,47 @@ static boolean is_special(tuple n)
     return table_find(n, sym(special)) ? true : false;
 }
 
-closure_function(5, 2, void, file_op_complete,
-                 thread, t, file, f, fsfile, fsf, boolean, is_file_offset, io_completion, completion,
-                 status, s, bytes, length)
+static inline void file_op_complete_internal(thread t, file f, fsfile fsf, boolean is_file_offset,
+                                             io_completion completion, status s, bytes length)
 {
-    thread t = bound(t);
-    file f = bound(f);
-
     thread_log(t, "%s: len %d, status %v (%s)", __func__,
             length, s, is_ok(s) ? "OK" : "NOTOK");
     sysreturn rv;
     if (is_ok(s)) {
         /* if regular file, update length */
-        if (bound(fsf))
-            f->length = fsfile_get_length(bound(fsf));
-        if (bound(is_file_offset)) /* vs specified offset (pread) */
+        if (fsf)
+            f->length = fsfile_get_length(fsf);
+        if (is_file_offset) /* vs specified offset (pread) */
             f->offset += length;
         rv = length;
     } else {
-        /* XXX should peek inside s and map to errno... */
+        /* report these to console for now */
+        msg_err("file op failed with %v\n", s);
         rv = -EIO;
     }
-    apply(bound(completion), t, rv);
+    apply(completion, t, rv);
+}
+
+closure_function(5, 2, void, file_op_complete,
+                 thread, t, file, f, fsfile, fsf, boolean, is_file_offset, io_completion, completion,
+                 status, s, bytes, length)
+{
+    file_op_complete_internal(bound(t), bound(f), bound(fsf), bound(is_file_offset),
+                              bound(completion), s, length);
+    closure_finish();
+}
+
+closure_function(6, 1, void, file_op_complete_sg,
+                 thread, t, file, f, fsfile, fsf, sg_list, sg, boolean, is_file_offset, io_completion, completion,
+                 status, s)
+{
+    file_op_complete_internal(bound(t), bound(f), bound(fsf), bound(is_file_offset),
+                              bound(completion), s, bound(sg)->count);
     closure_finish();
 }
 
 closure_function(9, 2, void, sendfile_bh,
-                 heap, h, fdesc, in, fdesc, out, int *, offset, void *, buf, bytes, count, bytes, readlen, bytes, written, boolean, bh,
+                 fdesc, in, fdesc, out, int *, offset, sg_list, sg, sg_buf, cur_buf, bytes, count, bytes, readlen, bytes, written, boolean, bh,
                  thread, t, sysreturn, rv)
 {
     thread_log(t, "%s: readlen %ld, written %ld, bh %d, rv %ld",
@@ -491,54 +505,87 @@ closure_function(9, 2, void, sendfile_bh,
         goto out_complete;
     }
 
-    /* !bh means read complete / initiating send */
+    /* !bh means read complete (rv == bytes read) */
     if (!bound(bh)) {
         bound(bh) = true;
         bound(readlen) = rv;
+
+        /* this whole offset advance / rewind thing can go away if we
+           redo the io methods so that the file_op_complete* only
+           happens at the end of the chain, using only status_handlers
+           (io_status_handler for linear) in the middle */
         if (bound(offset))
             *bound(offset) += rv;
-        thread_log(t, "   read %ld bytes, writing (@%p)", rv, bound(buf));
-        apply(bound(out)->write, bound(buf), rv, 0, t, true, (io_completion)closure_self());
-        return;
+        bound(cur_buf) = sg_list_head_remove(bound(sg)); /* initial dequeue */
+        assert(bound(cur_buf) != INVALID_ADDRESS);
+        bound(cur_buf)->misc = 0; /* offset for our use */
+        thread_log(t, "   read %ld bytes\n", rv);
+    } else {
+        bound(written) += rv;
+        bound(cur_buf)->misc += rv;
+        assert(bound(cur_buf)->length >= rv);
+        if (bound(cur_buf)->misc == bound(cur_buf)->length) {
+            sg_buf_release(bound(cur_buf));
+            if (bound(written) == bound(readlen)) {
+                rv = bound(written);
+                goto out_complete;
+            }
+            bound(cur_buf) = sg_list_head_remove(bound(sg));
+            assert(bound(cur_buf) != INVALID_ADDRESS);
+            bound(cur_buf)->misc = 0; /* offset for our use */
+        }
     }
 
-    bound(written) += rv;
-    if (bound(written) == bound(readlen)) {
-        rv = bound(written);
-        goto out_complete;
-    }
-
-    /* partially written; issue next */
-    s64 remain = bound(readlen) - bound(written);
-    assert(remain > 0);
-
-    void *target = bound(buf) + bound(written);
-    thread_log(t, "   continue writing %ld bytes (@%p)", remain, target);
-    apply(bound(out)->write, target, remain, 0, t, bound(bh), (io_completion)closure_self());
+    /* issue next write */
+    assert(bound(cur_buf));
+    void *buf = bound(cur_buf)->buf + bound(cur_buf)->misc;
+    u32 n = bound(cur_buf)->length - bound(cur_buf)->misc;
+    thread_log(t, "   writing %d bytes from %p", rv, n, buf);
+    apply(bound(out)->write, buf, n, 0, t, true, (io_completion)closure_self());
     return;
 out_complete:
-    deallocate(bound(h), bound(buf), bound(count));
+    sg_list_release(bound(sg));
+    deallocate_sg_list(bound(sg));
     set_syscall_return(t, rv);
     if (bound(bh))
         file_op_maybe_wake(t);
     closure_finish();
 }
 
+/* Should be determined more intelligently based on available
+   buffering on output side, modulated by link capacity
+   (e.g. bandwidth delay product). Right now assuming the common mode
+   is tcp output with 64kB max window size... */
+
+#define SENDFILE_READ_MAX (64 * KB)
+
+/* requires infile to have sg_read method - so sendfile from special files isn't supported */
 static sysreturn sendfile(int out_fd, int in_fd, int *offset, bytes count)
 {
     thread_log(current, "%s: out %d, in %d, offset %p, *offset %d, count %ld",
                __func__, out_fd, in_fd, offset, offset ? *offset : 0, count);
     fdesc infile = resolve_fd(current->p, in_fd);
     fdesc outfile = resolve_fd(current->p, out_fd);
-    heap h = heap_general(get_kernel_heaps());
-
-    if (!infile->read || !outfile->write)
+    if (!infile->sg_read || !outfile->write)
         return set_syscall_error(current, EINVAL);
 
-    void *buf = allocate(h, count);
-    io_completion read_complete = closure(h, sendfile_bh, h, infile, outfile, offset, buf, count, 0, 0, false);
-    apply(infile->read, buf, count, offset ? *offset : infinity, current, false, read_complete);
+    sg_list sg = allocate_sg_list();
+    if (sg == INVALID_ADDRESS)
+        return set_syscall_error(current, ENOMEM);
+
+    u64 n = MIN(count, SENDFILE_READ_MAX);
+    io_completion read_complete = closure(heap_general(get_kernel_heaps()), sendfile_bh, infile, outfile,
+                                          offset, sg, 0, n, 0, 0, false);
+    apply(infile->sg_read, sg, n, offset ? *offset : infinity, current, false, read_complete);
     return sysreturn_value(current);
+}
+
+static void begin_file_read(thread t, file f)
+{
+    if ((f->length > 0) && !(f->f.flags & O_NOATIME)) {
+        filesystem_update_atime(t->p->fs, f->n);
+    }
+    file_op_begin(t);
 }
 
 closure_function(2, 6, sysreturn, file_read,
@@ -557,23 +604,47 @@ closure_function(2, 6, sysreturn, file_read,
     if (is_special(f->n)) {
         return spec_read(f, dest, length, offset, t, bh, completion);
     }
-
-    if (offset < f->length) {
-        if ((f->length > 0) && !(f->f.flags & O_NOATIME)) {
-            filesystem_update_atime(t->p->fs, f->n);
-        }
-        file_op_begin(t);
-        filesystem_read_linear(t->p->fs, f->n, dest, length, offset,
-                               closure(heap_general(get_kernel_heaps()),
-                                       file_op_complete, t, f, fsf, is_file_offset,
-                                       completion));
-
-        /* possible direct return in top half */
-        return bh ? SYSRETURN_CONTINUE_BLOCKING : file_op_maybe_sleep(t);
-    } else {
-        /* XXX special handling for holes will need to go here */
+    if (offset >= f->length) {
         return 0;
     }
+    begin_file_read(t, f);
+    filesystem_read_linear(t->p->fs, f->n, dest, length, offset,
+                           closure(heap_general(get_kernel_heaps()),
+                                   file_op_complete, t, f, fsf, is_file_offset,
+                                   completion));
+
+    /* possible direct return in top half */
+    return bh ? SYSRETURN_CONTINUE_BLOCKING : file_op_maybe_sleep(t);
+}
+
+closure_function(2, 6, sysreturn, file_sg_read,
+                 file, f, fsfile, fsf,
+                 sg_list, sg, u64, length, u64, offset_arg, thread, t, boolean, bh, io_completion, completion)
+{
+    file f = bound(f);
+    fsfile fsf = bound(fsf);
+
+    boolean is_file_offset = offset_arg == infinity;
+    u64 offset = is_file_offset ? f->offset : offset_arg;
+    thread_log(t, "%s: f %p, sg %p, offset %ld (%s), length %ld, file length %ld",
+               __func__, f, sg, offset, is_file_offset ? "file" : "specified",
+               length, f->length);
+
+    /* TODO: special files not supported yet */
+    if (is_special(f->n)) {
+        apply(completion, t, -EIO);
+        goto out;
+    }
+
+    begin_file_read(t, f);
+    filesystem_read_sg(t->p->fs, f->n, sg, length, offset,
+                       closure(heap_general(get_kernel_heaps()),
+                               file_op_complete_sg, t, f, fsf, sg, is_file_offset,
+                               completion));
+
+  out:
+    /* possible direct return in top half */
+    return bh ? SYSRETURN_CONTINUE_BLOCKING : file_op_maybe_sleep(t);
 }
 
 #define PAD_WRITES 0
@@ -757,6 +828,7 @@ sysreturn open_internal(tuple cwd, const char *name, int flags, int mode)
     init_fdesc(h, &f->f, type);
     f->f.read = closure(h, file_read, f, fsf);
     f->f.write = closure(h, file_write, f, fsf);
+    f->f.sg_read = closure(h, file_sg_read, f, fsf);
     f->f.close = closure(h, file_close, f, fsf);
     f->f.events = closure(h, file_events, f);
     f->f.flags = flags;

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -563,10 +563,10 @@ closure_function(2, 6, sysreturn, file_read,
             filesystem_update_atime(t->p->fs, f->n);
         }
         file_op_begin(t);
-        filesystem_read(t->p->fs, f->n, dest, length, offset,
-                        closure(heap_general(get_kernel_heaps()),
-                                file_op_complete, t, f, fsf, is_file_offset,
-                                completion));
+        filesystem_read_linear(t->p->fs, f->n, dest, length, offset,
+                               closure(heap_general(get_kernel_heaps()),
+                                       file_op_complete, t, f, fsf, is_file_offset,
+                                       completion));
 
         /* possible direct return in top half */
         return bh ? SYSRETURN_CONTINUE_BLOCKING : file_op_maybe_sleep(t);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -253,6 +253,8 @@ typedef struct thread {
 
 typedef closure_type(io, sysreturn, void *buf, u64 length, u64 offset, thread t,
         boolean bh, io_completion completion);
+typedef closure_type(sg_io, sysreturn, sg_list sg, u64 length, u64 offset, thread t,
+        boolean bh, io_completion completion);
 
 #define FDESC_TYPE_REGULAR      1
 #define FDESC_TYPE_DIRECTORY    2
@@ -268,6 +270,7 @@ typedef closure_type(io, sysreturn, void *buf, u64 length, u64 offset, thread t,
 
 typedef struct fdesc {
     io read, write;
+    sg_io sg_read, sg_write;
     closure_type(events, u32, thread);
     closure_type(ioctl, sysreturn, unsigned long request, vlist ap);
 
@@ -393,6 +396,8 @@ static inline void init_fdesc(heap h, fdesc f, int type)
 {
     f->read = 0;
     f->write = 0;
+    f->sg_read = 0;
+    f->sg_write = 0;
     f->close = 0;
     f->events = 0;
     f->ioctl = 0;

--- a/src/unix_process/unix_process_runtime.c
+++ b/src/unix_process/unix_process_runtime.c
@@ -99,6 +99,7 @@ heap init_process_runtime()
     init_runtime(h);
     init_tuples(allocate_tagged_region(h, tag_tuple));
     init_symbols(allocate_tagged_region(h, tag_symbol), h);
+    init_sg(h);
     init_extra_prints();
     signal(SIGPIPE, SIG_IGN);
     return h;

--- a/src/x86_64/pagecache.c
+++ b/src/x86_64/pagecache.c
@@ -1,0 +1,456 @@
+#include <kernel.h>
+#include <page.h>
+#include <pagecache.h>
+
+//#define PAGECACHE_DEBUG
+#if defined(PAGECACHE_DEBUG)
+#define pagecache_debug(x, ...) do {rprintf("PGC: " x, ##__VA_ARGS__);} while(0)
+#else
+#define pagecache_debug(x, ...)
+#endif
+
+static inline range blocks_from_bytes(range r, int block_order)
+{
+    return irange(r.start >> block_order, r.end >> block_order);
+}
+
+static inline range bytes_from_blocks(range r, int block_order)
+{
+    return irange(r.start << block_order, r.end << block_order);
+}
+
+static inline u64 pagecache_pagesize(pagecache pc)
+{
+    return U64_FROM_BIT(pc->page_order);
+}
+
+static inline u64 pagecache_blocksize(pagecache pc)
+{
+    return U64_FROM_BIT(pc->block_order);
+}
+
+static int page_state(pagecache_page pp)
+{
+    return pp->state_phys >> PAGECACHE_PAGESTATE_SHIFT;
+}
+
+static inline void set_page_state_locked(pagecache pc, pagecache_page pp, int state)
+{
+    int old_state = page_state(pp);
+    switch (state) {
+    case PAGECACHE_PAGESTATE_FREE:
+        assert(old_state == PAGECACHE_PAGESTATE_NEW || old_state == PAGECACHE_PAGESTATE_ACTIVE);
+        list_delete(&pp->l);
+        list_insert_before(&pc->free, &pp->l);
+        break;
+    case PAGECACHE_PAGESTATE_ALLOC:
+        assert(old_state == PAGECACHE_PAGESTATE_FREE);
+        break;
+    case PAGECACHE_PAGESTATE_READING:
+        assert(old_state == PAGECACHE_PAGESTATE_ALLOC);
+        break;
+    case PAGECACHE_PAGESTATE_NEW:
+        /* later we can allow full page writes to move to new list after sync */
+        assert(old_state == PAGECACHE_PAGESTATE_READING);
+        list_insert_before(&pc->new, &pp->l);
+        break;
+    case PAGECACHE_PAGESTATE_ACTIVE:
+        assert(old_state == PAGECACHE_PAGESTATE_NEW);
+        list_delete(&pp->l);
+        list_insert_before(&pc->active, &pp->l);
+        break;
+    default:
+        halt("%s: bad state %d, old %d\n", __func__, state, old_state);
+    }
+
+    pp->state_phys = (pp->state_phys & MASK(PAGECACHE_PAGESTATE_SHIFT)) |
+        ((u64)state << PAGECACHE_PAGESTATE_SHIFT);
+}
+
+static inline void set_page_state(pagecache pc, pagecache_page pp, int state)
+{
+    spin_lock(&pc->lock);
+    set_page_state_locked(pc, pp, state);
+    spin_unlock(&pc->lock);
+}
+
+closure_function(2, 1, void, read_page_complete,
+                 pagecache, pc, pagecache_page, pp,
+                 status, s)
+{
+    pagecache_page pp = bound(pp);
+    pagecache_debug("%s: pc %p, pp %p, status %v\n", __func__, bound(pc), bound(pp), s);
+    spin_lock(&pp->lock);
+    assert(page_state(pp) == PAGECACHE_PAGESTATE_READING);
+    if (!is_ok(s)) {
+        /* XXX policy? */
+        msg_err("error reading page %R: %v\n", pp->node.r, s);
+    } else {
+        set_page_state(bound(pc), pp, PAGECACHE_PAGESTATE_NEW);
+    }
+    spin_unlock(&pp->lock);    // XXX not correct, faking it with big kernel lock...
+    status_handler sh;
+    vector_foreach(pp->completions, sh) {
+        apply(sh, s);
+    }
+    vector_clear(pp->completions);
+    closure_finish();
+}
+
+static void read_page_blocks(pagecache pc, pagecache_page pp)
+{
+    pagecache_debug("%s: start %lx, end %lx, len %lx\n", __func__,
+                    pp->node.r.start, pp->node.r.end, pc->length);
+    u64 end = pp->node.r.end;
+    if (end > pc->length) {
+        zero(pp->kvirt + (pc->length - pp->node.r.start), end - pc->length);
+        end = pc->length;
+    }
+
+    /* sg finally terminates to block io */
+    range blocks = blocks_from_bytes(irange(pp->node.r.start, end), pc->block_order);
+    pagecache_debug("%s: pc %p, pp %p, blocks %R, reading...\n", __func__, pc, pp, blocks);
+    apply(pc->block_read, pp->kvirt, blocks, closure(pc->h, read_page_complete, pc, pp));
+}
+
+static boolean pagecache_page_touch_if_filled_locked(pagecache pc, pagecache_page pp)
+{
+    int state = page_state(pp);
+    if (state == PAGECACHE_PAGESTATE_READING ||
+        state == PAGECACHE_PAGESTATE_ALLOC) {
+        return false;
+    }
+
+    /* move to bottom of active list */
+    if (state == PAGECACHE_PAGESTATE_ACTIVE) {
+        spin_lock(&pc->lock);
+        list_delete(&pp->l);
+        list_insert_before(&pc->active, &pp->l);
+        spin_unlock(&pc->lock);
+    } else if (state == PAGECACHE_PAGESTATE_NEW) {
+        /* cache hit -> active */
+        set_page_state(pc, pp, PAGECACHE_PAGESTATE_ACTIVE);
+    } else {
+        assert(state == PAGECACHE_PAGESTATE_DIRTY);
+    }
+    return true;
+}
+
+static void pagecache_page_fill_locked(pagecache pc, pagecache_page pp, status_handler sh)
+{
+    vector_push(pp->completions, sh);
+    if (page_state(pp) == PAGECACHE_PAGESTATE_ALLOC) {
+        set_page_state(pc, pp, PAGECACHE_PAGESTATE_READING);
+        read_page_blocks(pc, pp);
+    }
+}
+
+static void pagecache_read_page_internal_locked(pagecache pc, pagecache_page pp, sg_list sg, range q, merge m)
+{
+    range r = pp->node.r;
+    pagecache_debug("%s: pc %p, sg %p, q %R, m %p, r %R, pp %p, refcount %d, state %d\n",
+                    __func__, pc, sg, q, m, r, pp, pp->refcount.c, state);
+
+    // XXX verify ok to have merge completion here
+    if (!pagecache_page_touch_if_filled_locked(pc, pp))
+        pagecache_page_fill_locked(pc, pp, apply_merge(m));
+
+    range i = range_intersection(q, r);
+    bytes length = range_span(i);
+    bytes offset = i.start - r.start;
+    sg_buf sgb = sg_list_tail_add(sg, length);
+
+    sgb->buf = pp->kvirt + offset;
+    sgb->length = length;
+    sgb->refcount = &pp->refcount;
+    refcount_reserve(&pp->refcount); /* reference for being on sg list */
+}
+
+/* for existing pages, load blocks as necessary and move from new to active list
+   note: sg vec building depends on rangemap traversal being in order... */
+closure_function(4, 1, void, pagecache_read_page,
+                 pagecache, pc, sg_list, sg, range, q, merge, m,
+                 rmnode, node)
+{
+    pagecache_page pp = (pagecache_page)node;
+    spin_lock(&pp->lock);
+    pagecache_read_page_internal_locked(bound(pc), pp, bound(sg), bound(q), bound(m));
+    spin_unlock(&pp->lock);
+}
+
+closure_function(2, 0, void, pagecache_page_release,
+                 pagecache, pc, pagecache_page, pp)
+{
+    pagecache_page pp = bound(pp);
+    /* remove from existing list depending on state */
+    int state = page_state(pp);
+    if (state != PAGECACHE_PAGESTATE_NEW || state != PAGECACHE_PAGESTATE_ACTIVE)
+        halt("%s: pc %p, pp %p, invalid state %d\n", __func__, bound(pc), pp, page_state(pp));
+
+    pagecache pc = bound(pc);
+    spin_lock(&pc->lock);
+    rangemap_remove_node(pc->pages, &pp->node);
+    set_page_state_locked(pc, pp, PAGECACHE_PAGESTATE_FREE);
+    /* XXX zero - where? */
+
+    spin_unlock(&pc->lock);
+    /* leave closure intact and reuse */
+}
+
+static pagecache_page allocate_pagecache_page(pagecache pc)
+{
+    spin_lock(&pc->lock);
+    if (!list_empty(&pc->free)) {
+        list l = list_get_next(&pc->free);
+        assert(l);
+        pagecache_page pp = struct_from_list(l, pagecache_page, l);
+        list_delete(l);
+        set_page_state_locked(pc, pp, PAGECACHE_PAGESTATE_ALLOC);
+        refcount_reserve(&pp->refcount);
+        spin_unlock(&pc->lock);
+        return pp;
+    }
+    spin_unlock(&pc->lock);
+
+    /* allocate - later we can look at blocks of pages at a time */
+    u64 pagesize = U64_FROM_BIT(pc->page_order);
+    void *p = allocate(pc->backed, pagesize);
+    if (p == INVALID_ADDRESS)
+        return INVALID_ADDRESS;
+
+    pagecache_page pp = allocate(pc->h, sizeof(struct pagecache_page));
+    if (pp == INVALID_ADDRESS)
+        goto fail_dealloc_backed;
+
+    spin_lock_init(&pp->lock);
+    pp->completions = allocate_vector(pc->h, 8);
+    if (pp->completions == INVALID_ADDRESS)
+        goto fail_dealloc_pp;
+    pp->l.next = pp->l.prev = 0;
+
+    /* keeping physical for demand paging / multiple mappings */
+    pp->state_phys = ((u64)PAGECACHE_PAGESTATE_ALLOC << PAGECACHE_PAGESTATE_SHIFT) |
+        (physical_from_virtual(p) >> pc->page_order);
+    pp->kvirt = p;
+    init_refcount(&pp->refcount, 1, closure(pc->h, pagecache_page_release, pc, pp));
+    return pp;
+  fail_dealloc_pp:
+    deallocate(pc->h, pp, sizeof(struct pagecache_page));
+  fail_dealloc_backed:
+    deallocate(pc->backed, p, pagesize);
+    return INVALID_ADDRESS;
+}
+
+static void pagecache_page_insert_locked(pagecache pc, pagecache_page pp)
+{
+    assert(rangemap_insert(pc->pages, &pp->node));
+}
+
+/* populate missing pages, allocate buffers and install kernel mappings */
+closure_function(4, 1, void, pagecache_read_gap,
+                 pagecache, pc, sg_list, sg, range, q, merge, m,
+                 range, r)
+{
+    pagecache_debug("%s:    q %R, r %R\n", __func__, bound(q), r);
+    pagecache pc = bound(pc);
+    int order = pc->page_order;
+    u64 pagesize = U64_FROM_BIT(order);
+    u64 start = r.start & ~MASK(order);
+    for (u64 offset = start; offset < r.end; offset += pagesize) {
+        pagecache_page pp = allocate_pagecache_page(pc);
+        if (pp == INVALID_ADDRESS) {
+            apply(apply_merge(bound(m)), timm("result", "failed to allocate pagecache_page"));
+            return;
+        }
+
+        pp->node.r = irange(offset, offset + pagesize);
+        spin_lock(&pp->lock);
+        pagecache_page_insert_locked(pc, pp);
+        pagecache_read_page_internal_locked(pc, pp, bound(sg), bound(q), bound(m));
+        spin_unlock(&pp->lock);
+    }
+}
+
+/* XXX need to make sure partial end block is ok */
+/* XXX rangemap -> single point tree lookup */
+static boolean pagecache_read_internal(pagecache pc, sg_list sg, range q, status_handler completion)
+{
+    pagecache_debug("%s: pc %p, sg %p, q %R, completion %p\n", __func__, pc, sg, q, completion);
+    assert(range_span(q) > 0);
+    merge m = allocate_merge(pc->h, completion);
+
+    /* fill gaps and initiate reads */
+    status_handler sh = apply_merge(m);
+    if (!rangemap_range_lookup_with_gaps(pc->pages, q,
+                                         stack_closure(pagecache_read_page, pc, sg, q, m),
+                                         stack_closure(pagecache_read_gap, pc, sg, q, m))) {
+        apply(sh, timm("result", "%s: no matching pages for range %R", __func__, q));
+        return false;
+    }
+    /* finished issuing requests */
+    apply(sh, STATUS_OK);
+    return true;
+}
+
+closure_function(1, 3, void, pagecache_read_sg,
+                 pagecache, pc,
+                 sg_list, sg, range, q, status_handler, sh)
+{
+    pagecache_read_internal(bound(pc), sg, q, sh);
+}
+
+/* TODO for pagecache writing:
+
+   immediate:
+   - get rid of annoying write test output
+   - skip read for full page writes
+   - don't wait for block write to apply write completion, but do track (and report) any write errors
+
+   future:
+   - use the block mapper to convert between byte offset and block numbers
+     - this paves the way for per-fsfile cache, bypassing tfs extent lookup
+   - implement write-back
+*/
+
+static void pagecache_write_page_internal_locked(pagecache pc, pagecache_page pp,
+                                                 void *buf, range q, status_handler sh)
+{
+    int state = page_state(pp);
+    range i = range_intersection(q, pp->node.r);
+    u64 len = range_span(i);
+    u64 page_offset = i.start - pp->node.r.start;
+    void *dest = pp->kvirt + page_offset;
+    void *src = buf + (i.start - q.start);
+    pagecache_debug("%s: pc %p, pp %p, refcount %d, state %d, src %p, i %R, offset %d, len %d\n",
+                    __func__, pc, pp, pp->refcount.c, state, src, i, page_offset, len);
+
+    assert(state == PAGECACHE_PAGESTATE_NEW ||
+           state == PAGECACHE_PAGESTATE_ACTIVE ||
+           state == PAGECACHE_PAGESTATE_DIRTY);
+
+    pagecache_debug("   copy %p <- %p %d bytes\n", dest, src, len);
+    runtime_memcpy(dest, src, len);
+    range blocks = blocks_from_bytes(pp->node.r, pc->block_order);
+    pagecache_debug("   write %p to block range %R\n", pp->kvirt, blocks);
+    apply(pc->block_write, pp->kvirt, blocks, sh);
+}
+
+closure_function(5, 0, void, pagecache_write_io_complete,
+                 pagecache, pc, pagecache_page, pp, void *, buf, range, q, status_handler, sh)
+{
+    spin_lock(&bound(pp)->lock);
+    pagecache_write_page_internal_locked(bound(pc), bound(pp), bound(buf), bound(q), bound(sh));
+    spin_unlock(&bound(pp)->lock);
+    closure_finish();
+}
+
+static void pagecache_write_page_io_check(pagecache pc, pagecache_page pp,
+                                          void *buf, range q, status_handler sh)
+{
+    spin_lock(&pp->lock);
+    int state = page_state(pp);
+    assert(state != PAGECACHE_PAGESTATE_ALLOC);
+    if (state == PAGECACHE_PAGESTATE_READING) {
+        vector_push(pp->completions, closure(pc->h, pagecache_write_io_complete,
+                                        pc, pp, buf, q, sh));
+    } else {
+        pagecache_write_page_internal_locked(pc, pp, buf, q, sh);
+    }
+    spin_unlock(&pp->lock);
+}
+
+closure_function(4, 1, void, pagecache_write_page,
+                 pagecache, pc, void *, buf, range, q, merge, m,
+                 rmnode, node)
+{
+    pagecache_write_page_io_check(bound(pc), (pagecache_page)node, bound(buf), bound(q),
+                                  apply_merge(bound(m)));
+}
+
+closure_function(5, 1, void, pagecache_write_page_filled,
+                 pagecache, pc, pagecache_page, pp, void *, buf, range, q, status_handler, sh,
+                 status, s)
+{
+    pagecache_debug("%s: page %R, status %v\n", __func__, bound(pp)->node.r, s);
+    if (!is_ok(s)) {
+        apply(bound(sh), timm_up(s, "result", "%s: fill failed", __func__));
+    } else {
+        pagecache_write_page_io_check(bound(pc), bound(pp), bound(buf), bound(q), bound(sh));
+    }
+    closure_finish();
+}
+
+closure_function(4, 1, void, pagecache_write_gap,
+                 pagecache, pc, void *, buf, range, q, merge, m,
+                 range, r)
+{
+    pagecache pc = bound(pc);
+    pagecache_debug("%s: buf %p, q %R, r %R\n", __func__, bound(buf), bound(q), r);
+    int order = pc->page_order;
+    u64 pagesize = U64_FROM_BIT(order);
+    u64 start = r.start & ~MASK(order);
+    for (u64 offset = start; offset < r.end; offset += pagesize) {
+        pagecache_page pp = allocate_pagecache_page(pc);
+        if (pp == INVALID_ADDRESS) {
+            apply(apply_merge(bound(m)), timm("result", "failed to allocate pagecache_page"));
+            return;
+        }
+
+        pp->node.r = irange(offset, offset + pagesize);
+        spin_lock(&pp->lock);
+        pagecache_page_insert_locked(pc, pp);
+        pagecache_page_fill_locked(pc, pp, closure(pc->h, pagecache_write_page_filled,
+                                                   pc, pp, bound(buf), bound(q),
+                                                   apply_merge(bound(m))));
+        spin_unlock(&pp->lock);
+    }
+}
+
+closure_function(1, 3, void, pagecache_write,
+                 pagecache, pc,
+                 void *, buf, range, blocks, status_handler, sh)
+{
+    pagecache pc = bound(pc);
+    pagecache_debug("%s: buf %p, sg %p, blocks %R, completion %p\n", __func__, pc, buf, blocks, sh);
+    range q = bytes_from_blocks(blocks, pc->block_order);
+    merge m = allocate_merge(pc->h, sh);
+    status_handler k = apply_merge(m);
+    rangemap_range_lookup_with_gaps(pc->pages, q,
+                                    stack_closure(pagecache_write_page, pc, buf, q, m),
+                                    stack_closure(pagecache_write_gap, pc, buf, q, m));
+    apply(k, STATUS_OK);
+}
+
+pagecache allocate_pagecache(heap general, heap backed,
+                             u64 length, u64 pagesize, u64 block_size,
+                             block_mapper mapper, block_io read, block_io write)
+{
+    /* TODO get from free list */
+    
+    pagecache pc = allocate(general, sizeof(struct pagecache));
+    if (pc == INVALID_ADDRESS)
+        return pc;
+
+    pc->pages = allocate_rangemap(general);
+    if (pc->pages == INVALID_ADDRESS) {
+        deallocate(general, pc->pages, sizeof(struct pagecache));
+        return INVALID_ADDRESS;
+    }
+    list_init(&pc->free);
+    list_init(&pc->new);
+    list_init(&pc->active);
+    list_init(&pc->dirty);
+    pc->page_order = find_order(pagesize);
+    assert(pagesize == U64_FROM_BIT(pc->page_order));
+    pc->block_order = find_order(block_size);
+    assert(block_size == U64_FROM_BIT(pc->block_order));
+    pc->length = length;
+    pc->h = general;
+    pc->backed = backed;
+    pc->mapper = mapper;
+    pc->block_read = read;
+    pc->block_write = write;
+    pc->sg_read = closure(general, pagecache_read_sg, pc);
+    pc->write = closure(general, pagecache_write, pc);
+    return pc;
+}

--- a/src/x86_64/pagecache.h
+++ b/src/x86_64/pagecache.h
@@ -1,0 +1,61 @@
+/* cache index to volume index, in bytes */
+typedef closure_type(block_mapper, u64, u64);
+
+typedef struct pagecache {
+    rangemap pages;
+    struct spinlock lock;
+    struct list free;           /* see state descriptions */
+    struct list new;
+    struct list active;
+    struct list dirty;          /* phase 2 */
+    int page_order;
+    int block_order;            /* really only 9 or 12 at this point */
+    u64 length;                 /* hard limit */
+    heap h;
+    heap backed;
+    block_mapper mapper;
+    block_io block_read;
+    block_io block_write;
+    sg_block_io sg_read;
+    block_io write;
+} *pagecache;
+
+#define PAGECACHE_PAGESTATE_SHIFT   61
+
+#define PAGECACHE_PAGESTATE_FREE    0 /* unused */
+#define PAGECACHE_PAGESTATE_ALLOC   1 /* allocated, request not issued (not on list) */
+#define PAGECACHE_PAGESTATE_READING 2 /* block reads issued (not on list) */
+#define PAGECACHE_PAGESTATE_NEW     3 /* newly-loaded and full page writes - can be reclaimed */
+#define PAGECACHE_PAGESTATE_ACTIVE  4 /* cache hit for page */
+#define PAGECACHE_PAGESTATE_DIRTY   5 /* page not synced */
+#define PAGECACHE_PAGESTATE_WRITING 6 /* block writes in progress; back to tail of new on completion */
+
+/* TODO fix for block size > pagesize */
+typedef struct pagecache_page {
+    struct rmnode node;
+    struct refcount refcount;
+    struct list l;
+    struct spinlock lock;       /* cover changes to state / completions */
+    void *kvirt;
+    u64 state_phys;             /* state and physical page number */
+    vector completions;         /* status_handlers */
+} *pagecache_page;
+
+static inline void pagecache_release_page(pagecache_page pp)
+{
+    refcount_release(&pp->refcount);
+}
+
+static inline sg_block_io pagecache_reader_sg(pagecache pc)
+{
+    return pc->sg_read;
+}
+
+static inline block_io pagecache_writer(pagecache pc)
+{
+    return pc->write;
+}
+
+pagecache allocate_pagecache(heap general, heap backed,
+                             u64 length, u64 pagesize, u64 block_size,
+                             block_mapper mapper, block_io read, block_io write);

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -111,7 +111,7 @@ closure_function(2, 3, void, attach_storage,
     heap h = heap_general(&heaps);
     u64 offset = bound(fs_offset);
     length -= offset;
-    pagecache pc = allocate_pagecache(h, heap_backed(&heaps), length, PAGESIZE, SECTOR_SIZE,
+    pagecache pc = allocate_pagecache(h, heap_backed(&heaps), length, PAGESIZE_2M, SECTOR_SIZE,
                                       0 /* XXX mapper */,
                                       closure(h, offset_block_io, bound(fs_offset), r),
                                       closure(h, offset_block_io, bound(fs_offset), w));

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -1,6 +1,7 @@
 #include <kernel.h>
 #include <pci.h>
 #include <tfs.h>
+#include <pagecache.h>
 #include <apic.h>
 #include <region.h>
 #include <page.h>
@@ -108,13 +109,21 @@ closure_function(2, 3, void, attach_storage,
 {
     // with filesystem...should be hidden as functional handlers on the tuplespace
     heap h = heap_general(&heaps);
+    u64 offset = bound(fs_offset);
+    length -= offset;
+    pagecache pc = allocate_pagecache(h, heap_backed(&heaps), length, PAGESIZE, SECTOR_SIZE,
+                                      0 /* XXX mapper */,
+                                      closure(h, offset_block_io, bound(fs_offset), r),
+                                      closure(h, offset_block_io, bound(fs_offset), w));
+    if (pc == INVALID_ADDRESS)
+        halt("unable to create pagecache\n");
     create_filesystem(h,
                       SECTOR_SIZE,
                       SECTOR_SIZE,
                       length,
                       heap_backed(&heaps),
-                      closure(h, offset_block_io, bound(fs_offset), r),
-                      closure(h, offset_block_io, bound(fs_offset), w),
+                      pagecache_reader_sg(pc),
+                      pagecache_writer(pc),
                       bound(root),
                       false,
                       closure(h, fsstarted, bound(root)));
@@ -287,6 +296,7 @@ static void __attribute__((noinline)) init_service_new_stack()
     init_runtime(misc);
     init_tuples(allocate_tagged_region(kh, tag_tuple));
     init_symbols(allocate_tagged_region(kh, tag_symbol), misc);
+    init_sg(misc);
     unmap(0, PAGESIZE, pages);  /* unmap zero page */
     reclaim_regions();          /* unmap and reclaim stage2 stack */
     init_extra_prints();

--- a/src/x86_64/symtab.c
+++ b/src/x86_64/symtab.c
@@ -35,7 +35,7 @@ closure_function(0, 4, void, elf_symtable_add,
     assert(elf_symtable);
 
     range r = irange(a, a + len);
-    boolean match = rangemap_range_lookup(elf_symtable, r, 0);
+    boolean match = rangemap_range_intersects(elf_symtable, r);
     if (match) {
 #ifdef ELF_SYMTAB_DEBUG
 	msg_err("\"%s\" %R would overlap in rangemap; skipping\n", name, r);

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -30,6 +30,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
 	$(SRCDIR)/runtime/runtime_init.c \
+	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/sha256.c \
 	$(SRCDIR)/runtime/symbol.c \
 	$(SRCDIR)/runtime/table.c \
@@ -80,6 +81,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/x86_64/kvm_platform.c \
 	$(SRCDIR)/x86_64/mp.c \
 	$(SRCDIR)/x86_64/page.c \
+	$(SRCDIR)/x86_64/pagecache.c \
 	$(SRCDIR)/x86_64/pci.c \
 	$(SRCDIR)/x86_64/pvclock.c \
 	$(SRCDIR)/x86_64/rtc.c \
@@ -130,7 +132,7 @@ INCLUDES=\
 	-I$(SRCDIR)/xen/public \
 	-I$(LWIPDIR)/src/include
 
-CFLAGS+=$(KERNCFLAGS) -DSTAGE3
+CFLAGS+=$(KERNCFLAGS) -DSTAGE3 -DTFS_SG_IFACE
 CFLAGS+=$(INCLUDES)
 
 # Enable tracing by specifying TRACE=ftrace on command line

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -132,7 +132,7 @@ INCLUDES=\
 	-I$(SRCDIR)/xen/public \
 	-I$(LWIPDIR)/src/include
 
-CFLAGS+=$(KERNCFLAGS) -DSTAGE3 -DTFS_SG_IFACE
+CFLAGS+=$(KERNCFLAGS) -DSTAGE3
 CFLAGS+=$(INCLUDES)
 
 # Enable tracing by specifying TRACE=ftrace on command line

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -121,6 +121,7 @@ SRCS-pipe= \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
 	$(SRCDIR)/runtime/runtime_init.c \
+	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/string.c \
 	$(SRCDIR)/runtime/symbol.c \
 	$(SRCDIR)/runtime/table.c \
@@ -156,6 +157,7 @@ SRCS-signal= \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
 	$(SRCDIR)/runtime/runtime_init.c \
+	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/string.c \
 	$(SRCDIR)/runtime/symbol.c \
 	$(SRCDIR)/runtime/table.c \
@@ -216,6 +218,7 @@ SRCS-udploop= \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
 	$(SRCDIR)/runtime/runtime_init.c \
+	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/sha256.c \
 	$(SRCDIR)/runtime/signature.c \
 	$(SRCDIR)/runtime/string.c \
@@ -265,6 +268,7 @@ SRCS-web= \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
 	$(SRCDIR)/runtime/runtime_init.c \
+	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/sha256.c \
 	$(SRCDIR)/runtime/signature.c \
 	$(SRCDIR)/runtime/string.c \

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -28,6 +28,7 @@ RUNTIME = \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
 	$(SRCDIR)/runtime/runtime_init.c \
+	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/symbol.c \
 	$(SRCDIR)/runtime/table.c \
 	$(SRCDIR)/runtime/timer.c \


### PR DESCRIPTION
This PR proposes to merge an implementation of a page cache as well as a scatter-gather list type (sg_list) that can be used to support vectorized I/O operations. To support zero-copy operations, the page cache exposes a scatter-gather (sg) read interface.

In this phase, a page cache is instantiated as a transparent cache proxy for block storage. TFS has been modified to support only an sg read interface to the backing storage. In the case of stage3, this is the page cache used to create the filesystem. In stage2 and dump, the page cache is replaced with a wrapper that interfaces directly to the block device. Write interfaces are left as buffer-based for the time being, and writes to the page cache are currently write-through only.

While these changes will absorb redundant read accesses to the storage block device, there are a number of improvements to be made:

near-term:
- the cache presently isn't releasing pages, which limits the amount of storage that can be accessed at the moment ... implement a drain function as well as some sort of high watermark / heuristic to determine maximum cache size system-wide (highest priority)
- write methods for the page cache and tfs can be transformed to sg-only (linear writes map trivially to sg as a single fragment)
- the filesystem interface used in the syscall layer can become sg based
- sendfile(2) can take advantage of the sg interface to allow zero-copy
- readv implementation can be simplified using tfs sg read interface
- writev can be made to eliminate copies by interfacing directly with a tfs sg write
- sequential page accesses can be optimized by following links rather than doing a rangemap lookup per page - implementation TBD
- tfs writes can eliminate the intermediate head/tail sector read step by writing directly into the page cache (basically just moving those prerequisite reads into the page cache - which is partially there already to accommodate partial page writes) - this eliminates a copy as well as obviates the use of "dma bufs" in tfs
- allow pagecache writes to complete immediately - but create a facility for catching and reporting I/O errors from (deferred) block device operations
- possibly replace rangemap page lookup with e.g. hash table, r-b tree or skip list lookup (although the pages still need to be threaded in order for easy traversal)

future:
- implement true file-backed mmaps using pagecache buffers
- using a block mapper (table of offset -> sector number), make caches linked to fsfiles (our inode equivalent) instead of (or in addition to) the entire block storage device - this eliminates the need for tfs to do extent lookups on cached accesses
- write-back support to aggregate storage writes
