### PR TITLE
file_close(): add call to release_fdesc()

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -716,8 +716,10 @@ closure_function(2, 0, sysreturn, file_close,
         ret = spec_close(f);
     }
         
-    if (ret == 0)
+    if (ret == 0) {
+        release_fdesc(&f->f);
         unix_cache_free(get_unix_heaps(), file, f);
+    }
     return 0;
 }
 


### PR DESCRIPTION
Without this call, the notify set associated to a file descriptor being closed is leaked, and in addition any notify entries registered on the file descriptor fail to be notified of the file closure.