### PR TITLE
allocate_fd(): fail gracefully if descriptor cannot be allocated

### DIFF
--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -82,25 +82,28 @@ static inline bytes buffer_set_capacity(buffer b, bytes len)
     return len;
 }
 
-static inline void buffer_extend(buffer b, bytes len)
+static inline boolean buffer_extend(buffer b, bytes len)
 {
     // xxx - pad to pagesize
     if (b->length < (b->end + len)) {
         bytes new_len = 2 * (b->end - b->start + len);
-        assert(buffer_set_capacity(b, new_len) == new_len);
+        return (buffer_set_capacity(b, new_len) == new_len);
     }
+    return true;
 }
 
-static inline void extend_total(buffer b, int offset)
+static inline boolean extend_total(buffer b, int offset)
 {
     if (offset > b->end) {
-        buffer_extend(b, offset - b->end);
+        if (!buffer_extend(b, offset - b->end))
+            return false;
         // shouldn't need to in all cases - this is to preserve
         // the idea of the vector as a mapping - we need a reliable
         // sigleton to denote an empty slot
         zero(b->contents + b->end, offset - b->end);
         b->end = offset;
     }
+    return true;
 }
 
 static inline buffer wrap_buffer(heap h,

--- a/src/runtime/vector.h
+++ b/src/runtime/vector.h
@@ -12,11 +12,13 @@ static inline void *vector_get(vector v, int offset)
     return res;
 }
 
-static inline void vector_set(vector v, int offset, void *value)
+static inline boolean vector_set(vector v, int offset, void *value)
 {
     bytes base = v->start + offset * sizeof(void *);
-    extend_total(v, (offset + 1) *sizeof(void *));
+    if (!extend_total(v, (offset + 1) * sizeof(void *)))
+        return false;
     runtime_memcpy(v->contents + base, &value, sizeof(void *));
+    return true;
 }
 
 static inline int vector_length(vector v)

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -17,7 +17,10 @@ u64 allocate_fd(process p, void *f)
 	msg_err("fail; maxed out\n");
 	return fd;
     }
-    vector_set(p->files, fd, f);
+    if (!vector_set(p->files, fd, f)) {
+        deallocate_u64((heap)p->fdallocator, fd, 1);
+        fd = INVALID_PHYSICAL;
+    }
     return fd;
 }
 


### PR DESCRIPTION
File descriptor allocation is triggered by userspace, thus if the allocation fails it should fail gracefully instead of triggering an assertion failure.
This commit fixes the "assertion buffer_set_capacity(b, new_len) == new_len failed in src/runtime/buffer.h: buffer_extend() on line 90; halt" error that happens if the application tries to open more files than the system can handle.
vector_set(), extend_total() and buffer_extend() have been modified in order to return a boolean value indicating whether the operation was successful.