### PR TITLE
change default MTU for virtio-net; fix static IP configuration

### DIFF
--- a/src/net/net.h
+++ b/src/net/net.h
@@ -2,4 +2,5 @@
 #define NET_SYSCALLS 1
 
 boolean netsyscall_init(unix_heaps uh);
+void init_network_iface(tuple root);
 status listen_port(heap h, u16 port, connection_handler c);

--- a/src/virtio/virtio.h
+++ b/src/virtio/virtio.h
@@ -1,6 +1,5 @@
 #include <drivers/storage.h>
 
-void init_network_iface(tuple root);
 void init_virtio_network(kernel_heaps kh);
 
 void virtio_register_scsi(kernel_heaps kh, storage_attach a);


### PR DESCRIPTION
The maximum MTU on GCE is 1460. For ease of use and to avoid building special images for gce, we'll change the default to 1460 and allow the user to override the value with an "mtu" value in the manifest. This also fixes static IP configuration - which was using values as C strings (!)...

Resolves #1176 
