### PR TITLE
getsockopt(): add support for SO_PRIORITY and SO_LINGER

### DIFF
--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -830,6 +830,8 @@ typedef struct aio_ring *aio_context_t;
 #define SO_TYPE      3
 #define SO_ERROR     4
 #define SO_SNDBUF    7
+#define SO_PRIORITY  12
+#define SO_LINGER    13
 
 #define IPV6_V6ONLY     26
 


### PR DESCRIPTION
The values of these two options are requested by the Erlang runtime system. Changing the option values is currently not implemented.