### PR TITLE
red-black tree implementation

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -9,6 +9,7 @@ SRCS-stage2.elf= \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/sg.c \

--- a/mkfs/Makefile
+++ b/mkfs/Makefile
@@ -11,6 +11,7 @@ SRCS-mkfs= \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/symbol.c \
 	$(SRCDIR)/runtime/table.c \
@@ -36,6 +37,7 @@ SRCS-dump= \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/symbol.c \
 	$(SRCDIR)/runtime/table.c \

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -191,15 +191,19 @@ static void id_dealloc(heap h, u64 a, bytes count)
         msg_err("heap %p: no match for range %R\n", h, q);
 }
 
+closure_function(1, 1, void, destruct_id_range,
+                 id_heap, i,
+                 rmnode, n)
+{
+    id_range r = (id_range)n;
+    deallocate_bitmap(r->b);
+    deallocate(bound(i)->meta, r, sizeof(struct id_range));
+}
+
 static void id_destroy(heap h)
 {
     id_heap i = (id_heap)h;
-    id_range r = (id_range)rangemap_first_node(i->ranges);
-    while (r != INVALID_ADDRESS) {
-	deallocate_bitmap(r->b);
-        r = (id_range)rangemap_next_node(i->ranges, (rmnode)r);
-    }
-    deallocate_rangemap(i->ranges);
+    deallocate_rangemap(i->ranges, stack_closure(destruct_id_range, i));
     deallocate(i->meta, i, sizeof(struct id_heap));
 }
 

--- a/src/runtime/range.c
+++ b/src/runtime/range.c
@@ -2,20 +2,24 @@
 
 boolean rangemap_insert(rangemap rm, rmnode n)
 {
-    list_foreach(&rm->root, l) {
-        rmnode curr = struct_from_list(l, rmnode, l);
+    init_rbnode(&n->n);
+    rangemap_foreach_range(rm, curr, n) {
+        if (curr->r.start >= n->r.end)
+            break;
         range i = range_intersection(curr->r, n->r);
         if (range_span(i)) {
-            /* XXX bark for now until we know we have all potential cases handled... */
-            msg_warn("attempt to insert %p (%R) but overlap with %p (%R)\n", n, n->r, curr, curr->r);
+            msg_warn("attempt to insert %p (%R) but overlap with %p (%R)\n",
+                     n, n->r, curr, curr->r);
             return false;
         }
-        if (curr->r.start > n->r.start) {
-            list_insert_before(l, &n->l);
-            return true;
-        }
     }
-    list_insert_before(&rm->root, &n->l);
+    if (!rbtree_insert_node(&rm->t, &n->n)) {
+        /* TODO maybe assert/halt here? */
+        msg_err("scan found no intersection but rb insert failed, node %p (%R)\n",
+                n, n->r);
+        rbtree_dump(&rm->t, RB_PREORDER);
+        return false;
+    }
     return true;
 }
 
@@ -26,65 +30,15 @@ boolean rangemap_reinsert(rangemap rm, rmnode n, range k)
     return rangemap_insert(rm, n);
 }
 
