### PR TITLE
Network stack: add IPv6 support

### DIFF
--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -70,6 +70,9 @@ typedef unsigned long size_t;
 #define LWIP_TIMERS 1
 #define LWIP_TIMERS_CUSTOM 1
 #define LWIP_DHCP_BOOTP_FILE 1
+
+#define LWIP_IPV6   1
+
 typedef unsigned long u64_t;
 typedef unsigned u32_t;
 typedef int s32_t;

--- a/src/net/net_system_structs.h
+++ b/src/net/net_system_structs.h
@@ -27,6 +27,7 @@ enum protocol_type {
 
 #define AF_UNIX 1
 #define AF_INET 2
+#define AF_INET6    10
 
 
 // tuplify

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -3,6 +3,11 @@ struct sockaddr {
     u8 sa_data[14];
 } *sockaddr;
 
+struct sockaddr_storage {
+    u16 family;
+    u8 ss_data[126];
+};
+
 typedef u32 socklen_t;
 
 struct sock {

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -820,6 +820,10 @@ struct io_event {
 
 typedef struct aio_ring *aio_context_t;
 
+/* Socket option levels */
+#define SOL_SOCKET      1
+#define IPPROTO_IPV6    41
+
 /* set/getsockopt optnames */
 #define SO_DEBUG     1
 #define SO_REUSEADDR 2
@@ -827,6 +831,7 @@ typedef struct aio_ring *aio_context_t;
 #define SO_ERROR     4
 #define SO_SNDBUF    7
 
+#define IPV6_V6ONLY     26
 
 /* eventfd flags */
 #define EFD_CLOEXEC     02000000

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -109,6 +109,12 @@ SRCS-lwip= \
 	$(LWIPDIR)/src/core/ipv4/ip4_addr.c \
 	$(LWIPDIR)/src/core/ipv4/ip4_frag.c \
 	$(LWIPDIR)/src/core/ipv4/ip4.c \
+	$(LWIPDIR)/src/core/ipv6/icmp6.c \
+	$(LWIPDIR)/src/core/ipv6/ip6.c \
+	$(LWIPDIR)/src/core/ipv6/ip6_addr.c \
+	$(LWIPDIR)/src/core/ipv6/ip6_frag.c \
+	$(LWIPDIR)/src/core/ipv6/mld6.c \
+	$(LWIPDIR)/src/core/ipv6/nd6.c \
 	$(LWIPDIR)/src/core/mem.c \
 	$(LWIPDIR)/src/core/memp.c \
 	$(LWIPDIR)/src/core/netif.c \


### PR DESCRIPTION
Dual-stack operation (i.e. using an AF_INET6 socket to listen for IPv4 and IPv6 packets) is supported, for both TCP and UDP servers.

Closes #1179.