### PR TITLE
syscalls: add io_uring support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ test test-noaccel: mkfs boot stage3
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fallocate fcntl fst getdents getrandom hw hws mkdir mmap pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fallocate fcntl fst getdents getrandom hw hws io_uring mkdir mmap pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/contgen/contgen.c
+++ b/contgen/contgen.c
@@ -96,6 +96,10 @@ void cblock()
     p("  return (_rettype (**)(void *~))n;|", ", _rt%");
     p("}|");
     p("static _rettype _name(struct _closure_##_name *__self~)\n\n\n", ", _rt% _rn%");
+
+    p("#define CLOSURE_SIMPLE_DEFINE_%_%(_rettype, _name^~)|", nleft, nright, ", _lt%, _ln%", ", _rt%, _rn%");
+    p("typedef _rettype (**_name##_func)(void *~);|", ", _rt%");
+    p("static _rettype _name(struct _closure_##_name *__self~)\n\n\n", ", _rt% _rn%");
 }
 
 int main(int argc, char **argv)

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -515,7 +515,7 @@ closure_function(1, 6, sysreturn, socket_read,
     net_debug("sock %d, type %d, thread %ld, dest %p, length %ld, offset %ld\n",
 	      s->sock.fd, s->sock.type, t->tid, dest, length, offset);
     if (s->sock.type == SOCK_STREAM && s->info.tcp.state != TCP_SOCK_OPEN)
-        return -ENOTCONN;
+        return io_complete(completion, t, -ENOTCONN);
 
     blockq_action ba = closure(s->sock.h, sock_read_bh, s, t, dest, length, 0,
             0, completion);

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -762,8 +762,9 @@ closure_function(1, 2, sysreturn, netsock_ioctl,
 
 #define SOCK_QUEUE_LEN 128
 
-closure_function(1, 0, sysreturn, socket_close,
-                 netsock, s)
+closure_function(1, 2, sysreturn, socket_close,
+                 netsock, s,
+                 thread, t, io_completion, completion)
 {
     netsock s = bound(s);
     net_debug("sock %d, type %d\n", s->sock.fd, s->sock.type);
@@ -791,7 +792,7 @@ closure_function(1, 0, sysreturn, socket_close,
     deallocate_closure(s->sock.f.ioctl);
     socket_deinit(&s->sock);
     unix_cache_free(s->p->uh, socket, s);
-    return 0;
+    return io_complete(completion, t, 0);
 }
 
 static sysreturn netsock_shutdown(struct sock *sock, int how)

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -5,6 +5,20 @@
 #define __closure(__h, __p, __s, __name, ...)    \
     _fill_##__name(__h, __p, __s, ##__VA_ARGS__)
 
+#define closure_alloc(__h, __name, __var)   do {                \
+    __var = allocate(__h, sizeof(struct _closure_##__name));    \
+    if (__var != INVALID_ADDRESS) {                             \
+        __var->__apply = __name;                                 \
+        __var->__c.name = #__name;                              \
+        __var->__c.h = __h;                                     \
+        __var->__c.size = sizeof(struct _closure_##__name);     \
+    }                                                           \
+} while (0);
+
+#define closure_new(__h, __name, __var) \
+    struct _closure_##__name *__var;   \
+    closure_alloc(__h, __name, __var)
+
 #define closure(__h, __name, ...) ({                                    \
     struct _closure_##__name * __n = allocate(__h, sizeof(struct _closure_##__name)); \
     __closure(__h, __n, sizeof(struct _closure_##__name), __name, ##__VA_ARGS__);})
@@ -18,6 +32,8 @@
 
 #define closure_struct(__name, __field) struct _closure_##__name __field;
 
+#define closure_ref(__name, __var) struct _closure_##__name *__var = 0;
+
 struct _closure_common {
     char *name;
     heap h;
@@ -27,6 +43,7 @@ struct _closure_common {
 #define __closure_struct_declare(nl, nr) CLOSURE_STRUCT_ ## nl ## _ ## nr
 #define __closure_function_declare(nl, nr) CLOSURE_DECLARE_FUNCS_ ## nl ## _ ## nr
 #define __closure_define(nl, nr) CLOSURE_DEFINE_ ## nl ## _ ## nr
+#define __closure_simple_define(nl, nr) CLOSURE_SIMPLE_DEFINE_ ## nl ## _ ## nr
 
 #define closure_function(nl, nr, ...)                   \
     __closure_struct_declare(nl, nr)(__VA_ARGS__)       \
@@ -39,6 +56,12 @@ struct _closure_common {
 #define define_closure_function(nl, nr, ...)            \
     __closure_function_declare(nl, nr)(__VA_ARGS__)     \
     __closure_define(nl, nr)(__VA_ARGS__)
+
+/* use this for closures allocated and filled separately */
+#define simple_closure_function(nl, nr, ...)            \
+    __closure_struct_declare(nl, nr)(__VA_ARGS__)       \
+    __closure_simple_define(nl, nr)(__VA_ARGS__)
+#define closure_get(name, var)  ((name##_func)&(var->__apply))
 
 #define bound(v) (__self->v)
 #define closure_self() (&(__self->__apply))

--- a/src/runtime/list.h
+++ b/src/runtime/list.h
@@ -72,3 +72,26 @@ static inline struct list *list_pop_back(struct list *list)
     list_delete(back);
     return back;
 }
+
+static inline boolean list_find(struct list *head, struct list *elem)
+{
+    list_foreach(head, e) {
+        if (e == elem)
+            return true;
+    }
+    return false;
+}
+
+/* Move all elements from source list to destination list. */
+static inline void list_move(struct list *dest, struct list *src)
+{
+    if (list_empty(src)) {
+        list_init(dest);
+        return;
+    }
+    dest->next = src->next;
+    dest->next->prev = dest;
+    dest->prev = src->prev;
+    dest->prev->next = dest;
+    list_init(src); /* make it an empty list */
+}

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -261,7 +261,8 @@ sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_
 
     blockq_debug("queuing bi %p, a %p, tid %d\n", bi, bi->a, bi->t->tid);
     list_insert_before(&bq->waiters_head, &bi->l);
-    t->blocked_on = bq;
+    if (!in_bh)
+        t->blocked_on = bq;
 
     /* XXX release spinlock */
 

--- a/src/unix/eventfd.c
+++ b/src/unix/eventfd.c
@@ -52,7 +52,7 @@ closure_function(1, 6, sysreturn, efd_read,
                  void *, buf, u64, length, u64, offset_arg, thread, t, boolean, bh, io_completion, completion)
 {
     if (length < sizeof(u64)) {
-        return -EINVAL;
+        return io_complete(completion, t, -EINVAL);
     }
 
     blockq_action ba = closure(bound(efd)->h, efd_read_bh, bound(efd), t, buf, length,
@@ -95,7 +95,7 @@ closure_function(1, 6, sysreturn, efd_write,
                  void *, buf, u64, length, u64, offset, thread, t, boolean, bh, io_completion, completion)
 {
     if (length < sizeof(u64)) {
-        return -EINVAL;
+        return io_complete(completion, t, -EINVAL);
     }
 
     blockq_action ba = closure(bound(efd)->h, efd_write_bh, bound(efd), t, buf, length,

--- a/src/unix/eventfd.c
+++ b/src/unix/eventfd.c
@@ -117,8 +117,9 @@ closure_function(1, 1, u32, efd_events,
     return events;
 }
 
-closure_function(1, 0, sysreturn, efd_close,
-                 struct efd *, efd)
+closure_function(1, 2, sysreturn, efd_close,
+                 struct efd *, efd,
+                 thread, t, io_completion, completion)
 {
     struct efd *efd = bound(efd);
     deallocate_blockq(efd->read_bq);
@@ -129,7 +130,7 @@ closure_function(1, 0, sysreturn, efd_close,
     deallocate_closure(efd->f.close);
     release_fdesc(&efd->f);
     deallocate(efd->h, efd, sizeof(*efd));
-    return 0;
+    return io_complete(completion, t, 0);
 }
 
 int do_eventfd2(unsigned int count, int flags)

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -1,0 +1,1335 @@
+#include <unix_internal.h>
+#include <page.h>
+
+#define IORING_SETUP_CQSIZE     (1 << 3)
+
+#define IORING_FEAT_SINGLE_MMAP     (1 << 0)
+#define IORING_FEAT_RW_CUR_POS      (1 << 3)
+
+#define IORING_OFF_SQ_RING  0ULL
+#define IORING_OFF_CQ_RING  0x8000000ULL
+#define IORING_OFF_SQES     0x10000000ULL
+
+#define IORING_TIMEOUT_ABS  (1 << 0)
+
+#define IORING_ENTER_GETEVENTS  (1 << 0)
+
+#define IO_URING_OP_SUPPORTED   (1 << 0)
+
+#define IOUR_SQ_ENTRIES_MAX 0x40000000UL
+#define IOUR_CQ_ENTRIES_MAX (2 * IOUR_SQ_ENTRIES_MAX)
+#define IOUR_FILES_MAX      0x8000
+
+#define IOSQE_FIXED_FILE    (1 << 0)
+#define IOSQE_ASYNC         (1 << 4)
+
+//#define IOUR_DEBUG
+#ifdef IOUR_DEBUG
+#define iour_debug(x, ...) do { \
+    rprintf("%s: " x "\n", __func__, ##__VA_ARGS__); \
+} while(0)
+#else
+#define iour_debug(x, ...)
+#endif
+
+struct io_uring_sqe {
+    u8 opcode;
+    u8 flags;
+    u16 ioprio;
+    s32 fd;
+    u64 off;
+    u64 addr;
+    u32 len;
+    union {
+        u32 rw_flags;
+        u32 fsync_flags;
+        u16 poll_events;
+        u32 sync_range_flags;
+        u32 msg_flags;
+        u32 timeout_flags;
+    };
+    u64 user_data;
+    union{
+        u16 buf_index;
+        u64 __pad2[3];
+    };
+};
+
+struct io_uring_cqe {
+    u64 user_data;
+    s32 res;
+    u32 flags;
+};
+
+enum iour_enter_opcode {
+    IORING_OP_NOP,
+    IORING_OP_READV,
+    IORING_OP_WRITEV,
+    IORING_OP_FSYNC,
+    IORING_OP_READ_FIXED,
+    IORING_OP_WRITE_FIXED,
+    IORING_OP_POLL_ADD,
+    IORING_OP_POLL_REMOVE,
+    IORING_OP_SYNC_FILE_RANGE,
+    IORING_OP_SENDMSG,
+    IORING_OP_RECVMSG,
+    IORING_OP_TIMEOUT,
+    IORING_OP_TIMEOUT_REMOVE,
+    IORING_OP_ACCEPT,
+    IORING_OP_ASYNC_CANCEL,
+    IORING_OP_LINK_TIMEOUT,
+    IORING_OP_CONNECT,
+    IORING_OP_FALLOCATE,
+    IORING_OP_OPENAT,
+    IORING_OP_CLOSE,
+    IORING_OP_FILES_UPDATE,
+    IORING_OP_STATX,
+    IORING_OP_READ,
+    IORING_OP_WRITE,
+    IORING_OP_LAST,
+};
+
+enum iour_register_opcode {
+    IORING_REGISTER_BUFFERS,
+    IORING_UNREGISTER_BUFFERS,
+    IORING_REGISTER_FILES,
+    IORING_UNREGISTER_FILES,
+    IORING_REGISTER_EVENTFD,
+    IORING_UNREGISTER_EVENTFD,
+    IORING_REGISTER_FILES_UPDATE,
+    IORING_REGISTER_EVENTFD_ASYNC,
+    IORING_REGISTER_PROBE,
+};
+
+struct io_uring_files_update {
+    u32 offset;
+    u32 resv;
+    s32 *fds;
+};
+
+struct io_uring_probe_op {
+    u8 op;
+    u8 resv;
+    u16 flags;
+    u32 resv2;
+};
+
+struct io_uring_probe {
+    u8 last_op;
+    u8 ops_len;
+    u16 resv;
+    u32 resv2[3];
+    struct io_uring_probe_op ops[0];
+};
+
+typedef struct io_rings {
+    u32 sq_head, sq_tail;
+    u32 sq_mask, sq_entries;
+    u32 sq_flags;
+    u32 sq_dropped;
+    u32 cq_head, cq_tail;
+    u32 cq_mask, cq_entries;
+    u32 cq_overflow;
+    u32 pad;    /* for 8-byte alignment */
+} *io_rings;
+
+declare_closure_struct(1, 2, sysreturn, iour_close,
+                       struct io_uring *, iour,
+                       thread, t, io_completion, completion);
+
+typedef struct io_uring {
+    struct fdesc f;    /* must be first */
+    heap h;
+    heap vh;
+    struct spinlock lock;
+    u32 sq_mask, sq_entries;
+    u32 cq_mask, cq_entries;
+    io_rings rings;
+    u32 *sq_array;
+    struct io_uring_cqe *cqes;
+    struct io_uring_sqe *sqes;
+    u64 phys;
+    io_rings user_rings;
+    closure_struct(iour_close, close);
+    struct iovec *bufs;
+    u32 buf_count;
+    fdesc *files;
+    u32 file_count;
+    blockq bq;
+    u64 sigmask;
+    fdesc eventfd;
+    boolean eventfd_async;
+    struct list pollers;
+    struct list timers;
+    u32 cq_timeouts;
+    u64 noncancelable_ops;
+
+    /* When true, the io_uring context is being shut down in the background,
+     * i.e. no thread is blocked on close() and the context will be deallocated
+     * when its last non-cancelable operation is completed. This can happen if
+     * the file reference count is greater than 1 when close() is called, or if
+     * an error occurs during close(). */
+    boolean shutdown;
+
+    io_completion shutdown_completion;
+} *io_uring;
+
+declare_closure_struct(2, 2, void, iour_poll_notify,
+                       io_uring, iour, struct iour_poll *, p,
+                       u64, events, thread, t);
+
+typedef struct iour_poll {
+    struct list l;
+    u64 user_data;
+    fdesc f;
+    notify_entry ne;
+    closure_struct(iour_poll_notify, handler);
+} *iour_poll;
+
+declare_closure_struct(2, 1, void, iour_timeout,
+                       io_uring, iour, struct iour_timer *, t,
+                       u64, overruns);
+
+typedef struct iour_timer {
+    struct list l;
+    unsigned int target;
+    u64 user_data;
+    timer t;
+    closure_struct(iour_timeout, handler);
+} *iour_timer;
+
+/* Mmapped region layout:
+ * - Region 1
+ *   - struct io_rings
+ *   - array of sqe indices (sq_entries)
+ *   - array of struct io_uring_cqe (cq_entries)
+ * - Region 2
+ *   - array of struct io_uring_sqe (sq_entries)
+ */
+#define IOUR_REGION1_SIZE(iour) \
+        pad(sizeof(struct io_rings) + (iour)->sq_entries * sizeof(u32) + \
+        (iour)->cq_entries * sizeof(struct io_uring_cqe), PAGESIZE)
+#define IOUR_REGION2_SIZE(iour) \
+        pad((iour)->sq_entries * sizeof(struct io_uring_sqe), PAGESIZE)
+#define IOUR_ALLOC_SIZE(iour) \
+        (IOUR_REGION1_SIZE(iour) + IOUR_REGION2_SIZE(iour))
+
+#define iour_from_fd(__p, __fd) ({fdesc f = fdesc_get(__p, __fd); \
+    if (!f) return -EBADF; \
+    if (f->type != FDESC_TYPE_IORING) {fdesc_put(f); return -EOPNOTSUPP;} \
+    (io_uring)f;})
+
+#define iour_lock(iour)     u64 _irqflags = spin_lock_irq(&(iour)->lock)
+#define iour_unlock(iour)   spin_unlock_irq(&(iour)->lock, _irqflags)
+
+static void iour_release(io_uring iour)
+{
+    iour_debug("completion %p", iour->shutdown_completion);
+    if (iour->file_count) {
+        for (unsigned int i = 0; i < iour->file_count; i++)
+            if (iour->files[i])
+                fdesc_put(iour->files[i]);
+        deallocate(iour->h, iour->files, sizeof(fdesc) * iour->file_count);
+    }
+    if (iour->buf_count)
+        deallocate(iour->h, iour->bufs, sizeof(struct iovec) * iour->buf_count);
+    u64 alloc_size = IOUR_ALLOC_SIZE(iour);
+    unmap(u64_from_pointer(iour->user_rings), alloc_size);
+    release_fdesc(&iour->f);
+    deallocate(iour->vh, iour->user_rings, alloc_size);
+    deallocate(iour->h, iour->rings, alloc_size);
+    io_completion completion = iour->shutdown_completion;
+    deallocate(iour->h, iour, sizeof(*iour));
+    if (completion)
+        apply(completion, 0, 0);
+}
+
+closure_function(3, 1, sysreturn, iour_close_bh,
+                 io_uring, iour, thread, t, io_completion, completion,
+                 u64, flags)
+{
+    io_uring iour = bound(iour);
+    blockq bq = iour->bq;
+    sysreturn rv;
+    if (flags & BLOCKQ_ACTION_NULLIFY) {
+        rv = -EINTR;
+        iour->shutdown = true;
+        goto out;
+    }
+    if (iour->noncancelable_ops != 0) {
+        iour_debug("blocking");
+        return BLOCKQ_BLOCK_REQUIRED;
+    }
+    iour_release(iour);
+    rv = 0;
+out:
+    blockq_handle_completion(bq, flags, bound(completion), bound(t), rv);
+    closure_finish();
+    iour_debug("returning %d", rv);
+    return rv;
+}
+
+define_closure_function(1, 2, sysreturn, iour_close,
+                        io_uring, iour,
+                        thread, t, io_completion, completion)
+{
+    io_uring iour = bound(iour);
+    iour_debug("iour %p", iour);
+
+    /* Timers and pollers should be unregistered without the lock, to avoid
+     * deadlocks in implementations where the unregister functions ensure the
+     * corresponding handler function is not executing (even in SMP platforms)
+     * after the unregister function returns. */
+    struct list deleted_items;
+    u64 irqflags = spin_lock_irq(&iour->lock);
+    list_move(&deleted_items, &iour->timers);
+    spin_unlock_irq(&iour->lock, irqflags);
+    list_foreach(&deleted_items, l) {
+        iour_timer iour_tim = struct_from_list(l, iour_timer, l);
+        remove_timer(iour_tim->t, 0);
+        deallocate(iour->h, iour_tim, sizeof(*iour_tim));
+    }
+    irqflags = spin_lock_irq(&iour->lock);
+    list_move(&deleted_items, &iour->pollers);
+    spin_unlock_irq(&iour->lock, irqflags);
+    list_foreach(&deleted_items, l) {
+        iour_poll poller = struct_from_list(l, iour_poll, l);
+        notify_remove(poller->f->ns, poller->ne, false);
+        fdesc_put(poller->f);
+        deallocate(iour->h, poller, sizeof(*poller));
+    }
+
+    irqflags = spin_lock_irq(&iour->lock);
+    if (iour->eventfd) {
+        fdesc_put(iour->eventfd);
+        iour->eventfd = 0;
+    }
+    if (t) {
+        spin_unlock_irq(&iour->lock, irqflags);
+        if (iour->noncancelable_ops) {
+            blockq_action ba = closure(iour->h, iour_close_bh, iour, t,
+                completion);
+            if (ba != INVALID_ADDRESS) {
+                iour->bq = t->thread_bq;
+                return blockq_check(iour->bq, t, ba, false);
+            } else {
+                iour->shutdown = true;
+                return io_complete(completion, t, -ENOMEM);
+            }
+        } else {
+            iour_release(iour);
+            return io_complete(completion, t, 0);
+        }
+    }
+    iour->shutdown_completion = completion;
+    if (iour->noncancelable_ops) {
+        iour->shutdown = true;
+        spin_unlock_irq(&iour->lock, irqflags);
+    } else
+        iour_release(iour);
+    return 0;
+}
+
+static void iour_rings_init(io_uring iour)
+{
+    io_rings rings = iour->rings;
+    rings->sq_head = rings->sq_tail = 0;
+    rings->sq_mask = iour->sq_mask;
+    rings->sq_entries = iour->sq_entries;
+    rings->sq_flags = 0;
+    rings->sq_dropped = 0;
+    rings->cq_head = rings->cq_tail = 0;
+    rings->cq_mask = iour->cq_mask;
+    rings->cq_entries = iour->cq_entries;
+    rings->cq_overflow = 0;
+}
+
+sysreturn io_uring_setup(unsigned int entries, struct io_uring_params *params)
+{
+    if (!validate_user_memory(params, sizeof(*params), true))
+        return -EFAULT;
+    iour_debug("entries %d, flags 0x%x, CQ entries %d", entries, params->flags,
+               params->cq_entries);
+    if ((entries == 0) || (entries > IOUR_SQ_ENTRIES_MAX) ||
+            (params->flags & ~IORING_SETUP_CQSIZE) || params->resv[0] ||
+            params->resv[1] || params->resv[2] || params->resv[3])
+        return -EINVAL;
+    params->sq_entries = U64_FROM_BIT(find_order(entries));
+    if (params->flags & IORING_SETUP_CQSIZE) {
+        if ((params->cq_entries < params->sq_entries) ||
+                (params->cq_entries > IOUR_CQ_ENTRIES_MAX))
+            return -EINVAL;
+        params->cq_entries = U64_FROM_BIT(find_order(params->cq_entries));
+    } else
+        params->cq_entries = 2 * params->sq_entries;    /* Linux does that */
+
+    sysreturn ret;
+    kernel_heaps kh = get_kernel_heaps();
+    heap h = heap_general(kh);
+    io_uring iour = allocate(h, sizeof(*iour));
+    if (iour == INVALID_ADDRESS) {
+        return -ENOMEM;
+    }
+    iour->h = h;
+    iour->sq_entries = params->sq_entries;
+    iour->sq_mask = iour->sq_entries - 1;
+    iour->cq_entries = params->cq_entries;
+    iour->cq_mask = iour->cq_entries - 1;
+
+    iour->vh = (heap)current->p->virtual_page;
+    u64 alloc_size = IOUR_ALLOC_SIZE(iour);
+    iour_debug("allocating %ld bytes", alloc_size);
+    iour->rings = (io_rings)allocate(h, alloc_size);
+    if (iour->rings == INVALID_ADDRESS) {
+        ret = -ENOMEM;
+        goto err1;
+    }
+    iour->user_rings = (io_rings)allocate(iour->vh, alloc_size);
+    if (iour->user_rings == INVALID_ADDRESS) {
+        ret = -ENOMEM;
+        goto err2;
+    }
+    iour->sq_array = (u32 *)((u8 *)iour->rings + sizeof(struct io_rings));
+    iour->cqes = (struct io_uring_cqe *)((u8 *)iour->sq_array +
+            iour->sq_entries * sizeof(u32));
+    iour->sqes = (struct io_uring_sqe *)((u8 *)iour->rings +
+            IOUR_REGION1_SIZE(iour));
+    iour_debug("rings %p, SQ array %p, CQEs %p, SQEs %p", iour->rings,
+               iour->sq_array, iour->cqes, iour->sqes);
+
+    iour_rings_init(iour);
+    spin_lock_init(&iour->lock);
+    iour->buf_count = iour->file_count = 0;
+    iour->bq = 0;
+    iour->eventfd = 0;
+    list_init(&iour->pollers);
+    list_init(&iour->timers);
+    iour->cq_timeouts = 0;
+    iour->noncancelable_ops = 0;
+    iour->shutdown = false;
+    iour->shutdown_completion = 0;
+    ret = allocate_fd(current->p, iour);
+    if (ret == INVALID_PHYSICAL) {
+        ret = -EMFILE;
+        goto err3;
+    }
+    iour_debug("fd %d", ret);
+    init_fdesc(h, &iour->f, FDESC_TYPE_IORING);
+    iour->f.close = init_closure(&iour->close, iour_close, iour);
+    params->features = IORING_FEAT_SINGLE_MMAP | IORING_FEAT_RW_CUR_POS;
+    params->sq_off.head = offsetof(io_rings, sq_head);
+    params->sq_off.tail = offsetof(io_rings, sq_tail);
+    params->sq_off.ring_mask = offsetof(io_rings, sq_mask);
+    params->sq_off.ring_entries = offsetof(io_rings, sq_entries);
+    params->sq_off.flags = offsetof(io_rings, sq_flags);
+    params->sq_off.dropped = offsetof(io_rings, sq_dropped);
+    params->sq_off.array = (u8 *)iour->sq_array - (u8 *)iour->rings;
+    runtime_memset((u8 *)params->sq_off.resv, 0, sizeof(params->sq_off.resv));
+    params->cq_off.head = offsetof(io_rings, cq_head);
+    params->cq_off.tail = offsetof(io_rings, cq_tail);
+    params->cq_off.ring_mask = offsetof(io_rings, cq_mask);
+    params->cq_off.ring_entries = offsetof(io_rings, cq_entries);
+    params->cq_off.overflow = offsetof(io_rings, cq_overflow);
+    params->cq_off.cqes = (u8 *)iour->cqes - (u8 *)iour->rings;
+    runtime_memset((u8 *)params->cq_off.resv, 0, sizeof(params->cq_off.resv));
+    return ret;
+err3:
+    deallocate(iour->vh, iour->user_rings, alloc_size);
+err2:
+    deallocate(h, iour->rings, alloc_size);
+err1:
+    deallocate(h, iour, sizeof(*iour));
+    return ret;
+}
+
+sysreturn io_uring_mmap(fdesc desc, u64 len, u64 mapflags, u64 offset)
+{
+    iour_debug("len %ld, flags 0x%x, offset 0x%x", len, mapflags, offset);
+    io_uring iour = (io_uring)desc;
+    u64 region_offset;
+    switch (offset) {
+    case IORING_OFF_SQ_RING:
+    case IORING_OFF_CQ_RING:
+        if (len > IOUR_REGION1_SIZE(iour))
+            return -EINVAL;
+        region_offset = 0;
+        break;
+    case IORING_OFF_SQES:
+        if (len > IOUR_REGION2_SIZE(iour))
+            return -EINVAL;
+        region_offset = IOUR_REGION1_SIZE(iour);
+        break;
+    default:
+        return -EINVAL;
+    }
+    u64 virt = u64_from_pointer(iour->user_rings) + region_offset;
+    map(virt, physical_from_virtual(iour->rings) + region_offset, len,
+        mapflags);
+    return virt;
+}
+
+simple_closure_function(1, 2, void, iour_efd_complete,
+                        u64, efd_val,
+                        thread, t, sysreturn, rv)
+{
+    closure_finish();
+}
+
+static void iour_complete_locked(io_uring iour, u64 user_data, s32 res,
+                                 boolean async)
+{
+    io_rings rings = iour->rings;
+    iour_debug("user_data %ld, res %d, CQ tail %d", user_data, res,
+               rings->cq_tail);
+    if (rings->cq_tail < rings->cq_head + iour->cq_entries) {
+        struct io_uring_cqe *cqe = &iour->cqes[rings->cq_tail & iour->cq_mask];
+        cqe->user_data = user_data;
+        cqe->res = res;
+        cqe->flags = 0;
+        write_barrier();
+        rings->cq_tail++;
+    } else {
+        iour_debug("overflow");
+        rings->cq_overflow++;
+    }
+    if (iour->eventfd && (async || !iour->eventfd_async)) {
+        closure_new(iour->h, iour_efd_complete, completion);
+        if (completion != INVALID_ADDRESS) {
+            completion->efd_val = 1;
+            apply(iour->eventfd->write, &completion->efd_val,
+                  sizeof(completion->efd_val), 0, current, true,
+                  closure_get(iour_efd_complete, completion));
+        }
+    }
+}
+
+static void iour_complete(io_uring iour, u64 user_data, s32 res,
+                          boolean async, boolean noncancelable)
+{
+    iour_lock(iour);
+    iour_complete_locked(iour, user_data, res, async);
+    if (noncancelable) {
+        if ((fetch_and_add(&iour->noncancelable_ops, -1) == 1) &&
+                iour->shutdown) {
+            iour_release(iour);
+            return;
+        }
+    }
+    struct list deleted_timers;
+    list_init(&deleted_timers);
+check_timers:
+    list_foreach(&iour->timers, l) {
+        iour_timer iour_tim = struct_from_list(l, iour_timer, l);
+        if (iour_tim->target == iour->rings->cq_tail + iour->rings->cq_overflow) {
+            list_delete(l);
+            list_push_back(&deleted_timers, l);
+            iour->cq_timeouts++;
+            iour_complete_locked(iour, iour_tim->user_data, 0, async);
+
+            /* Increment the target of any remaining timers, to compensate the
+             * CQ tail increment due to the just completed timeout, then go
+             * through the timer list again. */
+            list_foreach(&iour->timers, l) {
+                iour_timer iour_tim = struct_from_list(l, iour_timer, l);
+                iour_tim->target++;
+            }
+            goto check_timers;
+        }
+    }
+    blockq bq = iour->bq;
+    iour_unlock(iour);
+    list_foreach(&deleted_timers, l) {
+        iour_timer iour_tim = struct_from_list(l, iour_timer, l);
+        remove_timer(iour_tim->t, 0);
+        deallocate(iour->h, iour_tim, sizeof(*iour_tim));
+    }
+    if (bq)
+        blockq_wake_one(bq);
+}
+
+static void iour_complete_timeout(io_uring iour, u64 user_data)
+{
+    iour_lock(iour);
+    iour->cq_timeouts++;
+    iour_complete_locked(iour, user_data, -ETIME, true);
+    blockq bq = iour->bq;
+    iour_unlock(iour);
+    if (bq)
+        blockq_wake_one(bq);
+}
+
+closure_function(3, 2, void, iour_rw_complete,
+                 io_uring, iour, fdesc, f, u64, user_data,
+                 thread, t, sysreturn, rv)
+{
+    fdesc_put(bound(f));
+    iour_complete(bound(iour), bound(user_data), rv, true, true);
+    closure_finish();
+}
+
+static void iour_iov(io_uring iour, fdesc f, boolean write, struct iovec *iov,
+                     u32 len, u64 off, u64 user_data)
+{
+    io_completion completion = closure(iour->h, iour_rw_complete, iour, f,
+        user_data);
+    if (completion == INVALID_ADDRESS) {
+        fdesc_put(f);
+        iour_complete(iour, user_data, -ENOMEM, false, false);
+    } else {
+        fetch_and_add(&iour->noncancelable_ops, 1);
+        iov_op(f, write, iov, len, off, false, completion);
+    }
+}
+
+static void iour_rw(io_uring iour, fdesc f, boolean write, void *addr, u32 len,
+                    u64 offset, u64 user_data)
+{
+    iour_debug("%s at %p, len %d, offset %ld", write ? "write" : "read", addr,
+            len, offset);
+    int err = 0;
+    io op = write ? f->write : f->read;
+    io_completion completion = 0;
+    if (!op) {
+        err = -EOPNOTSUPP;
+    } else {
+        completion = closure(iour->h, iour_rw_complete, iour, f, user_data);
+        if (completion == INVALID_ADDRESS)
+            err = -ENOMEM;
+    }
+    if (err) {
+        fdesc_put(f);
+        iour_complete(iour, user_data, err, false, false);
+    } else {
+        fetch_and_add(&iour->noncancelable_ops, 1);
+        apply(op, addr, len, offset, current, true, completion);
+    }
+}
+
+define_closure_function(2, 2, void, iour_poll_notify,
+                        io_uring, iour, iour_poll, p,
+                        u64, events, thread, t)
+{
+    if (!events)
+        return;
+    io_uring iour = bound(iour);
+    iour_poll p = bound(p);
+    iour_lock(iour);
+    boolean found = list_find(&iour->pollers, &p->l);
+    if (found) {
+        list_delete(&p->l);
+    }
+    iour_unlock(iour);
+    if (found) {
+        iour_debug("user_data %ld, events %ld", p->user_data, events);
+        iour_complete(iour, p->user_data, events, true, false);
+        notify_remove(p->f->ns, p->ne, false);
+        fdesc_put(p->f);
+        deallocate(iour->h, p, sizeof(*p));
+    }
+}
+
+static void iour_poll_add(io_uring iour, fdesc f, u16 events, u64 user_data)
+{
+    s32 err = 0;
+    iour_poll p = allocate(iour->h, sizeof(*p));
+    if (p == INVALID_ADDRESS) {
+        err = -ENOMEM;
+        goto done;
+    }
+    p->user_data = user_data;
+    p->f = f;
+    iour_lock(iour);
+    list_push_back(&iour->pollers, &p->l);
+    p->ne = notify_add(f->ns, events | EPOLLERR | EPOLLHUP,
+        init_closure(&p->handler, iour_poll_notify, iour, p));
+    if (p->ne == INVALID_ADDRESS) {
+        err = -ENOMEM;
+        list_delete(&p->l);
+        deallocate(iour->h, p, sizeof(*p));
+    }
+    iour_unlock(iour);
+done:
+    if (!err) {
+        if (f->events)
+            /* Check if poll events are already present. */
+            notify_dispatch_for_thread(f->ns, apply(f->events, current),
+                current);
+    } else
+        iour_complete(iour, user_data, err, false, false);
+}
+
+static void iour_poll_remove(io_uring iour, u64 addr, u64 user_data)
+{
+    iour_poll p = 0;
+    s32 res;
+    iour_lock(iour);
+    list_foreach(&iour->pollers, l) {
+        iour_poll elem = struct_from_list(l, iour_poll, l);
+        if (elem->user_data == addr) {
+            p = elem;
+            list_delete(l);
+            break;
+        }
+    }
+    iour_unlock(iour);
+    if (p) {
+        iour_complete(iour, addr, -ECANCELED, false, false);
+        res = 0;
+        notify_remove(p->f->ns, p->ne, false);
+        fdesc_put(p->f);
+        deallocate(iour->h, p, sizeof(*p));
+    } else
+        res = -ENOENT;
+    iour_complete(iour, user_data, res, false, false);
+}
+
+define_closure_function(2, 1, void, iour_timeout,
+                        io_uring, iour, iour_timer, t,
+                        u64, overruns)
+{
+    io_uring iour = bound(iour);
+    iour_timer t = bound(t);
+    iour_lock(iour);
+    boolean found = list_find(&iour->timers, &t->l);
+    if (found)
+        list_delete(&t->l);
+    iour_unlock(iour);
+    if (found) {
+        iour_debug("user_data %ld", t->user_data);
+        iour_complete_timeout(iour, t->user_data);
+        deallocate(iour->h, t, sizeof(*t));
+    }
+}
+
+static void iour_timeout_add(io_uring iour, struct timespec *ts, u32 flags,
+                             u64 off, u64 user_data)
+{
+    iour_debug("flags 0x%x, off %ld", flags, off);
+    int err = 0;
+    if (flags & ~IORING_TIMEOUT_ABS) {
+        err = -EINVAL;
+        goto done;
+    }
+    iour_timer iour_tim = allocate(iour->h, sizeof(*iour_tim));
+    if (iour_tim == INVALID_ADDRESS) {
+        err = -ENOMEM;
+        goto done;
+    }
+    iour_tim->user_data = user_data;
+    iour_lock(iour);
+
+    /* off == 0 indicates a pure timeout request, i.e. one not linked to
+     * completion of other requests; in this case, the target is set to the last
+     * completion (i.e. a past completion), so that it won't match future
+     * completions (until after UINT_MAX operations, at which point the timeout
+     * will have elapsed already, hopefully). */
+    iour_tim->target = iour->rings->cq_tail + off;
+    iour_debug("target %ld", iour_tim->target);
+
+    list_push_back(&iour->timers, &iour_tim->l);
+    iour_tim->t = register_timer(runloop_timers, CLOCK_ID_MONOTONIC,
+        time_from_timespec(ts), flags & IORING_TIMEOUT_ABS, 0,
+        init_closure(&iour_tim->handler, iour_timeout, iour, iour_tim));
+    if (iour_tim->t == INVALID_ADDRESS) {
+        err = -ENOMEM;
+        list_delete(&iour_tim->l);
+        deallocate(iour->h, iour_tim, sizeof(*iour_tim));
+    }
+    iour_unlock(iour);
+done:
+    if (err)
+        iour_complete(iour, user_data, err, false, false);
+}
+
+static void iour_timeout_remove(io_uring iour, u64 addr, u64 user_data)
+{
+    iour_timer t = 0;
+    s32 res;
+    iour_lock(iour);
+    list_foreach(&iour->timers, l) {
+        iour_timer elem = struct_from_list(l, iour_timer, l);
+        if (elem->user_data == addr) {
+            t = elem;
+            list_delete(l);
+            break;
+        }
+    }
+    iour_unlock(iour);
+    if (t) {
+        remove_timer(t->t, 0);
+        iour_complete(iour, addr, -ECANCELED, false, false);
+        res = 0;
+        deallocate(iour->h, t, sizeof(*t));
+    } else
+        res = -ENOENT;
+    iour_complete(iour, user_data, res, false, false);
+}
+
+closure_function(2, 2, void, iour_close_complete,
+                 io_uring, iour, u64, user_data,
+                 thread, t, sysreturn, rv)
+{
+    iour_complete(bound(iour), bound(user_data), rv, true, true);
+    closure_finish();
+}
+
+static int iour_register_files_update(io_uring iour, int *fds,
+                                      unsigned int count, unsigned int offset)
+{
+    iour_debug("count %d, offset %d", count, offset);
+    if ((count == 0) || (count > IOUR_FILES_MAX) || (offset >= IOUR_FILES_MAX))
+        return -EINVAL;
+    if (!validate_user_memory(fds, sizeof(fds[0]) * count, false))
+        return -EFAULT;
+    sysreturn ret;
+    iour_lock(iour);
+    if (offset + count > iour->file_count)
+        ret = -EINVAL;
+    else {
+        ret = 0;
+        for (unsigned int i = 0; i < count; i++) {
+            fdesc f;
+            if (fds[i] == -1)
+                f = 0;
+            else {
+                f = fdesc_get(current->p, fds[i]);
+                if (!f) {
+                    iour_debug("invalid fd %d", fds[i]);
+                    ret = -EBADF;
+                }
+            }
+            if (!ret) {
+                fdesc old = iour->files[offset + i];
+                if (old)
+                    fdesc_put(old);
+                iour->files[offset + i] = f;
+            } else {
+                if (i > 0)
+                    ret = i;
+                break;
+            }
+        }
+    }
+    iour_unlock(iour);
+    if (!ret)
+        ret = count;
+    return ret;
+}
+
+static boolean iour_submit(io_uring iour, struct io_uring_sqe *sqe)
+{
+    iour_debug("opcode %d, flags 0x%x, user_data %ld", sqe->opcode, sqe->flags,
+        sqe->user_data);
+    fdesc f = 0;
+    s32 res;
+    if (sqe->flags & ~(IOSQE_FIXED_FILE | IOSQE_ASYNC)) {
+        /* non-supported flags */
+        res = -EINVAL;
+        goto complete;
+    }
+    switch(sqe->opcode) {
+    case IORING_OP_READV:
+    case IORING_OP_WRITEV:
+    case IORING_OP_READ_FIXED:
+    case IORING_OP_WRITE_FIXED:
+    case IORING_OP_POLL_ADD:
+    case IORING_OP_READ:
+    case IORING_OP_WRITE:
+        if (sqe->flags & IOSQE_FIXED_FILE) {
+            iour_lock(iour);
+            int fd = sqe->fd;
+            if ((fd >= 0) && (fd < iour->file_count)) {
+                f = iour->files[fd];
+                if (f)
+                    f->refcnt++;
+            }
+            iour_unlock(iour);
+        } else
+            f = fdesc_get(current->p, sqe->fd);
+        if (!f) {
+            res = -EBADF;
+            goto complete;
+        }
+        break;
+    default:
+        break;
+    }
+    switch (sqe->opcode) {
+    case IORING_OP_NOP:
+        res = 0;
+        goto complete;
+    case IORING_OP_READV:
+    case IORING_OP_WRITEV: {
+        if (sqe->buf_index) {
+            res = -EINVAL;
+            goto complete;
+        }
+        struct iovec *iov = pointer_from_u64(sqe->addr);
+        u32 len = sqe->len;
+        boolean write = (sqe->opcode == IORING_OP_WRITEV);
+        if (!validate_iovec(iov, len, !write)) {
+            res = -EFAULT;
+            goto complete;
+        }
+        iour_iov(iour, f, write, iov, len, sqe->off, sqe->user_data);
+        break;
+    }
+    case IORING_OP_READ_FIXED:
+    case IORING_OP_WRITE_FIXED:
+        res = 0;
+        iour_lock(iour);
+        u16 buf_index = sqe->buf_index;
+        if (buf_index >= iour->buf_count) {
+            if (iour->buf_count != 0)
+                res = -EINVAL;
+            else
+                res = -EFAULT;
+        } else {
+            struct iovec *iov = &iour->bufs[buf_index];
+            void *buf = pointer_from_u64(sqe->addr);
+            u32 len = sqe->len;
+            boolean write = sqe->opcode == IORING_OP_WRITE_FIXED;
+            if ((buf < iov->iov_base) || (u64_from_pointer(buf) + len >
+                    u64_from_pointer(iov->iov_base) + iov->iov_len)) {
+                res = -EFAULT;
+            } else {
+                iour_unlock(iour);
+                iour_rw(iour, f, write, buf, len, sqe->off, sqe->user_data);
+                return true;
+            }
+        }
+        iour_unlock(iour);
+        goto complete;
+    case IORING_OP_POLL_ADD:
+        if (sqe->ioprio || sqe->off || sqe->addr || sqe->len ||
+                sqe->buf_index) {
+            res = -EINVAL;
+            goto complete;
+        }
+        iour_poll_add(iour, f, sqe->poll_events, sqe->user_data);
+        break;
+    case IORING_OP_POLL_REMOVE:
+        if (sqe->ioprio || sqe->off || sqe->len || sqe->poll_events ||
+                sqe->buf_index) {
+            res = -EINVAL;
+            goto complete;
+        }
+        iour_poll_remove(iour, sqe->addr, sqe->user_data);
+        break;
+    case IORING_OP_TIMEOUT: {
+        struct timespec *ts = (struct timespec *)sqe->addr;
+        if (sqe->ioprio || (sqe->len != 1) || sqe->buf_index) {
+            res = -EINVAL;
+            goto complete;
+        }
+        if (!validate_user_memory(ts, sizeof(*ts), false)) {
+            res = -EFAULT;
+            goto complete;
+        }
+        iour_timeout_add(iour, ts, sqe->timeout_flags, sqe->off,
+                         sqe->user_data);
+        break;
+    }
+    case IORING_OP_TIMEOUT_REMOVE:
+        if (sqe->ioprio || sqe->len || sqe->buf_index || sqe->timeout_flags) {
+            res = -EINVAL;
+            goto complete;
+        }
+        iour_timeout_remove(iour, sqe->addr, sqe->user_data);
+        break;
+    case IORING_OP_CLOSE:
+        if (sqe->ioprio || sqe->addr || sqe->len || sqe->off || sqe->buf_index
+                || sqe->rw_flags) {
+            res = -EINVAL;
+            goto complete;
+        }
+        int fd = sqe->fd;
+        if ((sqe->flags & IOSQE_FIXED_FILE) ||
+                !(f = fdesc_get(current->p, fd)) || (f == &iour->f)) {
+            res = -EBADF;
+            goto complete;
+        }
+        iour_debug("closing fd %d", fd);
+        deallocate_fd(current->p, fd);
+        if (fetch_and_add(&f->refcnt, -2) == 2) {
+            io_completion completion = closure(iour->h, iour_close_complete,
+                iour, sqe->user_data);
+            if (completion == INVALID_ADDRESS) {
+                iour_complete(iour, sqe->user_data, -ENOMEM, false, false);
+                completion = io_completion_ignore;
+            } else
+                fetch_and_add(&iour->noncancelable_ops, 1);
+            apply(f->close, 0, completion);
+        } else
+            iour_complete(iour, sqe->user_data, 0, false, false);
+        return true;
+    case IORING_OP_FILES_UPDATE:
+        if (sqe->flags || sqe->ioprio || sqe->rw_flags) {
+            res = -EINVAL;
+            goto complete;
+        }
+        res = iour_register_files_update(iour, (int *)sqe->addr, sqe->len,
+            sqe->off);
+        goto complete;
+    case IORING_OP_READ:
+    case IORING_OP_WRITE:
+        if (sqe->buf_index) {
+            res = -EINVAL;
+            goto complete;
+        } else {
+            void *buf = pointer_from_u64(sqe->addr);
+            u32 len = sqe->len;
+            boolean write = sqe->opcode == IORING_OP_WRITE;
+
+            if (!validate_user_memory(buf, len, !write)) {
+                res = -EFAULT;
+                goto complete;
+            }
+            iour_rw(iour, f, write, buf, len, sqe->off, sqe->user_data);
+        }
+        break;
+    default:
+        iour_complete(iour, sqe->user_data, -EINVAL, false, false);
+        return false;
+    }
+    return true;
+complete:
+    iour_complete(iour, sqe->user_data, res, false, false);
+    if (f)
+        fdesc_put(f);
+    return true;
+}
+
+simple_closure_function(7, 1, sysreturn, iour_getevents_bh,
+                        io_uring, iour, sysreturn, submitted, unsigned int, min_complete, unsigned int, timeouts, boolean, sig_set, thread, t, io_completion, completion,
+                        u64, flags)
+{
+    io_uring iour = bound(iour);
+    blockq bq = iour->bq;
+    sysreturn rv;
+    if (flags & BLOCKQ_ACTION_NULLIFY) {
+        rv = -EINTR;
+        goto out;
+    }
+    iour_lock(iour);
+    iour_debug("CQ head %d, CQ tail %d",iour->rings->cq_head,
+               iour->rings->cq_tail);
+    if ((iour->rings->cq_tail - iour->rings->cq_head < bound(min_complete)) &&
+            (iour->cq_timeouts == bound(timeouts)))
+        rv = BLOCKQ_BLOCK_REQUIRED;
+    else {
+        rv = bound(submitted);
+        iour->bq = 0;
+    }
+    iour_unlock(iour);
+out:
+    if (rv == BLOCKQ_BLOCK_REQUIRED) {
+        iour_debug("blocking");
+        return rv;
+    }
+    thread t = bound(t);
+    if (bound(sig_set))
+        t->signals.mask = iour->sigmask;
+    blockq_handle_completion(bq, flags, bound(completion), t, rv);
+    closure_finish();
+    iour_debug("returning %d", rv);
+    fdesc_put(&iour->f);
+    return rv;
+}
+
+sysreturn io_uring_enter(int fd, unsigned int to_submit,
+                         unsigned int min_complete, unsigned int flags,
+                         sigset_t *sig)
+{
+    iour_debug("fd %d, to_submit %d, min_complete %d, flags 0x%x, sig %p", fd,
+        to_submit, min_complete, flags, sig);
+    io_uring iour = iour_from_fd(current->p, fd);
+    sysreturn rv;
+    if (flags & ~IORING_ENTER_GETEVENTS) {
+        rv = -EINVAL;
+        goto out;
+    }
+    if (sig && !validate_user_memory(sig, sizeof(*sig), false)) {
+        rv = -EFAULT;
+        goto out;
+    }
+    closure_ref(iour_getevents_bh, bh);
+    if (flags & IORING_ENTER_GETEVENTS) {
+        closure_alloc(iour->h, iour_getevents_bh, bh);
+        if (bh == INVALID_ADDRESS) {
+            rv = -ENOMEM;
+            goto out;
+        }
+    }
+    io_rings rings = iour->rings;
+    read_barrier();
+    iour_debug("SQ head %d, SQ tail %d", rings->sq_head, rings->sq_tail);
+    unsigned int submitted;
+    for (submitted = 0; submitted < to_submit;) {
+        if (rings->sq_head >= rings->sq_tail)
+            break;
+        u32 sqe_index = iour->sq_array[rings->sq_head & iour->sq_mask];
+        rings->sq_head++;
+        if (sqe_index < iour->sq_entries) {
+            submitted++;
+            if (!iour_submit(iour, &iour->sqes[sqe_index]))
+                break;
+        } else {
+            iour_debug("sqe dropped: index %d, entries %d", sqe_index,
+                iour->sq_entries);
+            iour->rings->sq_dropped++;
+            break;
+        }
+    }
+    rv = submitted;
+    if (flags & IORING_ENTER_GETEVENTS) {
+        if (sig) {
+            iour->sigmask = current->signals.mask;
+            current->signals.mask = (*(u64 *)sig);
+            bh->sig_set = true;
+        } else
+            bh->sig_set = false;
+        iour->bq = current->thread_bq;
+        bh->iour = iour;
+        bh->submitted = submitted;
+        bh->min_complete = min_complete;
+        bh->timeouts = iour->cq_timeouts;
+        bh->t = current;
+        bh->completion = syscall_io_complete;
+        return blockq_check(iour->bq, current,
+            closure_get(iour_getevents_bh, bh), false);
+    }
+out:
+    fdesc_put(&iour->f);
+    return rv;
+}
+
+static sysreturn iour_register_buffers(io_uring iour, struct iovec *bufs,
+                                       unsigned int count)
+{
+    if ((count == 0) || (count > IOV_MAX))
+        return -EINVAL;
+    sysreturn ret;
+    iour_lock(iour);
+    if (iour->buf_count)
+        ret = -EBUSY;
+    else {
+        iour->bufs = allocate(iour->h, sizeof(struct iovec) * count);
+        if (iour->bufs == INVALID_ADDRESS) {
+            ret = -ENOMEM;
+        } else {
+            runtime_memcpy(iour->bufs, bufs, sizeof(struct iovec) * count);
+            iour->buf_count = count;
+            ret = 0;
+        }
+    }
+    iour_unlock(iour);
+    return ret;
+}
+
+static sysreturn iour_unregister_buffers(io_uring iour)
+{
+    sysreturn ret;
+    iour_lock(iour);
+    if (iour->buf_count == 0)
+        ret = -ENXIO;
+    else {
+        deallocate(iour->h, iour->bufs, sizeof(struct iovec) * iour->buf_count);
+        iour->buf_count = 0;
+        ret = 0;
+    }
+    iour_unlock(iour);
+    return ret;
+}
+
+static sysreturn iour_register_files(io_uring iour, s32 *fds,
+                                     unsigned int count)
+{
+    if ((count == 0) || (count > IOUR_FILES_MAX))
+        return -EINVAL;
+    sysreturn ret;
+    iour_lock(iour);
+    if (iour->file_count)
+        ret = -EBUSY;
+    else {
+        iour->files = allocate(iour->h, sizeof(fdesc) * count);
+        if (iour->files == INVALID_ADDRESS) {
+            ret = -ENOMEM;
+        } else {
+            ret = 0;
+            for (int i = 0; i < count; i++) {
+                if (fds[i] == -1)
+                    iour->files[i] = 0;
+                else {
+                    iour_debug("registering fd %d", fds[i]);
+                    iour->files[i] = fdesc_get(current->p, fds[i]);
+                    if (!iour->files[i]) {
+                        while (--i >= 0)
+                            if (iour->files[i])
+                                fdesc_put(iour->files[i]);
+                        deallocate(iour->h, iour->files, sizeof(fdesc) * count);
+                        ret = -EBADF;
+                        break;
+                    }
+                }
+            }
+            if (ret == 0)
+                iour->file_count = count;
+        }
+    }
+    iour_unlock(iour);
+    return ret;
+}
+
+static sysreturn iour_unregister_files(io_uring iour)
+{
+    if (iour->file_count == 0)
+        return -ENXIO;
+    iour_lock(iour);
+    for (unsigned int i = 0; i < iour->file_count; i++)
+        if (iour->files[i])
+            fdesc_put(iour->files[i]);
+    deallocate(iour->h, iour->files, sizeof(fdesc) * iour->file_count);
+    iour->file_count = 0;
+    iour_unlock(iour);
+    return 0;
+}
+
+static sysreturn iour_register_eventfd(io_uring iour, int fd, boolean async)
+{
+    sysreturn ret;
+    iour_lock(iour);
+    if (iour->eventfd)
+        ret = -EBUSY;
+    else {
+        iour->eventfd = fdesc_get(current->p, fd);
+        if (iour->eventfd) {
+            if (iour->eventfd->type == FDESC_TYPE_EVENTFD) {
+                iour->eventfd_async = async;
+                ret = 0;
+            } else {
+                fdesc_put(iour->eventfd);
+                iour->eventfd = 0;
+                ret = -EINVAL;
+            }
+        } else
+            ret = -EBADF;
+    }
+    iour_unlock(iour);
+    return ret;
+}
+
+static sysreturn iour_unregister_eventfd(io_uring iour)
+{
+    sysreturn ret;
+    iour_lock(iour);
+    if (!iour->eventfd)
+        ret = -ENXIO;
+    else {
+        fdesc_put(iour->eventfd);
+        iour->eventfd = 0;
+        ret = 0;
+    }
+    iour_unlock(iour);
+    return ret;
+}
+
+static sysreturn iour_register_probe(struct io_uring_probe *probe,
+                                     unsigned int op_count)
+{
+    iour_debug("op_count %d", op_count);
+    probe->last_op = IORING_OP_LAST - 1;
+    if (op_count > IORING_OP_LAST)
+        op_count = IORING_OP_LAST;
+    zero(probe->ops, sizeof(probe->ops[0]) * op_count);
+    for (unsigned int i = 0; i < op_count; i++)
+        probe->ops[i].op = i;
+    probe->ops_len = op_count;
+    probe->ops[IORING_OP_NOP].flags = probe->ops[IORING_OP_READV].flags =
+            probe->ops[IORING_OP_WRITEV].flags =
+            probe->ops[IORING_OP_READ_FIXED].flags =
+            probe->ops[IORING_OP_WRITE_FIXED].flags =
+            probe->ops[IORING_OP_POLL_ADD].flags =
+            probe->ops[IORING_OP_POLL_REMOVE].flags =
+            probe->ops[IORING_OP_TIMEOUT].flags =
+            probe->ops[IORING_OP_TIMEOUT_REMOVE].flags =
+            probe->ops[IORING_OP_CLOSE].flags =
+            probe->ops[IORING_OP_FILES_UPDATE].flags =
+            probe->ops[IORING_OP_READ].flags =
+            probe->ops[IORING_OP_WRITE].flags = IO_URING_OP_SUPPORTED;
+    return 0;
+}
+
+sysreturn io_uring_register(int fd, unsigned int opcode, void *arg,
+                            unsigned int nr_args)
+{
+    iour_debug("fd %d, opcode %d", fd, opcode);
+    io_uring iour = iour_from_fd(current->p, fd);
+    sysreturn rv;
+    switch (opcode) {
+    case IORING_REGISTER_BUFFERS:
+        if (!validate_iovec((struct iovec *)arg, nr_args, true))
+            rv = -EFAULT;
+        else
+            rv = iour_register_buffers(iour, (struct iovec *)arg, nr_args);
+        break;
+    case IORING_UNREGISTER_BUFFERS:
+        if (arg || nr_args)
+            rv = -EINVAL;
+        else
+            rv = iour_unregister_buffers(iour);
+        break;
+    case IORING_REGISTER_FILES:
+        if (!validate_user_memory(arg, sizeof(s32) * nr_args, false))
+            rv = -EFAULT;
+        else
+            rv = iour_register_files(iour, (s32 *)arg, nr_args);
+        break;
+    case IORING_REGISTER_FILES_UPDATE: {
+        struct io_uring_files_update *fu = (struct io_uring_files_update *)arg;
+        if (!validate_user_memory(fu, sizeof(*fu), false))
+            rv = -EFAULT;
+        else if (fu->resv)
+            rv = -EINVAL;
+        else
+            rv = iour_register_files_update(iour, fu->fds, nr_args, fu->offset);
+        break;
+    }
+    case IORING_UNREGISTER_FILES:
+        if (arg || nr_args)
+            rv = -EINVAL;
+        else
+            rv = iour_unregister_files(iour);
+        break;
+    case IORING_REGISTER_EVENTFD:
+    case IORING_REGISTER_EVENTFD_ASYNC:
+        if (!validate_user_memory(arg, sizeof(int), false))
+            rv = -EFAULT;
+        else if (nr_args != 1)
+            rv = -EINVAL;
+        else
+            rv = iour_register_eventfd(iour, *((int *)arg),
+                opcode == IORING_REGISTER_EVENTFD_ASYNC);
+        break;
+    case IORING_UNREGISTER_EVENTFD:
+        if (arg || nr_args)
+            rv = -EINVAL;
+        else
+            rv = iour_unregister_eventfd(iour);
+        break;
+    case IORING_REGISTER_PROBE: {
+        struct io_uring_probe *probe = (struct io_uring_probe *)arg;
+        if (!validate_user_memory(probe,
+                sizeof(*probe) + sizeof(probe->ops[0]) * nr_args, true))
+            rv = -EFAULT;
+        else
+            rv = iour_register_probe(probe, nr_args);
+        break;
+    }
+    default:
+        rv = -EINVAL;
+        break;
+    }
+    fdesc_put(&iour->f);
+    return rv;
+}

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -601,6 +601,9 @@ static sysreturn mmap(void *target, u64 size, int prot, int flags, int fd, u64 o
     thread_log(current, "mmap: target %p, size 0x%lx, len 0x%lx, prot 0x%x, flags 0x%x, fd %d, offset 0x%lx",
 	       target, size, len, prot, flags, fd, offset);
 
+    if (len == 0)
+        return -EINVAL;
+
     /* Determine vmap flags */
     u64 vmflags = VMAP_FLAG_MMAP;
     if ((flags & MAP_ANONYMOUS))

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -183,7 +183,7 @@ closure_function(1, 6, sysreturn, pipe_read,
     pipe_file pf = bound(pf);
 
     if (length == 0)
-        return 0;
+        return io_complete(completion, t, 0);
 
     blockq_action ba = closure(pf->pipe->h, pipe_read_bh, pf, t, dest, length,
                                completion);
@@ -238,7 +238,7 @@ closure_function(1, 6, sysreturn, pipe_write,
                  void *, dest, u64, length, u64, offset, thread, t, boolean, bh, io_completion, completion)
 {
     if (length == 0)
-        return 0;
+        return io_complete(completion, t, 0);
 
     pipe_file pf = bound(pf);
     blockq_action ba = closure(pf->pipe->h, pipe_write_bh, pf, t, dest, length,

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -130,11 +130,12 @@ static inline void pipe_dealloc_end(pipe p, pipe_file pf)
     }
 }
 
-closure_function(1, 0, sysreturn, pipe_close,
-                 pipe_file, pf)
+closure_function(1, 2, sysreturn, pipe_close,
+                 pipe_file, pf,
+                 thread, t, io_completion, completion)
 {
     pipe_dealloc_end(bound(pf)->pipe, bound(pf));
-    return 0;
+    return io_complete(completion, t, 0);
 }
 
 closure_function(5, 1, sysreturn, pipe_read_bh,

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -203,13 +203,14 @@ void epoll_finish(epoll e)
     refcount_release(&e->refcount);
 }
 
-closure_function(1, 0, sysreturn, epoll_close,
-                 epoll, e)
+closure_function(1, 2, sysreturn, epoll_close,
+                 epoll, e,
+                 thread, t, io_completion, completion)
 {
     epoll e = bound(e);
     release_fdesc(&e->f);
     epoll_finish(e);
-    return 0;
+    return io_complete(completion, t, 0);
 }
 
 sysreturn epoll_create(int flags)

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -937,8 +937,6 @@ closure_function(1, 6, sysreturn, signalfd_read,
                  signal_fd, sfd,
                  void *, buf, u64, length, u64, offset_arg, thread, t, boolean, bh, io_completion, completion)
 {
-    if (length < sizeof(struct signalfd_siginfo))
-        return 0;
     signal_fd sfd = bound(sfd);
     sig_debug("fd %d, buf %p, length %ld, tid %d, bh %d\n", sfd->fd, buf, length, t->tid, bh);
     blockq_action ba = closure(sfd->h, signalfd_read_bh, sfd, t, buf, length, completion);

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -950,8 +950,9 @@ closure_function(1, 1, u32, signalfd_events,
     return (get_all_pending_signals(t) & bound(sfd)->mask) ? EPOLLIN : 0;
 }
 
-closure_function(1, 0, sysreturn, signalfd_close,
-                 signal_fd, sfd)
+closure_function(1, 2, sysreturn, signalfd_close,
+                 signal_fd, sfd,
+                 thread, t, io_completion, completion)
 {
     signal_fd sfd = bound(sfd);
     deallocate_blockq(sfd->bq);
@@ -961,7 +962,7 @@ closure_function(1, 0, sysreturn, signalfd_close,
     deallocate_closure(sfd->f.close);
     release_fdesc(&sfd->f);
     deallocate(sfd->h, sfd, sizeof(struct signal_fd));
-    return 0;
+    return io_complete(completion, t, 0);
 }
 
 closure_function(1, 2, void, signalfd_notify,

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -119,7 +119,7 @@ closure_function(1, 6, sysreturn, unixsock_read,
 {
     unixsock s = bound(s);
     if ((s->sock.type == SOCK_STREAM) && (length == 0)) {
-        return 0;
+        return io_complete(completion, t, 0);
     }
 
     blockq_action ba = closure(s->sock.h, unixsock_read_bh, s, t, dest, length,
@@ -194,10 +194,10 @@ closure_function(1, 6, sysreturn, unixsock_write,
 {
     unixsock s = bound(s);
     if ((s->sock.type == SOCK_STREAM) && (length == 0)) {
-        return 0;
+        return io_complete(completion, t, 0);
     }
     if ((s->sock.type == SOCK_DGRAM) && (length > UNIXSOCK_BUF_MAX_SIZE)) {
-        return -EMSGSIZE;
+        return io_complete(completion, t, -EMSGSIZE);
     }
 
     blockq_action ba = closure(s->sock.h, unixsock_write_bh, s, t, src, length,

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -243,8 +243,9 @@ closure_function(1, 2, sysreturn, unixsock_ioctl,
     return socket_ioctl(&s->sock, request, ap);
 }
 
-closure_function(1, 0, sysreturn, unixsock_close,
-                 unixsock, s)
+closure_function(1, 2, sysreturn, unixsock_close,
+                 unixsock, s,
+                 thread, t, io_completion, completion)
 {
     unixsock s = bound(s);
     if (s->peer) {
@@ -266,7 +267,7 @@ closure_function(1, 0, sysreturn, unixsock_close,
         buffer_clear(table_find(s->fs_entry, sym(socket)));
     }
     unixsock_dealloc(s);
-    return 0;
+    return io_complete(completion, t, 0);
 }
 
 static sysreturn unixsock_bind(struct sock *sock, struct sockaddr *addr,

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -629,7 +629,7 @@ closure_function(2, 6, sysreturn, file_read,
         return spec_read(f, dest, length, offset, t, bh, completion);
     }
     if (offset >= f->length) {
-        return 0;
+        return io_complete(completion, t, 0);
     }
     begin_file_read(t, f);
     filesystem_read_linear(t->p->fs, f->n, dest, length, offset,

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -360,7 +360,9 @@ closure_function(5, 2, void, iov_op_each_complete,
     }
 
     /* If we're done, return the total length... */
-    if (p->curr == iovcnt) {
+    if ((p->curr == iovcnt) || ((rv == 0) && p->initialized) ||
+            ((p->total_len != 0) && f->events &&
+            !(apply(f->events, t) & (write ? EPOLLOUT : EPOLLIN)))) {
         rv = p->total_len;
         goto out_complete;
     }

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2243,6 +2243,9 @@ void register_file_syscalls(struct syscall *map)
     register_syscall(map, umask, umask);
     register_syscall(map, statfs, statfs);
     register_syscall(map, fstatfs, fstatfs);
+    register_syscall(map, io_uring_setup, io_uring_setup);
+    register_syscall(map, io_uring_enter, io_uring_enter);
+    register_syscall(map, io_uring_register, io_uring_register);
 }
 
 #define SYSCALL_F_NOTRACE 0x1

--- a/src/unix/syscalls.h
+++ b/src/unix/syscalls.h
@@ -330,5 +330,8 @@
 #define SYS_pkey_mprotect			329
 #define SYS_pkey_alloc				330
 #define SYS_pkey_free				331
+#define SYS_io_uring_setup			425
+#define SYS_io_uring_enter			426
+#define SYS_io_uring_register			427
 
-#define SYS_MAX 332
+#define SYS_MAX 428

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -99,6 +99,7 @@ typedef struct iovec {
 #define ELOOP           40              /* Too many symbolic links */
 #define ENOPROTOOPT     42              /* Protocol not available */
 
+#define ETIME           62		/* Timer expired */
 #define EDESTADDRREQ    89		/* Destination address required */
 #define EMSGSIZE        90		/* Message too long */
 #define EOPNOTSUPP      95		/* Operation not supported */
@@ -819,6 +820,39 @@ struct io_event {
 };
 
 typedef struct aio_ring *aio_context_t;
+
+struct io_sqring_offsets {
+    u32 head;
+    u32 tail;
+    u32 ring_mask;
+    u32 ring_entries;
+    u32 flags;
+    u32 dropped;
+    u32 array;
+    u32 resv[3];
+};
+
+struct io_cqring_offsets {
+    u32 head;
+    u32 tail;
+    u32 ring_mask;
+    u32 ring_entries;
+    u32 overflow;
+    u32 cqes;
+    u64 resv[2];
+};
+
+struct io_uring_params {
+    u32 sq_entries;
+    u32 cq_entries;
+    u32 flags;
+    u32 sq_thread_cpu;
+    u32 sq_thread_idle;
+    u32 features;
+    u32 resv[4];
+    struct io_sqring_offsets sq_off;
+    struct io_cqring_offsets cq_off;
+};
 
 /* Socket option levels */
 #define SOL_SOCKET      1

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -251,8 +251,9 @@ closure_function(1, 1, u32, timerfd_events,
     return bound(ut)->overruns > 0 ? EPOLLIN : 0;
 }
 
-closure_function(1, 0, sysreturn, timerfd_close,
-                 unix_timer, ut)
+closure_function(1, 2, sysreturn, timerfd_close,
+                 unix_timer, ut,
+                 thread, t, io_completion, completion)
 {
     unix_timer ut = bound(ut);
     remove_unix_timer(ut);
@@ -262,7 +263,7 @@ closure_function(1, 0, sysreturn, timerfd_close,
     deallocate_closure(ut->f.close);
     release_fdesc(&ut->f);
     deallocate_unix_timer(ut);
-    return 0;
+    return io_complete(completion, t, 0);
 }
 
 sysreturn timerfd_create(int clockid, int flags)

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -202,12 +202,6 @@ closure_function(5, 1, sysreturn, timerfd_read_bh,
     timer_debug("fd %d, dest %p, length %ld, tid %d, flags 0x%lx\n",
                 ut->info.timerfd.fd, bound(dest), bound(length), t->tid, flags);
 
-    if (bound(length) < sizeof(u64)) {
-        assert(!blocked);
-        rv = -EINVAL;
-        goto out;
-    }
-
     if (flags & BLOCKQ_ACTION_NULLIFY) {
         assert(blocked);
         rv = -EINTR;
@@ -241,8 +235,8 @@ closure_function(1, 6, sysreturn, timerfd_read,
                  unix_timer, ut,
                  void *, dest, u64, length, u64, offset_arg, thread, t, boolean, bh, io_completion, completion)
 {
-    if (length == 0)
-        return 0;
+    if (length < sizeof(u64))
+        return io_complete(completion, t, -EINVAL);
     unix_timer ut = bound(ut);
     timer_debug("fd %d, dest %p, length %ld, tid %d, bh %d, completion %p\n", ut->info.timerfd.fd,
                 dest, length, t->tid, bh, completion);

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -177,11 +177,12 @@ closure_function(0, 6, sysreturn, dummy_read,
     return 0;
 }
 
-closure_function(1, 0, sysreturn, std_close,
-                 file, f)
+closure_function(1, 2, sysreturn, std_close,
+                 file, f,
+                 thread, t, io_completion, completion)
 {
     unix_cache_free(get_unix_heaps(), file, bound(f));
-    return 0;
+    return io_complete(completion, t, 0);
 }
 
 closure_function(0, 6, sysreturn, stdout,

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -135,6 +135,12 @@ typedef struct blockq * blockq;
 
 extern io_completion syscall_io_complete;
 
+static inline sysreturn io_complete(io_completion completion, thread t,
+                                    sysreturn rv) {
+    apply(completion, t, rv);
+    return rv;
+}
+
 blockq allocate_blockq(heap h, char * name);
 void deallocate_blockq(blockq bq);
 const char * blockq_name(blockq bq);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -277,6 +277,7 @@ typedef closure_type(sg_io, sysreturn, sg_list sg, u64 length, u64 offset, threa
 #define FDESC_TYPE_SIGNALFD     9
 #define FDESC_TYPE_TIMERFD     10
 #define FDESC_TYPE_SYMLINK     11
+#define FDESC_TYPE_IORING      12
 
 typedef struct fdesc {
     io read, write;
@@ -306,6 +307,7 @@ void epoll_finish(epoll e);
 #define VMAP_FLAG_ANONYMOUS     2
 #define VMAP_FLAG_WRITABLE      4
 #define VMAP_FLAG_EXEC          8
+#define VMAP_FLAG_PREALLOC     16
 
 typedef struct vmap {
     struct rmnode node;
@@ -672,6 +674,14 @@ sysreturn io_submit(aio_context_t ctx_id, long nr, struct iocb **iocbpp);
 sysreturn io_getevents(aio_context_t ctx_id, long min_nr, long nr,
         struct io_event *events, struct timespec *timeout);
 sysreturn io_destroy(aio_context_t ctx_id);
+
+sysreturn io_uring_setup(unsigned int entries, struct io_uring_params *params);
+sysreturn io_uring_mmap(fdesc desc, u64 len, u64 mapflags, u64 offset);
+sysreturn io_uring_enter(int fd, unsigned int to_submit,
+                         unsigned int min_complete, unsigned int flags,
+                         sigset_t *sig);
+sysreturn io_uring_register(int fd, unsigned int opcode, void *arg,
+                            unsigned int nr_args);
 
 int do_pipe2(int fds[2], int flags);
 int pipe_set_capacity(fdesc f, int capacity);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -649,6 +649,9 @@ static inline void file_op_maybe_wake(thread t)
     irq_restore(flags);
 }
 
+void iov_op(fdesc f, boolean write, struct iovec *iov, int iovcnt, u64 offset,
+            boolean blocking, io_completion completion);
+
 #define resolve_fd_noret(__p, __fd) vector_get(__p->files, __fd)
 #define resolve_fd(__p, __fd) ({void *f ; if (!(f = resolve_fd_noret(__p, __fd))) return set_syscall_error(current, EBADF); f;})
 

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -47,6 +47,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/unix/eventfd.c \
 	$(SRCDIR)/unix/filesystem.c \
 	$(SRCDIR)/unix/futex.c \
+	$(SRCDIR)/unix/io_uring.c \
 	$(SRCDIR)/unix/mktime.c \
 	$(SRCDIR)/unix/mmap.c \
 	$(SRCDIR)/unix/notify.c \

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -13,6 +13,7 @@ PROGRAMS= \
 	getrandom \
 	hw \
 	hws \
+	io_uring \
 	mkdir \
 	mmap \
 	nullpage \
@@ -91,6 +92,11 @@ SRCS-hw=		$(CURDIR)/hw.c
 
 SRCS-hws=		$(SRCS-hw)
 LDFLAGS-hws=		-static
+
+SRCS-io_uring= \
+	$(CURDIR)/io_uring.c \
+	$(SRCDIR)/unix_process/ssp.c
+LDFLAGS-io_uring=	-static
 
 SRCS-mmap=		$(CURDIR)/mmap.c \
 			$(SRCDIR)/unix_process/ssp.c

--- a/test/runtime/io_uring.c
+++ b/test/runtime/io_uring.c
@@ -1,0 +1,1202 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/eventfd.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "runtime.h"
+
+#ifndef SYS_io_uring_setup
+#define SYS_io_uring_setup      425
+#endif
+#ifndef SYS_io_uring_enter
+#define SYS_io_uring_enter      426
+#endif
+#ifndef SYS_io_uring_register
+#define SYS_io_uring_register   427
+#endif
+
+#define IORING_SETUP_CQSIZE     (1 << 3)
+
+#define IO_URING_OP_SUPPORTED   (1 << 0)
+
+#define IORING_OFF_SQ_RING  0ULL
+#define IORING_OFF_SQES     0x10000000ULL
+
+struct io_sqring_offsets {
+    uint32_t head;
+    uint32_t tail;
+    uint32_t ring_mask;
+    uint32_t ring_entries;
+    uint32_t flags;
+    uint32_t dropped;
+    uint32_t array;
+    uint32_t resv[3];
+};
+
+struct io_cqring_offsets {
+    uint32_t head;
+    uint32_t tail;
+    uint32_t ring_mask;
+    uint32_t ring_entries;
+    uint32_t overflow;
+    uint32_t cqes;
+    uint32_t resv[4];
+};
+
+struct io_uring_params {
+    uint32_t sq_entries;
+    uint32_t cq_entries;
+    uint32_t flags;
+    uint32_t sq_thread_cpu;
+    uint32_t sq_thread_idle;
+    uint32_t features;
+    uint32_t resv[4];
+    struct io_sqring_offsets sq_off;
+    struct io_cqring_offsets cq_off;
+};
+
+struct io_uring_sqe {
+    uint8_t opcode;
+    uint8_t flags;
+    uint16_t ioprio;
+    uint32_t fd;
+    union {
+        uint64_t off;
+        uint64_t addr2;
+    };
+    uint64_t addr;
+    uint32_t len;
+    union {
+        uint32_t rw_flags;
+        uint32_t fsync_flags;
+        uint16_t poll_events;
+        uint32_t sync_range_flags;
+        uint32_t msg_flags;
+        uint32_t timeout_flags;
+        uint32_t accept_flags;
+        uint32_t cancel_flags;
+    };
+    uint32_t user_data;
+    union {
+        struct {
+            uint16_t buf_index;
+            uint16_t personality;
+        };
+        uint64_t __pad2[3];
+    };
+};
+
+struct io_uring_cqe {
+    uint64_t user_data;
+    uint32_t res;
+    uint32_t flags;
+};
+
+struct io_uring_probe_op {
+    uint8_t op;
+    uint8_t resv;
+    uint16_t flags;
+    uint32_t resv2;
+};
+
+struct io_uring_probe {
+    uint8_t last_op;
+    uint8_t ops_len;
+    uint16_t resv;
+    uint32_t resv2[3];
+    struct io_uring_probe_op ops[0];
+};
+
+struct io_uring_files_update {
+    uint32_t offset;
+    uint32_t resv;
+    int32_t *fds;
+};
+
+enum {
+    IORING_OP_NOP,
+    IORING_OP_READV,
+    IORING_OP_WRITEV,
+    IORING_OP_FSYNC,
+    IORING_OP_READ_FIXED,
+    IORING_OP_WRITE_FIXED,
+    IORING_OP_POLL_ADD,
+    IORING_OP_POLL_REMOVE,
+    IORING_OP_SYNC_FILE_RANGE,
+    IORING_OP_SENDMSG,
+    IORING_OP_RECVMSG,
+    IORING_OP_TIMEOUT,
+    IORING_OP_TIMEOUT_REMOVE,
+    IORING_OP_ACCEPT,
+    IORING_OP_ASYNC_CANCEL,
+    IORING_OP_LINK_TIMEOUT,
+    IORING_OP_CONNECT,
+    IORING_OP_FALLOCATE,
+    IORING_OP_OPENAT,
+    IORING_OP_CLOSE,
+    IORING_OP_FILES_UPDATE,
+    IORING_OP_STATX,
+    IORING_OP_READ,
+    IORING_OP_WRITE,
+};
+
+#define IORING_FEAT_SINGLE_MMAP (1 << 0)
+
+#define IOSQE_FIXED_FILE    (1 << 0)
+
+#define IORING_TIMEOUT_ABS  (1 << 0)
+
+#define IORING_ENTER_GETEVENTS  (1 << 0)
+
+#define IORING_REGISTER_BUFFERS         0
+#define IORING_UNREGISTER_BUFFERS       1
+#define IORING_REGISTER_FILES           2
+#define IORING_UNREGISTER_FILES         3
+#define IORING_REGISTER_EVENTFD         4
+#define IORING_UNREGISTER_EVENTFD       5
+#define IORING_REGISTER_FILES_UPDATE    6
+#define IORING_REGISTER_EVENTFD_ASYNC   7
+#define IORING_REGISTER_PROBE           8
+
+#define BUF_SIZE        8192
+
+#define test_assert(expr) do { \
+    if (!(expr)) { \
+        printf("Error: %s -- failed at %s:%d\n", #expr, __FILE__, __LINE__); \
+        exit(EXIT_FAILURE); \
+    } \
+} while (0)
+
+struct iour {
+    struct io_uring_params params;
+    int fd;
+    uint8_t *rings;
+    struct io_uring_sqe *sqes;
+    uint32_t *sq_head;
+    uint32_t *sq_tail;
+    uint32_t sq_mask;
+    uint32_t *sq_array;
+    uint32_t *cq_head;
+    uint32_t *cq_tail;
+    uint32_t cq_mask;
+    struct io_uring_cqe *cqes;
+};
+
+static int iour_init(struct iour *iour, unsigned int entries)
+{
+    iour->fd = syscall(SYS_io_uring_setup, entries, &iour->params);
+    if (iour->fd < 0)
+        return iour->fd;
+
+    test_assert(iour->params.features & IORING_FEAT_SINGLE_MMAP);
+
+    /* Exploit the single mmap feature and map both SQ and CQ rings with a
+     * single syscall. */
+    uint32_t sqring_size = iour->params.sq_off.array +
+            iour->params.sq_entries * sizeof(uint32_t);
+    uint32_t cqring_size = iour->params.cq_off.cqes +
+            iour->params.cq_entries * sizeof(struct io_uring_cqe);
+    iour->rings = mmap(0, MAX(sqring_size, cqring_size), PROT_READ | PROT_WRITE,
+        MAP_SHARED | MAP_POPULATE, iour->fd, IORING_OFF_SQ_RING);
+    test_assert(iour->rings != MAP_FAILED);
+
+    iour->sq_head = (uint32_t *)(iour->rings + iour->params.sq_off.head);
+    iour->sq_tail = (uint32_t *)(iour->rings + iour->params.sq_off.tail);
+    iour->sq_mask = *(uint32_t *)(iour->rings + iour->params.sq_off.ring_mask);
+    iour->sq_array = (uint32_t *)(iour->rings + iour->params.sq_off.array);
+    iour->cq_head = (uint32_t *)(iour->rings + iour->params.cq_off.head);
+    iour->cq_tail = (uint32_t *)(iour->rings + iour->params.cq_off.tail);
+    iour->cq_mask = *(uint32_t *)(iour->rings + iour->params.cq_off.ring_mask);
+    iour->cqes =
+            (struct io_uring_cqe *)(iour->rings + iour->params.cq_off.cqes);
+    iour->sqes = mmap(0, iour->params.sq_entries * sizeof(struct io_uring_sqe),
+        PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, iour->fd,
+        IORING_OFF_SQES);
+    test_assert(iour->sqes != MAP_FAILED);
+
+    test_assert(iour->params.sq_entries >= entries);
+    test_assert(*iour->sq_head == 0 && *iour->sq_tail == 0);
+    test_assert(iour->sq_mask == iour->params.sq_entries - 1);
+    test_assert(*(uint32_t *)(iour->rings + iour->params.sq_off.flags) == 0);
+    test_assert(*(uint32_t *)(iour->rings + iour->params.sq_off.dropped) == 0);
+    test_assert(iour->params.cq_entries >= entries);
+    test_assert(*iour->cq_head == 0 && *iour->cq_tail == 0);
+    test_assert(iour->cq_mask == iour->params.cq_entries - 1);
+    test_assert(*(uint32_t *)(iour->rings + iour->params.cq_off.overflow) == 0);
+
+    /* Use some non-trivial ordering of SQEs */
+    for (int i = 0; i < iour->params.sq_entries; i++)
+        iour->sq_array[i] = iour->params.sq_entries - 1  - i;
+
+    return 0;
+}
+
+static struct io_uring_sqe *iour_get_sqe(struct iour *iour)
+{
+    test_assert(*iour->sq_tail >= *iour->sq_head);
+    test_assert(*iour->sq_tail - *iour->sq_head <= iour->params.sq_entries);
+    if (*iour->sq_tail == *iour->sq_head + iour->params.sq_entries)
+        return NULL;
+    return &iour->sqes[iour->sq_array[*iour->sq_tail & iour->sq_mask]];
+}
+
+static void iour_setup_sqe(struct iour *iour, uint8_t opcode, int fd,
+                           uint64_t addr, uint32_t len, uint64_t offset,
+                           uint64_t user_data)
+{
+    struct io_uring_sqe *sqe = iour_get_sqe(iour);
+
+    test_assert(sqe);
+    memset(sqe, 0, sizeof(*sqe));
+    sqe->opcode = opcode;
+    sqe->fd = fd;
+    sqe->addr = addr;
+    sqe->len = len;
+    sqe->off = offset;
+    sqe->user_data = user_data;
+    write_barrier();
+    (*iour->sq_tail)++;
+}
+
+static void iour_setup_nop(struct iour *iour, uint64_t user_data)
+{
+    iour_setup_sqe(iour, IORING_OP_NOP, 0, 0, 0, 0, user_data);
+}
+
+static void iour_setup_readv(struct iour *iour, int fd, struct iovec *iov,
+                            uint32_t len, uint64_t offset, uint64_t user_data)
+{
+    iour_setup_sqe(iour, IORING_OP_READV, fd, (uint64_t)iov, len, offset,
+        user_data);
+}
+
+static void iour_setup_writev(struct iour *iour, int fd, struct iovec *iov,
+                            uint32_t len, uint64_t offset, uint64_t user_data)
+{
+    iour_setup_sqe(iour, IORING_OP_WRITEV, fd, (uint64_t)iov, len, offset,
+        user_data);
+}
+
+static void iour_setup_rw_fixed(struct iour *iour, int fd, uint16_t buf_index,
+                                bool write, uint8_t *buf, uint32_t len,
+                                uint64_t offset, uint64_t user_data)
+{
+    struct io_uring_sqe *sqe = iour_get_sqe(iour);
+
+    test_assert(sqe);
+    memset(sqe, 0, sizeof(*sqe));
+    sqe->opcode = write? IORING_OP_WRITE_FIXED : IORING_OP_READ_FIXED;
+    sqe->fd = fd;
+    sqe->off = offset;
+    sqe->addr = (uint64_t)buf;
+    sqe->len = len;
+    sqe->user_data = user_data;
+    sqe->buf_index = buf_index;
+    write_barrier();
+    (*iour->sq_tail)++;
+}
+
+static void iour_setup_poll_add(struct iour *iour, int fd, uint16_t events,
+                                uint64_t user_data)
+{
+    struct io_uring_sqe *sqe = iour_get_sqe(iour);
+
+    test_assert(sqe);
+    memset(sqe, 0, sizeof(*sqe));
+    sqe->opcode = IORING_OP_POLL_ADD;
+    sqe->fd = fd;
+    sqe->poll_events = events;
+    sqe->user_data = user_data;
+    write_barrier();
+    (*iour->sq_tail)++;
+}
+
+static void iour_setup_poll_remove(struct iour *iour, uint64_t addr,
+                                   uint64_t user_data)
+{
+    iour_setup_sqe(iour, IORING_OP_POLL_REMOVE, 0, addr, 0, 0, user_data);
+}
+
+static void iour_setup_poll_fixed_file(struct iour *iour, int fd_index,
+                                       uint16_t events, uint64_t user_data)
+{
+    struct io_uring_sqe *sqe = iour_get_sqe(iour);
+
+    test_assert(sqe);
+    memset(sqe, 0, sizeof(*sqe));
+    sqe->opcode = IORING_OP_POLL_ADD;
+    sqe->flags = IOSQE_FIXED_FILE;
+    sqe->fd = fd_index;
+    sqe->poll_events = events;
+    sqe->user_data = user_data;
+    write_barrier();
+    (*iour->sq_tail)++;
+}
+
+static void iour_setup_timeout(struct iour *iour, struct timespec *ts,
+                               uint64_t off, uint32_t flags, uint64_t user_data)
+{
+    struct io_uring_sqe *sqe = iour_get_sqe(iour);
+
+    test_assert(sqe);
+    memset(sqe, 0, sizeof(*sqe));
+    sqe->opcode = IORING_OP_TIMEOUT;
+    sqe->fd = 0;
+    sqe->off = off;
+    sqe->addr = (uint64_t)ts;
+    sqe->len = 1;
+    sqe->timeout_flags = flags;
+    sqe->user_data = user_data;
+    write_barrier();
+    (*iour->sq_tail)++;
+}
+
+static void iour_setup_timeout_remove(struct iour *iour, uint64_t addr,
+                                      uint64_t user_data)
+{
+    iour_setup_sqe(iour, IORING_OP_TIMEOUT_REMOVE, 0, addr, 0, 0, user_data);
+}
+
+static void iour_setup_close(struct iour *iour, int fd, uint64_t user_data)
+{
+    iour_setup_sqe(iour, IORING_OP_CLOSE, fd, 0, 0, 0, user_data);
+}
+
+static void iour_setup_files_update(struct iour *iour, int *fds, uint32_t len,
+                                    uint64_t offset, uint64_t user_data)
+{
+    iour_setup_sqe(iour, IORING_OP_FILES_UPDATE, 0, (uint64_t)fds, len, offset,
+        user_data);
+}
+
+static void iour_setup_read(struct iour *iour, int fd, uint8_t *buf,
+                            uint32_t len, uint64_t offset, uint64_t user_data)
+{
+    iour_setup_sqe(iour, IORING_OP_READ, fd, (uint64_t)buf, len, offset,
+        user_data);
+}
+
+static void iour_setup_write(struct iour *iour, int fd, uint8_t *buf,
+                             uint32_t len, uint64_t offset, uint64_t user_data)
+{
+    iour_setup_sqe(iour, IORING_OP_WRITE, fd, (uint64_t)buf, len, offset,
+        user_data);
+}
+
+static int iour_submit(struct iour *iour, unsigned int count,
+                       unsigned int min_complete)
+{
+    return syscall(SYS_io_uring_enter, iour->fd, count, min_complete,
+        IORING_ENTER_GETEVENTS, NULL);
+}
+
+static struct io_uring_cqe *iour_get_cqe(struct iour *iour)
+{
+    struct io_uring_cqe *cqe;
+
+    read_barrier();
+    if (*iour->cq_tail == *iour->cq_head)
+        return NULL;
+    test_assert(*iour->cq_tail > *iour->cq_head);
+    test_assert(*iour->cq_tail - *iour->cq_head <= iour->params.cq_entries);
+    cqe = &iour->cqes[*iour->cq_head & iour->cq_mask];
+    (*iour->cq_head)++;
+    return cqe;
+}
+
+static int iour_exit(struct iour *iour)
+{
+    return close(iour->fd);
+}
+
+static void iour_test_basic(void)
+{
+    struct iour iour;
+    struct io_uring_params params;
+    int fd;
+    struct io_uring_probe *probe;
+    const int probe_ops = IORING_OP_WRITE + 1;
+    void *ptr;
+    struct timespec ts;
+    struct io_uring_cqe *cqe;
+    int ret;
+
+    test_assert(syscall(SYS_io_uring_setup, 1, NULL) == -1);
+    test_assert(errno == EFAULT);
+
+    memset(&iour.params, 0, sizeof(iour.params));
+    memset(&params, 0, sizeof(params));
+
+    test_assert(syscall(SYS_io_uring_setup, 0, &params) == -1);
+    test_assert(errno == EINVAL);
+
+    params.resv[3] = 1;
+    test_assert(syscall(SYS_io_uring_setup, 1, &params) == -1);
+    test_assert(errno == EINVAL);
+    params.resv[3] = 0;
+
+    /* CQ size smaller than SQ size */
+    params.flags = IORING_SETUP_CQSIZE;
+    params.cq_entries = 1;
+    test_assert(syscall(SYS_io_uring_setup, 2, &params) == -1);
+    test_assert(errno == EINVAL);
+
+    params.cq_entries = 8;
+    fd = syscall(SYS_io_uring_setup, 1, &params);
+    test_assert((fd > 0) && (params.cq_entries == 8));
+
+    ret = syscall(SYS_io_uring_register, fd, -1, NULL, 0);  /* invalid opcode */
+    test_assert((ret == -1) && (errno == EINVAL));
+
+    ret = syscall(SYS_io_uring_register, fd, IORING_REGISTER_PROBE, NULL,
+        probe_ops);
+    test_assert((ret == -1) && (errno == EFAULT));
+
+    probe = malloc(sizeof(*probe) + sizeof(probe->ops[0]) * probe_ops);
+    test_assert(probe);
+    ret = syscall(SYS_io_uring_register, fd, IORING_REGISTER_PROBE, probe,
+        probe_ops);
+    test_assert((ret == 0) && (probe->last_op >= probe_ops - 1));
+    test_assert(probe->ops_len <= probe_ops);
+    for (int i = 0; i < probe->ops_len; i++) {
+        switch (probe->ops[i].op) {
+        case IORING_OP_NOP:
+        case IORING_OP_READV:
+        case IORING_OP_WRITEV:
+        case IORING_OP_READ_FIXED:
+        case IORING_OP_WRITE_FIXED:
+        case IORING_OP_POLL_ADD:
+        case IORING_OP_POLL_REMOVE:
+        case IORING_OP_TIMEOUT:
+        case IORING_OP_TIMEOUT_REMOVE:
+        case IORING_OP_CLOSE:
+        case IORING_OP_FILES_UPDATE:
+        case IORING_OP_READ:
+        case IORING_OP_WRITE:
+            test_assert(probe->ops[i].flags & IO_URING_OP_SUPPORTED);
+            break;
+        default:
+            break;
+        }
+    }
+
+    ptr = mmap(0, params.sq_off.array, PROT_READ | PROT_WRITE,
+        MAP_SHARED | MAP_POPULATE, fd, -1ULL);  /* invalid offset */
+    test_assert((ptr == MAP_FAILED) && (errno == EINVAL));
+
+    ptr = mmap(0, -1ULL, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, fd,
+        IORING_OFF_SQ_RING);  /* invalid length */
+    test_assert((ptr == MAP_FAILED) && (errno == EINVAL));
+
+    test_assert(close(fd) == 0);
+
+    /* Close file descriptor without having mapped any memory. */
+    iour.fd = syscall(SYS_io_uring_setup, 1, &iour.params);
+    test_assert(iour.fd > 0);
+    test_assert(close(iour.fd) == 0);
+
+    /* Reference io_uring fd from another io_uring, and trigger io_uring context
+     * release from invocation of io_uring_enter() on the other io_uring
+     * context. */
+    test_assert(iour_init(&iour, 1) == 0);
+    test_assert(iour.fd > 0);
+    fd = syscall(SYS_io_uring_setup, 1, &params);
+    test_assert(fd > 0);
+    iour_setup_poll_add(&iour, fd, POLLIN, 0);
+    test_assert(iour_submit(&iour, 1, 0) == 1);
+    test_assert(close(fd) == 0);    /* fdesc refcount is still not zero **/
+    iour_setup_poll_remove(&iour, 0, 0);
+    test_assert(iour_submit(&iour, 1, 2) == 1);    /* fdesc refcount now zero */
+    test_assert(iour_exit(&iour) == 0);
+
+    /* Cancel ongoing poll and timeout requests when closing io_uring file
+     * descriptor. */
+    test_assert(iour_init(&iour, 2) == 0);
+    test_assert(iour.fd > 0);
+    fd = syscall(SYS_io_uring_setup, 1, &params);
+    test_assert(fd > 0);
+    iour_setup_poll_add(&iour, fd, POLLIN, 0);
+    ts.tv_sec = 1;
+    ts.tv_nsec = 0;
+    iour_setup_timeout(&iour, &ts, 0, 0, 0);
+    test_assert(iour_submit(&iour, 2, 0) == 2);
+    test_assert(iour_exit(&iour) == 0);
+    test_assert(close(fd) == 0);
+
+    test_assert(iour_init(&iour, 1) == 0);
+    test_assert(iour.fd > 0);
+    iour_setup_sqe(&iour, -1, 0, 0, 0, 0, 0);    /* invalid opcode */
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == -EINVAL));
+
+    test_assert(iour_submit(&iour, 1, 0) == 0); /* no SQEs available */
+
+    /* CQ overflow */
+    for (int i = 0; i <= iour.params.cq_entries; i++) {
+        iour_setup_nop(&iour, 0);
+        test_assert(iour_submit(&iour, 1, 1) == 1);
+    }
+    test_assert(*(uint32_t *)(iour.rings + iour.params.cq_off.overflow) == 1);
+
+    test_assert(iour_exit(&iour) == 0);
+    test_assert(iour_init(&iour, 1) == 0);
+    test_assert(iour.fd > 0);
+
+    /* Invalid SQE index */
+    iour.sq_array[*iour.sq_tail] = iour.params.sq_entries;
+    iour_setup_nop(&iour, 0);
+    test_assert(iour_submit(&iour, 1, 0) == 0);
+    test_assert(*(uint32_t *)(iour.rings + iour.params.sq_off.dropped) == 1);
+
+    /* Invalid flags */
+    iour_setup_nop(&iour, 0);
+    ret = syscall(SYS_io_uring_enter, iour.fd, 1, 1, -1U, NULL);
+    test_assert((ret == -1) && (errno == EINVAL));
+
+    test_assert(iour_exit(&iour) == 0);
+
+    /* Try to use the stdin file descriptor as an io_uring. */
+    ret = syscall(SYS_io_uring_enter, 0, 0, 0, 0, NULL);
+    test_assert((ret == -1) && (errno == EOPNOTSUPP));
+}
+
+static void iour_test_readwrite(void)
+{
+    int fd;
+    uint8_t read_buf[BUF_SIZE], write_buf[BUF_SIZE];
+    struct iour iour;
+    struct io_uring_cqe *cqe;
+
+    memset(&iour.params, 0, sizeof(iour.params));
+    test_assert(iour_init(&iour, 1) == 0);
+
+    fd = open("file_rw", O_RDWR | O_CREAT, S_IRWXU);
+    test_assert(fd > 0);
+
+    test_assert(iour_submit(&iour, 0, 0) == 0);
+
+    iour_setup_write(&iour, fd, NULL, BUF_SIZE, 0, 123);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == -EFAULT) && (cqe->user_data == 123));
+
+    iour_setup_sqe(&iour, -1, fd, (uint64_t)write_buf, BUF_SIZE, 0, 456);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == -EINVAL) && (cqe->user_data == 456));
+
+    iour_setup_write(&iour, -fd, write_buf, BUF_SIZE, 0, 789);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == -EBADF) && (cqe->user_data == 789));
+
+    for (int i = 0; i < BUF_SIZE; i++)
+        write_buf[i] = i & 0xFF;
+    iour_setup_write(&iour, fd, write_buf, BUF_SIZE, 0, (uint64_t)read_buf);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == BUF_SIZE));
+    test_assert(cqe->user_data == (uint64_t)read_buf);
+
+    iour_setup_read(&iour, fd, read_buf, BUF_SIZE, 0, (uint64_t)write_buf);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == BUF_SIZE));
+    test_assert(cqe->user_data == (uint64_t)write_buf);
+    for (int i = 0; i < BUF_SIZE; i++)
+        test_assert(read_buf[i] == (i & 0xFF));
+
+    test_assert(iour_exit(&iour) == 0);
+
+    /* Close file descriptor without waiting for CQE. */
+    test_assert(iour_init(&iour, 1) == 0);
+    iour_setup_read(&iour, fd, read_buf, BUF_SIZE, 0, 0);
+    test_assert(iour_submit(&iour, 1, 0) == 1);
+    test_assert(iour_exit(&iour) == 0);
+
+    test_assert(close(fd) == 0);
+}
+
+static void iour_test_eventfd(void)
+{
+    int fd;
+    struct iour iour;
+    int ret;
+    int efd;
+    uint64_t efd_val;
+    struct io_uring_cqe *cqe;
+    fd_set select_fd;
+    struct timeval timeout;
+
+    fd = open("file_efd", O_RDWR | O_CREAT, S_IRWXU);
+    test_assert(fd > 0);
+
+    memset(&iour.params, 0, sizeof(iour.params));
+    test_assert(iour_init(&iour, 1) == 0);
+
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_EVENTFD, NULL,
+        1); /* invalid pointer */
+    test_assert((ret == -1) && (errno == EFAULT));
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_EVENTFD, &efd,
+        0); /* invalid number of file descriptors */
+    test_assert((ret == -1) && (errno == EINVAL));
+    efd = -1; /* invalid file descriptor */
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_EVENTFD, &efd,
+        1);
+    test_assert((ret == -1) && (errno == EBADF));
+    efd = 0; /* non-eventfd file descriptor */
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_EVENTFD, &efd,
+        1);
+    test_assert((ret == -1) && (errno == EINVAL));
+
+    efd = eventfd(0, 0);
+    test_assert(efd > 0);
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_EVENTFD, &efd,
+        1);
+    test_assert(ret == 0);
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_EVENTFD, &efd,
+        1);
+    test_assert((ret == -1) && (errno == EBUSY));
+
+    iour_setup_write(&iour, fd, (uint8_t *)"test", strlen("test"), 0, 0);
+    test_assert(iour_submit(&iour, 1, 0) == 1);
+    test_assert(read(efd, &efd_val, sizeof(efd_val)) == sizeof(efd_val));
+    test_assert(efd_val == 1);
+
+    /* The CQE should now be available. */
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == strlen("test")));
+
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_UNREGISTER_EVENTFD,
+        NULL, 0);
+    test_assert(ret == 0);
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_UNREGISTER_EVENTFD,
+        NULL, 0);
+    test_assert((ret == -1) && (errno == ENXIO));
+
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_EVENTFD_ASYNC,
+        &efd, 1);
+    test_assert(ret == 0);
+
+    iour_setup_nop(&iour, 0);   /* this operation completes inline */
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    FD_ZERO(&select_fd);
+    FD_SET(efd, &select_fd);
+    timeout.tv_sec = 0;
+    timeout.tv_usec = 0;
+    test_assert(select(efd + 1, &select_fd, NULL, NULL, &timeout) == 0);
+
+    /* Write operations complete asynchronously. */
+    iour_setup_write(&iour, fd, (uint8_t *)"test", strlen("test"), 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    FD_ZERO(&select_fd);
+    FD_SET(efd, &select_fd);
+    test_assert(select(efd + 1, &select_fd, NULL, NULL, &timeout) == 1);
+    test_assert(FD_ISSET(efd, &select_fd));
+
+    test_assert(close(efd) == 0);
+    test_assert(iour_exit(&iour) == 0);
+    test_assert(close(fd) == 0);
+}
+
+static void iour_test_multiple(void)
+{
+    int fd;
+    struct iour iour;
+    uint8_t read_buf[BUF_SIZE], write_buf[BUF_SIZE];
+    const int chunk_len = 8;
+    const int chunk_count = BUF_SIZE / chunk_len;
+    struct io_uring_cqe *cqe;
+
+    fd = open("file_mult", O_RDWR | O_CREAT, S_IRWXU);
+    test_assert(fd > 0);
+
+    memset(&iour.params, 0, sizeof(iour.params));
+    test_assert(iour_init(&iour, chunk_count) == 0);
+
+    for (int i = 0; i < BUF_SIZE; i++) {
+        write_buf[i] = i;
+    }
+    for (int i = 0; i < chunk_count; i++)
+        iour_setup_write(&iour, fd, write_buf + i * chunk_len, chunk_len,
+            i * chunk_len, (uint64_t)write_buf);
+    test_assert(iour_submit(&iour, chunk_count, chunk_count) == chunk_count);
+    for (int i = 0; i < chunk_count; i++) {
+        cqe = iour_get_cqe(&iour);
+        test_assert(cqe && (cqe->res == chunk_len));
+        test_assert(cqe->user_data == (uint64_t)write_buf);
+        iour_setup_read(&iour, fd, read_buf + i * chunk_len, chunk_len,
+                        i * chunk_len, (uint64_t)read_buf);
+    }
+    test_assert(iour_submit(&iour, chunk_count, chunk_count) == chunk_count);
+    for (int i = 0; i < chunk_count; i++) {
+        cqe = iour_get_cqe(&iour);
+        test_assert(cqe && (cqe->res == chunk_len));
+        test_assert(cqe->user_data == (uint64_t)read_buf);
+    }
+    for (int i = 0; i < BUF_SIZE; i++) {
+        test_assert(read_buf[i] == (i & 0xFF));
+    }
+
+    test_assert(lseek(fd, 0, SEEK_CUR) == 0);
+    iour_setup_read(&iour, fd, read_buf, chunk_len, -1, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    test_assert(lseek(fd, 0, SEEK_CUR) == chunk_len);
+
+    test_assert(iour_exit(&iour) == 0);
+    test_assert(close(fd) == 0);
+}
+
+static void iour_test_iovec(void)
+{
+    int fd;
+    struct iour iour;
+    uint8_t read_buf[BUF_SIZE], write_buf[BUF_SIZE];
+    const int chunk_len = 64;
+    const int chunk_count = BUF_SIZE / chunk_len;
+    struct iovec iov[chunk_count];
+    struct io_uring_cqe *cqe;
+
+    fd = open("file_iov", O_RDWR | O_CREAT, S_IRWXU);
+    test_assert(fd > 0);
+
+    memset(&iour.params, 0, sizeof(iour.params));
+    test_assert(iour_init(&iour, 1) == 0);
+
+    iov[0].iov_base = NULL;
+    iov[0].iov_len = chunk_len;
+    iour_setup_writev(&iour, fd, iov, 1, 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == -EFAULT));
+
+    for (int i = 0; i < BUF_SIZE; i++)
+        write_buf[i] = i;
+    for (int i = 0; i < chunk_count; i++) {
+        iov[i].iov_base = write_buf + i * chunk_len;
+        iov[i].iov_len = chunk_len;
+    }
+    iour_setup_writev(&iour, fd, iov, chunk_count, -1, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == BUF_SIZE));
+    test_assert(lseek(fd, 0, SEEK_CUR) == BUF_SIZE);
+
+    /* Set file offset to arbitrary value and check that it has not changed
+     * after the read operation. */
+    test_assert(lseek(fd, BUF_SIZE / 2, SEEK_SET) == BUF_SIZE / 2);
+    for (int i = 0; i < chunk_count; i++)
+        iov[i].iov_base = read_buf + i * chunk_len;
+    iour_setup_readv(&iour, fd, iov, chunk_count, 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == BUF_SIZE));
+    for (int i = 0; i < BUF_SIZE; i++)
+        test_assert(read_buf[i] == (i & 0xFF));
+    test_assert(lseek(fd, 0, SEEK_CUR) == BUF_SIZE / 2);
+
+    test_assert(iour_exit(&iour) == 0);
+    test_assert(close(fd) == 0);
+}
+
+static void iour_test_rw_fixed(void)
+{
+    int fd;
+    struct iour iour;
+    uint8_t read_buf[BUF_SIZE], write_buf[BUF_SIZE];
+    struct iovec iov[2];
+    int ret;
+    struct io_uring_cqe *cqe;
+
+    fd = open("file_rw_fixed", O_RDWR | O_CREAT, S_IRWXU);
+    test_assert(fd > 0);
+
+    memset(&iour.params, 0, sizeof(iour.params));
+    test_assert(iour_init(&iour, 1) == 0);
+
+    iour_setup_rw_fixed(&iour, fd, 0, true, write_buf, sizeof(write_buf), 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == -EFAULT));
+
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_BUFFERS, NULL,
+        1);
+    test_assert((ret == -1) && (errno == EFAULT));
+
+    iov[0].iov_base = write_buf;
+    iov[0].iov_len = BUF_SIZE;
+    iov[1].iov_base = read_buf;
+    iov[1].iov_len = BUF_SIZE;
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_BUFFERS, iov,
+        0);
+    test_assert((ret == -1) && (errno == EINVAL));
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_BUFFERS, iov,
+        2);
+    test_assert(ret == 0);
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_BUFFERS, iov,
+        2);
+    test_assert((ret == -1) && (errno == EBUSY));
+
+    iour_setup_rw_fixed(&iour, fd, 2, true, write_buf, sizeof(write_buf), 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == -EINVAL));  /* invalid buffer index */
+
+    /* Mismatch between buffer index and buffer pointer */
+    iour_setup_rw_fixed(&iour, fd, 0, true, read_buf, sizeof(read_buf), 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == -EFAULT));
+
+    iour_setup_rw_fixed(&iour, fd, 0, true, write_buf, sizeof(write_buf) + 1, 0,
+                        0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == -EFAULT));  /* invalid buffer length */
+
+    for (int i = 0; i < BUF_SIZE; i++)
+        write_buf[i] = i;
+    iour_setup_rw_fixed(&iour, fd, 0, true, write_buf, sizeof(write_buf), 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == BUF_SIZE));
+
+    iour_setup_rw_fixed(&iour, fd, 1, false, read_buf, sizeof(read_buf), 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == BUF_SIZE));
+    for (int i = 0; i < BUF_SIZE; i++)
+        test_assert(read_buf[i] == (i & 0xFF));
+
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_UNREGISTER_BUFFERS,
+        NULL, 0);
+    test_assert(ret == 0);
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_UNREGISTER_BUFFERS,
+        NULL, 0);
+    test_assert((ret == -1) && (errno == ENXIO));
+
+    test_assert(iour_exit(&iour) == 0);
+    test_assert(close(fd) == 0);
+}
+
+static void iour_test_poll(void)
+{
+    struct iour iour;
+    int pipe_fds[2];
+    uint8_t pipe_buf[8];
+    struct io_uring_cqe *cqe;
+
+    memset(&iour.params, 0, sizeof(iour.params));
+    test_assert(iour_init(&iour, 2) == 0);
+
+    test_assert(pipe(pipe_fds) == 0);
+
+    iour_setup_poll_add(&iour, pipe_fds[1], POLLOUT, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == POLLOUT));
+
+    iour_setup_poll_add(&iour, pipe_fds[0], POLLIN, 0);
+    test_assert(iour_submit(&iour, 1, 0) == 1);
+    test_assert(iour_get_cqe(&iour) == NULL);
+
+    test_assert(write(pipe_fds[1], pipe_buf, sizeof(pipe_buf)) ==
+            sizeof(pipe_buf));
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == POLLIN));
+    test_assert(read(pipe_fds[0], pipe_buf, sizeof(pipe_buf)) ==
+            sizeof(pipe_buf));
+
+    iour_setup_poll_add(&iour, pipe_fds[0], POLLIN, 0);
+    iour_setup_poll_remove(&iour, 0, 0);
+    test_assert(iour_submit(&iour, 2, 2) == 2);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == -ECANCELED));
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == 0));
+
+    iour_setup_poll_remove(&iour, 0xdeadbeef, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->res == -ENOENT));
+
+    test_assert(iour_exit(&iour) == 0);
+    test_assert(close(pipe_fds[0]) == 0);
+    test_assert(close(pipe_fds[1]) == 0);
+}
+
+static void iour_test_timeout(void)
+{
+    struct iour iour;
+    struct timespec ts1, ts2;
+    const uint64_t t1_userdata = 1;
+    const uint64_t t2_userdata = 2;
+    struct io_uring_cqe *cqe;
+
+    memset(&iour.params, 0, sizeof(iour.params));
+    test_assert(iour_init(&iour, 2) == 0);
+
+    iour_setup_timeout(&iour, NULL, 0, 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == -EFAULT));
+
+    ts1.tv_sec = 1000000;
+    ts1.tv_nsec = 0;
+    iour_setup_timeout(&iour, &ts1, 1, 0, t1_userdata);
+    iour_setup_nop(&iour, 0);
+    test_assert(iour_submit(&iour, 2, 2) == 2);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == 0));
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == t1_userdata) && (cqe->res == 0));
+
+    test_assert(clock_gettime(CLOCK_MONOTONIC, &ts1) == 0);
+    ts2.tv_sec = ts1.tv_sec;
+    ts2.tv_nsec = ts1.tv_nsec + 1000000;
+    if (ts2.tv_nsec >= 1000000000) {
+        ts2.tv_sec++;
+        ts2.tv_nsec -= 1000000000;
+    }
+    iour_setup_timeout(&iour, &ts2, 0, IORING_TIMEOUT_ABS, t2_userdata);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == t2_userdata) && (cqe->res == -ETIME));
+
+    ts1.tv_sec = 1000000;
+    ts1.tv_nsec = 0;
+    iour_setup_timeout(&iour, &ts1, 0, 0, t1_userdata);
+    iour_setup_timeout_remove(&iour, t1_userdata, 0);
+    test_assert(iour_submit(&iour, 2, 2) == 2);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == t1_userdata) &&
+                (cqe->res == -ECANCELED));
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == 0));
+
+    iour_setup_timeout_remove(&iour, 0xdeadbeef, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == -ENOENT));
+
+    ts1.tv_sec = 0;
+    ts1.tv_nsec = 1000000;
+    iour_setup_timeout(&iour, &ts1, 0, 0, t1_userdata);
+    ts2.tv_sec = 1;
+    ts2.tv_nsec = 0;
+    iour_setup_timeout(&iour, &ts2, 0, 0, t2_userdata);
+    test_assert(iour_submit(&iour, 2, 2) == 2);
+    /* The first timeout wakes up this thread even if fewer than `min_complete`
+     * operations have completed. */
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe);
+    test_assert((cqe->user_data == t1_userdata) && (cqe->res == -ETIME));
+    test_assert(iour_get_cqe(&iour) == NULL);
+
+    test_assert(iour_exit(&iour) == 0);
+}
+
+static void iour_test_close(void)
+{
+    struct iour iour;
+    int fd, fd1;
+    const uint64_t close_userdata = 1;
+    struct io_uring_cqe *cqe;
+
+    memset(&iour.params, 0, sizeof(iour.params));
+    test_assert(iour_init(&iour, 1) == 0);
+
+    fd = open("file_close", O_RDWR | O_CREAT, S_IRWXU);
+    test_assert(fd > 0);
+    iour_setup_close(&iour, fd, close_userdata);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == close_userdata) && (cqe->res == 0));
+    test_assert((close(fd) == -1) && (errno == EBADF));
+
+    /* Close fd without de-allocating file resources (because of duplicated fd).
+     */
+    fd = open("file_close", O_RDWR | O_CREAT, S_IRWXU);
+    test_assert(fd > 0);
+    fd1 = dup(fd);
+    test_assert(fd1 > 0);
+    iour_setup_close(&iour, fd, close_userdata);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == close_userdata) && (cqe->res == 0));
+    test_assert(close(fd1) == 0);
+
+    /* Close invalid fd. */
+    iour_setup_close(&iour, fd, close_userdata);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe);
+    test_assert((cqe->user_data == close_userdata) && (cqe->res == -EBADF));
+
+    /* Close fd of io_uring context. */
+    iour_setup_close(&iour, iour.fd, close_userdata);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe);
+    test_assert((cqe->user_data == close_userdata) && (cqe->res == -EBADF));
+
+    test_assert(iour_exit(&iour) == 0);
+}
+
+static void iour_test_sig(void)
+{
+    struct iour iour;
+    sigset_t old, new;
+    int ret;
+    struct io_uring_cqe *cqe;
+
+    memset(&iour.params, 0, sizeof(iour.params));
+    test_assert(iour_init(&iour, 1) == 0);
+
+    test_assert(sigprocmask(SIG_SETMASK, NULL, &old) == 0);
+    memcpy(&new, &old, sizeof(sigset_t));
+    test_assert(sigaddset(&new, SIGUSR1) == 0);
+    test_assert(memcmp(&new, &old, sizeof(sigset_t)) != 0);
+
+    iour_setup_nop(&iour, 0);
+    ret = syscall(SYS_io_uring_enter, iour.fd, 1, 0, 0, -1L);
+    test_assert((ret == -1) && (errno == EFAULT)); /* invalid sig pointer */
+    ret = syscall(SYS_io_uring_enter, iour.fd, 1, 1, IORING_ENTER_GETEVENTS,
+        &new);
+    test_assert(ret == 1);
+    test_assert(sigprocmask(SIG_SETMASK, NULL, &new) == 0);
+    test_assert(memcmp(&new, &old, sizeof(sigset_t)) == 0);
+
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == 0));
+
+    test_assert(iour_exit(&iour) == 0);
+}
+
+static void iour_test_register_files(void)
+{
+    struct iour iour;
+    int fds[3];
+    int ret;
+    struct io_uring_cqe *cqe;
+    struct io_uring_files_update update;
+
+    memset(&iour.params, 0, sizeof(iour.params));
+    test_assert(iour_init(&iour, 1) == 0);
+
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_FILES, NULL,
+        3); /* invalid file descriptor array pointer */
+    test_assert((ret == -1) && (errno == EFAULT));
+
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_FILES, fds,
+        0); /* invalid number of file descriptors */
+    test_assert((ret == -1) && (errno == EINVAL));
+
+    fds[0] = 0;
+    fds[1] = 1;
+    fds[2] = -2;    /* invalid file descriptor */
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_FILES, fds,
+        3);
+    test_assert((ret == -1) && (errno == EBADF));
+
+    fds[2] = 2;
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_FILES, fds,
+        3);
+    test_assert(ret == 0);
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_FILES, fds,
+        3);
+    test_assert((ret == -1) && (errno == EBUSY));
+
+    iour_setup_poll_fixed_file(&iour, 1, POLLOUT, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == POLLOUT));
+
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_FILES_UPDATE,
+        NULL, 1);   /* invalid pointer */
+    test_assert((ret == -1) && (errno == EFAULT));
+
+    iour_setup_files_update(&iour, fds, 0, 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == -EINVAL));
+
+    iour_setup_files_update(&iour, NULL, 1, 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == -EFAULT));
+
+    iour_setup_files_update(&iour, fds, 3, 1, 0);   /* invalid length/offset */
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == -EINVAL));
+
+    fds[0] = 0xdeadbeef;    /* invalid fd */
+    iour_setup_files_update(&iour, fds, 3, 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == -EBADF));
+
+    fds[0] = 0;
+    fds[1] = -1;    /* unregister fd */
+    fds[2] = 0xdeadbeef;    /* invalid fd */
+    update.offset = 0;
+    update.fds = fds;
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_REGISTER_FILES_UPDATE,
+        &update, 3);
+    test_assert(ret == 2);
+    iour_setup_poll_fixed_file(&iour, 1, POLLOUT, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == -EBADF));
+
+    fds[1] = 1;
+    fds[2] = 2;
+    iour_setup_files_update(&iour, fds, 3, 0, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == 3));
+    iour_setup_poll_fixed_file(&iour, 1, POLLOUT, 0);
+    test_assert(iour_submit(&iour, 1, 1) == 1);
+    cqe = iour_get_cqe(&iour);
+    test_assert(cqe && (cqe->user_data == 0) && (cqe->res == POLLOUT));
+
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_UNREGISTER_FILES, NULL,
+        0);
+    test_assert(ret == 0);
+    ret = syscall(SYS_io_uring_register, iour.fd, IORING_UNREGISTER_FILES, NULL,
+        0);
+    test_assert((ret == -1) && (errno == ENXIO));
+    test_assert(iour_exit(&iour) == 0);
+}
+
+int main(int argc, char **argv)
+{
+    setbuf(stdout, NULL);
+
+    iour_test_basic();
+    iour_test_readwrite();
+    iour_test_eventfd();
+    iour_test_multiple();
+    iour_test_iovec();
+    iour_test_rw_fixed();
+    iour_test_poll();
+    iour_test_timeout();
+    iour_test_close();
+    iour_test_sig();
+    iour_test_register_files();
+    printf("IO uring test OK\n");
+    return EXIT_SUCCESS;
+}

--- a/test/runtime/io_uring.manifest
+++ b/test/runtime/io_uring.manifest
@@ -1,0 +1,18 @@
+(
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
+        io_uring:(contents:(host:output/test/runtime/bin/io_uring))
+        etc:(children:(ld.so.cache:(contents:(host:/etc/ld.so.cache)) passwd:(contents:(host:/etc/passwd)) group:(contents:(host:/etc/group))))
+    )
+    program:/io_uring
+#    trace:t
+#    debugsyscalls:t
+#    futex_trace:t
+    fault:t
+    environment:()
+    imagesize:30M
+)


### PR DESCRIPTION
Supported operations are nop, readv, writev, read_fixed, write_fixed, poll_add, poll_remove, timeout, timeout_remove, close, files_update, read, and write.
A new vmap flag, VMAP_FLAG_PREALLOC, is being defined in order to support mapping and unmapping pre-allocated memory regions.
