### PR TITLE
ftruncate(2): update length member of file structure

### DIFF
--- a/test/runtime/write.c
+++ b/test/runtime/write.c
@@ -208,6 +208,15 @@ void truncate_test()
         perror("ftruncate to BUFLEN / 2");
         exit(EXIT_FAILURE);
     }
+    rv = lseek(fd, 0, SEEK_END);
+    if (rv < 0) {
+        perror("lseek");
+        exit(EXIT_FAILURE);
+    }
+    if (rv != BUFLEN / 2) {
+        printf("unexpected file size %ld\n", rv);
+        exit(EXIT_FAILURE);
+    }
     close(fd);
 
     rv = stat("new_file", &s);


### PR DESCRIPTION
Any change in the length of an open file done via ftruncate() must be reflected not only in the filesystem but also in the file struct allocated for the open file.
This commit implements the above behavior and adds a test case that would trigger a failure if the above was not implemented.