### PR TITLE
Fix webg /req handling

### DIFF
--- a/test/runtime/resolv.conf
+++ b/test/runtime/resolv.conf
@@ -1,0 +1,1 @@
+nameserver 8.8.8.8

--- a/test/runtime/webg.go
+++ b/test/runtime/webg.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 	"net"
+	"crypto/tls"
 )
 
 var count int64
@@ -24,6 +25,8 @@ func reqTestHandler(w http.ResponseWriter, r *http.Request) {
 	resp, err := http.Get("https://ops.city")
 	if err != nil {
 		fmt.Println(err)
+		fmt.Fprint(w, err)
+		return
 	}
 	defer resp.Body.Close()
 
@@ -80,6 +83,7 @@ func filePersistenceHandler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	port := "8080"
 
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	http.HandleFunc("/", handler)
 	http.HandleFunc("/req", reqTestHandler)
 	http.HandleFunc("/args", argsHandler)

--- a/test/runtime/webg.manifest
+++ b/test/runtime/webg.manifest
@@ -3,7 +3,7 @@
     children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
 	      #user program
 	      webg:(contents:(host:output/test/runtime/bin/webg))
-	      etc:(children:(ld.so.cache:(contents:(host:/etc/ld.so.cache))))
+	      etc:(children:(ld.so.cache:(contents:(host:/etc/ld.so.cache)) resolv.conf:(contents:(host:test/runtime/resolv.conf))))
 	      lib:(children:(x86_64-linux-gnu:(children:(libc.so.6:(contents:(host:/lib/x86_64-linux-gnu/libc.so.6)) libpthread.so.0:(contents:(host:/lib/x86_64-linux-gnu/libpthread.so.0))))))
 	      lib64:(children:(ld-linux-x86-64.so.2:(contents:(host:/lib64/ld-linux-x86-64.so.2)))))
     # filesystem path to elf for kernel to run


### PR DESCRIPTION
- Add resolv.conf (nameserver set to 8.8.8.8)
- Fix panic when http.Get() fails
- Ignore SSL certificate security checks