### PR TITLE
Socket shutdown: set lwIP callback argument to NULL

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -695,6 +695,9 @@ static sysreturn netsock_shutdown(struct sock *sock, int how)
         if (s->info.tcp.state != TCP_SOCK_OPEN) {
             return -ENOTCONN;
         }
+        if (shut_rx && shut_tx) {
+            tcp_arg(s->info.tcp.lw, 0);
+        }
         tcp_shutdown(s->info.tcp.lw, shut_rx, shut_tx);
         if (shut_rx && shut_tx) {
             /* Shutting down both TX and RX is equivalent to calling


### PR DESCRIPTION
When both TX and RX are shut down on a network socket, we ensure that the the lwIP PCB is not referenced anymore by setting `s->info.tcp.lw` to NULL, but we should also set the TCP callback
argument to NULL (which is needed to prevent callbacks from accessing a deallocated socket structure), because that won't be done by socket_close() if `s->info.tcp.lw` is already NULL when a socket is closed.