### PR TITLE
Kernel ELF file: move from root filesystem to boot filesystem

### DIFF
--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -8,6 +8,7 @@ struct partition_entry {
 } __attribute__((packed));
 
 enum partition {
+    PARTITION_BOOTFS,
     PARTITION_ROOTFS,
 };
 

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -1,0 +1,47 @@
+struct partition_entry {
+    u8 active;
+    u8 chs_start[3];
+    u8 type;
+    u8 chs_end[3];
+    u32 lba_start;
+    u32 nsectors;
+} __attribute__((packed));
+
+enum partition {
+    PARTITION_ROOTFS,
+};
+
+#define SEC_PER_TRACK 63
+#define HEADS 255
+#define MAX_CYL 1023
+
+#define partition_get(mbr, index)    \
+    (struct partition_entry *)((u64)(mbr) + SECTOR_SIZE - 2 - \
+    (4 - (index)) * sizeof(struct partition_entry))
+
+static inline void mbr_chs(u8 *chs, u64 offset)
+{
+    u64 cyl = ((offset / SECTOR_SIZE) / SEC_PER_TRACK) / HEADS;
+    u64 head = ((offset / SECTOR_SIZE) / SEC_PER_TRACK) % HEADS;
+    u64 sec = ((offset / SECTOR_SIZE) % SEC_PER_TRACK) + 1;
+    if (cyl > MAX_CYL) {
+        cyl = MAX_CYL;
+    head = 254;
+    sec = 63;
+    }
+
+    chs[0] = head;
+    chs[1] = (cyl >> 8) | sec;
+    chs[2] = cyl & 0xff;
+}
+
+static inline void partition_write(struct partition_entry *e, boolean active,
+                                   u8 type, u64 offset, u64 size)
+{
+    e->active = active ? 0x80 : 0x00;
+    e->type = type;
+    mbr_chs(e->chs_start, offset);
+    mbr_chs(e->chs_end, offset + size - SECTOR_SIZE);
+    e->lba_start = offset / SECTOR_SIZE;
+    e->nsectors = size / SECTOR_SIZE;
+}

--- a/src/runtime/uniboot.h
+++ b/src/runtime/uniboot.h
@@ -1,5 +1,7 @@
 #include <predef.h>
 
+#define BOOTFS_SIZE (8 * MB)
+
 #define KMEM_BASE   0xffff800000000000ull
 #define KERNEL_BASE 0xffffffff80000000ull
 #define KMEM_LIMIT  0xffffffff00000000ull

--- a/src/runtime/x86.h
+++ b/src/runtime/x86.h
@@ -1,3 +1,5 @@
+#define MBR_ADDRESS 0x7c00
+
 static inline word fetch_and_add(word *variable, word value)
 {
     asm volatile("lock; xadd %0, %1" : "+r" (value), "+m" (*variable) :: "memory", "cc");

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -7,6 +7,7 @@
 #include <apic.h>
 #include <region.h>
 #include <page.h>
+#include <storage.h>
 #include <symtab.h>
 #include <virtio/virtio.h>
 #include <vmware/vmxnet3.h>
@@ -407,13 +408,11 @@ static void __attribute__((noinline)) init_service_new_stack()
 
     init_debug("probe fs, register storage drivers");
     root = allocate_tuple();
-    u64 fs_offset = 0;
-    for_regions(e) {
-        if (e->type == REGION_FILESYSTEM)
-            fs_offset = SECTOR_SIZE + e->length;
-    }
-    if (fs_offset == 0)
-        halt("filesystem region not found; halt\n");
+    struct partition_entry *rootfs_part = partition_get(MBR_ADDRESS,
+        PARTITION_ROOTFS);
+    if (!rootfs_part)
+        halt("filesystem partition not found; halt\n");
+    u64 fs_offset = rootfs_part->lba_start * SECTOR_SIZE;
     init_storage(kh, closure(misc, attach_storage, root, fs_offset));
 
     /* Probe for PV devices */

--- a/test/runtime/aio.manifest
+++ b/test/runtime/aio.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      aio:(contents:(host:output/test/runtime/bin/aio))
 	      )

--- a/test/runtime/creat.c
+++ b/test/runtime/creat.c
@@ -58,7 +58,7 @@ void check(const char *path, int expect)
 
 int main(int argc, char **argv)
 {
-    check("/kernel", 0);
+    check("/creat", 0);
     _creat("/test", 0, 0);
     check("/test", 0);
     _creat("/blurb/test/deep", 0, ENOENT);

--- a/test/runtime/creat.manifest
+++ b/test/runtime/creat.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      creat:(contents:(host:output/test/runtime/bin/creat))
 	      )

--- a/test/runtime/dup.manifest
+++ b/test/runtime/dup.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      dup:(contents:(host:output/test/runtime/bin/dup))
 	      )