-boolean rangemap_remove_range(rangemap rm, range k)
-{
-    boolean match = false;
-    list l = list_get_next(&rm->root);
-
-    while (l && l != &rm->root) {
-        rmnode curr = struct_from_list(l, rmnode, l);
-        list next = list_get_next(l);
-        range i = range_intersection(curr->r, k);
-
-        /* no intersection */
-        if (range_empty(i)) {
-            l = next;
-            continue;
-        }
-
-        match = true;
-
-        /* complete overlap (delete) */
-        if (range_equal(curr->r, i)) {
-            rangemap_remove_node(rm, curr);
-            l = next;
-            continue;
-        }
-
-        /* check for tail trim */
-        if (curr->r.start < i.start) {
-            /* check for hole */
-            if (curr->r.end > i.end) {
-                halt("unexpected hole trim: curr %R, key %R\n", curr->r, k);
-#if 0
-                /* XXX - I'm not positive that this is the right thing
-                   to do; take a closer look at what, if anything,
-                   would need benefit from this - plus this would
-                   violate any refcounts kept on behalf of opaque
-                   value. */
-                rmnode rn = allocate(rt->h, sizeof(struct rmnode));
-                rn->r.start = i.end;
-                rn->r.end = curr->r.end;
-                rn->value = curr->value; /* XXX this is perhaps most dubious */
-                msg_warn("unexpected hole trim: curr %R, key %R\n", curr->r, k);
-                list_insert_after(l, &rn->l);
-#endif
-            }
-            curr->r.end = i.start;
-        } else if (curr->r.end > i.end) { /* head trim */
-            curr->r.start = i.end;
-        }
-        l = next;               /* valid even if we inserted one */
-    }
-
-    return match;
-}
+#define ikey(point) {r: irange(point, point + 1)}
 
 rmnode rangemap_lookup(rangemap rm, u64 point)
 {
-    list_foreach(&rm->root, i) {
-        rmnode curr = struct_from_list(i, rmnode, l);
-        if (point_in_range(curr->r, point))
+    struct rmnode k = ikey(point);
+    rangemap_foreach_range(rm, curr, &k) {
+        if (curr->r.start >= k.r.end)
+            break;
+        if (range_span(range_intersection(curr->r, k.r)))
             return curr;
     }
     return INVALID_ADDRESS;
@@ -93,20 +47,28 @@ rmnode rangemap_lookup(rangemap rm, u64 point)
 /* return either an exact match or the neighbor to the right */
 rmnode rangemap_lookup_at_or_next(rangemap rm, u64 point)
 {
-    list_foreach(&rm->root, i) {
-        rmnode curr = struct_from_list(i, rmnode, l);
-        if (point_in_range(curr->r, point) ||
-            curr->r.start > point)
-            return curr;
+    struct rmnode k = ikey(point);
+    if (!rm->t.root)
+        return INVALID_ADDRESS;
+    rmnode n = (rmnode)rbtree_lookup_max_lte(&rm->t, &k.n);
+    if (n == INVALID_ADDRESS) {
+        n = (rmnode)rbtree_find_first(&rm->t);
+        assert(n);              /* already checked root */
     }
-    return INVALID_ADDRESS;
+
+    /* we use max lte because rbtree isn't aware of range ends...so we
+       may need to advance by one if the result end is less than k start */
+    while (n != INVALID_ADDRESS && n->r.end <= k.r.start)
+        n = rangemap_next_node(rm, n);
+    return n;
 }
 
 boolean rangemap_range_intersects(rangemap rm, range q)
 {
-    list_foreach(&rm->root, i) {
-        rmnode curr = struct_from_list(i, rmnode, l);
-        if (!range_empty(range_intersection(curr->r, q)))
+    struct rmnode k;
+    k.r = q;
+    rangemap_foreach_range(rm, n, &k) {
+        if (!range_empty(range_intersection(n->r, q)))
             return true;
     }
     return false;
@@ -119,9 +81,9 @@ static inline boolean rangemap_range_lookup_internal(rangemap rm, range q,
 {
     boolean match = false;
     u64 lastedge = q.start;
-    list_foreach(&rm->root, i) {
-        rmnode curr = struct_from_list(i, rmnode, l);
-
+    struct rmnode k;
+    k.r = q;
+    rangemap_foreach_range(rm, curr, &k) {
         if (gap_handler) {
             u64 edge = curr->r.start;
             range i = range_intersection(irange(lastedge, edge), q);
@@ -168,16 +130,31 @@ boolean rangemap_range_find_gaps(rangemap rm, range q, range_handler gap_handler
     return rangemap_range_lookup_internal(rm, q, 0, gap_handler);
 }
 
+closure_function(0, 2, int, rmnode_compare,
+                 rbnode, a, rbnode, b)
+{
+    u64 sa = ((rmnode)a)->r.start;
+    u64 sb = ((rmnode)b)->r.start;
+    return sa == sb ? 0 : (sa < sb ? -1 : 1);
+}
+
+closure_function(0, 1, boolean, print_key,
+                 rbnode, n)
+{
+    rprintf(" %R", ((rmnode)n)->r);
+    return true;
+}
+
 rangemap allocate_rangemap(heap h)
 {
     rangemap rm = allocate(h, sizeof(struct rangemap));
+    if (rm == INVALID_ADDRESS)
+        return rm;
     rm->h = h;
-    list_init(&rm->root);
+    init_rbtree(&rm->t, closure(h, rmnode_compare), closure(h, print_key));
     return rm;
 }
 
 void deallocate_rangemap(rangemap r)
 {
 }
-
-

--- a/src/runtime/range.h
+++ b/src/runtime/range.h
@@ -1,6 +1,6 @@
 typedef struct rangemap {
     heap h;
-    struct list root;
+    struct rbtree t;
 } *rangemap;
 
 // [start, end)
@@ -9,8 +9,8 @@ typedef struct range {
 } range;
 
 typedef struct rmnode {
+    struct rbnode n;            /* must be first */
     range r;
-    struct list l;
 } *rmnode;
 
 #define irange(__s, __e)  (range){__s, __e}        
@@ -30,6 +30,7 @@ boolean rangemap_range_lookup(rangemap rm, range q, rmnode_handler node_handler)
 boolean rangemap_range_lookup_with_gaps(rangemap rm, range q, rmnode_handler node_handler,
                                         range_handler gap_handler);
 boolean rangemap_range_find_gaps(rangemap rm, range q, range_handler gap_handler);
+
 rangemap allocate_rangemap(heap h);
 void deallocate_rangemap(rangemap rm);
 
@@ -56,34 +57,27 @@ static inline void rmnode_set_range(rmnode n, range r)
 static inline void rmnode_init(rmnode n, range r)
 {
     rmnode_set_range(n, r);
-    list_init(&n->l);
+    init_rbnode(&n->n);
 }
 
 static inline rmnode rangemap_prev_node(rangemap rm, rmnode n)
 {
-    if (n->l.prev == &rm->root)
-        return INVALID_ADDRESS;
-    return struct_from_list(n->l.prev, rmnode, l);
+    return (rmnode)rbnode_get_prev(&n->n);
 }
 
 static inline rmnode rangemap_next_node(rangemap rm, rmnode n)
 {
-    if (n->l.next == &rm->root)
-        return INVALID_ADDRESS;
-    return struct_from_list(n->l.next, rmnode, l);
+    return (rmnode)rbnode_get_next(&n->n);
 }
 
 static inline rmnode rangemap_first_node(rangemap rm)
 {
-    if (rm->root.next == &rm->root)
-        return INVALID_ADDRESS;
-    else
-        return struct_from_list(rm->root.next, rmnode, l);
+    return (rmnode)rbtree_find_first(&rm->t);
 }
 
 static inline void rangemap_remove_node(rangemap rm, rmnode n)
 {
-    list_delete(&n->l);
+    rbtree_remove_node(&(rm->t), &n->n);
 }
 
 static inline range range_intersection(range a, range b)
@@ -128,3 +122,16 @@ static inline void range_add(range *r, s64 delta)
     r->start += delta;
     r->end += delta;
 }
+
+#define rangemap_foreach(rm, n)                                         \
+    for (rmnode __next, (n) = (rmnode)rbtree_find_first(&rm->t);        \
+         __next = ((n) == INVALID_ADDRESS) ? 0 : rangemap_next_node(rm, n), \
+             ((n) != INVALID_ADDRESS);                                  \
+         (n) = __next)
+
+#define rangemap_foreach_range(rm, n, k)                                \
+    for (rmnode __next, (n) = rangemap_lookup_at_or_next(rm, (k)->r.start); \
+         (__next = ((n) == INVALID_ADDRESS) ? 0 : rangemap_next_node(rm, n)), \
+             ((n) != INVALID_ADDRESS &&                                 \
+              range_span(range_intersection((k)->r, (n)->r)) > 0);      \
+         (n) = __next)

--- a/src/runtime/range.h
+++ b/src/runtime/range.h
@@ -32,7 +32,8 @@ boolean rangemap_range_lookup_with_gaps(rangemap rm, range q, rmnode_handler nod
 boolean rangemap_range_find_gaps(rangemap rm, range q, range_handler gap_handler);
 
 rangemap allocate_rangemap(heap h);
-void deallocate_rangemap(rangemap rm);
+void destruct_rangemap(rangemap rm, rmnode_handler destructor);
+void deallocate_rangemap(rangemap rm, rmnode_handler destructor);
 
 static inline range range_rshift(range r, int order)
 {
@@ -129,7 +130,7 @@ static inline void range_add(range *r, s64 delta)
              ((n) != INVALID_ADDRESS);                                  \
          (n) = __next)
 
-#define rangemap_foreach_range(rm, n, k)                                \
+#define rangemap_foreach_of_range(rm, n, k)                                \
     for (rmnode __next, (n) = rangemap_lookup_at_or_next(rm, (k)->r.start); \
          (__next = ((n) == INVALID_ADDRESS) ? 0 : rangemap_next_node(rm, n)), \
              ((n) != INVALID_ADDRESS &&                                 \

--- a/src/runtime/rbtree.c
+++ b/src/runtime/rbtree.c
@@ -1,0 +1,510 @@
+/* implementation of Sedgewick's left-leaning red-black tree
+
+   https://www.cs.princeton.edu/~rs/talks/rb/LLRB.pdf
+   https://www.cs.princeton.edu/~rs/talks/LLRB/RedBlack.pdf
+*/
+
+#include <runtime.h>
+
+//#define RBTREE_DEBUG
+#ifdef RBTREE_DEBUG
+#define rbtree_debug(x, ...) do {rprintf("RBTREE %s: " x, __func__, ##__VA_ARGS__);} while(0)
+#else
+#define rbtree_debug(x, ...)
+#endif
+
+#define left 0
+#define right 1
+#define black 0
+#define red 1
+#define COLOR_MASK 1
+
+#define parent(n) ((rbnode)((n)->parent_color & ~COLOR_MASK))
+#define set_parent(n, p) ((n)->parent_color = (((n)->parent_color) & COLOR_MASK) | \
+                          u64_from_pointer(p))
+#define child(n, i) ((n)->c[i])
+#define get_color(n) ((n)->parent_color & COLOR_MASK)
+#define set_color(n, c) do { (n)->parent_color = ((n)->parent_color & ~COLOR_MASK) | (c); } while(0)
+#define set_parent_and_color(n, p, c) do { (n)->parent_color = u64_from_pointer(p) | (c); } while(0)
+#define invert_color(n) do { (n)->parent_color ^= 1; } while(0)
+#define is_black(n) (get_color(n) == black) // XXX eliminate?
+#define is_red(n) ((n) && !is_black(n))
+#define is_black_or_null(n) (!is_red(n)) /* a little more descriptive than !is_red... */
+#define is_leaf(n) (!child(n, left) && !child(n, right))
+
+static inline void augment_node(rbtree t, rbnode n)
+{
+    if (t->augment)
+        apply(t->augment, n);
+}
+
+static inline int compare_nodes(rbtree t, rbnode a, rbnode b)
+{
+    assert(t->key_compare);
+    return apply(t->key_compare, a, b);
+}
+
+static inline int other(int side)
+{
+    return right - side;
+}
+
+// XXX take augment into account here
+
+static inline rbnode rotate(int hand, rbnode h)
+{
+    int oh = other(hand);
+    rbnode x = child(h, oh);
+    assert(x);
+    rbnode xh = child(x, hand);
+    child(h, oh) = xh;
+    if (xh)
+        set_parent(xh, h);
+    child(x, hand) = h;
+    set_parent_and_color(x, parent(h), get_color(h));
+    set_parent_and_color(h, x, red);
+    return x;
+}
+
+static inline void color_flip(rbnode n)
+{
+    assert(n);
+    invert_color(n);
+    assert(child(n, left));
+    invert_color(child(n, left));
+    assert(child(n, right));
+    invert_color(child(n, right));
+}
+
+static inline rbnode find_limit(rbnode h, boolean max)
+{
+    assert(h);
+    do {
+        rbnode c = child(h, max ? right : left);
+        if (!c)
+            return h;
+        h = c;
+    } while (1);
+}
+
+/* find first parent that has this path on hand */
+static inline rbnode find_ancestor_of_hand(rbnode h, boolean hand)
+{
+    assert(h);
+    rbnode p;
+    do {
+        p = parent(h);
+        if (!p)
+            return INVALID_ADDRESS; /* not found */
+        if (child(p, other(hand)) == h)
+            return p;
+        h = p;
+    } while (1);
+}
+
+static inline rbnode get_adjacent_inorder(rbnode h, int hand)
+{
+    rbnode hh = child(h, hand);
+    return hh ? find_limit(hh, hand == left ? true : false) :
+        find_ancestor_of_hand(h, hand);
+}
+
+rbnode rbnode_get_prev(rbnode h)
+{
+    return get_adjacent_inorder(h, left);
+}
+
+rbnode rbnode_get_next(rbnode h)
+{
+    return get_adjacent_inorder(h, right);
+}
+
+rbnode rbtree_lookup(rbtree t, rbnode k)
+{
+    rbnode h = t->root;
+    while (h) {
+        int d = compare_nodes(t, k, h);
+        if (d == 0)
+            return h;
+        h = child(h, d < 0 ? left : right);
+    }
+    return INVALID_ADDRESS;
+}
+
+rbnode rbtree_lookup_next_gte(rbtree t, rbnode k)
+{
+    rbnode h = t->root;
+    /* find largest <= k */
+    do {
+        if (!h)
+            return INVALID_ADDRESS;
+        int d = compare_nodes(t, k, h);
+        if (d == 0)
+            return h;
+        if (d > 0)
+            break;
+        h = child(h, left);
+    } while (1);
+
+    /* largest descendant <= k */
+    rbnode r;
+    while ((r = child(h, right)) && compare_nodes(t, k, r) <= 0)
+        h = r;
+    return h;
+}
+
+static inline rbnode check_move_red(rbnode h, int hand)
+{
+    int oh = other(hand);
+    rbnode hh = child(h, hand);
+    rbtree_debug("h %p, hand %d, hh %p\n", h, hand, hh);
+    if (!hh || (is_black(hh) && is_black_or_null(child(hh, left)))) {
+        color_flip(h);
+        rbnode ho = child(h, oh);
+        if (!ho || is_black_or_null(child(ho, left)))
+            return h;
+        if (hand == left)
+            child(h, right) = rotate(right, child(h, right));
+        h = rotate(hand, h);
+        color_flip(h);
+    }
+    return h;
+}
+
+/* correct violations of invariant properties on way back up the tree */
+static rbnode fix_up(rbnode h)
+{
+    /* rotate right-leaning red links into left-leaning */
+//    if ((is_red(child(h, right))) && is_black_or_null(child(h, left))) {
+    if (is_red(child(h, right))) {
+        rbtree_debug("rl -> ll: %p\n", h);
+        h = rotate(left, h);
+        rbtree_debug("  head now %p\n", h);
+    }
+
+    /* break up consecutive red links */
+    if (is_red(child(h, left))) {
+        rbnode lgc = child(child(h, left), left);
+        if (is_red(lgc)) {
+            rbtree_debug("breakup reds (%p, %p)\n", child(h, left),
+                         child(child(h, left), left));
+            h = rotate(right, h);
+            rbtree_debug("  head now %p\n", h);
+        }
+    }
+
+    /* break up 4-nodes - leaving a 2-3 tree */
+    if (is_red(child(h, left)) && is_red(child(h, right)))
+        color_flip(h);
+    return h;
+}
+
+static rbnode remove_min(rbnode h, rbnode *removed)
+{
+    if (!child(h, left)) {
+        *removed = h;
+        return 0;
+    }
+
+    /* push red links down left spine to accommodate min remove */
+    h = check_move_red(h, left);
+    child(h, left) = remove_min(child(h, left), removed);
+    return fix_up(h);
+}
+
+static inline char char_from_delta(int d)
+{
+    return d == 0 ? '=' : (d < 0 ? '<' : '>');
+}
+
+static rbnode delete_internal(rbtree t, rbnode h, rbnode k, boolean *result)
+{
+    if (!h)
+        return h;
+    int d = compare_nodes(t, k, h);
+    rbtree_debug("compare1 h %p: %c, result %d\n", h, char_from_delta(d), *result);
+    if (d < 0) {
+        if (!child(h, left))
+            return h;           /* search failed */
+
+        /* push red links down left spine */
+        h = check_move_red(h, left);
+        child(h, left) = delete_internal(t, child(h, left), k, result);
+        return fix_up(h);
+    }
+
+    if (d > 0 && !child(h, right))
+        return h;           /* search failed */
+
+    /* rotate red to move down right spine */
+    if (is_red(child(h, left)))
+        h = rotate(right, h);
+    assert(h);
+    d = compare_nodes(t, k, h);
+    rbtree_debug("  compare2 h %p: %c, rt %p\n", h, char_from_delta(d), child(h, right));
+    if (d == 0 && is_leaf(h)) {
+        /* match at leaf */
+        *result = true;
+        return 0;
+    }
+
+    /* keep pushing red links down */
+    h = check_move_red(h, right);
+    assert(h);
+    d = compare_nodes(t, k, h);
+    rbtree_debug("    compare3 h %p: %c, rt %p\n", h, char_from_delta(d), child(h, right));
+    if (d != 0) {
+        if (!child(h, right))
+            return h;           /* search failed */
+        child(h, right) = delete_internal(t, child(h, right), k, result);
+        return fix_up(h);
+    }
+
+    /* replace match with min of right subtree */
+    assert(child(h, right)); /* invariant: not 2-node */
+    rbnode rmin = 0;
+    rbnode rnew = remove_min(child(h, right), &rmin);
+    assert(rmin);
+    if (rnew)
+        set_parent(rnew, rmin);
+    set_parent_and_color(rmin, parent(h), get_color(h));
+    assert(!child(rmin, left));
+    if (child(h, left))
+        set_parent(child(h, left), rmin);
+    child(rmin, left) = child(h, left);
+    child(rmin, right) = rnew;
+    if (parent(h)) /* not root */
+        child(parent(h), child(parent(h), left) == h ? left : right) = rmin;
+    h = rmin;
+    *result = true;
+    return fix_up(h);
+}
+
+boolean rbtree_delete_by_key(rbtree t, rbnode k)
+{
+    boolean result = 0;
+    rbtree_debug("t %p, k %p\n", t, k);
+    t->root = delete_internal(t, t->root, k, &result);
+    if (t->root)
+        set_color(t->root, black);
+    if (result) {
+        assert(t->count > 0);
+        t->count--;
+    }
+    return result;
+}
+
+/* recursive version */
+static rbnode insert_node_internal(rbtree t, rbnode h, rbnode n, boolean *result)
+{
+    rbtree_debug("   pre  h %p, n %p, result %d\n", h, n, *result);
+
+    /* insert */
+    int d = compare_nodes(t, n, h);
+    if (d != 0) {
+        int hand = d < 0 ? left : right;
+        rbnode hh = child(h, hand);
+        if (!hh) {
+            child(h, hand) = n;
+            set_parent(n, h);
+            *result = true;
+        } else {
+            child(h, hand) = insert_node_internal(t, hh, n, result);
+        }
+    }
+    rbtree_debug("   post h %p, n %p, result %d, fixup...\n", h, n, *result);
+    h = fix_up(h);
+    rbtree_debug("   head now %p\n", h);
+    return h;
+}
+
+boolean rbtree_insert_node(rbtree t, rbnode n)
+{
+    rbtree_debug("t %p, n %p\n", t, n);
+    boolean result = false;
+    if (!t->root) {
+        t->root = n;
+        result = true;
+    } else {
+        set_color(n, red);
+        t->root = insert_node_internal(t, t->root, n, &result);
+    }
+    set_color(t->root, black);
+    if (result)
+        t->count++;
+    return result;
+}
+
+static void print_key(rbtree t, rbnode n)
+{
+    if (n) {
+        if (t->print_key)
+            apply(t->print_key, n);
+        else
+            rprintf("%p", n);
+    }
+}
+
+static void dump_node(rbtree t, rbnode n)
+{
+    rprintf(" %c ", is_red(n) ? 'r' : 'b');
+    print_key(t, n);
+    if (n) {
+        rprintf("\t-> ");
+        print_key(t, child(n, left));
+        rprintf("\t");
+        print_key(t, child(n, right));
+        rprintf("\t(addr: %p, p: ", n);
+        print_key(t, parent(n));
+        rprintf(")\n");
+    }
+}
+
+closure_function(1, 1, boolean, dump_internal,
+                 rbtree, t,
+                 rbnode, n)
+{
+    dump_node(bound(t), n);
+    return true;
+}
+
+static inline boolean traverse_inorder(rbnode n, rbnode_handler rh)
+{
+    if (!n)
+        return true;
+    if (!traverse_inorder(child(n, left), rh))
+        return false;
+    if (!apply(rh, n))
+        return false;
+    return traverse_inorder(child(n, right), rh);
+}
+
+static inline boolean traverse_preorder(rbnode n, rbnode_handler rh)
+{
+    if (!n)
+        return true;
+    if (!apply(rh, n))
+        return false;
+    if (!traverse_preorder(child(n, left), rh))
+        return false;
+    return traverse_preorder(child(n, right), rh);
+}
+
+static inline boolean traverse_postorder(rbnode n, rbnode_handler rh)
+{
+    if (!n)
+        return true;
+    if (!traverse_postorder(child(n, left), rh))
+        return false;
+    if (!traverse_postorder(child(n, right), rh))
+        return false;
+    return apply(rh, n);
+}
+
+boolean rbtree_traverse(rbtree t, int order, rbnode_handler rh)
+{
+    if (order == RB_INORDER)
+        return traverse_inorder(t->root, rh);
+    if (order == RB_PREORDER)
+        return traverse_preorder(t->root, rh);
+    assert(order == RB_POSTORDER);
+    return traverse_postorder(t->root, rh);
+}
+
+void rbtree_dump(rbtree t, int order)
+{
+    rbtree_traverse(t, RB_PREORDER, stack_closure(dump_internal, t));
+}
+
+static boolean validate_internal(rbtree t, rbnode n, u64 black_links, u64 *black_count)
+{
+    if (!n)
+        return true;
+
+    rbnode nl = child(n, left);
+    rbnode nr = child(n, right);
+//    rbtree_debug("n %p, l %p, r %p\n", n, nl, nr);
+
+    if (!nl && !nr) {
+        /* leaf checks */
+//        rbtree_debug("leaf, black_links %d, count %d\n", black_links, *black_count);
+        if (*black_count != -1ull) {
+            if (*black_count != black_links) {
+                rprintf("black line count mismatch\n");
+                return false;
+            }
+        } else {
+            *black_count = black_links;
+        }
+        return true;
+    }
+
+    if (is_black_or_null(nl) && (nr && is_red(nr))) {
+        rprintf("right-leaning 3-node: ");
+        dump_node(t, n);
+        return false;
+    }
+
+    // XXX refactor, return status
+    if (nl) {
+        if (parent(nl) != n) {
+            rprintf("parent of left child (%p) doesn't match self\n", parent(nl));
+            dump_node(t, n);
+            return false;
+        }
+        if (is_red(n) && is_red(nl)) {
+            rprintf("both node %p and left child %p are red\n", n, nl);
+            dump_node(t, n);
+            return false;
+        }
+    }
+
+    if (nr) {
+        if (parent(nr) != n) {
+            rprintf("parent of right child (%p) doesn't match self\n", parent(nr));
+            dump_node(t, n);
+            return false;
+        }
+        if (is_red(n) && is_red(nr)) {
+            rprintf("both node %p and right child %p are red\n", n, nr);
+            dump_node(t, n);
+            return false;
+        }
+    }
+
+    if ((nl && !validate_internal(t, nl, black_links + (is_black(nl) ? 1 : 0), black_count)) ||
+        (nr && !validate_internal(t, nr, black_links + (is_black(nr) ? 1 : 0), black_count)))
+        return false;
+
+    return true;
+}
+
+boolean rbtree_validate(rbtree t)
+{
+    /* traverse while testing for invariants:
+
+       - node child's parent link must point to node
+       - no consecutive red links
+       - no right-leaning 3-nodes
+       - number of black links from root is same for all leaves
+    */
+    u64 black_count = -1ull;
+    return validate_internal(t, t->root, 0, &black_count);
+}
+
+rbtree allocate_rbtree(heap h, rb_key_compare key_compare, rb_augment augment,
+                       rbnode_handler print_key)
+{
+    rbtree t = allocate(h, sizeof(struct rbtree));
+    t->root = 0;
+    t->count = 0;
+    t->key_compare = key_compare;
+    t->augment = augment;
+    t->print_key = print_key;
+    return t;
+}
+
+void deallocate_rbtree(rbtree rb)
+{
+    // postorder traverse and delete notes
+}

--- a/src/runtime/rbtree.h
+++ b/src/runtime/rbtree.h
@@ -1,0 +1,63 @@
+typedef struct rbnode *rbnode;
+struct rbnode {
+    u64 parent_color;           /* parent used for verification */
+    rbnode c[2];
+};
+
+typedef closure_type(rbnode_handler, boolean, rbnode n);
+typedef closure_type(rb_key_compare, int, rbnode a, rbnode b);
+typedef closure_type(rb_augment, void, rbnode n);
+
+typedef struct rbtree {
+    rbnode root;
+    u64 count;
+    rb_key_compare key_compare;
+    rb_augment augment;
+    rbnode_handler print_key;
+} *rbtree;
+
+static inline void init_rbnode(rbnode n)
+{
+    n->parent_color = 0;
+    n->c[0] = n->c[1] = 0;
+}
+
+boolean rbtree_insert_node(rbtree t, rbnode n);
+
+boolean rbtree_delete_by_key(rbtree t, rbnode k);
+
+/* Delete by node is really delete by key, because we need to perform
+   transformations while decending the tree in order to do a safe
+   removal - but we'll keep the call as part of the interface in case
+   a more optimal solution arises later. */
+static inline void rbtree_delete_node(rbtree t, rbnode n)
+{
+    assert(rbtree_delete_by_key(t, n));
+}
+
+rbnode rbtree_lookup(rbtree t, rbnode k);
+
+rbtree allocate_rbtree(heap h, rb_key_compare key_compare, rb_augment augment, rbnode_handler print_key);
+
+void deallocate_rbtree(rbtree rb);
+
+#define RB_INORDER 0
+#define RB_PREORDER 1
+#define RB_POSTORDER 2
+
+void rbtree_dump(rbtree t, int order);
+
+boolean rbtree_traverse(rbtree t, int order, rbnode_handler rh);
+
+boolean rbtree_validate(rbtree t);
+
+static inline u64 rbtree_get_count(rbtree t)
+{
+    return t->count;
+}
+
+/* not for key nodes! */
+rbnode rbnode_get_prev(rbnode h);
+rbnode rbnode_get_next(rbnode h);
+
+rbnode rbtree_lookup_next_gte(rbtree t, rbnode k);

--- a/src/runtime/rbtree.h
+++ b/src/runtime/rbtree.h
@@ -6,14 +6,13 @@ struct rbnode {
 
 typedef closure_type(rbnode_handler, boolean, rbnode n);
 typedef closure_type(rb_key_compare, int, rbnode a, rbnode b);
-typedef closure_type(rb_augment, void, rbnode n);
 
 typedef struct rbtree {
     rbnode root;
     u64 count;
     rb_key_compare key_compare;
-    rb_augment augment;
     rbnode_handler print_key;
+    heap h;
 } *rbtree;
 
 boolean rbtree_insert_node(rbtree t, rbnode n);
@@ -21,7 +20,7 @@ boolean rbtree_insert_node(rbtree t, rbnode n);
 boolean rbtree_remove_by_key(rbtree t, rbnode k);
 
 /* Delete by node is really delete by key, because we need to perform
-   transformations while decending the tree in order to do a safe
+   transformations while descending the tree in order to do a safe
    removal - but we'll keep the call as part of the interface in case
    a more optimal solution arises later. */
 static inline void rbtree_remove_node(rbtree t, rbnode n)
@@ -35,7 +34,9 @@ void init_rbtree(rbtree t, rb_key_compare key_compare, rbnode_handler print_key)
 
 rbtree allocate_rbtree(heap h, rb_key_compare key_compare, rbnode_handler print_key);
 
-void deallocate_rbtree(rbtree rb);
+void destruct_rbtree(rbtree t, rbnode_handler destructor);
+
+void deallocate_rbtree(rbtree rb, rbnode_handler destructor);
 
 #define RB_INORDER 0
 #define RB_PREORDER 1
@@ -45,7 +46,7 @@ void rbtree_dump(rbtree t, int order);
 
 boolean rbtree_traverse(rbtree t, int order, rbnode_handler rh);
 
-boolean rbtree_validate(rbtree t);
+status rbtree_validate(rbtree t);
 
 static inline u64 rbtree_get_count(rbtree t)
 {

--- a/src/runtime/rbtree.h
+++ b/src/runtime/rbtree.h
@@ -1,6 +1,6 @@
 typedef struct rbnode *rbnode;
 struct rbnode {
-    u64 parent_color;           /* parent used for verification */
+    word parent_color;           /* parent used for verification */
     rbnode c[2];
 };
 
@@ -16,28 +16,24 @@ typedef struct rbtree {
     rbnode_handler print_key;
 } *rbtree;
 
-static inline void init_rbnode(rbnode n)
-{
-    n->parent_color = 0;
-    n->c[0] = n->c[1] = 0;
-}
-
 boolean rbtree_insert_node(rbtree t, rbnode n);
 
-boolean rbtree_delete_by_key(rbtree t, rbnode k);
+boolean rbtree_remove_by_key(rbtree t, rbnode k);
 
 /* Delete by node is really delete by key, because we need to perform
    transformations while decending the tree in order to do a safe
    removal - but we'll keep the call as part of the interface in case
    a more optimal solution arises later. */
-static inline void rbtree_delete_node(rbtree t, rbnode n)
+static inline void rbtree_remove_node(rbtree t, rbnode n)
 {
-    assert(rbtree_delete_by_key(t, n));
+    assert(rbtree_remove_by_key(t, n));
 }
 
 rbnode rbtree_lookup(rbtree t, rbnode k);
 
-rbtree allocate_rbtree(heap h, rb_key_compare key_compare, rb_augment augment, rbnode_handler print_key);
+void init_rbtree(rbtree t, rb_key_compare key_compare, rbnode_handler print_key);
+
+rbtree allocate_rbtree(heap h, rb_key_compare key_compare, rbnode_handler print_key);
 
 void deallocate_rbtree(rbtree rb);
 
@@ -56,8 +52,15 @@ static inline u64 rbtree_get_count(rbtree t)
     return t->count;
 }
 
+static inline void init_rbnode(rbnode n)
+{
+    n->parent_color = 0;
+    n->c[0] = n->c[1] = 0;
+}
+
 /* not for key nodes! */
 rbnode rbnode_get_prev(rbnode h);
 rbnode rbnode_get_next(rbnode h);
 
-rbnode rbtree_lookup_next_gte(rbtree t, rbnode k);
+rbnode rbtree_lookup_max_lte(rbtree t, rbnode k);
+rbnode rbtree_find_first(rbtree t);

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -167,6 +167,7 @@ typedef closure_type(thunk, void);
 #include <tuple.h>
 #include <status.h>
 #include <pqueue.h>
+#include <rbtree.h>
 #include <range.h>
 #include <queue.h>
 #include <refcount.h>

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -520,6 +520,19 @@ static void destroy_extent(filesystem fs, extent ex)
     deallocate(fs->h, ex, sizeof(*ex));
 }
 
+closure_function(1, 1, void, destroy_extent_node,
+                 filesystem, fs,
+                 rmnode, n)
+{
+    destroy_extent(bound(fs), (extent)n);
+}
+
+closure_function(0, 1, void, assert_no_node,
+                 rmnode, n)
+{
+    halt("tfs: temporary rangemap not empty on dealloc\n");
+}
+
 static void add_extent_to_file(fsfile f, extent ex, merge m)
 {
     heap h = f->fs->h;
@@ -604,6 +617,7 @@ static void add_extents_to_file(fsfile f, rangemap rm, merge m)
 {
     tfs_debug("%s: tuple %p\n", __func__, f->md);
     rangemap_foreach(rm, node) {
+        rangemap_remove_node(rm, node);
         add_extent_to_file(f, (extent) node, m);
     }
 }
@@ -659,6 +673,7 @@ void ingest_extent(fsfile f, symbol off, tuple value)
     assert(rangemap_insert(f->extentmap, &ex->node));
 }
 
+#if 0 // XXX unused - can we nuke this?
 boolean set_extent_length(fsfile f, extent ex, u64 length, merge m)
 {
     tfs_debug("set_extent_length: range %R, allocated %ld, new length %ld\n",
@@ -691,10 +706,7 @@ boolean set_extent_length(fsfile f, extent ex, u64 length, merge m)
     }
 
     /* re-insert in rangemap */
-    rangemap_remove_node(f->extentmap, &ex->node);
-
-    ex->node.r = r; // XXX
-    if (!rangemap_insert(f->extentmap, &ex->node)) {
+    if (!rangemap_reinsert(f->extentmap, &ex->node, r)) {
         tfs_debug("failed: rangemap_insert failed\n");
         return false;
     }
@@ -705,6 +717,7 @@ boolean set_extent_length(fsfile f, extent ex, u64 length, merge m)
     filesystem_write_eav(f->fs, extent_tuple, sym(length), v, apply_merge(m));
     return true;
 }
+#endif
 
 closure_function(2, 1, void, filesystem_write_meta_complete,
                  range, q, io_status_handler, ish,
@@ -977,7 +990,6 @@ void filesystem_alloc(filesystem fs, tuple t, long offset, long len,
     tfs_debug("%s: t %v, q %R%s\n", __func__, t, q,
             keep_size ? " (keep size)" : "");
 
-    /* XXX do we really need a temp rangemap here? */
     rangemap new_rm = allocate_rangemap(fs->h);
     assert(new_rm != INVALID_ADDRESS);
     fs_status status = FS_STATUS_OK;
@@ -1017,16 +1029,12 @@ void filesystem_alloc(filesystem fs, tuple t, long offset, long len,
     }
     filesystem_flush_log(fs);
     apply(sh, STATUS_OK);
-    // XXX leaking temporary nodes
-    deallocate_rangemap(new_rm);
+    deallocate_rangemap(new_rm, stack_closure(assert_no_node));
     return;
 
 error:
-    rangemap_foreach(new_rm, n) {
-        destroy_extent(fs, (extent) n);
-    }
+    deallocate_rangemap(new_rm, stack_closure(destroy_extent_node, fs));
     apply(completion, f, status);
-    deallocate_rangemap(new_rm);
 }
 
 void filesystem_dealloc(filesystem fs, tuple t, long offset, long len,

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -29,6 +29,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/runtime/queue.c \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/sha256.c \

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -120,6 +120,7 @@ SRCS-pipe= \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/string.c \
@@ -156,6 +157,7 @@ SRCS-signal= \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/string.c \
@@ -217,6 +219,7 @@ SRCS-udploop= \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/sha256.c \
@@ -267,6 +270,7 @@ SRCS-web= \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/sha256.c \

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -10,6 +10,7 @@ PROGRAMS= \
 	queue_test \
 	range_test \
 	random_test \
+	rbtree_test \
 	table_test \
 	tuple_test \
 	udp_test \
@@ -27,6 +28,7 @@ RUNTIME = \
 	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/symbol.c \
@@ -107,6 +109,11 @@ SRCS-random_test = \
 	$(RUNTIME)\
 	$(SRCDIR)/tfs/tfs.c \
 	$(SRCDIR)/tfs/tlog.c \
+	$(SRCDIR)/unix_process/unix_process_runtime.c
+
+SRCS-rbtree_test= \
+	$(CURDIR)/rbtree_test.c \
+	$(RUNTIME)\
 	$(SRCDIR)/unix_process/unix_process_runtime.c
 
 SRCS-table_test= \

--- a/test/unit/range_test.c
+++ b/test/unit/range_test.c
@@ -13,8 +13,8 @@ struct rm_result {
 
 /* XXX restore to original glory */
 static struct rm_result rm_results[] = {
-    { irange(15, 20), 1 },
-    { irange(20, 25), 3 } };
+    { irange(10, 20), 1 },
+    { irange(20, 30), 3 } };
 
 typedef struct test_node {
     struct rmnode node;
@@ -120,6 +120,7 @@ boolean basic_test(heap h)
         goto fail;
     }
 
+#if 0
     /* test partial delete (head trim) */
     if (!rangemap_remove_range(rm, (range){5, 15})) {
         msg = "remove 0 - no match";
@@ -161,7 +162,6 @@ boolean basic_test(heap h)
         goto fail;
     }
 
-#if 0
     /* test partial delete (hole trim) */
     rv = rangemap_remove_range(rm, (range){21, 24});
     if (!rv) {

--- a/test/unit/range_test.c
+++ b/test/unit/range_test.c
@@ -52,7 +52,12 @@ static test_node allocate_test_node(heap h, range r, int val)
     return tn;
 }
 
-/* XXX do node free */
+closure_function(1, 1, void, dealloc_test_node,
+                 heap, h,
+                 rmnode, n)
+{
+    deallocate(bound(h), n, sizeof(struct test_node));
+}
 
 boolean basic_test(heap h)
 {
@@ -120,91 +125,13 @@ boolean basic_test(heap h)
         goto fail;
     }
 
-#if 0
-    /* test partial delete (head trim) */
-    if (!rangemap_remove_range(rm, (range){5, 15})) {
-        msg = "remove 0 - no match";
-        goto fail;
-    }
-
-    /* should fail */
-    if (rangemap_lookup(rm, 14) != INVALID_ADDRESS) {
-        msg = "remove 0 - lookup 0";
-        goto fail;
-    }
-
-    /* pass */
-    if (rangemap_lookup(rm, 15) != &tn1->node) {
-        msg = "remove 0 - lookup 1";
-        goto fail;
-    }
-
-    /* test partial delete (tail trim) */
-    if (!rangemap_remove_range(rm, (range){25, 31})) {
-        msg = "remove 1 - no match";
-        goto fail;
-    }
-
-    /* should fail */
-    if (rangemap_lookup(rm, 25) != INVALID_ADDRESS) {
-        msg = "remove 1 - lookup 0";
-        goto fail;
-    }
-
-    if (rangemap_lookup(rm, 29) != INVALID_ADDRESS) {
-        msg = "remove 1 - lookup 1";
-        goto fail;
-    }
-
-    /* pass */
-    if (rangemap_lookup(rm, 24) != &tn3->node) {
-        msg = "remove 1 - lookup 2";
-        goto fail;
-    }
-
-    /* test partial delete (hole trim) */
-    rv = rangemap_remove_range(rm, (range){21, 24});
-    if (!rv) {
-        msg = "remove 2 - no match";
-        goto fail;
-    }
-
-    /* should fail */
-    if (rangemap_lookup(rm, 21, &r) != INVALID_ADDRESS) {
-        msg = "remove 2 - lookup 0";
-        goto fail;
-    }
-
-    if (rangemap_lookup(rm, 23, &r) != INVALID_ADDRESS) {
-        msg = "remove 2 - lookup 1";
-        goto fail;
-    }
-
-    /* pass */
-    v = rangemap_lookup(rm, 20, &r);
-    if (v != (void *)3 ||
-        r.start != 20 ||
-        r.end != 21) {
-        msg = "remove 2 - lookup 2";
-        goto fail;
-    }
-
-    v = rangemap_lookup(rm, 24, &r);
-    if (v != (void *)3 ||
-        r.start != 24 ||
-        r.end != 25) {
-        msg = "remove 2 - lookup 3";
-        goto fail;
-    }
-#endif
-
     /* range lookup */
     rmnode_handler rh = stack_closure(basic_test_validate);
     rangemap_range_lookup(rm, irange(0, 26), rh);
     return true;
 
   fail:
-    deallocate_rangemap(rm);
+    deallocate_rangemap(rm, stack_closure(dealloc_test_node, h));
     msg_err("rangemap basic test failed: %s\n", msg);
     return false;
 }

--- a/test/unit/rbtree_test.c
+++ b/test/unit/rbtree_test.c
@@ -11,7 +11,6 @@
 typedef struct testnode {
     struct rbnode node;
     int key;
-    int value;
 } *testnode;
 
 closure_function(0, 2, int, test_compare,
@@ -38,27 +37,20 @@ void test_dump(rbtree t)
     rprintf("\n");
 }
 
-closure_function(1, 1, boolean, test_inorder_node,
-                 rbnode *, last,
+closure_function(3, 1, boolean, test_max_lte_node,
+                 rbtree, t, rbnode *, last, boolean *, result,
                  rbnode, n)
 {
-//    rprintf("-> %d (%p)\n", ((testnode)n)->key, n);
-    if (*bound(last) != 0) {
-        rbnode last = *bound(last);
-        rbnode prev = rbnode_get_prev(n);
-        if (prev != last) {
-            msg_err("prev of n %p doesn't match last %p\n", prev, last);
-            return false;
-        }
-        rbnode next = rbnode_get_next(last);
-        if (next != n) {
-            msg_err("next of last %p doesn't match node %p\n", next, n);
-            return false;
-        }
-    } else {
-        rbnode prev = rbnode_get_prev(n);
-        if (prev != INVALID_ADDRESS) {
-            msg_err("first element %p, prev %p, should be invalid\n", n, prev);
+    testnode tn = (testnode)n;
+    if (tn->key > 0) {
+        struct testnode k;
+        k.key = tn->key - 1;
+        rbnode ml = rbtree_lookup_max_lte(bound(t), &k.node);
+        rbnode x = *bound(last) ? *bound(last) : INVALID_ADDRESS;
+        if (ml != x) {
+            rprintf("%s: lookup max lte returned %p, should be last (%p)\n",
+                    __func__, ml, x);
+            *bound(result) = false;
             return false;
         }
     }
@@ -66,47 +58,54 @@ closure_function(1, 1, boolean, test_inorder_node,
     return true;
 }
 
-static boolean test_inorder(rbtree t)
+static boolean test_max_lte(rbtree t)
 {
-    if (!t->root)
-        return true;
     rbnode last = 0;
-    boolean r = rbtree_traverse(t, RB_INORDER, stack_closure(test_inorder_node, &last));
-    if (!r)
-        return false;
-    if (rbnode_get_next(last) != INVALID_ADDRESS) {
-        msg_err("next of last element should be invalid\n");
-        return false;
+    boolean result = true;
+    rbtree_traverse(t, RB_INORDER, stack_closure(test_max_lte_node, t, &last, &result));
+    if (last) {
+        struct testnode k;
+        k.key = ((testnode)last)->key + 1;
+        rbnode ml = rbtree_lookup_max_lte(t, &k.node);
+        if (ml != last) {
+            rprintf("%s: lookup max lte for key %d after last node "
+                    "returned %p instead of last (%p)\n", __func__,
+                    k.key, ml, last);
+            return false;
+        }
     }
-    return true;
+    return result;
 }
 
-static boolean test_insert(heap h, rbtree t, int key, int value, boolean validate)
+static boolean test_insert(heap h, rbtree t, int key, boolean validate)
 {
     testnode tn = allocate(h, sizeof(struct testnode));
     if (tn == INVALID_ADDRESS)
         return false;
     tn->key = key;
-    tn->value = value;
     init_rbnode(&tn->node);
     rbtest_debug("inserting node %p, key %d\n", &tn->node, key);
     boolean r = rbtree_insert_node(t, &tn->node);
     if (validate) {
-        if (!rbtree_validate(t)) {
-            msg_err("validate failed after inserting node %p (key %d)\n", &tn->node, key);
-            return false;
+        status s = rbtree_validate(t);
+        if (!is_ok(s)) {
+            rprintf("%s: rbtree_validate failed with %v ", __func__, s);
+            goto out_fail;
         }
         rbnode r = rbtree_lookup(t, &tn->node);
         if (r != &tn->node) {
-            msg_err("lookup returned %p for node %p (key %d)\n", r, &tn->node, key);
-            return false;
+            rprintf("%s: rbtree_lookup failed (returned %p) ", __func__, r);
+            goto out_fail;
         }
-        if (!test_inorder(t)) {
-            msg_err("inorder test failed after inserting node %p (key %d)\n", &tn->node, key);
-            return false;
+        if (!test_max_lte(t)) {
+            rprintf("%s: max lte test failed ", __func__);
+            goto out_fail;
         }
     }
     return r;
+  out_fail:
+    rprintf("after inserting node %p (key %d)\n", &tn->node, key);
+    return false;
 }
 
 static boolean test_remove(heap h, rbtree t, int key, boolean expect)
@@ -122,8 +121,9 @@ static boolean test_remove(heap h, rbtree t, int key, boolean expect)
 #ifdef RBTEST_DEBUG
     test_dump(t);
 #endif
-    if (!rbtree_validate(t)) {
-        msg_err("validate failed\n");
+    status s = rbtree_validate(t);
+    if (!is_ok(s)) {
+        msg_err("validate failed: %v\n", s);
         return false;
     }
     rbtest_debug("lookup:\n");
@@ -133,22 +133,170 @@ static boolean test_remove(heap h, rbtree t, int key, boolean expect)
                 key, r, ((testnode)r)->key);
         return false;
     }
-    rbtest_debug("test inorder:\n");
-    if (!test_inorder(t)) {
-        msg_err("inorder test failed after deleting key %d\n", key);
+    return true;
+}
+
+closure_function(1, 1, boolean, dealloc_testnode,
+                 heap, h,
+                 rbnode, n)
+{
+    deallocate(bound(h), n, sizeof(struct testnode));
+    return true;
+}
+
+closure_function(1, 1, boolean, assert_no_node,
+                 boolean *, result,
+                 rbnode, n)
+{
+    *bound(result) = false;
+    return false;
+}
+
+/* TODO: add test vectors to cover each tree transformation */
+#define N_INSERT_NODES 12
+static int insert_keys[][N_INSERT_NODES] = {
+    { 1, -1 },
+    { 1, 2, -1 },
+    { 1, 2, 3, -1 },
+    { 1, 2, 3, 4, -1 },
+    { 1, 2, 3, 4, 5, -1 },
+    { 1, 2, 3, 4, 5, 6, -1 },
+    { 1, 2, 3, 4, 5, 6, 7, -1 },
+    { 1, 2, 3, 4, 5, 6, 7, 8, -1 },
+    { 1, 2, 3, 4, 5, 6, 7, 8, 9, -1 },
+    { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, -1 },
+    { 3, 2, 1, -1 },
+    { -1 },
+};
+
+static int insert_preorder[][N_INSERT_NODES] = {
+    { 1, -1 },
+    { 2, 1, -1 },               /* rotate to make left leaning */
+    { 2, 1, 3, -1 },            /* break up 4-node */
+    { 2, 1, 4, 3, -1 },
+    { 4, 2, 1, 3, 5, -1 },
+    { 4, 2, 1, 3, 6, 5, -1 },
+    { 4, 2, 1, 3, 6, 5, 7, -1 },
+    { 4, 2, 1, 3, 6, 5, 8, 7, -1 },
+    { 4, 2, 1, 3, 8, 6, 5, 7, 9, -1 },
+    { 4, 2, 1, 3, 8, 6, 5, 7, 10, 9, -1 },
+    { 2, 1, 3, -1 },            /* break up consecutive reds */
+};
+
+static int remove_keys[][N_INSERT_NODES] = {
+    { 1, -1 },
+    { 1, -1 },
+    { 1, -1 },
+    { 4, -1 },
+    { 5, -1 },
+    { 1, -1 },
+    { 3, 4, -1 },
+    { 4, -1 },
+    { 9, -1 },
+    { 2, -1 },
+    { 3, 2, 1, -1 },
+    { -1 },
+};
+
+/* consecutive red fixup remaining? */
+static int remove_preorder[][N_INSERT_NODES] = {
+    { -1 },
+    { 2, -1 },
+    { 3, 2, -1 },               /* check_move_red left: color flip */
+    { 2, 1, 3, -1 },            /* left is red, rotate right */
+    { 2, 1, 4, 3, -1 },         /* right rotate, check red right color flip */
+    { 4, 3, 2, 6, 5, -1 },      /* lh color flip and make left leaning */
+    { 6, 2, 1, 5, 7, -1 },      /* color flip, other left red */
+    { 5, 2, 1, 3, 7, 6, 8, -1}, /* same, plus left hand, rotate right, break up 4-node */
+    { 4, 2, 1, 3, 6, 5, 8, 7, -1}, /* left is red, rotate right */
+    { 6, 4, 3, 1, 5, 8, 7, 10, 9, -1},
+    { -1 },
+};
+
+closure_function(3, 1, boolean, validate_preorder_vec,
+                 int *, vec, int *, index, boolean *, match,
+                 rbnode, n)
+{
+    testnode tn = (testnode)n;
+    int i = *bound(index);
+    int *p = bound(vec) + i;
+    rbtest_debug("index %d, expect %d, tn->key %d\n", i, *p, tn->key);
+    if (*p == -1) {
+        rprintf("%s: result vec exceeded at index %d\n", __func__, i);
+        *bound(match) = false;
         return false;
+    }
+    if (*p != tn->key) {
+        rprintf("%s: key %d at index %d, expected %d\n", __func__, tn->key, i, *p);
+        *bound(match) = false;
+        return false;
+    }
+    *bound(index) = i + 1;
+    return true;
+}
+
+static boolean do_transformation_test(rbtree t, heap h, int i, boolean insert)
+{
+    int index, k;
+    boolean match;
+    char *op = insert ? "insertion" : "removal";
+    int *keys = insert ? insert_keys[i] : remove_keys[i];
+
+    if (keys[0] == -1)
+        return true;
+
+    rbtest_debug("%s test %d:\n", op, i);
+    for (int j = 0; j < N_INSERT_NODES && (k = keys[j]) != -1; j++) {
+        rbtest_debug("   %d: %d\n", j, k);
+        boolean result = insert ? test_insert(h, t, k, true) : test_remove(h, t, k, true);
+        if (!result) {
+            rprintf("%s: %s failed for test %d, idx %d, key %d\n", __func__, op, i, j, k);
+            return false;   /* XXX leak */
+        }
+    }
+#ifdef RBTEST_DEBUG
+    rbtree_dump(t, RB_PREORDER);
+#endif
+    rbtest_debug("validate %ss:\n", op);
+    index = 0;
+    match = true;
+    int *rvec = insert ? insert_preorder[i] : remove_preorder[i];
+    rbtree_traverse(t, RB_PREORDER,
+                    stack_closure(validate_preorder_vec, rvec, &index, &match));
+    if (match) {
+        if (rvec[index] != -1) {
+            rprintf("%s: in-order traversal for %s test %d gave incomplete results, end index %d\n",
+                    __func__, op, i, index);
+            return false;
+        }
+    }
+    if (!match) {
+        rprintf("%s: validate for %s test %d failed\n", __func__, op, i);
+        return false;
+    }
+    rbtest_debug("passed\n\n");
+    return true;
+}
+
+static boolean transformation_tests(heap h)
+{
+    for (int i = 0; insert_keys[i][0] != -1; i++) {
+        struct rbtree t;
+        init_rbtree(&t, stack_closure(test_compare), stack_closure(dump_node));
+
+        if (!do_transformation_test(&t, h, i, true))
+            return false;
+
+        if (!do_transformation_test(&t, h, i, false))
+            return false;
+
+        /* dealloc remaining nodes */
+        destruct_rbtree(&t, stack_closure(dealloc_testnode, h));
     }
     return true;
 }
 
-#if 0
-static testnode test_lookup(rbtree t, int key)
-{
-
-
-}
-#endif
-
+/* braindead test */
 static boolean basic_test(heap h)
 {
     rbtree t = allocate_rbtree(h, closure(h, test_compare), closure(h, dump_node));
@@ -156,48 +304,42 @@ static boolean basic_test(heap h)
         msg_err("allocate_rbtree() failed\n");
         return false;
     }
-#if 0
-    int insertion_keys[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, -1 };
-    int k;
-    for (int i = 0; (k = insertion_keys[i]) != -1; i++) {
-        if (!test_insert(h, t, k, k))
-            return false;
-    }
 
-    if (!test_remove(h, t, 11, false))
-        return false;
-
-    for (int i = 0; (k = insertion_keys[i]) != -1; i++) {
-        if (!test_remove(h, t, k, true))
-            return false;
-    }
-#endif
-
-#if 1
+    rbtest_debug("insert 0 - 99\n");
     for (int i = 0; i < 100; i++) {
-        if (!test_insert(h, t, i, i, true))
+        if (!test_insert(h, t, i, true))
             return false;
     }
-#if 1
+
+    rbtest_debug("insert 199 - 100\n");
     for (int i = 199; i >= 100; i--) {
-        if (!test_insert(h, t, i, i, true))
+        if (!test_insert(h, t, i, true))
             return false;
     }
+
+    rbtest_debug("attempt to insert duplicates\n");
     for (int i = 0; i < 200; i++) {
-        if (test_insert(h, t, i, i, true)) {
+        if (test_insert(h, t, i, false)) {
             msg_err("insert should have failed\n");
             return false;
         }
     }
-#endif
-    for (int i = 199; i >= 0; i--) {
+
+    rbtest_debug("remove all nodes\n");
+    for (int i = 0; i < 200; i++) {
         if (!test_remove(h, t, i, true))
             return false;
     }
-#endif
 
-    // destruct
-    return true;
+    destruct_rbtree(t, stack_closure(dealloc_testnode, h));
+    status s = rbtree_validate(t);
+    if (!is_ok(s)) {
+        rprintf("validate failed after tree destruct: %v\n", s);
+        return false;
+    }
+    boolean result = true;
+    deallocate_rbtree(t, stack_closure(assert_no_node, &result));
+    return result;
 }
 
 #define RANDOM_VEC_ORDER 14
@@ -217,8 +359,8 @@ static boolean random_test(heap h)
         boolean r;
       redo:
         /* restrict range so as to induce collisions */
-        vec[i] = random_u64() & MASK(RANDOM_VEC_ORDER); // XXX prob add some
-        r = test_insert(h, t, vec[i], vec[i], false);
+        vec[i] = random_u64() & MASK(RANDOM_VEC_ORDER + 1);
+        r = test_insert(h, t, vec[i], false);
         if (!r) {
             struct testnode tn;
             tn.key = vec[i];
@@ -236,21 +378,30 @@ static boolean random_test(heap h)
     }
     assert(rbtree_get_count(t) == RANDOM_VECLEN);
 
-//    test_dump(t);
-
     for (int i = 0; i < RANDOM_VECLEN; i++) {
         test_remove(h, t, vec[i], true);
     }
     assert(rbtree_get_count(t) == 0);
 
-    return true;
+    destruct_rbtree(t, stack_closure(dealloc_testnode, h));
+    status s = rbtree_validate(t);
+    if (!is_ok(s)) {
+        rprintf("validate failed after tree destruct: %v\n", s);
+        return false;
+    }
+    boolean result = true;
+    deallocate_rbtree(t, stack_closure(assert_no_node, &result));
+    return result;
 }
 
 int main(int argc, char **argv)
 {
     heap h = init_process_runtime();
 
-    if (0 && !basic_test(h))
+    if (!basic_test(h))
+        goto fail;
+
+    if (!transformation_tests(h))
         goto fail;
 
     if (!random_test(h))

--- a/test/unit/rbtree_test.c
+++ b/test/unit/rbtree_test.c
@@ -1,0 +1,277 @@
+#include <runtime.h>
+#include <stdlib.h>
+
+//#define RBTEST_DEBUG
+#ifdef RBTEST_DEBUG
+#define rbtest_debug(x, ...) do {rprintf("RBTEST %s: " x, __func__, ##__VA_ARGS__);} while(0)
+#else
+#define rbtest_debug(x, ...)
+#endif
+
+typedef struct testnode {
+    struct rbnode node;
+    int key;
+    int value;
+} *testnode;
+
+closure_function(0, 2, int, test_compare,
+                 rbnode, a, rbnode, b)
+{
+    testnode ta = (testnode)a, tb = (testnode)b;
+    return ta->key < tb->key ? -1 : (ta->key > tb->key ? 1 : 0);
+}
+
+closure_function(0, 1, void, test_augment,
+                 rbnode, n)
+{
+    rbtest_debug("augment %p\n", n);
+}
+
+closure_function(0, 1, boolean, dump_node,
+                 rbnode, n)
+{
+    testnode tn = (testnode)n;
+    rprintf(" %d", tn->key);
+    return true;
+}
+
+void test_dump(rbtree t)
+{
+    rprintf("tree %p, preorder:\n", t);
+    rbtree_dump(t, RB_PREORDER);
+    rprintf("in order:\n");
+    rbtree_traverse(t, RB_INORDER, stack_closure(dump_node));
+    rprintf("\n");
+}
+
+closure_function(1, 1, boolean, test_inorder_node,
+                 rbnode *, last,
+                 rbnode, n)
+{
+//    rprintf("-> %d (%p)\n", ((testnode)n)->key, n);
+    if (*bound(last) != 0) {
+        rbnode last = *bound(last);
+        rbnode prev = rbnode_get_prev(n);
+        if (prev != last) {
+            msg_err("prev of n %p doesn't match last %p\n", prev, last);
+            return false;
+        }
+        rbnode next = rbnode_get_next(last);
+        if (next != n) {
+            msg_err("next of last %p doesn't match node %p\n", next, n);
+            return false;
+        }
+    } else {
+        rbnode prev = rbnode_get_prev(n);
+        if (prev != INVALID_ADDRESS) {
+            msg_err("first element %p, prev %p, should be invalid\n", n, prev);
+            return false;
+        }
+    }
+    *bound(last) = n;
+    return true;
+}
+
+static boolean test_inorder(rbtree t)
+{
+    if (!t->root)
+        return true;
+    rbnode last = 0;
+    boolean r = rbtree_traverse(t, RB_INORDER, stack_closure(test_inorder_node, &last));
+    if (!r)
+        return false;
+    if (rbnode_get_next(last) != INVALID_ADDRESS) {
+        msg_err("next of last element should be invalid\n");
+        return false;
+    }
+    return true;
+}
+
+static boolean test_insert(heap h, rbtree t, int key, int value, boolean validate)
+{
+    testnode tn = allocate(h, sizeof(struct testnode));
+    if (tn == INVALID_ADDRESS)
+        return false;
+    tn->key = key;
+    tn->value = value;
+    init_rbnode(&tn->node);
+    rbtest_debug("inserting node %p, key %d\n", &tn->node, key);
+    boolean r = rbtree_insert_node(t, &tn->node);
+    if (validate) {
+        if (!rbtree_validate(t)) {
+            msg_err("validate failed after inserting node %p (key %d)\n", &tn->node, key);
+            return false;
+        }
+        rbnode r = rbtree_lookup(t, &tn->node);
+        if (r != &tn->node) {
+            msg_err("lookup returned %p for node %p (key %d)\n", r, &tn->node, key);
+            return false;
+        }
+        if (!test_inorder(t)) {
+            msg_err("inorder test failed after inserting node %p (key %d)\n", &tn->node, key);
+            return false;
+        }
+    }
+    return r;
+}
+
+static boolean test_delete(heap h, rbtree t, int key, boolean expect)
+{
+    struct testnode tk;
+    tk.key = key;
+    rbtest_debug("deleting by key %d\n", key);
+    boolean result = rbtree_delete_by_key(t, &tk.node);
+    if (result != expect) {
+        msg_err("delete failed (result %d)\n", result);
+        return false;
+    }
+#ifdef RBTEST_DEBUG
+    test_dump(t);
+#endif
+    if (!rbtree_validate(t)) {
+        msg_err("validate failed\n");
+        return false;
+    }
+    rbtest_debug("lookup:\n");
+    rbnode r = rbtree_lookup(t, &tk.node);
+    if (r != INVALID_ADDRESS) {
+        msg_err("lookup for key %d should have failed (returned %p, key %d)\n",
+                key, r, ((testnode)r)->key);
+        return false;
+    }
+    rbtest_debug("test inorder:\n");
+    if (!test_inorder(t)) {
+        msg_err("inorder test failed after deleting key %d\n", key);
+        return false;
+    }
+    return true;
+}
+
+#if 0
+static testnode test_lookup(rbtree t, int key)
+{
+
+
+}
+#endif
+
+static boolean basic_test(heap h)
+{
+    rbtree t = allocate_rbtree(h, closure(h, test_compare),
+                               closure(h, test_augment),
+                               closure(h, dump_node));
+    if (t == INVALID_ADDRESS) {
+        msg_err("allocate_rbtree() failed\n");
+        return false;
+    }
+#if 0
+    int insertion_keys[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, -1 };
+    int k;
+    for (int i = 0; (k = insertion_keys[i]) != -1; i++) {
+        if (!test_insert(h, t, k, k))
+            return false;
+    }
+
+    if (!test_delete(h, t, 11, false))
+        return false;
+
+    for (int i = 0; (k = insertion_keys[i]) != -1; i++) {
+        if (!test_delete(h, t, k, true))
+            return false;
+    }
+#endif
+
+#if 1
+    for (int i = 0; i < 100; i++) {
+        if (!test_insert(h, t, i, i, true))
+            return false;
+    }
+#if 1
+    for (int i = 199; i >= 100; i--) {
+        if (!test_insert(h, t, i, i, true))
+            return false;
+    }
+    for (int i = 0; i < 200; i++) {
+        if (test_insert(h, t, i, i, true)) {
+            msg_err("insert should have failed\n");
+            return false;
+        }
+    }
+#endif
+    for (int i = 199; i >= 0; i--) {
+        if (!test_delete(h, t, i, true))
+            return false;
+    }
+#endif
+
+    // destruct
+    return true;
+}
+
+#define RANDOM_VEC_ORDER 14
+#define RANDOM_VECLEN    U64_FROM_BIT(RANDOM_VEC_ORDER)
+
+static boolean random_test(heap h)
+{
+    int vec[RANDOM_VECLEN];
+    rbtree t = allocate_rbtree(h, closure(h, test_compare),
+                               closure(h, test_augment),
+                               closure(h, dump_node));
+    assert(rbtree_get_count(t) == 0);
+    if (t == INVALID_ADDRESS) {
+        msg_err("allocate_rbtree() failed\n");
+        return false;
+    }
+
+    for (int i = 0; i < RANDOM_VECLEN; i++) {
+        boolean r;
+      redo:
+        /* restrict range so as to induce collisions */
+        vec[i] = random_u64() & MASK(RANDOM_VEC_ORDER); // XXX prob add some
+        r = test_insert(h, t, vec[i], vec[i], false);
+        if (!r) {
+            struct testnode tn;
+            tn.key = vec[i];
+            rbnode rn = rbtree_lookup(t, &tn.node);
+            if (rn == INVALID_ADDRESS) {
+                msg_err("both insert and lookup failed\n");
+                return false;
+            }
+            if (((testnode)rn)->key != vec[i]) {
+                msg_err("found node key mismatch\n");
+                return false;
+            }
+            goto redo;
+        }
+    }
+    assert(rbtree_get_count(t) == RANDOM_VECLEN);
+
+//    test_dump(t);
+
+    for (int i = 0; i < RANDOM_VECLEN; i++) {
+//        rprintf("delete %d:\n", vec[i]);
+        test_delete(h, t, vec[i], true);
+//        test_dump(t);
+    }
+    assert(rbtree_get_count(t) == 0);
+
+    return true;
+}
+
+int main(int argc, char **argv)
+{
+    heap h = init_process_runtime();
+
+    if (0 && !basic_test(h))
+        goto fail;
+
+    if (!random_test(h))
+        goto fail;
+
+    rprintf("pass\n");
+    msg_debug("test passed\n");
+    exit(EXIT_SUCCESS);
+  fail:
+    msg_err("test failed\n");
+    exit(EXIT_FAILURE);
+}

--- a/test/unit/rbtree_test.c
+++ b/test/unit/rbtree_test.c
@@ -21,12 +21,6 @@ closure_function(0, 2, int, test_compare,
     return ta->key < tb->key ? -1 : (ta->key > tb->key ? 1 : 0);
 }
 
-closure_function(0, 1, void, test_augment,
-                 rbnode, n)
-{
-    rbtest_debug("augment %p\n", n);
-}
-
 closure_function(0, 1, boolean, dump_node,
                  rbnode, n)
 {
@@ -115,12 +109,12 @@ static boolean test_insert(heap h, rbtree t, int key, int value, boolean validat
     return r;
 }
 
-static boolean test_delete(heap h, rbtree t, int key, boolean expect)
+static boolean test_remove(heap h, rbtree t, int key, boolean expect)
 {
     struct testnode tk;
     tk.key = key;
     rbtest_debug("deleting by key %d\n", key);
-    boolean result = rbtree_delete_by_key(t, &tk.node);
+    boolean result = rbtree_remove_by_key(t, &tk.node);
     if (result != expect) {
         msg_err("delete failed (result %d)\n", result);
         return false;
@@ -157,9 +151,7 @@ static testnode test_lookup(rbtree t, int key)
 
 static boolean basic_test(heap h)
 {
-    rbtree t = allocate_rbtree(h, closure(h, test_compare),
-                               closure(h, test_augment),
-                               closure(h, dump_node));
+    rbtree t = allocate_rbtree(h, closure(h, test_compare), closure(h, dump_node));
     if (t == INVALID_ADDRESS) {
         msg_err("allocate_rbtree() failed\n");
         return false;
@@ -172,11 +164,11 @@ static boolean basic_test(heap h)
             return false;
     }
 
-    if (!test_delete(h, t, 11, false))
+    if (!test_remove(h, t, 11, false))
         return false;
 
     for (int i = 0; (k = insertion_keys[i]) != -1; i++) {
-        if (!test_delete(h, t, k, true))
+        if (!test_remove(h, t, k, true))
             return false;
     }
 #endif
@@ -199,7 +191,7 @@ static boolean basic_test(heap h)
     }
 #endif
     for (int i = 199; i >= 0; i--) {
-        if (!test_delete(h, t, i, true))
+        if (!test_remove(h, t, i, true))
             return false;
     }
 #endif
@@ -214,9 +206,7 @@ static boolean basic_test(heap h)
 static boolean random_test(heap h)
 {
     int vec[RANDOM_VECLEN];
-    rbtree t = allocate_rbtree(h, closure(h, test_compare),
-                               closure(h, test_augment),
-                               closure(h, dump_node));
+    rbtree t = allocate_rbtree(h, closure(h, test_compare), closure(h, dump_node));
     assert(rbtree_get_count(t) == 0);
     if (t == INVALID_ADDRESS) {
         msg_err("allocate_rbtree() failed\n");
@@ -249,9 +239,7 @@ static boolean random_test(heap h)
 //    test_dump(t);
 
     for (int i = 0; i < RANDOM_VECLEN; i++) {
-//        rprintf("delete %d:\n", vec[i]);
-        test_delete(h, t, vec[i], true);
-//        test_dump(t);
+        test_remove(h, t, vec[i], true);
     }
     assert(rbtree_get_count(t) == 0);
 
@@ -268,7 +256,6 @@ int main(int argc, char **argv)
     if (!random_test(h))
         goto fail;
 
-    rprintf("pass\n");
     msg_debug("test passed\n");
     exit(EXIT_SUCCESS);
   fail:


### PR DESCRIPTION
This introduces a left-leaning red black tree implementation for more efficient rangemap operations. The rbtree type can be used in non-range situations as an alternative to a list, vector or table.

Resolves #1152 and #235 
