### PR TITLE
pagecache asynchronous writes

### DIFF
--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -316,6 +316,11 @@ void vm_exit(u8 code)
     QEMU_HALT(code);
 }
 
+void kernel_shutdown(int status)
+{
+    vm_exit(status);
+}
+
 static struct heap working_heap;
 static u8 early_working[EARLY_WORKING_SIZE] __attribute__((aligned(8)));
 static u64 working_p;

--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -303,6 +303,7 @@ void newstack()
                       0,         /* ignored in boot */
                       sg_wrapped_block_reader(get_stage2_disk_read(h, fs_offset), SECTOR_OFFSET, h),
                       closure(h, stage2_empty_write),
+                      0, /* no write sync */
                       root,
                       false,
                       closure(h, filesystem_initialized, h, heap_backed(&kh), root, bh));

--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -303,7 +303,7 @@ void newstack()
                       0,         /* ignored in boot */
                       sg_wrapped_block_reader(get_stage2_disk_read(h, fs_offset), SECTOR_OFFSET, h),
                       closure(h, stage2_empty_write),
-                      0, /* no write sync */
+                      0, /* no sync */
                       root,
                       false,
                       closure(h, filesystem_initialized, h, heap_backed(&kh), root, bh));

--- a/mkfs/dump.c
+++ b/mkfs/dump.c
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
                       h,
                       sg_wrapped_block_reader(closure(h, bread, fd, get_fs_offset(fd)), SECTOR_OFFSET, h),
                       closure(h, bwrite, fd),
-                      0, /* no write sync */
+                      0, /* no sync */
                       root,
                       false,
                       closure(h, fsc, h, alloca_wrap_buffer(argv[2], runtime_strlen(argv[2])), root));

--- a/mkfs/dump.c
+++ b/mkfs/dump.c
@@ -147,6 +147,7 @@ int main(int argc, char **argv)
                       h,
                       sg_wrapped_block_reader(closure(h, bread, fd, get_fs_offset(fd)), SECTOR_OFFSET, h),
                       closure(h, bwrite, fd),
+                      0, /* no write sync */
                       root,
                       false,
                       closure(h, fsc, h, alloca_wrap_buffer(argv[2], runtime_strlen(argv[2])), root));

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -29,6 +29,7 @@ void console_write(const char *s, bytes count);
 void print_u64(u64 s);
 
 void halt(char *format, ...) __attribute__((noreturn));
+void kernel_shutdown(int status) __attribute__((noreturn));
 void vm_exit(u8 code) __attribute__((noreturn));
 void print_stack_from_here();
 

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -183,6 +183,7 @@ typedef closure_type(buffer_handler, status, buffer);
 typedef closure_type(connection_handler, buffer_handler, buffer_handler);
 typedef closure_type(io_status_handler, void, status, bytes);
 typedef closure_type(block_io, void, void *, range, status_handler);
+typedef closure_type(block_sync, void, thunk);
 
 #include <sg.h>
 

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -183,7 +183,7 @@ typedef closure_type(buffer_handler, status, buffer);
 typedef closure_type(connection_handler, buffer_handler, buffer_handler);
 typedef closure_type(io_status_handler, void, status, bytes);
 typedef closure_type(block_io, void, void *, range, status_handler);
-typedef closure_type(block_sync, void, thunk);
+typedef closure_type(block_sync, void, status_handler);
 
 #include <sg.h>
 

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -17,6 +17,7 @@ void create_filesystem(heap h,
                        heap dma,
                        sg_block_io read,
                        block_io write,
+                       block_sync write_sync,
                        tuple root,
                        boolean initialize,
                        filesystem_complete complete);
@@ -28,7 +29,7 @@ void filesystem_read_linear(filesystem fs, tuple t, void *dest, u64 offset, u64 
 void filesystem_write(filesystem fs, tuple t, buffer b, u64 offset, io_status_handler completion);
 boolean filesystem_truncate(filesystem fs, fsfile f, u64 len,
         status_handler completion);
-void filesystem_flush(filesystem fs, tuple t, status_handler completion);
+void filesystem_flush(filesystem fs, status_handler completion);
 
 timestamp filesystem_get_atime(filesystem fs, tuple t);
 timestamp filesystem_get_mtime(filesystem fs, tuple t);

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -17,7 +17,7 @@ void create_filesystem(heap h,
                        heap dma,
                        sg_block_io read,
                        block_io write,
-                       block_sync write_sync,
+                       block_sync cache_sync,
                        tuple root,
                        boolean initialize,
                        filesystem_complete complete);

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -20,6 +20,7 @@ typedef struct filesystem {
     heap dma;
     sg_block_io sg_r;
     block_io w;
+    block_sync write_sync;
     log tl;
     tuple root;
     int blocksize_order;

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -20,7 +20,7 @@ typedef struct filesystem {
     heap dma;
     sg_block_io sg_r;
     block_io w;
-    block_sync write_sync;
+    block_sync cache_sync;
     log tl;
     tuple root;
     int blocksize_order;
@@ -31,8 +31,7 @@ void ingest_extent(fsfile f, symbol foff, tuple value);
 log log_create(heap h, filesystem fs, boolean initialize, status_handler sh);
 void log_write(log tl, tuple t, status_handler sh);
 void log_write_eav(log tl, tuple e, symbol a, value v, status_handler sh);
-void log_flush(log tl);
-void log_flush_complete(log tl, status_handler completion);
+void log_flush(log tl, status_handler completion);
 void flush(filesystem fs, status_handler);
 boolean filesystem_reserve_storage(filesystem fs, u64 start, u64 length);
     

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2012,7 +2012,12 @@ void exit(int code)
 
 sysreturn exit_group(int status)
 {
-    vm_exit(status);
+    thread t;
+    vector_foreach(current->p->threads, t) {
+        if (t)
+            exit_thread(t);
+    }
+    kernel_shutdown(status);
 }
 
 sysreturn pipe2(int fds[2], int flags)

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -84,7 +84,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, _sysctl, 0);
     register_syscall(map, adjtimex, 0);
     register_syscall(map, chroot, 0);
-    register_syscall(map, sync, 0);
     register_syscall(map, acct, 0);
     register_syscall(map, settimeofday, 0);
     register_syscall(map, mount, 0);
@@ -178,7 +177,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, name_to_handle_at, 0);
     register_syscall(map, open_by_handle_at, 0);
     register_syscall(map, clock_adjtime, 0);
-    register_syscall(map, syncfs, 0);
     register_syscall(map, setns, 0);
     register_syscall(map, getcpu, 0);
     register_syscall(map, process_vm_readv, 0);
@@ -1259,8 +1257,8 @@ sysreturn ftruncate(int fd, long length)
     return truncate_internal(f, f->n, length);
 }
 