--- a/test/runtime/epoll.manifest
+++ b/test/runtime/epoll.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      epoll:(contents:(host:output/test/runtime/bin/epoll))
 	      )

--- a/test/runtime/eventfd.manifest
+++ b/test/runtime/eventfd.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
 	      #user program
 	      eventfd:(contents:(host:output/test/runtime/bin/eventfd))
 	      )

--- a/test/runtime/fallocate.manifest
+++ b/test/runtime/fallocate.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      fallocate:(contents:(host:output/test/runtime/bin/fallocate))
 	      )

--- a/test/runtime/fcntl.manifest
+++ b/test/runtime/fcntl.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      fcntl:(contents:(host:output/test/runtime/bin/fcntl))
 	      )

--- a/test/runtime/fst.manifest
+++ b/test/runtime/fst.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      fst:(contents:(host:output/test/runtime/bin/fst))
           a:(children:(hello:(contents:(host:test/runtime/getdents_contents/a/hello))))

--- a/test/runtime/ftrace.manifest
+++ b/test/runtime/ftrace.manifest
@@ -1,7 +1,11 @@
 (
     #64 bit elf to boot from host
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
     children:(
-	kernel:(contents:(host:output/stage3/bin/stage3.img))
         ftrace:(contents:(host:output/test/runtime/bin/ftrace))
 	infile:(contents:(host:test/runtime/read_contents/hello))
     )

--- a/test/runtime/getdents.manifest
+++ b/test/runtime/getdents.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
               getdents:(contents:(host:output/test/runtime/bin/getdents))
 	      a:(children:(hello:(contents:(host:test/runtime/getdents_contents/a/hello))))

--- a/test/runtime/getrandom.manifest
+++ b/test/runtime/getrandom.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      getrandom:(contents:(host:output/test/runtime/bin/getrandom))
 	      )

--- a/test/runtime/hw.manifest
+++ b/test/runtime/hw.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      hw:(contents:(host:output/test/runtime/bin/hw))
 	      etc:(children:(ld.so.cache:(contents:(host:/etc/ld.so.cache))))

--- a/test/runtime/hws.manifest
+++ b/test/runtime/hws.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
               hws:(contents:(host:output/test/runtime/bin/hws)))
     # filesystem path to elf for kernel to run

--- a/test/runtime/mkdir.manifest
+++ b/test/runtime/mkdir.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      mkdir:(contents:(host:output/test/runtime/bin/mkdir))
 	      )

--- a/test/runtime/mmap.manifest
+++ b/test/runtime/mmap.manifest
@@ -1,7 +1,11 @@
 (
     #64 bit elf to boot from host
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
     children:(
-	kernel:(contents:(host:output/stage3/bin/stage3.img))
         mmap:(contents:(host:output/test/runtime/bin/mmap))
 	infile:(contents:(host:test/runtime/read_contents/hello))
     )

--- a/test/runtime/nullpage.manifest
+++ b/test/runtime/nullpage.manifest
@@ -1,6 +1,10 @@
 (
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
     children:(
-        kernel:(contents:(host:output/stage3/bin/stage3.img))
         nullpage:(contents:(host:output/test/runtime/bin/nullpage))
     )
     program:/nullpage

--- a/test/runtime/paging.manifest
+++ b/test/runtime/paging.manifest
@@ -1,6 +1,10 @@
 (
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
     children:(
-        kernel:(contents:(host:output/stage3/bin/stage3.img))
         paging:(contents:(host:output/test/runtime/bin/paging))
     )
     program:/paging

--- a/test/runtime/pipe.manifest
+++ b/test/runtime/pipe.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      pipe:(contents:(host:output/test/runtime/bin/pipe))
 	      )

--- a/test/runtime/readv.manifest
+++ b/test/runtime/readv.manifest
@@ -1,6 +1,10 @@
 (
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
     children:(
-              kernel:(contents:(host:output/stage3/bin/stage3.img))
               readv:(contents:(host:output/test/runtime/bin/readv))
               hello:(contents:(host:test/runtime/read_contents/hello))
 	      )

--- a/test/runtime/rename.manifest
+++ b/test/runtime/rename.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      rename:(contents:(host:output/test/runtime/bin/rename))
 	      )

--- a/test/runtime/sendfile.manifest
+++ b/test/runtime/sendfile.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
           # files
    		  infile:(contents:(host:test/runtime/write_contents/infile))
 	      outfile:(contents:(host:test/runtime/write_contents/outfile))

--- a/test/runtime/signal.manifest
+++ b/test/runtime/signal.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      signal:(contents:(host:output/test/runtime/bin/signal))
 	      )

--- a/test/runtime/socketpair.manifest
+++ b/test/runtime/socketpair.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
 	      #user program
 	      socketpair:(contents:(host:output/test/runtime/bin/socketpair))
 	      )

