### PR TITLE
Socket syscalls: properly validate file descriptor number

### DIFF
--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -504,7 +504,7 @@ static unixsock unixsock_alloc(heap h, int type, u32 flags)
         msg_err("failed to allocate data buffer\n");
         goto err_queue;
     }
-    if (socket_init(current->p, h, type, flags, &s->sock) < 0) {
+    if (socket_init(current->p, h, AF_UNIX, type, flags, &s->sock) < 0) {
         msg_err("failed to initialize socket\n");
         goto err_socket;
     }

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -33,7 +33,7 @@ struct sock {
     sysreturn (*shutdown)(struct sock *sock, int how);
 };
 
-static inline int socket_init(process p, heap h, int type, u32 flags,
+static inline int socket_init(process p, heap h, int domain, int type, u32 flags,
         struct sock *s)
 {
     runtime_memset((u8 *) s, 0, sizeof(*s));
@@ -54,6 +54,7 @@ static inline int socket_init(process p, heap h, int type, u32 flags,
     }
     init_fdesc(h, &s->f, FDESC_TYPE_SOCKET);
     s->f.flags = flags;
+    s->domain = domain;
     s->type = type;
     s->h = h;
     return s->fd;


### PR DESCRIPTION
Every socket-related syscall must validate the supplied file descriptor number by not only checking that it corresponds to an open file descriptor, but also checking the file type and, if the file type is verified to be a socket, checking the socket domain; otherwise, it's unsafe to dereference the netsock pointer derived from the open file descriptor.
In addition, this allows user programs to call functions such as getsockopt() to check whether a given file descriptor is a socket descriptor (all socket-related syscalls must return -ENOTSOCK if called on a non-socket file descriptor).