### PR TITLE
fcntl: add support for F_SETPIPE_SZ and F_SETPIPE_SZ commands

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1915,6 +1915,18 @@ sysreturn fcntl(int fd, int cmd, s64 arg)
         fetch_and_add(&f->refcnt, 1);
         return set_syscall_return(current, newfd);
     }
+    case F_SETPIPE_SZ:
+        if (f->type == FDESC_TYPE_PIPE) {
+            return pipe_set_capacity(f, (int)arg);
+        } else {
+            return -EINVAL;
+        }
+    case F_GETPIPE_SZ:
+        if (f->type == FDESC_TYPE_PIPE) {
+            return pipe_get_capacity(f);
+        } else {
+            return -EINVAL;
+        }
     default:
         return set_syscall_error(current, ENOSYS);
     }

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -136,6 +136,8 @@ typedef struct iovec {
 #define F_SETLK         6       /* Set record locking info (non-blocking).  */
 #define F_SETLKW        7       /* Set record locking info (blocking).  */
 #define F_DUPFD_CLOEXEC (F_LINUX_SPECIFIC_BASE + 6)
+#define F_SETPIPE_SZ    (F_LINUX_SPECIFIC_BASE + 7)
+#define F_GETPIPE_SZ    (F_LINUX_SPECIFIC_BASE + 8)
 
 struct flock {
     s16 l_type;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -649,6 +649,8 @@ sysreturn io_getevents(aio_context_t ctx_id, long min_nr, long nr,
 sysreturn io_destroy(aio_context_t ctx_id);
 
 int do_pipe2(int fds[2], int flags);
+int pipe_set_capacity(fdesc f, int capacity);
+int pipe_get_capacity(fdesc f);
 
 sysreturn socketpair(int domain, int type, int protocol, int sv[2]);
 

--- a/test/unit/buffer_test.c
+++ b/test/unit/buffer_test.c
@@ -42,6 +42,14 @@ boolean basic_tests(heap h)
     push_varint(b, 0xdeadbeef);
     test_assert(pop_varint(b) == 0xdeadbeef);
     test_assert(buffer_length(b) == 0);
+
+    /* Buffer capacity */
+    buffer_write_cstring(b, test_str);
+    test_assert(buffer_set_capacity(b, 1) >= strlen(test_str));
+    test_assert(buffer_set_capacity(b, b->length) == b->length);
+    buffer_set_capacity(b, 3 * b->length);
+    test_assert(buffer_compare_with_cstring(b, test_str));
+
     /*
      * Validate wrap_buffer_cstring initialization, and contents
      */


### PR DESCRIPTION
These commands allow to set and get the capacity of a pipe.