### PR TITLE
disable ingesting of program symbols by default

### DIFF
--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -253,6 +253,12 @@ process exec_elf(buffer ex, process kp)
 
     build_exec_stack(proc, t, e, entry, load_range.start, root, aslr);
 
+    if (table_find(proc->process_root, sym(ingest_program_symbols))) {
+        exec_debug("ingesting symbols...\n");
+        add_elf_syms(ex);
+        exec_debug("...done\n");
+    }
+
     if (interp) {
         exec_debug("reading interp...\n");
         filesystem_read_entire(fs, interp, heap_backed(kh),
@@ -263,7 +269,6 @@ process exec_elf(buffer ex, process kp)
 
     exec_debug("starting process...\n");
     start_process(t, entry);
-    add_elf_syms(ex);
     return proc;    
 }
 


### PR DESCRIPTION
Loading the program symbol table only adds to startup time (and badly so given the inefficient implementation), so make it conditional on presence of the 'ingest_program_symbols' flag in the manifest.

Also, the ingest was being skipped for dynamic executables (which is why the delay in #1150 wasn't showing up for a native Linux build, as the musl cross build produced a static binary). This moves the optional ingest to just before the interpreter load.

Resolves #1150 
