### PR TITLE
Network interfaces: add loopback interface

### DIFF
--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -63,6 +63,7 @@
 // and then cede if there is a collison? or at least
 // some other policy
 #define DHCP_DOES_ARP_CHECK 0
+#define LWIP_NETIF_LOOPBACK 1
 #define LWIP_NETIF_HOSTNAME 1
 #define MEMP_MEM_MALLOC 1
 typedef unsigned long size_t;

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -149,7 +149,7 @@ static boolean get_static_config(tuple root, struct netif *n, boolean trace) {
 }
 
 void init_network_iface(tuple root) {
-    struct netif *n = netif_find("en0");
+    struct netif *n = netif_find("en1");
     if (!n) {
         rprintf("no network interface found\n");
         return;


### PR DESCRIPTION
This is needed by the Erlang runtime system, which when started in "distributed" mode spawns the Erlang process mapper daemon and then communicates with it via the loopback interface. This also prevents a "Failed to find the loopback interface" NetUtil warning from OpenJDK.
The loopback interface is assigned index number 0 in the network interface list, thus the "real" network interface is assigned index number 1 and then named "en1".
In order to receive packets from the loopback interface, netif_poll() must be called by the kernel, and this is achieved via the netsock_poll() thunk, which is put in the runqueue and then invoked by the scheduler.