### PR TITLE
exit_thread(): do not deallocate alternate signal stack

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -365,10 +365,6 @@ void exit_thread(thread t)
     deallocate_blockq(t->thread_bq);
     t->thread_bq = INVALID_ADDRESS;
 
-    /* consider having a thread heap that we can just discard ?*/
-    if (t->signal_stack) {
-        deallocate((heap)t->p->virtual_page, t->signal_stack, SIGNAL_STACK_SIZE);
-    }
     t->default_frame[FRAME_RUN] = INVALID_PHYSICAL;
     t->default_frame[FRAME_QUEUE] = INVALID_PHYSICAL;
     t->sighandler_frame[FRAME_RUN] = INVALID_PHYSICAL;


### PR DESCRIPTION
Any alternate signal stack that may have been assigned to a given thread is part of memory allocated by the user application, and as such it is memory available for the entire process; therefore, it should not be deallocated by the kernel when the thread is destroyed.