### PR TITLE
EPOLL_CTL_ADD: fix handling of unregistered file descriptors

### DIFF
--- a/test/runtime/epoll.c
+++ b/test/runtime/epoll.c
@@ -43,6 +43,13 @@ void test_ctl()
         goto fail;
     }
 
+    close(fd);
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (epoll_ctl(efd, EPOLL_CTL_ADD, fd, &event)) {
+        printf("Cannot re-add descriptor to epoll\n");
+        goto fail;
+    }
+
     /* EPOLL_CTL_DEL must accept NULL for the event pointer */
     if (epoll_ctl(efd, EPOLL_CTL_DEL, fd, NULL)) {
         printf("Cannot remove descriptor from epoll\n");


### PR DESCRIPTION
If a file descriptor is registered to an epoll instance, when the file is closed the descriptor is unregistered from the epoll instance, while the corresponding epollfd structure remains associated to the epoll instance. If the file descriptor is later re-used (by opening another file) and re-added to the epoll instance, the EPOLL_CTL_ADD operation fails with -EEXIST when the epollfd structure is found in the epoll instance, but the correct behavior is for EPOLL_CTL_ADD not to fail. Fix this issue by checking whether a given epollfd is registered, and only failing if it is actually registered.
A test case that catches this issue has been added to the epoll runtime tests.