### PR TITLE
id_heap_alloc_gte(): search for non-allocated ids starting from min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ test test-noaccel: mkfs boot stage3
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat epoll eventfd fallocate fcntl fst getdents getrandom hw hws mkdir mmap pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fallocate fcntl fst getdents getrandom hw hws mkdir mmap pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -341,3 +341,14 @@ id_heap create_id_heap_backed(heap meta, heap map, heap parent, bytes pagesize)
     }
     return i;
 }
+
+void id_heap_set_next(id_heap h, u64 next)
+{
+    rangemap_foreach(h->ranges, n) {
+        id_range r = (id_range)n;
+        if (point_in_range(r->n.r, next))
+            r->next_bit = next;
+        else if (r->n.r.start > next)
+            r->next_bit = 0;
+    }
+}

--- a/src/runtime/heap/id.h
+++ b/src/runtime/heap/id.h
@@ -23,7 +23,13 @@ id_heap allocate_id_heap(heap meta, heap map, bytes pagesize); /* id heap with n
 #define id_heap_set_randomize(__h, __r) ((__h)->set_randomize(__h, __r))
 #define id_heap_alloc_subrange(__h, __c, __s, __e) ((__h)->alloc_subrange(__h, __c, __s, __e))
 
+/* Provides a hint as to what id should be allocated next. */
+void id_heap_set_next(id_heap h, u64 next);
+
+/* If count == 1, the return value is guaranteed to be the lowest-numbered
+ * non-allocated id starting from min. */
 static inline u64 id_heap_alloc_gte(id_heap h, bytes count, u64 min)
 {
+    id_heap_set_next(h, min);
     return id_heap_alloc_subrange(h, count, min, infinity);
 }


### PR DESCRIPTION
If the count argument passed to id_heap_alloc_gte() is 1, the return value is guaranteed to be the lowest-numbered non-allocated id starting from the min argument.
This is needed to correctly implement the semantics of dup2() and fcntl(F_DUPFD).
Now that the dup runtime test passes, it is being added to the set of CI-enforced tests. The fcntl runtime test has been amended with a new test case that would have failed without this commit.

Closes #1012.