### PR TITLE
validation of user address arguments in syscalls

### DIFF
--- a/src/runtime/uniboot.h
+++ b/src/runtime/uniboot.h
@@ -4,6 +4,7 @@
 #define KERNEL_BASE 0xffffffff80000000ull
 #define KMEM_LIMIT  0xffffffff00000000ull
 #define PAGES_BASE  0xffffffffc0000000ull
+#define USER_LIMIT  0x0000800000000000ull
 
 #ifdef BOOT
 

--- a/src/unix/aio.c
+++ b/src/unix/aio.c
@@ -66,7 +66,7 @@ static inline struct aio *aio_from_ring(process p, aio_ring ring)
 
 sysreturn io_setup(unsigned int nr_events, aio_context_t *ctx_idp)
 {
-    if (!ctx_idp) {
+    if (!validate_user_memory(ctx_idp, sizeof(aio_context_t), true)) {
         return -EFAULT;
     }
     if (nr_events == 0) {
@@ -172,7 +172,7 @@ static unsigned int aio_avail_events(struct aio *aio)
 
 static sysreturn iocb_enqueue(struct aio *aio, struct iocb *iocb)
 {
-    if (!iocb) {
+    if (!validate_user_memory(iocb, sizeof(struct iocb), false)) {
         return -EFAULT;
     }
     thread_log(current, "%s: fd %d, op %d", __func__, iocb->aio_fildes,
@@ -225,7 +225,8 @@ inval:
 sysreturn io_submit(aio_context_t ctx_id, long nr, struct iocb **iocbpp)
 {
     struct aio *aio;
-    if (!ctx_id || !iocbpp) {
+    if (!validate_user_memory(ctx_id, sizeof(struct aio_ring), false) ||
+        !validate_user_memory(iocbpp, sizeof(struct iocb *), false)) {
         return -EFAULT;
     }
     if (!(aio = aio_from_ring(current->p, ctx_id))) {
@@ -298,7 +299,8 @@ out:
 sysreturn io_getevents(aio_context_t ctx_id, long min_nr, long nr,
         struct io_event *events, struct timespec *timeout)
 {
-    if (!ctx_id || !events) {
+    if (!validate_user_memory(ctx_id, sizeof(struct aio_ring), false) ||
+        !validate_user_memory(events, sizeof(struct io_event) * nr, true)) {
         return -EFAULT;
     }
     struct aio *aio;
@@ -361,7 +363,7 @@ static sysreturn io_destroy_internal(struct aio *aio, thread t, boolean in_bh)
 
 sysreturn io_destroy(aio_context_t ctx_id)
 {
-    if (!ctx_id) {
+    if (!validate_user_memory(ctx_id, sizeof(struct aio_ring), true)) {
         return -EFAULT;
     }
     struct aio *aio;

--- a/src/unix/aio.c
+++ b/src/unix/aio.c
@@ -226,7 +226,7 @@ sysreturn io_submit(aio_context_t ctx_id, long nr, struct iocb **iocbpp)
 {
     struct aio *aio;
     if (!validate_user_memory(ctx_id, sizeof(struct aio_ring), false) ||
-        !validate_user_memory(iocbpp, sizeof(struct iocb *), false)) {
+        !validate_user_memory(iocbpp, sizeof(struct iocb *) * nr, false)) {
         return -EFAULT;
     }
     if (!(aio = aio_from_ring(current->p, ctx_id))) {
@@ -363,7 +363,7 @@ static sysreturn io_destroy_internal(struct aio *aio, thread t, boolean in_bh)
 
 sysreturn io_destroy(aio_context_t ctx_id)
 {
-    if (!validate_user_memory(ctx_id, sizeof(struct aio_ring), true)) {
+    if (!validate_user_memory(ctx_id, sizeof(struct aio_ring), false)) {
         return -EFAULT;
     }
     struct aio *aio;

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -176,7 +176,7 @@ closure_function(2, 1, status, load_interp_complete,
     kernel_heaps kh = bound(kh);
 
     exec_debug("interpreter load complete, reading elf\n");
-    u64 where = allocate_u64((heap)heap_virtual_huge(kh), HUGE_PAGESIZE);
+    u64 where = allocate_u64((heap)t->p->virtual, HUGE_PAGESIZE);
     void * start = load_elf(b, where, stack_closure(exec_elf_map, t->p, kh));
     exec_debug("starting process tid %d, start %p\n", t->tid, start);
     start_process(t, start);

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -168,6 +168,7 @@ closure_function(1, 1, void, symlink_complete,
     closure_finish();
 }
 
+// TODO user string validation
 static sysreturn symlink_internal(tuple cwd, const char *path,
         const char *target)
 {
@@ -229,6 +230,7 @@ sysreturn utimes(const char *filename, const struct timeval times[2])
     return utime_internal(filename, atime, mtime);
 }
 
+// TODO user string validate
 static sysreturn statfs_internal(tuple t, struct statfs *buf)
 {
     if (!buf) {

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -168,12 +168,11 @@ closure_function(1, 1, void, symlink_complete,
     closure_finish();
 }
 
-// TODO user string validation
 static sysreturn symlink_internal(tuple cwd, const char *path,
         const char *target)
 {
-    if (!target) {
-        set_syscall_error(current, EFAULT);
+    if (!validate_user_string(path) || !validate_user_string(target)) {
+        return set_syscall_error(current, EFAULT);
     }
     tuple parent;
     int ret = resolve_cstring(cwd, path, 0, &parent);
@@ -215,6 +214,9 @@ static sysreturn utime_internal(const char *filename, timestamp actime,
 
 sysreturn utime(const char *filename, const struct utimbuf *times)
 {
+    if (!validate_user_string(filename) ||
+        !validate_user_memory(times, sizeof(struct utimbuf), false))
+        return set_syscall_error(current, EFAULT);
     timestamp atime = times ? seconds(times->actime) : now(CLOCK_ID_REALTIME);
     timestamp mtime = times ? seconds(times->modtime) : now(CLOCK_ID_REALTIME);
     return utime_internal(filename, atime, mtime);
@@ -222,6 +224,9 @@ sysreturn utime(const char *filename, const struct utimbuf *times)
 
 sysreturn utimes(const char *filename, const struct timeval times[2])
 {
+    if (!validate_user_string(filename) ||
+        !validate_user_memory(times, 2 * sizeof(struct timeval), false))
+        return set_syscall_error(current, EFAULT);
     /* Sub-second precision is not supported. */
     timestamp atime =
             times ? time_from_timeval(&times[0]) : now(CLOCK_ID_REALTIME);
@@ -230,7 +235,6 @@ sysreturn utimes(const char *filename, const struct timeval times[2])
     return utime_internal(filename, atime, mtime);
 }
 
-// TODO user string validate
 static sysreturn statfs_internal(tuple t, struct statfs *buf)
 {
     if (!buf) {
@@ -255,6 +259,9 @@ static sysreturn statfs_internal(tuple t, struct statfs *buf)
 
 sysreturn statfs(const char *path, struct statfs *buf)
 {
+    if (!validate_user_string(path) ||
+        !validate_user_memory(buf, sizeof(struct statfs), true))
+        return set_syscall_error(current, EFAULT);
     tuple t;
     int ret = resolve_cstring(current->p->cwd, path, &t, 0);
     if (ret) {

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -139,6 +139,8 @@ sysreturn futex(int *uaddr, int futex_op, int val,
     timestamp ts;
     int op;
 
+    if (!validate_user_memory(uaddr, sizeof(int), false))
+        return set_syscall_error(current, EFAULT);
     boolean verbose = table_find(current->p->process_root, sym(futex_trace))
         ? true : false;
 
@@ -178,6 +180,9 @@ sysreturn futex(int *uaddr, int futex_op, int val,
     case FUTEX_CMP_REQUEUE: {
         int woken, requeued;
 
+        if (!validate_user_memory(uaddr2, sizeof(int), false))
+            return set_syscall_error(current, EFAULT);
+
         if (verbose)
             thread_log(current, "futex_cmp_requeue [%ld %p %d] val: %d val2: %d uaddr2: %p %d val3: %d",
                        current->tid, uaddr, *uaddr, val, val2, uaddr2, *uaddr2, val3);
@@ -206,6 +211,9 @@ sysreturn futex(int *uaddr, int futex_op, int val,
         unsigned int cmp = (val3 >> 24) & MASK(4);
         unsigned int op = (val3 >> 28) & MASK(4);
         int oldval, wake1, wake2, c;
+
+        if (!validate_user_memory(uaddr2, sizeof(int), true))
+            return set_syscall_error(current, EFAULT);
 
         if (verbose) {
             thread_log(current, "futex_wake_op: [%ld %p %d] %p %d %d %d %d",

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -778,7 +778,7 @@ void mmap_process_init(process p)
     add_varea(p, user_va_tag_start, user_va_tag_end, 0, true);
 
     /* reserve kernel memory and non-canonical addresses */
-    add_varea(p, U64_FROM_BIT(47), -1ull, 0, false);
+    add_varea(p, USER_LIMIT, -1ull, 0, false);
 
     /* randomly determine vdso/vvar base and track it */
     u64 vdso_size, vvar_size, vvar_start;

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -502,7 +502,7 @@ sysreturn epoll_ctl(int epfd, int op, int fd, struct epoll_event *event)
     fdesc f = resolve_fd(current->p, fd);
 
     /* A valid event pointer is required for all operations but EPOLL_CTL_DEL */
-    if ((op != EPOLL_CTL_DEL) && !event) {
+    if ((op != EPOLL_CTL_DEL) && !validate_user_memory(event, sizeof(struct epoll_event), false)) {
         return set_syscall_error(current, EFAULT);
     }
 

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -401,6 +401,9 @@ sysreturn epoll_wait(int epfd,
                      int maxevents,
                      int timeout)
 {
+    if (!validate_user_memory(events, sizeof(struct epoll_event) * maxevents, true))
+        return -EFAULT;
+
     epoll e = resolve_fd(current->p, epfd);
     epoll_blocked w = alloc_epoll_blocked(e);
     if (w == INVALID_ADDRESS)
@@ -649,6 +652,12 @@ static sysreturn select_internal(int nfds,
     if (nfds == 0 && timeout == infinity)
         return 0;
 
+    u64 set_bytes = pad(nfds, 64) / 8;
+    if ((readfds && !validate_user_memory(readfds, set_bytes, true)) ||
+        (writefds && !validate_user_memory(writefds, set_bytes, true)) ||
+        (exceptfds && !validate_user_memory(exceptfds, set_bytes, true)))
+        return -EFAULT;
+
     epoll e = select_get_epoll();
     if (e == INVALID_ADDRESS)
 	return -ENOMEM;
@@ -850,13 +859,14 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
                                timestamp timeout,
                                const sigset_t * sigmask)
 {
+    if (!validate_user_memory(fds, sizeof(struct pollfd) * nfds, true))
+        return -EFAULT;
     epoll e = select_get_epoll();
     if (e == INVALID_ADDRESS)
         return -ENOMEM;
     epoll_blocked w = alloc_epoll_blocked(e);
     if (w == INVALID_ADDRESS)
         return -ENOMEM;
-
     epoll_debug("epoll nfds %ld, new blocked %p, timeout %d\n", nfds, w, timeout);
     w->epoll_type = EPOLL_TYPE_POLL;
     w->poll_fds = wrap_buffer(e->h, fds, nfds * sizeof(struct pollfd));

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -485,11 +485,18 @@ sysreturn rt_sigaction(int signum,
 
     sigaction sa = sigaction_from_sig(signum);
 
-    if (oldact)
-        runtime_memcpy(oldact, sa, sizeof(struct sigaction));
+    if (oldact) {
+        if (validate_user_memory(oldact, sizeof(struct sigaction), true))
+            runtime_memcpy(oldact, sa, sizeof(struct sigaction));
+        else
+            return -EFAULT;
+    }
 
     if (!act)
         return 0;
+
+    if (!validate_user_memory(act, sizeof(struct sigaction), false))
+        return -EFAULT;
 
     if (signum == SIGKILL || signum == SIGSTOP)
         return -EINVAL;
@@ -530,10 +537,16 @@ sysreturn rt_sigprocmask(int how, const u64 *set, u64 *oldset, u64 sigsetsize)
     if (sigsetsize != (NSIG / 8))
         return -EINVAL;
 
-    if (oldset)
-        *oldset = sigstate_get_mask(&current->signals);
+    if (oldset) {
+        if (validate_user_memory(oldset, sigsetsize, true))
+            *oldset = sigstate_get_mask(&current->signals);
+        else
+            return -EFAULT;
+    }
 
     if (set) {
+        if (!validate_user_memory(set, sigsetsize, false))
+            return -EFAULT;
         switch (how) {
         case SIG_BLOCK:
             sigstate_block(&current->signals, *set);
@@ -598,9 +611,10 @@ static boolean thread_is_on_altsigstack(thread t)
 
 sysreturn sigaltstack(const stack_t *ss, stack_t *oss)
 {
-
     thread t = current;
     if (oss) {
+        if (!validate_user_memory(oss, sizeof(stack_t), true))
+            return -EFAULT;
         if (t->signal_stack) {
             oss->ss_sp = t->signal_stack;
             oss->ss_size = t->signal_stack_length;
@@ -612,6 +626,9 @@ sysreturn sigaltstack(const stack_t *ss, stack_t *oss)
     // it doesn't seem possible to re-enable without setting
     // a new stack....so we think this is a valid interpretation
     if (ss) {
+        if (!validate_user_memory(ss, sizeof(stack_t), false) ||
+            !validate_user_memory(ss->ss_sp, ss->ss_size, true))
+            return -EFAULT;
         if (thread_is_on_altsigstack(t)) {
             return -EPERM;
         }
@@ -682,7 +699,7 @@ sysreturn kill(int pid, int sig)
 
 static inline sysreturn sigqueueinfo_sanitize_args(int tgid, int sig, siginfo_t *uinfo)
 {
-    if (!validate_user_memory(uinfo, sizeof(siginfo_t), false))
+    if (!validate_user_memory(uinfo, sizeof(siginfo_t), true))
         return -EFAULT;
 
     if (tgid != current->p->pid)
@@ -811,8 +828,9 @@ sysreturn rt_sigtimedwait(const u64 * set, siginfo_t * info, const struct timesp
 {
     if (sigsetsize != (NSIG / 8))
         return -EINVAL;
-    if (!validate_user_memory(set, sizeof(sigsetsize), false) ||
-        (info && !validate_user_memory(info, sizeof(siginfo_t), true)))
+    if (!validate_user_memory(set, sigsetsize, false) ||
+        (info && !validate_user_memory(info, sizeof(siginfo_t), true)) ||
+        (timeout && !validate_user_memory(timeout, sizeof(struct timespec), false)))
         return -EFAULT;
     sig_debug("tid %d, interest 0x%lx, info %p, timeout %p\n", current->tid, *set, info, timeout);
     heap h = heap_general(get_kernel_heaps());

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -80,6 +80,8 @@ static inline sysreturn socket_ioctl(struct sock *s, unsigned long request,
     switch (request) {
     case FIONBIO: {
         int *opt = varg(ap, int *);
+        if (!validate_user_memory(opt, sizeof(int), false))
+            return -EFAULT;
         if (*opt) {
             s->f.flags |= SOCK_NONBLOCK;
         }

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -973,11 +973,11 @@ sysreturn getrandom(void *buf, u64 buflen, unsigned int flags)
     heap h = heap_general(get_kernel_heaps());
     buffer b;
 
-    if (!buf)
-        return set_syscall_error(current, EFAULT);
-
     if (!buflen)
         return set_syscall_error(current, EINVAL);
+
+    if (!validate_user_memory(buf, buflen, true))
+        return set_syscall_error(current, EFAULT);
 
     if (flags & ~(GRND_NONBLOCK | GRND_RANDOM))
         return set_syscall_error(current, EINVAL);
@@ -1022,7 +1022,7 @@ static int try_write_dirent(tuple root, struct linux_dirent *dirp, char *p,
 
 sysreturn getdents(int fd, struct linux_dirent *dirp, unsigned int count)
 {
-    if (!dirp)
+    if (!validate_user_memory(dirp, count, true))
         return set_syscall_error(current, EFAULT);
     file f = resolve_fd(current->p, fd);
     tuple c = children(f->n);

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -2,6 +2,8 @@
 
 sysreturn gettimeofday(struct timeval *tv, void *tz)
 {
+    if (!validate_user_memory(tv, sizeof(struct timeval), true))
+        return -EFAULT;
     timeval_from_time(tv, now(CLOCK_ID_REALTIME));
     return 0;
 }
@@ -83,6 +85,8 @@ sysreturn clock_nanosleep(clockid_t _clock_id, int flags, const struct timespec 
 
 sysreturn sys_time(time_t *tloc)
 {
+    if (tloc && !validate_user_memory(tloc, sizeof(time_t), true))
+        return -EFAULT;
     time_t t = time_t_from_time(now(CLOCK_ID_REALTIME));
 
     if (tloc)
@@ -92,6 +96,8 @@ sysreturn sys_time(time_t *tloc)
 
 sysreturn times(struct tms *buf)
 {
+    if (!validate_user_memory(buf, sizeof(struct tms), true))
+        return -EFAULT;
     buf->tms_utime = CLOCKS_PER_SEC * proc_utime(current->p) / TIMESTAMP_SECOND;
     buf->tms_stime = CLOCKS_PER_SEC * proc_stime(current->p) / TIMESTAMP_SECOND;
     buf->tms_cutime = buf->tms_cstime = 0;  /* there are no child processes */
@@ -103,7 +109,9 @@ sysreturn times(struct tms *buf)
 
 sysreturn clock_gettime(clockid_t clk_id, struct timespec *tp)
 {
-    thread_log(current, "clock_gettime: clk_id %d", clk_id);
+    thread_log(current, "clock_gettime: clk_id %d, tp %p", clk_id, tp);
+    if (!validate_user_memory(tp, sizeof(struct timespec), true))
+        return -EFAULT;
     timestamp t;
     switch (clk_id) {
     case CLOCK_MONOTONIC:

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -35,7 +35,10 @@ closure_function(5, 1, sysreturn, nanosleep_bh,
 
 sysreturn nanosleep(const struct timespec *req, struct timespec *rem)
 {
-    if (!req)
+    if (!validate_user_memory(req, sizeof(struct timespec), false))
+        return -EFAULT;
+
+    if (rem && !validate_user_memory(rem, sizeof(struct timespec), true))
         return -EFAULT;
 
     timestamp interval = time_from_timespec(req);
@@ -50,7 +53,10 @@ sysreturn nanosleep(const struct timespec *req, struct timespec *rem)
 sysreturn clock_nanosleep(clockid_t _clock_id, int flags, const struct timespec *req,
                           struct timespec *rem)
 {
-    if (!req)
+    if (!validate_user_memory(req, sizeof(struct timespec), false))
+        return -EFAULT;
+
+    if (rem && !validate_user_memory(rem, sizeof(struct timespec), true))
         return -EFAULT;
 
     /* Report any attempted use of CLOCK_PROCESS_CPUTIME_ID */

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -675,3 +675,5 @@ u32 spec_events(file f);
 
 void syscall_debug(context f);
 
+boolean validate_iovec(struct iovec *iov, u64 len, boolean write);
+boolean validate_user_string(const char *name);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -432,6 +432,26 @@ void init_vdso(process p);
 
 void mmap_process_init(process p);
 
+/* This "validation" is just a simple limit check right now, but this
+   could optionally expand to do more rigorous validation (e.g. vmap
+   lookup or page table walk). We may also want to place attributes on
+   user pointer arguments for use with a static analysis tool like
+   Sparse. */
+
+static inline boolean validate_user_memory(const void *p, bytes length, boolean write)
+{
+    u64 v = u64_from_pointer(p);
+
+    /* no zero page access */
+    if (v < PAGESIZE)
+        return false;
+
+    if (length >= USER_LIMIT)
+        return false;
+
+    return v < USER_LIMIT - length;
+}
+
 static inline u64 get_aslr_offset(u64 range)
 {
     assert((range & (range - 1)) == 0);


### PR DESCRIPTION
Now that there is a clean delineation between user and kernel addresses, we can do trivial range checks to validate that no kernel memory is referenced in a syscall. This adds functions to validate user buffers, including null-terminated constant strings and iovec arrays. A first pass has been made through the syscalls to insert such checks, which typically return -EFAULT on failure.

Also fix mistaken mapping of interpreter ELF in virtual_huge rather than p->virtual.
