### PR TITLE
getrlimit(): add support for RLIMIT_CORE

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1446,6 +1446,9 @@ sysreturn getrlimit(int resource, struct rlimit *rlim)
         rlim->rlim_cur = 2*1024*1024;
         rlim->rlim_max = 2*1024*1024;
         return 0;
+    case RLIMIT_CORE:
+        rlim->rlim_cur = rlim->rlim_max = 0;    // core dump not supported
+        return 0;
     case RLIMIT_NOFILE:
         if (!rlim)
             return set_syscall_error(current, EINVAL);


### PR DESCRIPTION
This argument allows to retrieve the maximum size of a core file.
Limit values are set to zero because core dumps are not supported yet.