-closure_function(2, 1, void, fsync_complete,
-                 thread, t, file, f,
+closure_function(1, 1, void, sync_complete,
+                 thread, t,
                  status, s)
 {
     thread t = bound(t);
@@ -1271,15 +1269,27 @@ closure_function(2, 1, void, fsync_complete,
     closure_finish();
 }
 
+sysreturn sync(void)
+{
+    file_op_begin(current);
+    filesystem_flush(current->p->fs, closure(heap_general(get_kernel_heaps()),
+                                             sync_complete, current));
+    return file_op_maybe_sleep(current);
+}
+
+sysreturn syncfs(int fd)
+{
+    /* Resolve to check validity of fd. For multiple volume support,
+       this will give us the filesystem. */
+    resolve_fd(current->p, fd);
+    return sync();
+}
+
+/* We don't currently have a per-file flush, so flush all filesystem
+   writes for fsync and fdatasync. */
 sysreturn fsync(int fd)
 {
-    file f = resolve_fd(current->p, fd);
-
-    file_op_begin(current);
-    filesystem_flush(current->p->fs, f->n,
-                     closure(heap_general(get_kernel_heaps()),
-                             fsync_complete, current, f));
-    return file_op_maybe_sleep(current);
+    return syncfs(fd);
 }
 
 sysreturn fdatasync(int fd)
@@ -2141,6 +2151,8 @@ void register_file_syscalls(struct syscall *map)
     register_syscall(map, ftruncate, ftruncate);
     register_syscall(map, fdatasync, fdatasync);
     register_syscall(map, fsync, fsync);
+    register_syscall(map, sync, sync);
+    register_syscall(map, syncfs, syncfs);
     register_syscall(map, io_setup, io_setup);
     register_syscall(map, io_submit, io_submit);
     register_syscall(map, io_getevents, io_getevents);

--- a/src/x86_64/kvm_platform.c
+++ b/src/x86_64/kvm_platform.c
@@ -31,7 +31,7 @@ void halt(char *format, ...)
     vstart(a, format);
     vbprintf(b, &f, &a);
     buffer_print(b);
-    vm_exit(VM_EXIT_HALT);
+    kernel_shutdown(VM_EXIT_HALT);
 }
 
 static boolean probe_kvm_pvclock(kernel_heaps kh)

--- a/src/x86_64/pagecache.c
+++ b/src/x86_64/pagecache.c
@@ -396,7 +396,6 @@ closure_function(1, 3, void, pagecache_read_sg,
    - implement write-back
 */
 
-/* completion likely from bhqueue service and without kernel lock */
 closure_function(2, 1, void, pagecache_write_page_merge_complete,
                  pagecache, pc, pagecache_page, pp,
                  status, s)
@@ -411,7 +410,6 @@ closure_function(2, 1, void, pagecache_write_page_merge_complete,
     closure_finish();
 }
 
-/* cache lock may or may not be held here */
 static void pagecache_write_page_internal(pagecache pc, pagecache_page pp,
                                           void *buf, range q, status_handler sh)
 {
@@ -446,7 +444,6 @@ static void pagecache_write_page_internal(pagecache pc, pagecache_page pp,
     apply(sh, STATUS_OK);
 }
 
-/* cache lock may or may not be held here */
 closure_function(5, 1, void, pagecache_write_io_check_complete,
                  pagecache, pc, pagecache_page, pp, void *, buf, range, q, status_handler, sh,
                  status, s)

--- a/src/x86_64/pagecache.c
+++ b/src/x86_64/pagecache.c
@@ -9,6 +9,8 @@
 #define pagecache_debug(x, ...)
 #endif
 
+#define MAX_PAGE_COMPLETION_VECS 128
+
 static inline u64 pagecache_pagesize(pagecache pc)
 {
     return U64_FROM_BIT(pc->page_order);
@@ -19,7 +21,31 @@ static int page_state(pagecache_page pp)
     return pp->state_phys >> PAGECACHE_PAGESTATE_SHIFT;
 }
 
-static inline void change_page_state_cache_locked(pagecache pc, pagecache_page pp, int state)
+static inline void pagelist_enqueue(pagelist pl, pagecache_page pp)
+{
+    list_insert_before(&pl->l, &pp->l);
+    pl->pages++;
+}
+
+static inline void pagelist_remove(pagelist pl, pagecache_page pp)
+{
+    list_delete(&pp->l);
+    pl->pages--;
+}
+
+static inline void pagelist_move(pagelist dest, pagelist src, pagecache_page pp)
+{
+    pagelist_remove(src, pp);
+    pagelist_enqueue(dest, pp);
+}
+
+static inline void pagelist_touch(pagelist pl, pagecache_page pp)
+{
+    list_delete(&pp->l);
+    list_insert_before(&pl->l, &pp->l);
+}
+
+static inline void change_page_state_locked(pagecache pc, pagecache_page pp, int state)
 {
     int old_state = page_state(pp);
     switch (state) {
@@ -28,45 +54,51 @@ static inline void change_page_state_cache_locked(pagecache pc, pagecache_page p
        keep and act on "refault" data */
     case PAGECACHE_PAGESTATE_FREE:
         assert(old_state == PAGECACHE_PAGESTATE_EVICTED);
-        list_insert_before(&pc->free.l, &pp->l);
-        pc->free.pages++;
+        pagelist_enqueue(&pc->free, pp);
         break;
 #endif
     case PAGECACHE_PAGESTATE_EVICTED:
         if (old_state == PAGECACHE_PAGESTATE_NEW) {
-            pc->new.pages--;
+            pagelist_remove(&pc->new, pp);
         } else {
             assert(old_state == PAGECACHE_PAGESTATE_ACTIVE);
-            pc->active.pages--;
+            pagelist_remove(&pc->active, pp);
         }
-        list_delete(&pp->l);
         /* caller must do release following state change to evicted */
         break;
     case PAGECACHE_PAGESTATE_ALLOC:
         assert(old_state == PAGECACHE_PAGESTATE_FREE);
-        list_delete(&pp->l);
-        pc->free.pages--;
+        pagelist_remove(&pc->free, pp);
         break;
     case PAGECACHE_PAGESTATE_READING:
         assert(old_state == PAGECACHE_PAGESTATE_ALLOC);
         break;
+    case PAGECACHE_PAGESTATE_WRITING:
+        if (old_state == PAGECACHE_PAGESTATE_NEW) {
+            pagelist_move(&pc->writing, &pc->new, pp);
+        } else if (old_state == PAGECACHE_PAGESTATE_ACTIVE) {
+            pagelist_move(&pc->writing, &pc->active, pp);
+        } else if (old_state == PAGECACHE_PAGESTATE_WRITING) {
+            /* write already pending, move to tail of queue */
+            pagelist_touch(&pc->writing, pp);
+        } else {
+            assert(old_state == PAGECACHE_PAGESTATE_ALLOC);
+            pagelist_enqueue(&pc->writing, pp);
+        }
+        break;
     case PAGECACHE_PAGESTATE_NEW:
         if (old_state == PAGECACHE_PAGESTATE_ACTIVE) {
-            pc->active.pages--;
-            list_delete(&pp->l);
+            pagelist_move(&pc->new, &pc->active, pp);
+        } else if (old_state == PAGECACHE_PAGESTATE_WRITING) {
+            pagelist_move(&pc->new, &pc->writing, pp);
         } else {
-            assert(old_state == PAGECACHE_PAGESTATE_READING ||
-                   old_state == PAGECACHE_PAGESTATE_WRITING);
+            assert(old_state == PAGECACHE_PAGESTATE_READING);
+            pagelist_enqueue(&pc->new, pp);
         }
-        pc->new.pages++;
-        list_insert_before(&pc->new.l, &pp->l);
         break;
     case PAGECACHE_PAGESTATE_ACTIVE:
         assert(old_state == PAGECACHE_PAGESTATE_NEW);
-        list_delete(&pp->l);
-        pc->new.pages--;
-        pc->active.pages++;
-        list_insert_before(&pc->active.l, &pp->l);
+        pagelist_move(&pc->active, &pc->new, pp);
         break;
     default:
         halt("%s: bad state %d, old %d\n", __func__, state, old_state);
@@ -76,58 +108,53 @@ static inline void change_page_state_cache_locked(pagecache pc, pagecache_page p
         ((u64)state << PAGECACHE_PAGESTATE_SHIFT);
 }
 
-closure_function(3, 0, void, service_read_page_completions,
-                 pagecache, pc, pagecache_page, pp, status, s)
+closure_function(1, 0, void, pagecache_service_completions,
+                 pagecache, pc)
 {
-    pagecache_debug("%s: pc %p, pp %p, status %v\n", __func__, bound(pc), bound(pp), bound(s));
-    pagecache_page pp = bound(pp);
-
-    /* seems kind of ridiculous...recycle these? */
-    spin_lock(&pp->lock);
-    vector cv = pp->completions;
-    pp->completions = allocate_vector(bound(pc)->h, 8);
-    spin_unlock(&pp->lock);
-
-    status_handler sh;
-    vector_foreach(cv, sh) {
-        apply(sh, bound(s));
+    /* we don't need the pagecache lock here; flag reset is atomic and dequeue is safe */
+    bound(pc)->service_enqueued = false;
+    vector v;
+    while ((v = dequeue(bound(pc)->completion_vecs)) != INVALID_ADDRESS) {
+        status_handler sh;
+        status s = vector_pop(v);
+        vector_foreach(v, sh) {
+            assert(sh);
+            apply(sh, s);
+        }
+        deallocate_vector(v);
     }
-    deallocate_vector(cv);
-    closure_finish();
 }
 
-/* This is the completion from the block read, appied from bhqueue service.
+static void pagecache_page_queue_completions_locked(pagecache pc, pagecache_page pp, status s)
+{
+    if (pp->completions && vector_length(pp->completions) > 0) {
+        vector_push(pp->completions, s);
+        assert(enqueue(pc->completion_vecs, pp->completions));
+        pp->completions = 0;
+        if (!pc->service_enqueued) {
+            pc->service_enqueued = true;
+            assert(enqueue(runqueue, pc->service_completions));
+        }
+    }
+}
 
-   TODO; Since a storage completion isn't always deferred and may be called directly by
-   the storage read (e.g. ATA driver currently), the cache lock may be held by the
-   block read caller. So we take the lock if we can but change the page state
-   anyhow. This isn't relevant right now because 1) with the big kernel lock there can't be
-   more than one processor making requests on the cache at a time, and 2) kernel code
-   runs with interrupts off, so kernel code that is operating on the cache can't be
-   interrupted or have a race with an access from the bottom half. But it will need to
-   be revised once these conditions change. */
-
-closure_function(2, 1, void, read_page_complete,
+closure_function(2, 1, void, pagecache_read_page_complete,
                  pagecache, pc, pagecache_page, pp,
                  status, s)
 {
     pagecache pc = bound(pc);
     pagecache_page pp = bound(pp);
     pagecache_debug("%s: pc %p, pp %p, status %v\n", __func__, pc, bound(pp), s);
-    spin_lock(&pp->lock);
     assert(page_state(pp) == PAGECACHE_PAGESTATE_READING);
+
     if (!is_ok(s)) {
         /* TODO need policy for capturing/reporting I/O errors... */
         msg_err("error reading page %R: %v\n", pp->node.r, s);
-    } else {
-        /* See comment above */
-        boolean unlocked = spin_try(&pc->lock);
-        change_page_state_cache_locked(bound(pc), pp, PAGECACHE_PAGESTATE_NEW);
-        if (unlocked)
-            spin_unlock(&pc->lock);
     }
-    spin_unlock(&pp->lock);
-    enqueue(runqueue, closure(pc->h, service_read_page_completions, pc, pp, s));
+    spin_lock(&pc->state_lock);
+    change_page_state_locked(bound(pc), pp, PAGECACHE_PAGESTATE_NEW);
+    pagecache_page_queue_completions_locked(pc, pp, s);
+    spin_unlock(&pc->state_lock);
     closure_finish();
 }
 
@@ -135,11 +162,13 @@ closure_function(2, 1, void, read_page_complete,
    faults wired up; new -> active transitions occur as a result of sg
    reads from fs.
 */
-static boolean pagecache_page_touch_if_filled_cache_locked(pagecache pc, pagecache_page pp)
+static boolean pagecache_page_touch_if_filled(pagecache pc, pagecache_page pp)
 {
+    spin_lock(&pc->state_lock);
     int state = page_state(pp);
     if (state == PAGECACHE_PAGESTATE_READING ||
         state == PAGECACHE_PAGESTATE_ALLOC) {
+        spin_unlock(&pc->state_lock);
         return false;
     }
 
@@ -149,35 +178,50 @@ static boolean pagecache_page_touch_if_filled_cache_locked(pagecache pc, pagecac
         list_insert_before(&pc->active.l, &pp->l);
     } else if (state == PAGECACHE_PAGESTATE_NEW) {
         /* cache hit -> active */
-        change_page_state_cache_locked(pc, pp, PAGECACHE_PAGESTATE_ACTIVE);
+        change_page_state_locked(pc, pp, PAGECACHE_PAGESTATE_ACTIVE);
     } else {
-        assert(state == PAGECACHE_PAGESTATE_DIRTY);
+        assert(state == PAGECACHE_PAGESTATE_WRITING ||
+               state == PAGECACHE_PAGESTATE_DIRTY);
     }
+    spin_unlock(&pc->state_lock);
     return true;
 }
 
-static void pagecache_page_fill_cache_locked(pagecache pc, pagecache_page pp, status_handler sh)
+static void enqueue_page_completion_statelocked(pagecache pc, pagecache_page pp, status_handler sh)
 {
+    /* completions may have been consumed on service */
+    if (!pp->completions)
+        pp->completions = allocate_vector(pc->h, 4);
     vector_push(pp->completions, sh);
-    if (page_state(pp) == PAGECACHE_PAGESTATE_ALLOC) {
-        change_page_state_cache_locked(pc, pp, PAGECACHE_PAGESTATE_READING);
-
-        /* zero pad anything extending past end of backing storage */
-        u64 end = pp->node.r.end;
-        if (end > pc->length) {
-            zero(pp->kvirt + (pc->length - pp->node.r.start), end - pc->length);
-            end = pc->length;
-        }
-
-        /* issue block reads */
-        range blocks = range_rshift(irange(pp->node.r.start, end), pc->block_order);
-        pagecache_debug("%s: pc %p, pp %p, blocks %R, reading...\n", __func__, pc, pp, blocks);
-        apply(pc->block_read, pp->kvirt, blocks, closure(pc->h, read_page_complete, pc, pp));
-    }
 }
 
-static void pagecache_read_page_internal_cache_locked(pagecache pc, pagecache_page pp,
-                                                      sg_list sg, range q, merge m)
+static void pagecache_page_fill(pagecache pc, pagecache_page pp, status_handler sh)
+{
+    spin_lock(&pc->state_lock);
+    enqueue_page_completion_statelocked(pc, pp, sh);
+    if (page_state(pp) != PAGECACHE_PAGESTATE_ALLOC) {
+        spin_unlock(&pc->state_lock);
+        return;
+    }
+    change_page_state_locked(pc, pp, PAGECACHE_PAGESTATE_READING);
+    spin_unlock(&pc->state_lock);
+
+    /* zero pad anything extending past end of backing storage */
+    u64 end = pp->node.r.end;
+    if (end > pc->length) {
+        zero(pp->kvirt + (pc->length - pp->node.r.start), end - pc->length);
+        end = pc->length;
+    }
+
+    /* issue block reads */
+    range blocks = range_rshift(irange(pp->node.r.start, end), pc->block_order);
+    pagecache_debug("%s: pc %p, pp %p, blocks %R, reading...\n", __func__, pc, pp, blocks);
+    apply(pc->block_read, pp->kvirt, blocks,
+          closure(pc->h, pagecache_read_page_complete, pc, pp));
+}
+
+static void pagecache_read_page_internal(pagecache pc, pagecache_page pp,
+                                         sg_list sg, range q, merge m)
 {
     range r = pp->node.r;
     pagecache_debug("%s: pc %p, sg %p, q %R, m %p, r %R, pp %p, refcount %d, state %d\n",
@@ -193,22 +237,22 @@ static void pagecache_read_page_internal_cache_locked(pagecache pc, pagecache_pa
     sgb->refcount = &pp->refcount;
     refcount_reserve(&pp->refcount); /* reference for being on sg list */
 
-    if (!pagecache_page_touch_if_filled_cache_locked(pc, pp)) {
-        pagecache_page_fill_cache_locked(pc, pp, apply_merge(m));
+    if (!pagecache_page_touch_if_filled(pc, pp)) {
+        pagecache_page_fill(pc, pp, apply_merge(m));
     }
 }
 
 /* for existing pages, load blocks as necessary and move from new to active list
    note: sg vec building depends on rangemap traversal being in order... */
-closure_function(4, 1, void, pagecache_read_page_cache_locked,
+closure_function(4, 1, void, pagecache_read_page,
                  pagecache, pc, sg_list, sg, range, q, merge, m,
                  rmnode, node)
 {
     pagecache_page pp = (pagecache_page)node;
-    pagecache_read_page_internal_cache_locked(bound(pc), pp, bound(sg), bound(q), bound(m));
+    pagecache_read_page_internal(bound(pc), pp, bound(sg), bound(q), bound(m));
 }
 
-static u64 evict_from_list_cache_locked(pagecache pc, struct pagelist *pl, u64 pages)
+static u64 evict_from_list_locked(pagecache pc, struct pagelist *pl, u64 pages)
 {
     u64 evicted = 0;
     list_foreach(&pl->l, l) {
@@ -219,7 +263,7 @@ static u64 evict_from_list_cache_locked(pagecache pc, struct pagelist *pl, u64 p
         pagecache_debug("%s: list %s, release pp %R, state %d, count %ld\n", __func__,
                         pl == &pc->new ? "new" : "active",
                         pp->node.r, page_state(pp), pp->refcount.c);
-        change_page_state_cache_locked(pc, pp, PAGECACHE_PAGESTATE_EVICTED);
+        change_page_state_locked(pc, pp, PAGECACHE_PAGESTATE_EVICTED);
         rangemap_remove_node(pc->pages, &pp->node);
         refcount_release(&pp->refcount); /* eviction, as far as cache is concerned */
         evicted++;
@@ -227,7 +271,7 @@ static u64 evict_from_list_cache_locked(pagecache pc, struct pagelist *pl, u64 p
     return evicted;
 }
 
-static void balance_page_lists_cache_locked(pagecache pc)
+static void balance_page_lists_locked(pagecache pc)
 {
     /* balance active and new lists */
     s64 dp = ((s64)pc->active.pages - (s64)pc->new.pages) / 2;
@@ -236,32 +280,16 @@ static void balance_page_lists_cache_locked(pagecache pc)
         if (dp <= 0)
             break;
         pagecache_page pp = struct_from_list(l, pagecache_page, l);
-        spin_lock(&pp->lock);
         /* We don't presently have a notion of "time" in the cache, so
            just cull unreferenced buffers in LRU fashion until active
            pages are equivalent to new...loosely inspired by linux
            approach. */
         if (pp->refcount.c == 1) {
             pagecache_debug("   pp %R -> new\n", pp->node.r);
-            change_page_state_cache_locked(pc, pp, PAGECACHE_PAGESTATE_NEW);
+            change_page_state_locked(pc, pp, PAGECACHE_PAGESTATE_NEW);
             dp--;
         }
-        spin_unlock(&pp->lock);
     }
-}
-
-/* evict pages from new and active lists, then rebalance */
-static u64 evict_pages_cache_locked(pagecache pc, u64 pages)
-{
-    u64 evicted = evict_from_list_cache_locked(pc, &pc->new, pages);
-    if (evicted < pages) {
-        /* To fill the requested pages evictions, we are more
-           aggressive here, evicting even in-use pages (rc > 1) in the
-           active list. */
-        evicted += evict_from_list_cache_locked(pc, &pc->active, pages - evicted);
-    }
-    balance_page_lists_cache_locked(pc);
-    return evicted;
 }
 
 closure_function(2, 0, void, pagecache_page_release,
@@ -281,7 +309,7 @@ closure_function(2, 0, void, pagecache_page_release,
     closure_finish();
 }
 
-static pagecache_page allocate_pagecache_page_cache_locked(pagecache pc, range r)
+static pagecache_page allocate_pagecache_page(pagecache pc, range r)
 {
     /* allocate - later we can look at blocks of pages at a time */
     u64 pagesize = U64_FROM_BIT(pc->page_order);
@@ -293,28 +321,24 @@ static pagecache_page allocate_pagecache_page_cache_locked(pagecache pc, range r
     if (pp == INVALID_ADDRESS)
         goto fail_dealloc_backed;
 
-    spin_lock_init(&pp->lock);
-    pp->completions = allocate_vector(pc->h, 8);
-    if (pp->completions == INVALID_ADDRESS)
-        goto fail_dealloc_pp;
     pp->l.next = pp->l.prev = 0;
     pp->state_phys = ((u64)PAGECACHE_PAGESTATE_ALLOC << PAGECACHE_PAGESTATE_SHIFT) |
         (physical_from_virtual(p) >> pc->page_order);
+    pp->write_merge = 0;        /* allocated on demand */
+    pp->completions = 0;
     init_refcount(&pp->refcount, 1, closure(pc->h, pagecache_page_release, pc, pp));
     pp->kvirt = p;
     pp->node.r = r;
     assert(rangemap_insert(pc->pages, &pp->node));
     fetch_and_add(&pc->total_pages, 1); /* decrement happens without cache lock */
     return pp;
-  fail_dealloc_pp:
-    deallocate(pc->h, pp, sizeof(struct pagecache_page));
   fail_dealloc_backed:
     deallocate(pc->backed, p, pagesize);
     return INVALID_ADDRESS;
 }
 
 /* populate missing pages, allocate buffers and install kernel mappings */
-closure_function(4, 1, void, pagecache_read_gap_cache_locked,
+closure_function(4, 1, void, pagecache_read_gap,
                  pagecache, pc, sg_list, sg, range, q, merge, m,
                  range, r)
 {
@@ -324,29 +348,29 @@ closure_function(4, 1, void, pagecache_read_gap_cache_locked,
     u64 pagesize = U64_FROM_BIT(order);
     u64 start = r.start & ~MASK(order);
     for (u64 offset = start; offset < r.end; offset += pagesize) {
-        pagecache_page pp = allocate_pagecache_page_cache_locked(pc, irange(offset, offset + pagesize));
+        pagecache_page pp = allocate_pagecache_page(pc, irange(offset, offset + pagesize));
         if (pp == INVALID_ADDRESS) {
             apply(apply_merge(bound(m)), timm("result", "failed to allocate pagecache_page"));
             return;
         }
-        pagecache_read_page_internal_cache_locked(pc, pp, bound(sg), bound(q), bound(m));
+        pagecache_read_page_internal(pc, pp, bound(sg), bound(q), bound(m));
     }
 }
 
 /* TODO rangemap -> single point tree lookup */
-static boolean pagecache_read_internal(pagecache pc, sg_list sg, range q, status_handler completion)
+static boolean pagecache_read_internal(pagecache pc, sg_list sg, range q, status_handler complete)
 {
-    pagecache_debug("%s: pc %p, sg %p, q %R, completion %p\n", __func__, pc, sg, q, completion);
+    pagecache_debug("%s: pc %p, sg %p, q %R, completion %p\n", __func__, pc, sg, q, complete);
     assert(range_span(q) > 0);
-    merge m = allocate_merge(pc->h, completion);
+    merge m = allocate_merge(pc->h, complete);
     status_handler sh = apply_merge(m);
 
     /* fill gaps and initiate reads */
-    spin_lock(&pc->lock);
-    rmnode_handler nh = stack_closure(pagecache_read_page_cache_locked, pc, sg, q, m);
-    range_handler rh = stack_closure(pagecache_read_gap_cache_locked, pc, sg, q, m);
+    spin_lock(&pc->pages_lock);
+    rmnode_handler nh = stack_closure(pagecache_read_page, pc, sg, q, m);
+    range_handler rh = stack_closure(pagecache_read_gap, pc, sg, q, m);
     boolean match = rangemap_range_lookup_with_gaps(pc->pages, q, nh, rh);
-    spin_unlock(&pc->lock);
+    spin_unlock(&pc->pages_lock);
 
     if (!match) {
         apply(sh, timm("result", "%s: no matching pages for range %R", __func__, q));
@@ -372,42 +396,35 @@ closure_function(1, 3, void, pagecache_read_sg,
    - implement write-back
 */
 
-/* don't forget: not holding kernel lock here */
-closure_function(2, 1, void, pagecache_block_write_complete,
+/* completion likely from bhqueue service and without kernel lock */
+closure_function(2, 1, void, pagecache_write_page_merge_complete,
                  pagecache, pc, pagecache_page, pp,
                  status, s)
 {
     pagecache pc = bound(pc);
-    u64 n = fetch_and_add(&pc->pages_writing, -1);
-    pagecache_debug("%s: pc %p, pp %p, pages_writing %ld\n", __func__, pc, bound(pp),
-                    pc->pages_writing);
-
-    if (!is_ok(s)) {
-        msg_err("write I/O failed for pp %p: %v\n", bound(pp), s);
-        /* XXX accounting, logging... */
-    }
-
-    if (n == 1 && vector_length(pc->sync_completions) > 0) {
-        enqueue(runqueue, pc->sync_complete);
-    }
+    pagecache_page pp = bound(pp);
+    spin_lock(&pc->state_lock);
+    change_page_state_locked(pc, pp, PAGECACHE_PAGESTATE_NEW);
+    pagecache_page_queue_completions_locked(pc, pp, s);
+    pp->write_merge = 0;
+    spin_unlock(&pc->state_lock);
     closure_finish();
 }
 
 /* cache lock may or may not be held here */
-static void pagecache_write_page_internal_page_locked(pagecache pc, pagecache_page pp,
-                                                      void *buf, range q, status_handler sh)
+static void pagecache_write_page_internal(pagecache pc, pagecache_page pp,
+                                          void *buf, range q, status_handler sh)
 {
-    int state = page_state(pp);
     range i = range_intersection(q, pp->node.r);
     u64 len = range_span(i);
     u64 page_offset = i.start - pp->node.r.start;
     void *dest = pp->kvirt + page_offset;
     void *src = buf + (i.start - q.start);
     pagecache_debug("%s: pc %p, pp %p, refcount %d, state %d, src %p, i %R, offset %d, len %d\n",
-                    __func__, pc, pp, pp->refcount.c, state, src, i, page_offset, len);
+                    __func__, pc, pp, pp->refcount.c, page_state(pp), src, i, page_offset, len);
 
-    assert(state == PAGECACHE_PAGESTATE_ALLOC || state == PAGECACHE_PAGESTATE_NEW ||
-           state == PAGECACHE_PAGESTATE_ACTIVE || state == PAGECACHE_PAGESTATE_DIRTY);
+    spin_lock(&pc->state_lock);
+    change_page_state_locked(pc, pp, PAGECACHE_PAGESTATE_WRITING);
 
     /* write to cache buffer and commit to storage */
     pagecache_debug("   copy %p <- %p %d bytes\n", dest, src, len);
@@ -415,40 +432,51 @@ static void pagecache_write_page_internal_page_locked(pagecache pc, pagecache_pa
     runtime_memcpy(dest, src, len);
     range blocks = range_rshift(i, pc->block_order);
     pagecache_debug("   write %p to block range %R\n", dest, blocks);
-    fetch_and_add(&pc->pages_writing, 1);
-    apply(pc->block_write, dest, blocks, closure(pc->h, pagecache_block_write_complete, pc, pp));
+    if (!pp->write_merge) {
+        /* TODO make inline merge to eliminate alloc? */
+        pp->write_merge = allocate_merge(pc->h, closure(pc->h, pagecache_write_page_merge_complete,
+                                                        pc, pp));
+        assert(pp->write_merge != INVALID_ADDRESS);
+        assert(!pp->completions || vector_length(pp->completions) == 0);
+    }
+    spin_unlock(&pc->state_lock);
+    apply(pc->block_write, dest, blocks, apply_merge(pp->write_merge));
 
     /* TODO check to see if an error was posted already... */
     apply(sh, STATUS_OK);
 }
 
 /* cache lock may or may not be held here */
-closure_function(5, 0, void, pagecache_write_io_complete,
-                 pagecache, pc, pagecache_page, pp, void *, buf, range, q, status_handler, sh)
+closure_function(5, 1, void, pagecache_write_io_check_complete,
+                 pagecache, pc, pagecache_page, pp, void *, buf, range, q, status_handler, sh,
+                 status, s)
 {
-    spin_lock(&bound(pp)->lock);
-    pagecache_write_page_internal_page_locked(bound(pc), bound(pp), bound(buf), bound(q), bound(sh));
-    spin_unlock(&bound(pp)->lock);
+    if (!is_ok(s)) {
+        apply(bound(sh), s);
+    } else {
+        pagecache_write_page_internal(bound(pc), bound(pp), bound(buf), bound(q), bound(sh));
+    }
     closure_finish();
 }
 
-/* cache lock may or may not be held here */
 static void pagecache_write_page_io_check(pagecache pc, pagecache_page pp,
                                           void *buf, range q, status_handler sh)
 {
-    spin_lock(&pp->lock);
+    spin_lock(&pc->state_lock);
     int state = page_state(pp);
     assert(state != PAGECACHE_PAGESTATE_ALLOC);
     if (state == PAGECACHE_PAGESTATE_READING) {
-        vector_push(pp->completions, closure(pc->h, pagecache_write_io_complete,
-                                             pc, pp, buf, q, sh));
+        enqueue_page_completion_statelocked(pc, pp,
+                                            closure(pc->h, pagecache_write_io_check_complete,
+                                                    pc, pp, buf, q, sh));
+        spin_unlock(&pc->state_lock);
     } else {
-        pagecache_write_page_internal_page_locked(pc, pp, buf, q, sh);
+        spin_unlock(&pc->state_lock);
+        pagecache_write_page_internal(pc, pp, buf, q, sh);
     }
-    spin_unlock(&pp->lock);
 }
 
-closure_function(4, 1, void, pagecache_write_page_cache_locked,
+closure_function(4, 1, void, pagecache_write_page,
                  pagecache, pc, void *, buf, range, q, merge, m,
                  rmnode, node)
 {
@@ -469,7 +497,7 @@ closure_function(5, 1, void, pagecache_write_page_filled,
     closure_finish();
 }
 
-closure_function(4, 1, void, pagecache_write_gap_cache_locked,
+closure_function(4, 1, void, pagecache_write_gap,
                  pagecache, pc, void *, buf, range, q, merge, m,
                  range, r)
 {
@@ -479,7 +507,7 @@ closure_function(4, 1, void, pagecache_write_gap_cache_locked,
     u64 pagesize = U64_FROM_BIT(order);
     u64 start = r.start & ~MASK(order);
     for (u64 offset = start; offset < r.end; offset += pagesize) {
-        pagecache_page pp = allocate_pagecache_page_cache_locked(pc, irange(offset, offset + pagesize));
+        pagecache_page pp = allocate_pagecache_page(pc, irange(offset, offset + pagesize));
         if (pp == INVALID_ADDRESS) {
             apply(apply_merge(bound(m)), timm("result", "failed to allocate pagecache_page"));
             return;
@@ -488,13 +516,11 @@ closure_function(4, 1, void, pagecache_write_gap_cache_locked,
         /* if this write covers the entire page, don't bother trying to fill it first */
         range i = range_intersection(pp->node.r, bound(q));
         if (i.start == pp->node.r.start && i.end == MIN(pp->node.r.end, pc->length)) {
-            spin_lock(&pp->lock);
-            pagecache_write_page_internal_page_locked(pc, pp, bound(buf), bound(q), apply_merge(bound(m)));
-            spin_unlock(&pp->lock);
+            pagecache_write_page_internal(pc, pp, bound(buf), bound(q), apply_merge(bound(m)));
         } else {
-            pagecache_page_fill_cache_locked(pc, pp, closure(pc->h, pagecache_write_page_filled,
-                                                             pc, pp, bound(buf), bound(q),
-                                                             apply_merge(bound(m))));
+            pagecache_page_fill(pc, pp, closure(pc->h, pagecache_write_page_filled,
+                                                pc, pp, bound(buf), bound(q),
+                                                apply_merge(bound(m))));
         }
     }
 }
@@ -510,11 +536,11 @@ closure_function(1, 3, void, pagecache_write,
     status_handler sh = apply_merge(m);
 
     /* fill gaps and initiate writes (and prerequisite reads) */
-    spin_lock(&pc->lock);
-    rmnode_handler nh = stack_closure(pagecache_write_page_cache_locked, pc, buf, q, m);
-    range_handler rh = stack_closure(pagecache_write_gap_cache_locked, pc, buf, q, m);
+    spin_lock(&pc->pages_lock);
+    rmnode_handler nh = stack_closure(pagecache_write_page, pc, buf, q, m);
+    range_handler rh = stack_closure(pagecache_write_gap, pc, buf, q, m);
     boolean match = rangemap_range_lookup_with_gaps(pc->pages, q, nh, rh);
-    spin_unlock(&pc->lock);
+    spin_unlock(&pc->pages_lock);
 
     if (!match) {
         apply(sh, timm("result", "%s: no matching pages for range %R", __func__, q));
@@ -529,45 +555,54 @@ static inline void page_list_init(struct pagelist *pl)
     pl->pages = 0;
 }
 
+/* evict pages from new and active lists, then rebalance */
+static u64 evict_pages_locked(pagecache pc, u64 pages)
+{
+    u64 evicted = evict_from_list_locked(pc, &pc->new, pages);
+    if (evicted < pages) {
+        /* To fill the requested pages evictions, we are more
+           aggressive here, evicting even in-use pages (rc > 1) in the
+           active list. */
+        evicted += evict_from_list_locked(pc, &pc->active, pages - evicted);
+    }
+    balance_page_lists_locked(pc);
+    return evicted;
+}
+
 u64 pagecache_drain(pagecache pc, u64 drain_bytes)
 {
     u64 pages = pad(drain_bytes, pagecache_pagesize(pc)) >> pc->page_order;
-    spin_lock(&pc->lock);
-    u64 evicted = evict_pages_cache_locked(pc, pages);
-    spin_unlock(&pc->lock);
+
+    /* We could avoid taking both locks here if we keep drained page
+       objects around (which incidentally could be useful to keep
+       refault data). */
+    spin_lock(&pc->pages_lock);
+    spin_lock(&pc->state_lock);
+    u64 evicted = evict_pages_locked(pc, pages);
+    spin_unlock(&pc->state_lock);
+    spin_unlock(&pc->pages_lock);
     return evicted << pc->page_order;
 }
 
-/* holding lock throughout, so completions cannot do pagecache operations */
-closure_function(1, 0, void, pagecache_sync_complete,
-                 pagecache, pc)
-{
-    pagecache pc = bound(pc);
-    spin_lock(&pc->lock);
-    thunk c;
-    vector_foreach(pc->sync_completions, c) {
-        assert(c);
-        apply(c);
-    }
-    vector_clear(pc->sync_completions);
-    spin_unlock(&pc->lock);
-}
-
-// XXX could bh completions happen prematurely here?
-closure_function(1, 1, void, pagecache_write_sync,
+closure_function(1, 1, void, pagecache_sync,
                  pagecache, pc,
-                 thunk, complete)
+                 status_handler, complete)
 {
     pagecache pc = bound(pc);
     assert(complete);
-    spin_lock(&pc->lock);
-    if (pc->pages_writing == 0) {
-        apply(complete);
-        goto out;
+
+    pagecache_page pp = 0;
+    /* If writes are pending, tack completion onto the mostly recently written page. */
+    spin_lock(&pc->state_lock);
+    if (!list_empty(&pc->writing.l)) {
+        list l = pc->writing.l.prev;
+        pp = struct_from_list(l, pagecache_page, l);
+        enqueue_page_completion_statelocked(pc, pp, complete);
+        spin_unlock(&pc->state_lock);
+        return;
     }
-    vector_push(pc->sync_completions, complete);
-  out:
-    spin_unlock(&pc->lock);
+    spin_unlock(&pc->state_lock);
+    apply(complete, STATUS_OK);
 }
 
 pagecache allocate_pagecache(heap general, heap backed,
@@ -578,32 +613,39 @@ pagecache allocate_pagecache(heap general, heap backed,
     if (pc == INVALID_ADDRESS)
         return pc;
 
+    pc->total_pages = 0;
+    pc->length = length;
+    pc->page_order = find_order(pagesize);
+    assert(pagesize == U64_FROM_BIT(pc->page_order));
+    pc->block_order = find_order(block_size);
+    assert(block_size == U64_FROM_BIT(pc->block_order));
+    pc->h = general;
+    pc->backed = backed;
+
+    spin_lock_init(&pc->pages_lock);
     pc->pages = allocate_rangemap(general);
     if (pc->pages == INVALID_ADDRESS) {
         deallocate(general, pc->pages, sizeof(struct pagecache));
         return INVALID_ADDRESS;
     }
+
+    spin_lock_init(&pc->state_lock);
     page_list_init(&pc->free);
     page_list_init(&pc->new);
     page_list_init(&pc->active);
+    page_list_init(&pc->writing);
     page_list_init(&pc->dirty);
-    pc->page_order = find_order(pagesize);
-    assert(pagesize == U64_FROM_BIT(pc->page_order));
-    pc->block_order = find_order(block_size);
-    assert(block_size == U64_FROM_BIT(pc->block_order));
-    pc->total_pages = 0;
-    pc->length = length;
-    pc->h = general;
-    pc->backed = backed;
+
     pc->mapper = mapper;
     pc->block_read = read;
     pc->block_write = write;
     pc->sg_read = closure(general, pagecache_read_sg, pc);
     pc->write = closure(general, pagecache_write, pc);
-    pc->write_sync = closure(general, pagecache_write_sync, pc);
-    pc->pages_writing = 0;
-    pc->sync_completions = allocate_vector(general, 8);
-    assert(pc->sync_completions != INVALID_ADDRESS);
-    pc->sync_complete = closure(general, pagecache_sync_complete, pc);
+    pc->sync = closure(general, pagecache_sync, pc);
+
+    pc->completion_vecs = allocate_queue(general, MAX_PAGE_COMPLETION_VECS);
+    assert(pc->completion_vecs != INVALID_ADDRESS);
+    pc->service_completions = closure(general, pagecache_service_completions, pc);
+    pc->service_enqueued = false;
     return pc;
 }

--- a/src/x86_64/pagecache.h
+++ b/src/x86_64/pagecache.h
@@ -1,33 +1,49 @@
 /* cache index to volume index, in bytes */
 typedef closure_type(block_mapper, u64, u64);
 
-struct pagelist {
+typedef struct pagelist {
     struct list l;
     u64 pages;
-};
+} *pagelist;
 
 typedef struct pagecache {
+    u64 total_pages;
+    u64 length;                 /* hard limit */
     int page_order;
     int block_order;
-    struct spinlock lock;
+    heap h;
+    heap backed;
+
+    /* pages_lock covers traversal, insertions and removals
+       should be some kind of rw lock */
+    struct spinlock pages_lock;
     rangemap pages;
+
+    /* state_lock covers list access, page state changes and
+       alterations to page completion vecs */
+    struct spinlock state_lock;
     struct pagelist free;      /* see state descriptions */
     struct pagelist new;
     struct pagelist active;
+    struct pagelist writing;
     struct pagelist dirty;     /* phase 2 */
-    u64 total_pages;
-    u64 length;                 /* hard limit */
-    heap h;
-    heap backed;
+
+    /* fs callbacks */
     block_mapper mapper;
+
+    /* block device interface */
     block_io block_read;
     block_io block_write;
+
+    /* interface exposed to fs */
     sg_block_io sg_read;
     block_io write;
-    block_sync write_sync;
-    u64 pages_writing;
-    vector sync_completions;    /* thunks to apply on completion of last write */
-    thunk sync_complete;
+    block_sync sync;
+
+    /* not under lock */
+    queue completion_vecs;
+    thunk service_completions;
+    boolean service_enqueued;
 } *pagecache;
 
 #define PAGECACHE_PAGESTATE_SHIFT   61
@@ -46,9 +62,9 @@ typedef struct pagecache_page {
     struct rmnode node;
     struct refcount refcount;
     struct list l;
-    struct spinlock lock;       /* cover changes to state / completions */
     void *kvirt;
     u64 state_phys;             /* state and physical page number */
+    merge write_merge;          /* completion merge for pending block writes */
     vector completions;         /* status_handlers */
 } *pagecache_page;
 
@@ -67,9 +83,9 @@ static inline block_io pagecache_writer(pagecache pc)
     return pc->write;
 }
 
-static inline block_sync pagecache_write_syncer(pagecache pc)
+static inline block_sync pagecache_syncer(pagecache pc)
 {
-    return pc->write_sync;
+    return pc->sync;
 }
 
 u64 pagecache_drain(pagecache pc, u64 drain_bytes);

--- a/src/x86_64/pagecache.h
+++ b/src/x86_64/pagecache.h
@@ -24,6 +24,10 @@ typedef struct pagecache {
     block_io block_write;
     sg_block_io sg_read;
     block_io write;
+    block_sync write_sync;
+    u64 pages_writing;
+    vector sync_completions;    /* thunks to apply on completion of last write */
+    thunk sync_complete;
 } *pagecache;
 
 #define PAGECACHE_PAGESTATE_SHIFT   61
@@ -63,7 +67,13 @@ static inline block_io pagecache_writer(pagecache pc)
     return pc->write;
 }
 
+static inline block_sync pagecache_write_syncer(pagecache pc)
+{
+    return pc->write_sync;
+}
+
 u64 pagecache_drain(pagecache pc, u64 drain_bytes);
+
 pagecache allocate_pagecache(heap general, heap backed,
                              u64 length, u64 pagesize, u64 block_size,
                              block_mapper mapper, block_io read, block_io write);

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -159,7 +159,7 @@ closure_function(2, 3, void, attach_storage,
                       heap_backed(&heaps),
                       pagecache_reader_sg(pc),
                       pagecache_writer(pc),
-                      pagecache_write_syncer(pc),
+                      pagecache_syncer(pc),
                       bound(root),
                       false,
                       closure(h, fsstarted, bound(root)));

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -159,6 +159,7 @@ closure_function(2, 3, void, attach_storage,
                       heap_backed(&heaps),
                       pagecache_reader_sg(pc),
                       pagecache_writer(pc),
+                      pagecache_write_syncer(pc),
                       bound(root),
                       false,
                       closure(h, fsstarted, bound(root)));

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -267,6 +267,25 @@ void vm_exit(u8 code)
     }
 }
 
+closure_function(1, 1, void, sync_complete,
+                 u8, code,
+                 status, s)
+{
+    vm_exit(bound(code));
+}
+
+void kernel_shutdown(int status)
+{
+    if (global_pagecache) {
+        block_sync bs = pagecache_syncer(global_pagecache);
+        if (bs) {
+            apply(bs, closure(heap_general(&heaps), sync_complete, status));
+            runloop();
+        }
+    }
+    vm_exit(status);
+}
+
 struct cpuinfo cpuinfos[MAX_CPUS];
 
 static void init_cpuinfos(kernel_heaps kh)

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -145,6 +145,7 @@ INCLUDES=\
 AFLAGS+=-I$(SRCDIR)/x86_64
 
 CFLAGS+=$(KERNCFLAGS) -DSTAGE3 -mcmodel=kernel
+CFLAGS+=-Wno-address # lwIP build sadness
 CFLAGS+=$(INCLUDES)
 
 # Enable tracing by specifying TRACE=ftrace on command line

--- a/test/runtime/write.c
+++ b/test/runtime/write.c
@@ -444,7 +444,7 @@ void bulk_write_test(unsigned long long size)
         do {
             int rv = read(fd, p, bufremain);
             if (rv < 0) {
-                perror("bulk_write_test: write");
+                perror("bulk_write_test: read");
                 goto out_fail;
             }
             if (rv == 0) {

--- a/test/runtime/write.c
+++ b/test/runtime/write.c
@@ -6,12 +6,22 @@
 #include <limits.h>
 #include <ctype.h>
 #include <errno.h>
+#include <time.h>
+#include <sys/time.h>
 #include <sys/eventfd.h>
 #include <sys/stat.h>
 
-#define BUFLEN 256
+//#define WRITETEST_DEBUG
+#ifdef WRITETEST_DEBUG
+#define writetest_debug(x, ...) do {printf("%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#else
+#define writetest_debug(x, ...)
+#endif
 
-static char *str = "This seems to have worked.";
+#define BUFLEN 256
+#define DEFAULT_BULK_SIZE (20 << 20) /* 20M */
+
+static char *str = "I'm staying. Finishing my coffee. Enjoying my coffee.";
 
 #define _READ(b, l)                             \
     rv = read(fd, b, l);                        \
@@ -47,12 +57,12 @@ void basic_write_test()
     _READ(buf, BUFLEN);
 
     if (rv == 0)
-        printf("empty source file\n");
+        writetest_debug("empty source file\n");
 
     if (rv >= BUFLEN)
         rv = BUFLEN - 1;
     buf[rv] = '\0';
-    printf("original: \"%s\"\n", buf);
+    writetest_debug("original: \"%s\"\n", buf);
 
     _LSEEK(0, SEEK_SET);
 
@@ -71,14 +81,14 @@ void basic_write_test()
         goto out_fail;
     }
 
-    printf("new: \"%s\"\n", buf);
+    writetest_debug("new: \"%s\"\n", buf);
 
     if (strncmp(str, buf, strlen(str))) {
         printf("basic write fail: string mismatch\n");
         exit(EXIT_FAILURE);
     }
     close(fd);
-    printf("basic write test passed\n");
+    writetest_debug("basic write test passed\n");
     return;
   out_fail:
     close(fd);
@@ -147,7 +157,7 @@ void scatter_write_test(ssize_t buflen, int iterations, int max_writesize)
             n += rv;
         } while (n < rmost);
     }
-    printf("scatter write test passed\n");
+    writetest_debug("scatter write test passed\n");
     close(fd);
     return;
   out_fail:
@@ -166,25 +176,32 @@ void append_write_test()
     }
 
     /* XXX kinda stupid, this should use some known pattern and check it */
-    printf("existing content: \"");
+    writetest_debug("existing content: \"");
     do {
         _READ(tmp, BUFLEN);
+#ifdef WRITETEST_DEBUG
         for (int i = 0; i < rv; i++) {
             if (isalpha(tmp[i]))
                 putchar(tmp[i]);
             else
                 putchar('_');
         }
+        printf("\"\n");
+#endif
     } while (rv > 0);
-    printf("\"\nappending \"");
+    writetest_debug("appending \"");
 
     ssize_t len = _random() % (BUFLEN / 4);
     for (int i = 0; i < len; i++) {
         tmp[i] = 'a' + (_random() % 26);
+#ifdef WRITETEST_DEBUG
         putchar(tmp[i]);
+#endif
     }
 
+#ifdef WRITETEST_DEBUG
     printf("\"\n");
+#endif
     _WRITE(tmp, len);
     close(fd);
     return;
@@ -328,13 +345,206 @@ void truncate_test()
     exit(EXIT_FAILURE);
 }
 
+/* isn't this in a std include somewhere? */
+static inline void timerspec_sub(struct timespec *a, struct timespec *b, struct timespec *r)
+{
+    r->tv_sec = a->tv_sec - b->tv_sec;
+    r->tv_nsec = a->tv_nsec - b->tv_nsec;
+    if (a->tv_nsec < b->tv_nsec) {
+        r->tv_sec--;
+        r->tv_nsec += 1000000000ull;
+    }
+}
+
+#define BULK_WRITE_BUFLEN (64 << 10)
+
+void bulk_write_test(unsigned long long size)
+{
+    if (size == 0)
+        return;
+
+    int rv, fd;
+    fd = open("new_file_2", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    if (fd < 0) {
+        perror("bulk_write_test: open");
+        exit(EXIT_FAILURE);
+    }
+
+    writetest_debug("starting bulk write test...\n");
+    struct timespec start, postwrite, delta;
+    if (clock_gettime(CLOCK_MONOTONIC, &start) < 0) {
+        perror("bulk_write_test: clock_gettime");
+        goto out_fail;
+    }
+
+    unsigned char buf[BULK_WRITE_BUFLEN];
+    for (int i = 0; i < BULK_WRITE_BUFLEN; i++) {
+        buf[i] = i & 0xff;
+    }
+    unsigned long long remain = size;
+    do {
+        int bufremain = remain < BULK_WRITE_BUFLEN ? remain : BULK_WRITE_BUFLEN;
+        unsigned char *p = buf;
+        do {
+            int rv = write(fd, p, bufremain);
+            if (rv < 0) {
+                perror("bulk_write_test: write");
+                goto out_fail;
+            }
+            bufremain -= rv;
+            remain -= rv;
+            p += rv;
+        } while (bufremain > 0);
+    } while (remain > 0);
+
+    if (clock_gettime(CLOCK_MONOTONIC, &postwrite) < 0) {
+        perror("bulk_write_test: clock_gettime");
+        goto out_fail;
+    }
+    timerspec_sub(&postwrite, &start, &delta);
+    printf("bulk write test, size %llu KB:\n\twrite\t%ld.%.9lds\n", size >> 10,
+           delta.tv_sec, delta.tv_nsec);
+
+    /* fsync */
+    if (fsync(fd) < 0) {
+        perror("bulk_write_test: fsync");
+        goto out_fail;
+    }
+
+    struct timespec postsync;
+    if (clock_gettime(CLOCK_MONOTONIC, &postsync) < 0) {
+        perror("bulk_write_test: clock_gettime");
+        goto out_fail;
+    }
+    timerspec_sub(&postsync, &postwrite, &delta);
+    printf("\tfsync\t%ld.%.9lds\n", delta.tv_sec, delta.tv_nsec);
+
+    /* read / verify - we're not dropping cached data, so this isn't any kind of I/O test */
+    _LSEEK(0, SEEK_SET);
+    remain = size;
+    unsigned char readbuf[BULK_WRITE_BUFLEN];
+    do {
+        int readlen = remain < BULK_WRITE_BUFLEN ? remain : BULK_WRITE_BUFLEN;
+        int bufremain = readlen;
+        unsigned char *p = readbuf;
+        do {
+            int rv = read(fd, p, bufremain);
+            if (rv < 0) {
+                perror("bulk_write_test: write");
+                goto out_fail;
+            }
+            if (rv == 0) {
+                printf("premature EOF during read at offset %lld\n", size - remain + (readlen - bufremain));
+                goto out_fail;
+            }
+            bufremain -= rv;
+            p += rv;
+        } while (bufremain > 0);
+
+        for (int i = 0; i < readlen; i++) {
+            if (readbuf[i] != buf[i]) {
+                printf("read validate mismatch at offset %lld\n", size - remain + i);
+                goto out_fail;
+            }
+        }
+        remain -= readlen;
+    } while (remain > 0);
+
+    struct timespec postread;
+    if (clock_gettime(CLOCK_MONOTONIC, &postread) < 0) {
+        perror("bulk_write_test: clock_gettime");
+        goto out_fail;
+    }
+    timerspec_sub(&postread, &postsync, &delta);
+    printf("\tread\t%ld.%.9lds\n", delta.tv_sec, delta.tv_nsec);
+    close(fd);
+    return;
+  out_fail:
+    close(fd);
+    exit(EXIT_FAILURE);
+}
+
+enum {
+    WRITE_OP_ALL,
+    WRITE_OP_BASIC_ONLY,
+    WRITE_OP_BULK_ONLY,
+};
+
+static void usage(const char *program_name)
+{
+    const char *p = strrchr(program_name, '/');
+    p = p != NULL ? p + 1 : program_name;
+    printf("Usage: %s [-b file-size]\n"
+           "\n"
+           "-b - run basic tests only (no bulk / performance tests)\n"
+           "-w - run bulk data write test only\n"
+           "-s - set bulk data size; size may be expressed by suffix\n"
+           "     (k or K for KB, m or M for MB, g or G for GB)\n",
+           p);
+}
+
 int main(int argc, char **argv)
 {
+    int c, op = WRITE_OP_ALL;
+    long long size = DEFAULT_BULK_SIZE;
+    char *endptr;
     setvbuf(stdout, NULL, _IOLBF, 0);
-    basic_write_test();
-    scatter_write_test(1 << 18, 64, 1 << 12);
-    append_write_test();
-    truncate_test();
+
+    while ((c = getopt(argc, argv, "hbws:")) != EOF) {
+        switch (c) {
+        case 'h':
+            usage(argv[0]);
+            break;
+        case 'b':
+            op = WRITE_OP_BASIC_ONLY;
+            break;
+        case 'w':
+            op = WRITE_OP_BULK_ONLY;
+            break;
+        case 's':
+            size = strtoll(optarg, &endptr, 0);
+            if (size <= 0) {
+                printf("invalid write file size %lld\n", size);
+                usage(argv[0]);
+                exit(1);
+            }
+            switch (*endptr) {
+            case 'k':
+            case 'K':
+                size <<= 10;
+                break;
+            case 'm':
+            case 'M':
+                size <<= 20;
+                break;
+            case 'g':
+            case 'G':
+                size <<= 30;
+                break;
+            case '\0':
+                break;
+            default:
+                printf("invalid write file size suffix '%s'\n", endptr);
+                usage(argv[0]);
+                exit(1);
+            }
+            break;
+        default:
+            usage(argv[0]);
+            break;
+        }
+    }
+
+    if (op == WRITE_OP_ALL || op == WRITE_OP_BASIC_ONLY) {
+        basic_write_test();
+        scatter_write_test(1 << 18, 64, 1 << 12);
+        append_write_test();
+        truncate_test();
+    }
+
+    if (op != WRITE_OP_BASIC_ONLY) {
+        bulk_write_test(size);
+    }
     printf("write test passed\n");
     return EXIT_SUCCESS;
 }

--- a/test/runtime/write.manifest
+++ b/test/runtime/write.manifest
@@ -9,6 +9,6 @@
 #    debugsyscalls:t
 #    futex_trace:t
     fault:t
-    arguments:[/]
     environment:(USER:bobby PWD:/)
+    imagesize:30M
 )

--- a/test/runtime/write_contents/hello
+++ b/test/runtime/write_contents/hello
@@ -1,1 +1,1 @@
-vim > emacs
+The ringer cannot look empty.


### PR DESCRIPTION
This update to the pagecache applies write completions immediately upon posting the write to the page buffer, resulting in improved performance as file writes no longer need to wait for I/O completion to finish. Spurred by scheduling changes needed to implement file-backed page faults in the kernel, this also allows pagecache storage I/O completions to be safely applied outside of the scope of the kernel lock (upcoming PR). Pagecache read/write completions are now queued up to be applied in a service routine that runs on runqueue (which will remain under the kernel lock).

A sync function has been added to the cache to allow flushing of pending writes on fsync(2), fdatasync(2), newly-added sync(2) and syncfs(2), and on system shutdown.

A simple bulk write performance test has been added to the write runtime test. Comparison with master shows a > 40% improvement when writing, syncing and reading (from cache) a 20M file (with virtio-scsi). Other file sizes can be specified on the command line with the '-s' option.

master:
```
bulk write test, size 20480 KB:
   write   0.079221725s
   fsync   0.000997913s
    read   0.020217010s
   total   0.100436648s (203909 KB/s)
write test passed
```

async writes:
```
bulk write test, size 20480 KB:
   write   0.048795145s
   fsync   0.000968155s
    read   0.020555042s
   total   0.070318342s (291246 KB/s)
write test passed
```

the write test also exposes serious performance degradations with virito-blk and ata drivers:

with STORAGE=virtio-blk:
```
bulk write test, size 20480 KB:
   write   4.313854939s
   fsync   0.062707746s
    read   0.022653938s
   total   4.399216623s (4655 KB/s)
write test passed
```

with STORAGE=ide:
```
bulk write test, size 20480 KB:
   write   33.672703707s
   fsync   0.000907161s
    read   0.020189055s
   total   33.693799923s (607 KB/s)
write test passed
```

Resolves #1128 and #1166
