### PR TITLE
syscalls: validate_iovec(): skip array entries with zero length

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -308,7 +308,8 @@ boolean validate_iovec(struct iovec *iov, u64 len, boolean write)
     if (!validate_user_memory(iov, sizeof(struct iovec) * len, false))
         return false;
     for (u64 i = 0; i < len; i++) {
-        if (!validate_user_memory(iov[i].iov_base, iov[i].iov_len, write))
+        if ((iov[i].iov_len != 0) &&
+                !validate_user_memory(iov[i].iov_base, iov[i].iov_len, write))
             return false;
     }
     return true;


### PR DESCRIPTION
It is legal to pass to the readv and writev syscalls iovec structures with zero length (which should be simply ignored). When such a structure is found, the corresponding iov_base field should not be checked for validity (it will most likely be a NULL pointer), otherwise spurious EFAULT errors may be returned to userspace.