### PR TITLE
fix exception handling for user mode

### DIFF
--- a/src/runtime/uniboot.h
+++ b/src/runtime/uniboot.h
@@ -52,7 +52,7 @@ extern void * AP_BOOT_PAGE;
 
 #define STAGE2_STACK_SIZE  (128 * KB)  /* stage2 stack is recycled, too */
 #define KERNEL_STACK_SIZE  (128 * KB)
-#define FAULT_STACK_SIZE   (32 * KB)
+#define EXCEPT_STACK_SIZE  (32 * KB)
 #define INT_STACK_SIZE     (32 * KB)
 #define BH_STACK_SIZE      (32 * KB)
 #define SYSCALL_STACK_SIZE (32 * KB)

--- a/src/x86_64/kernel.h
+++ b/src/x86_64/kernel.h
@@ -42,15 +42,10 @@ typedef struct cpuinfo {
 
     /* The following fields are used rarely or only on initialization. */
 
-    /* Stack for page faults, switched by hardware
+    /* Stack for exceptions (which may occur in interrupt handlers) */
+    void *exception_stack;
 
-       This could just be the kernel stack, but we might like to have
-       a safe stack to run on should we get a fault in kernel space,
-       or even in an interrupt handler. */
-    void *fault_stack;
-
-    /* Stack for exceptions (aside from page fault) and interrupts,
-       switched by hardware */
+    /* Stack for interrupts */
     void *int_stack;
 
     /* leaky unix stuff */
@@ -170,8 +165,8 @@ void start_cpu(heap h, heap stackheap, int index, void (*ap_entry)());
 void *allocate_stack(heap pages, u64 size);
 void install_idt(void);
 
-#define IST_INTERRUPT 1         /* for all interrupts */
-#define IST_PAGEFAULT 2         /* page fault specific */
+#define IST_EXCEPTION 1
+#define IST_INTERRUPT 2
 
 void set_ist(int cpu, int i, u64 sp);
 void install_gdt64_and_tss(u64 cpu);

--- a/src/x86_64/mp.c
+++ b/src/x86_64/mp.c
@@ -32,7 +32,7 @@ static void __attribute__((noinline)) ap_new_stack()
     cpu_setgs(id);
     cpuinfo ci = current_cpu();
 
-    set_ist(id, IST_PAGEFAULT, u64_from_pointer(ci->fault_stack));
+    set_ist(id, IST_EXCEPTION, u64_from_pointer(ci->exception_stack));
     set_ist(id, IST_INTERRUPT, u64_from_pointer(ci->int_stack));
     set_running_frame(ci->kernel_frame);
     mp_debug(", install gdt");

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -291,7 +291,7 @@ static void init_cpuinfos(kernel_heaps kh)
         /* frame and stacks */
         ci->kernel_frame = allocate_frame(h);
         ci->kernel_stack = allocate_stack(backed, KERNEL_STACK_SIZE);
-        ci->fault_stack = allocate_stack(backed, FAULT_STACK_SIZE);
+        ci->exception_stack = allocate_stack(backed, EXCEPT_STACK_SIZE);
         ci->int_stack = allocate_stack(backed, INT_STACK_SIZE);
         //        init_debug("cpu %2d: kernel_frame %p, kernel_stack %p", i, ci->kernel_frame, ci->kernel_stack);
         //        init_debug("        fault_stack  %p, int_stack    %p", ci->fault_stack, ci->int_stack);


### PR DESCRIPTION
This resolves a problem where an uninitialized TSS stack base was causing a page fault whenever a process triggered an exception other than a page fault. Change the page fault stack, once necessary to allow faulting in pages at interrupt level (!), into one for use with all exceptions, so that if an interrupt handler causes any exception, its stack won't be trashed. All possible vectors are now covered with an IST, obviating the use of the TSS stack switch triggered by protection level change.

In addition, send segv to a process which causes a general protection fault (i.e. as a result of an illegal instruction).
