### PR TITLE
mkdir/mkdirat: fix directory creation when path ends with '/'

### DIFF
--- a/src/runtime/text.h
+++ b/src/runtime/text.h
@@ -146,14 +146,17 @@ static inline const u8 *utf8_find(const u8 *x, character c)
     return false;
 }
 
-static inline const u8 *utf8_find_r(const u8 *x, character c)
+static inline const u8 *utf8_findn_r(const u8 *x, bytes n, character c)
 {
+    if (!x)
+        return false;
     int nbytes;
+    bytes offset = 0;
     const u8 *found = false;
 
-    while (x && *x) {
-        if (utf8_decode(x, &nbytes) == c) found = x;
-        x += nbytes;
+    while ((offset < n) && *(x + offset)) {
+        if (utf8_decode(x + offset, &nbytes) == c) found = x + offset;
+        offset += nbytes;
     }
     return found;
 }

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -57,6 +57,36 @@ static inline const char *filename_from_path(const char *path)
     return filename;
 }
 
+/* Expects an empty buffer, and never resizes the buffer. */
+static inline boolean dirname_from_path(buffer dest, const char *path)
+{
+    int pathlen = runtime_strlen(path);
+    const char *last_delim = path_find_last_delim(path, PATH_MAX);
+    const char *dirname;
+    int len;
+    if (!last_delim) {
+        dirname = path;
+        len = pathlen;
+    } else if (last_delim < path + pathlen - 1) {
+        dirname = last_delim + 1;
+        len = pathlen - (dirname - path);
+    } else {    /* The path ends with '/'. */
+        const char *delim = path_find_last_delim(path, last_delim - path);
+        if (!delim) {
+            dirname = path;
+            len = pathlen - 1;
+        } else {
+            dirname = delim + 1;
+            len = last_delim - dirname;
+        }
+    }
+    if (len >= dest->length)
+        return false;
+    buffer_write(dest, dirname, len);
+    push_u8(dest, '\0');
+    return true;
+}
+
 int resolve_cstring(tuple cwd, const char *f, tuple *entry, tuple *parent);
 
 /* Same as resolve_cstring(), except that if the entry is a symbolic link this

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -41,9 +41,14 @@ static inline symbol lookup_sym(tuple parent, tuple t)
     return false;
 }
 
+static inline char *path_find_last_delim(const char *path, unsigned int len)
+{
+    return (char *)utf8_findn_r((u8 *)path, len, '/');
+}
+
 static inline const char *filename_from_path(const char *path)
 {
-    const char *filename = (char *) utf8_find_r((u8 *) path, '/');
+    const char *filename = path_find_last_delim(path, PATH_MAX);
     if (!filename) {
         filename = path;
     } else {

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -969,9 +969,12 @@ static sysreturn mkdir_internal(tuple cwd, const char *pathname, int mode)
     if ((ret != -ENOENT) || !parent) {
         return set_syscall_return(current, ret);
     }
+    buffer b = little_stack_buffer(NAME_MAX + 1);
+    if (!dirname_from_path(b, pathname))
+        return -ENAMETOOLONG;
     filesystem_update_mtime(current->p->fs, parent);
     file_op_begin(current);
-    filesystem_mkdir(current->p->fs, parent, filename_from_path(pathname),
+    filesystem_mkdir(current->p->fs, parent, (char *)buffer_ref(b, 0),
             closure(heap_general(get_kernel_heaps()), mkdir_complete, current));
     return file_op_maybe_sleep(current);
 }

--- a/test/runtime/mkdir.c
+++ b/test/runtime/mkdir.c
@@ -77,6 +77,8 @@ void _mkdir(const char *path, int m)
     int dfd = open(path, O_RDONLY | O_DIRECTORY);
     if (dfd == -1) {
         printf("dfd = %d, for %s, errno = %d\n", dfd, path, errno);
+        if (!r) /* couldn't open the directory after having created it */
+            exit(EXIT_FAILURE);
     } else {
         close(dfd);
         printf("ok\n");
@@ -274,6 +276,7 @@ int main(int argc, char **argv)
     }
 
     _mkdir("/test", 0); check("/test");
+    _mkdir("/test_slash/", 0);
     _mkdir("/blurb/test/deep", 0);
     _mkdir("/test/subdir", 0); check("/test/subdir");
     _mkdir("/test/subdira", 0); check("/test/subdira");


### PR DESCRIPTION
mkdir() and mkdirat() should detect if the supplied path ends with the '/' delimiter, and strip the trailing delimiter if found. The newly defined dirname_from_path() function implements this.

The mkdir suite of runtime tests has been modified so that it would fail if the above was not implemented correctly.