--- a/test/runtime/symlink.manifest
+++ b/test/runtime/symlink.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      symlink:(contents:(host:output/test/runtime/bin/symlink))
 	      )

--- a/test/runtime/thread_test.manifest
+++ b/test/runtime/thread_test.manifest
@@ -1,5 +1,10 @@
 (
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
 	      tt:(contents:(host:output/test/runtime/bin/thread_test)))
     program:/tt
     arguments:[thread_test]

--- a/test/runtime/time.manifest
+++ b/test/runtime/time.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      time:(contents:(host:output/test/runtime/bin/time))
 	      )

--- a/test/runtime/udploop.manifest
+++ b/test/runtime/udploop.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
               udploop:(contents:(host:output/test/runtime/bin/udploop)))
     # filesystem path to elf for kernel to run

--- a/test/runtime/unixsocket.manifest
+++ b/test/runtime/unixsocket.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      unixsocket:(contents:(host:output/test/runtime/bin/unixsocket))
 	      )

--- a/test/runtime/unlink.c
+++ b/test/runtime/unlink.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
         printf("non-existing directory rmdir test failed\n");
         return EXIT_FAILURE;
     }
-    if ((rmdir("/kernel") == 0) || (errno != ENOTDIR)) {
+    if ((rmdir("/unlink") == 0) || (errno != ENOTDIR)) {
         printf("file rmdir test failed\n");
         return EXIT_FAILURE;
     }

--- a/test/runtime/unlink.manifest
+++ b/test/runtime/unlink.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      unlink:(contents:(host:output/test/runtime/bin/unlink))
 	      )

--- a/test/runtime/vsyscall.manifest
+++ b/test/runtime/vsyscall.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
 	      vsyscall:(contents:(host:output/test/runtime/bin/vsyscall))
 	      )

--- a/test/runtime/web.manifest
+++ b/test/runtime/web.manifest
@@ -1,6 +1,10 @@
 (
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
     children:(
-        kernel:(contents:(host:output/stage3/bin/stage3.img))
         web:(contents:(host:output/test/runtime/bin/web))
 	etc:(children:(
             ld.so.cache:(contents:(host:/etc/ld.so.cache))

--- a/test/runtime/webg.manifest
+++ b/test/runtime/webg.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
 	      #user program
 	      webg:(contents:(host:output/test/runtime/bin/webg))
 	      etc:(children:(ld.so.cache:(contents:(host:/etc/ld.so.cache)) resolv.conf:(contents:(host:test/runtime/resolv.conf))))

--- a/test/runtime/webs-poll.manifest
+++ b/test/runtime/webs-poll.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
               webs:(contents:(host:output/test/runtime/bin/webs)))
     # filesystem path to elf for kernel to run

--- a/test/runtime/webs-select.manifest
+++ b/test/runtime/webs-select.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
               webs:(contents:(host:output/test/runtime/bin/webs)))
     # filesystem path to elf for kernel to run

--- a/test/runtime/webs.manifest
+++ b/test/runtime/webs.manifest
@@ -1,6 +1,11 @@
 (
     #64 bit elf to boot from host
-    children:(kernel:(contents:(host:output/stage3/bin/stage3.img))
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
               #user program
               webs:(contents:(host:output/test/runtime/bin/webs)))
     # filesystem path to elf for kernel to run

--- a/test/runtime/write.manifest
+++ b/test/runtime/write.manifest
@@ -1,6 +1,10 @@
 (
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
     children:(
-    	      kernel:(contents:(host:output/stage3/bin/stage3.img))
               write:(contents:(host:output/test/runtime/bin/write))
               hello:(contents:(host:test/runtime/write_contents/hello))
 	      )

--- a/test/runtime/writev.manifest
+++ b/test/runtime/writev.manifest
@@ -1,6 +1,10 @@
 (
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
     children:(
-              kernel:(contents:(host:output/stage3/bin/stage3.img))
               writev:(contents:(host:output/test/runtime/bin/writev))
               hello:(contents:(host:test/runtime/write_contents/hello))
               )


### PR DESCRIPTION
This PR adds a new partition, containing the "boot filesystem", and moves the kernel file from the existing root filesystem to the new boot filesystem. This prevents the user process from accessing (and possibly overwriting) the kernel file.
As a side effect, stage2, which now loads the boot filesystem, no longer needs to load metadata for the entire root filesystem, which was unnecessary overhead at boot time.
The location of the root filesystem is no longer derived from the REGION_FILESYSTEM memory region, but is found from the MBR partition table.
The contents of the boot filesystem are specified in the manifest file via the "boot" tuple. If such tuple is not found in a given manifest, for backward compatibility the mkfs tool retrieves the kernel from the root tuple.