### PR TITLE
page eviction and simple mm service routine

### DIFF
--- a/src/runtime/uniboot.h
+++ b/src/runtime/uniboot.h
@@ -75,6 +75,9 @@ extern void * AP_BOOT_PAGE;
 #define XENNET_RX_SERVICEQUEUE_DEPTH 512
 #define XENNET_TX_SERVICEQUEUE_DEPTH 512
 
+/* mm stuff */
+#define CACHE_DRAIN_CUTOFF (64 * MB)
+
 #include <x86.h>
 void xsave(void *);
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -498,6 +498,7 @@ closure_function(9, 2, void, sendfile_bh,
                 thread_log(t, "   rewound %ld bytes to %ld", rewind, f_in->offset);
             }
             rv = bound(written) == 0 ? -EAGAIN : bound(written);
+            sg_buf_release(bound(cur_buf));
             thread_log(t, "   write would block, returning %ld", rv);
         } else {
             thread_log(t, "   zero or error, rv %ld", rv);
@@ -523,7 +524,6 @@ closure_function(9, 2, void, sendfile_bh,
     } else {
         bound(written) += rv;
         bound(cur_buf)->misc += rv;
-        assert(bound(cur_buf)->length >= rv);
         if (bound(cur_buf)->misc == bound(cur_buf)->length) {
             sg_buf_release(bound(cur_buf));
             if (bound(written) == bound(readlen)) {
@@ -534,6 +534,7 @@ closure_function(9, 2, void, sendfile_bh,
             assert(bound(cur_buf) != INVALID_ADDRESS);
             bound(cur_buf)->misc = 0; /* offset for our use */
         }
+        assert(bound(cur_buf)->misc < bound(cur_buf)->length);
     }
 
     /* issue next write */

--- a/src/x86_64/kernel.h
+++ b/src/x86_64/kernel.h
@@ -180,6 +180,8 @@ void kern_lock(void);
 boolean kern_try_lock(void);
 void kern_unlock(void);
 void init_scheduler(heap);
+void mm_service(void);
+
 extern void interrupt_exit(void);
 extern char **state_strings;
 

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -570,6 +570,17 @@ static u64 wrap_alloc_subrange(id_heap i, bytes count, u64 start, u64 end)
     return r;
 }
 
+/* don't need lock for these */
+static u64 wrap_total(heap h)
+{
+    return phys_internal->total;
+}
+
+static u64 wrap_allocated(heap h)
+{
+    return phys_internal->allocated;
+}
+
 /* this happens even before moving to the new stack, so ... be cool */
 id_heap init_page_tables(heap h, id_heap physical)
 {
@@ -581,8 +592,8 @@ id_heap init_page_tables(heap h, id_heap physical)
     i->h.alloc = wrap_alloc;
     i->h.dealloc = wrap_dealloc;
     i->h.destroy = 0;
-    i->h.allocated = physical->h.allocated;
-    i->h.total = physical->h.total;
+    i->h.allocated = wrap_allocated;
+    i->h.total = wrap_total;
     i->h.pagesize = physical->h.pagesize;
     i->add_range = wrap_add_range;
     i->set_area = wrap_set_area;

--- a/src/x86_64/pagecache.c
+++ b/src/x86_64/pagecache.c
@@ -491,7 +491,7 @@ static inline void page_list_init(struct pagelist *pl)
 
 u64 pagecache_drain(pagecache pc, u64 drain_bytes)
 {
-    u64 pages = drain_bytes >> pc->page_order;
+    u64 pages = pad(drain_bytes, pagecache_pagesize(pc)) >> pc->page_order;
     spin_lock(&pc->lock);
     u64 evicted = evict_pages_cache_locked(pc, pages);
     spin_unlock(&pc->lock);

--- a/src/x86_64/pagecache.h
+++ b/src/x86_64/pagecache.h
@@ -1,15 +1,21 @@
 /* cache index to volume index, in bytes */
 typedef closure_type(block_mapper, u64, u64);
 
+struct pagelist {
+    struct list l;
+    u64 pages;
+};
+
 typedef struct pagecache {
-    rangemap pages;
-    struct spinlock lock;
-    struct list free;           /* see state descriptions */
-    struct list new;
-    struct list active;
-    struct list dirty;          /* phase 2 */
     int page_order;
-    int block_order;            /* really only 9 or 12 at this point */
+    int block_order;
+    struct spinlock lock;
+    rangemap pages;
+    struct pagelist free;      /* see state descriptions */
+    struct pagelist new;
+    struct pagelist active;
+    struct pagelist dirty;     /* phase 2 */
+    u64 total_pages;
     u64 length;                 /* hard limit */
     heap h;
     heap backed;
@@ -22,13 +28,14 @@ typedef struct pagecache {
 
 #define PAGECACHE_PAGESTATE_SHIFT   61
 
-#define PAGECACHE_PAGESTATE_FREE    0 /* unused */
-#define PAGECACHE_PAGESTATE_ALLOC   1 /* allocated, request not issued (not on list) */
-#define PAGECACHE_PAGESTATE_READING 2 /* block reads issued (not on list) */
-#define PAGECACHE_PAGESTATE_NEW     3 /* newly-loaded and full page writes - can be reclaimed */
-#define PAGECACHE_PAGESTATE_ACTIVE  4 /* cache hit for page */
-#define PAGECACHE_PAGESTATE_DIRTY   5 /* page not synced */
-#define PAGECACHE_PAGESTATE_WRITING 6 /* block writes in progress; back to tail of new on completion */
+#define PAGECACHE_PAGESTATE_FREE    0 /* unused, yet may remain in search tree and retain usage stats */
+#define PAGECACHE_PAGESTATE_EVICTED 1 /* evicted, awaiting release by user (not on list) */
+#define PAGECACHE_PAGESTATE_ALLOC   2 /* allocated, request not issued (not on list) */
+#define PAGECACHE_PAGESTATE_READING 3 /* block reads issued (not on list) */
+#define PAGECACHE_PAGESTATE_NEW     4 /* newly-loaded and full page writes - can be reclaimed */
+#define PAGECACHE_PAGESTATE_ACTIVE  5 /* cache hit for page */
+#define PAGECACHE_PAGESTATE_DIRTY   6 /* page not synced */
+#define PAGECACHE_PAGESTATE_WRITING 7 /* block writes in progress; back to tail of new on completion */
 
 /* TODO fix for block size > pagesize */
 typedef struct pagecache_page {
@@ -56,6 +63,7 @@ static inline block_io pagecache_writer(pagecache pc)
     return pc->write;
 }
 
+u64 pagecache_drain(pagecache pc, u64 drain_bytes);
 pagecache allocate_pagecache(heap general, heap backed,
                              u64 length, u64 pagesize, u64 block_size,
                              block_mapper mapper, block_io read, block_io write);

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -127,7 +127,7 @@ void mm_service(void)
     u64 free = heap_total(p) - heap_allocated(p);
     mm_debug("%s: total %ld, alloc %ld, free %ld\n", __func__, heap_total(p), heap_allocated(p), free);
     if (free < CACHE_DRAIN_CUTOFF) {
-        u64 drain_bytes = CACHE_DRAIN_CUTOFF - free + PAGESIZE - 1;
+        u64 drain_bytes = CACHE_DRAIN_CUTOFF - free;
         u64 drained = pagecache_drain(global_pagecache, drain_bytes);
         if (drained > 0)
             mm_debug("   drained %ld / %ld requested...\n", drained, drain_bytes);


### PR DESCRIPTION
Add drain function to pagecache to evict cached pages. The mm_service routine, called from runloop_internal, simply checks if free physical memory dips below a threshold (CACHE_DRAIN_CUTOFF) and calls the pagecache drain with the delta.

Clearly more can be done to address low memory situations (#1130). Perhaps we could chain drain functions for various caches in the system (of varying types - including object caches) and drain according to some priority scheme. And a low memory threshold could be something more intelligent - a proportion of total memory or something determined dynamically. But a fixed threshold is better than not draining the pagecache at all.

There isn't a runtime test to stress the cache or page eviction. To test these changes, I raised CACHE_DRAIN_CUTOFF to various levels (up to system memory) to force drainage while running 'make test' and a go webserver serving large files.

Also fixes a missing sg_buf release in sendfile(2).

Resolves #1117, partially addresses #1130
