### PR TITLE
Signals: implement sigaltstack()

### DIFF
--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -547,6 +547,7 @@ typedef struct {
 #define SS_ONSTACK      1
 #define SS_DISABLE      2
 
+#define MINSIGSTKSZ     2048
 
 #define UC_FP_XSTATE            0x1
 #define UC_SIGCONTEXT_SS        0x2


### PR DESCRIPTION
Commit 47a38f6e03ffc62b931997e1fb73f0f8eed4382c added an implementation of sigaltstack() but didn't acctually link it to the corresponding syscall number. This commit modifies the implementation to properly handle NULL arguments and invalid argument data, and links the sigaltstack() function to the syscall number; in addition, runtime tests to exercise the new code are being added.

Closes #927.
Closes #1131.