### PR TITLE
select_notify(): check fd sets before setting event flags

### DIFF
--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -577,16 +577,15 @@ closure_function(1, 2, void, select_notify,
     assert(w->epoll_type == EPOLL_TYPE_SELECT);
     int count = 0;
     /* XXX need thread safe / cas bitmap ops */
-    /* trusting that notifier masked events */
-    if (events & POLLFDMASK_READ) {
+    if (w->rset && (events & POLLFDMASK_READ)) {
         bitmap_set(w->rset, efd->fd, 1);
         count++;
     }
-    if (events & POLLFDMASK_WRITE) {
+    if (w->wset && (events & POLLFDMASK_WRITE)) {
         bitmap_set(w->wset, efd->fd, 1);
         count++;
     }
-    if (events & POLLFDMASK_EXCEPT) {
+    if (w->eset && (events & POLLFDMASK_EXCEPT)) {
         bitmap_set(w->eset, efd->fd, 1);
         count++;
     }


### PR DESCRIPTION
If a file descriptor on which a select() call is waiting is closed, the EPOLLHUP event flag is set; this flag is included in both POLLFDMASK_READ and POLLFDMASK_WRITE, thus if the select() caller is interested in either read or write events (but not both), either wset or rset may be NULL in the epoll_blocked kernel structure, and as a result select_notify() could dereference a NULL pointer.
Fix the above issue by checking that a given bitmap (rset, wset or eset) is non-NULL before accessing it.