### PR TITLE
AWS Firecracker support

### DIFF
--- a/boot/service32.s
+++ b/boot/service32.s
@@ -340,14 +340,13 @@ bios_tty_write:
 global run64        
 run64:
         mov eax, cr4     
-        or eax, CR4_PAE | CR4_OSFXSR | CR4_OSXMMEXCPT | CR4_OSXSAVE
+        or eax, CR4_PAE
         mov cr4, eax  
 
         mov ecx, 0xC0000080 ; EFER MSR.
         
         rdmsr      
         or eax, 1 << 8      ; Set the LM-bit which is the 9th bit (bit 8).
-        or eax, 1 << 11     ; NXE - enable no exec flag in page tables
         wrmsr
 
         pop edx                 ; return
@@ -358,7 +357,6 @@ run64:
 
         mov eax, cr0    
         or eax, 1 << 31 | 1 ; Set the PG-bit and the PM bit 
-        and eax, ~4 ; clear the EM bit
         mov cr0, eax
         
         ;; 64 bit compatibility into the proper long mode

--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -7,6 +7,7 @@
 #include <kvm_platform.h>
 #include <serial.h>
 #include <drivers/ata.h>
+#include <storage.h>
 
 //#define STAGE2_DEBUG
 //#define DEBUG_STAGE2_ALLOC

--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -343,10 +343,6 @@ static u64 stage2_allocator(heap h, bytes b)
     return result;
 }
 
-#define CR4_OSFXSR (1<<9)
-#define CR4_OSXMMEXCPT (1<<10)
-#define CR4_OSXSAVE (1<<18)
-
 void centry()
 {
     working_heap.alloc = stage2_allocator;
@@ -361,19 +357,6 @@ void centry()
     init_extra_prints();
     stage2_debug("%s\n", __func__);
 
-    u32 cr0, cr4;
-    mov_from_cr("cr0", cr0);
-    mov_from_cr("cr4", cr4);
-    // make a header
-    cr0 &= ~(1<<2); // clear EM
-    cr0 |= 1<<1; // set MP EM
-    cr4 |= CR4_OSFXSR;
-    cr4 |= CR4_OSXMMEXCPT;
-    cr4 |= CR4_OSXSAVE;
-//    cr4 |= 1<<20; // set smep - use once we do kernel / user split
-    mov_to_cr("cr0", cr0);
-    mov_to_cr("cr4", cr4);    
-
     /* Validate support for no-exec (NX) bits in ptes. */
     u32 v[4];
     cpuid(0x80000001, 0, v);
@@ -384,8 +367,7 @@ void centry()
            cookie for the page table code to mask out any attempt to
            set NX. Otherwise, a page fault for use of reserved bits
            will be thrown, or worse a sudden exit if a map() with NX
-           occurs before exception handler setup. NXE is set in
-           service32.s:run64. */
+           occurs before exception handler setup. NXE is set in stage3. */
         halt("halt: platform doesn't support no-exec page protection\n");
     }
 

--- a/boot/stage2.c
+++ b/boot/stage2.c
@@ -226,6 +226,7 @@ closure_function(0, 1, status, kernel_read_complete,
     if (!k) {
         halt("kernel elf parse failed\n");
     }
+    k += KERNEL_BASE - KERNEL_BASE_PHYS;
 
     /* tell stage3 that pages from the stage2 working heap can be reclaimed */
     assert(working_saved_base);

--- a/mkfs/dump.c
+++ b/mkfs/dump.c
@@ -146,11 +146,9 @@ static u64 get_fs_offset(descriptor fd)
 	exit(EXIT_FAILURE);
     }
 
-    // last two bytes should be MBR signature
-    u16 *mbr_sig = (u16 *) (buf + sizeof(buf) - sizeof(*mbr_sig));
     struct partition_entry *rootfs_part = partition_get(buf, PARTITION_ROOTFS);
 
-    if (*mbr_sig != 0xaa55 || rootfs_part->lba_start == 0 ||
+    if (rootfs_part->lba_start == 0 ||
             rootfs_part->nsectors == 0) {
         // probably raw filesystem
         return 0;

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -262,13 +262,10 @@ static void write_mbr(descriptor f)
     else if (res != sizeof(buf))
         halt("could not read MBR (short read)\n");
 
-    // MBR signature
-    u16 *mbr_sig = (u16 *) (buf + sizeof(buf) - sizeof(*mbr_sig));
-    if (*mbr_sig != 0xaa55)
-        halt("invalid MBR signature\n");
-
     // first MBR partition entry
-    struct partition_entry *e = (struct partition_entry *) ((char *) mbr_sig - 4 * sizeof(*e));
+    struct partition_entry *e = partition_get(buf, 0);
+    if (!e)
+        halt("invalid MBR signature\n");
 
     // FS region comes right before MBR partitions (see boot/stage1.s)
     region r = (region) ((char *) e - sizeof(*r));

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -293,6 +293,36 @@ static inline boolean buffer_compare_with_cstring(buffer b, const char *x)
     return x[len] == '\0';
 }
 
+static inline int buffer_memcmp(buffer b, void *mem, bytes n)
+{
+    bytes len = buffer_length(b);
+    int ret = runtime_memcmp(buffer_ref(b, 0), mem, MIN(len, n));
+    if (ret)
+        return ret;
+    else if (len < n)
+        return -1;
+    else
+        return 0;
+}
+
+/* Can only be used with literal strings. */
+#define buffer_strcmp(b, str)   ({  \
+    int res = buffer_memcmp(b, str, sizeof(str) - 1);   \
+    if (!res && buffer_length(b) >= sizeof(str))    \
+        res = 1;    \
+    res;    \
+})
+
+static inline int buffer_strchr(buffer b, int c)
+{
+    bytes len = buffer_length(b);
+    for (bytes i = 0; i < len; i++) {
+        if (byte(b, i) == c)
+            return i;
+    }
+    return -1;
+}
+
 // the ascii subset..utf8 me
 #define foreach_character(__i, __c, __s)                                \
     for (u32 __i = 0, __c, __limit = buffer_length(__s);                \

--- a/src/runtime/heap/id.h
+++ b/src/runtime/heap/id.h
@@ -18,6 +18,7 @@ typedef struct id_heap {
 id_heap create_id_heap(heap meta, heap map, u64 base, u64 length, bytes pagesize);
 id_heap create_id_heap_backed(heap meta, heap map, heap parent, bytes pagesize);
 id_heap allocate_id_heap(heap meta, heap map, bytes pagesize); /* id heap with no ranges */
+#define destroy_id_heap(__h) destroy_heap(&(__h)->h)
 #define id_heap_add_range(__h, __b, __l) ((__h)->add_range(__h, __b, __l))
 #define id_heap_set_area(__h, __b, __l, __v, __a) ((__h)->set_area(__h, __b, __l, __v, __a))
 #define id_heap_set_randomize(__h, __r) ((__h)->set_randomize(__h, __r))

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -19,9 +19,16 @@ enum partition {
 #define HEADS 255
 #define MAX_CYL 1023
 
-#define partition_get(mbr, index)    \
-    (struct partition_entry *)((u64)(mbr) + SECTOR_SIZE - 2 - \
-    (4 - (index)) * sizeof(struct partition_entry))
+#define partition_get(mbr, index)    ({ \
+    u16 *mbr_sig = (u16 *)((u64)(mbr) + SECTOR_SIZE - sizeof(*mbr_sig));  \
+    struct partition_entry *e;  \
+    if (*mbr_sig == 0xaa55) \
+        e = (struct partition_entry *)((u64_from_pointer(mbr_sig)) -    \
+                (4 - (index)) * sizeof(struct partition_entry));    \
+    else    \
+        e = 0;  \
+    e;  \
+})
 
 static inline void mbr_chs(u8 *chs, u64 offset)
 {

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -12,6 +12,9 @@ enum partition {
     PARTITION_ROOTFS,
 };
 
+#define SECTOR_OFFSET 9ULL
+#define SECTOR_SIZE (1ULL << SECTOR_OFFSET)
+
 #define SEC_PER_TRACK 63
 #define HEADS 255
 #define MAX_CYL 1023

--- a/src/runtime/uniboot.h
+++ b/src/runtime/uniboot.h
@@ -8,6 +8,9 @@
 #define PAGES_BASE  0xffffffffc0000000ull
 #define USER_LIMIT  0x0000800000000000ull
 
+/* Physical address where kernel ELF is loaded in case of direct stage3 load */
+#define KERNEL_BASE_PHYS    0x00200000ul
+
 #ifdef BOOT
 
 #include <def32.h>

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -27,6 +27,7 @@ void create_filesystem(heap h,
                        tuple root,
                        boolean initialize,
                        filesystem_complete complete);
+void destroy_filesystem(filesystem fs);
 
 // there is a question as to whether tuple->fs file should be mapped inside out outside the filesystem
 // status

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -15,8 +15,6 @@ pagecache_node fsfile_get_cachenode(fsfile f);
 
 extern io_status_handler ignore_io_status;
 
-#define SECTOR_OFFSET 9ULL
-#define SECTOR_SIZE (1ULL << SECTOR_OFFSET)
 #define MIN_EXTENT_SIZE PAGESIZE
 #define MAX_EXTENT_SIZE (1 * MB)
 

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -55,6 +55,7 @@ log log_create(heap h, filesystem fs, boolean initialize, status_handler sh);
 void log_write(log tl, tuple t);
 void log_write_eav(log tl, tuple e, symbol a, value v);
 void log_flush(log tl, status_handler completion);
+void log_destroy(log tl);
 void flush(filesystem fs, status_handler);
 boolean filesystem_reserve_storage(filesystem fs, range storage_blocks);
 void filesystem_storage_op(filesystem fs, sg_list sg, merge m, range blocks, block_io op);

--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -678,3 +678,13 @@ log log_create(heap h, filesystem fs, boolean initialize, status_handler sh)
     deallocate(h, tl, sizeof(struct log));
     return INVALID_ADDRESS;
 }
+
+void log_destroy(log tl)
+{
+    deallocate_vector(tl->flush_completions);
+    deallocate_vector(tl->encoding_lengths);
+    deallocate_buffer(tl->tuple_staging);
+    close_log_extension(tl->current);
+    deallocate_table(tl->dictionary);
+    deallocate(tl->h, tl, sizeof(*tl));
+}

--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -1,0 +1,48 @@
+#include <kernel.h>
+
+#include "virtio_internal.h"
+#include "virtio_pci.h"
+
+u32 vtdev_cfg_read_4(vtdev dev, u64 offset)
+{
+    switch (dev->transport) {
+    case VTIO_TRANSPORT_PCI:
+        return pci_bar_read_4(&((vtpci)dev)->device_config, offset);
+    default:
+        return 0;
+    }
+}
+
+void vtdev_cfg_read_mem(vtdev dev, void *dest, bytes len)
+{
+    switch (dev->transport) {
+    case VTIO_TRANSPORT_PCI:
+        for (int i = 0; i < len; i++)
+            *((u8 *)dest + i) = pci_bar_read_1(&((vtpci)dev)->device_config, i);
+        break;
+    default:
+        break;
+    }
+}
+
+void vtdev_set_status(vtdev dev, u8 status)
+{
+    switch (dev->transport) {
+    case VTIO_TRANSPORT_PCI:
+        vtpci_set_status((vtpci)dev, status);
+        break;
+    default:
+        break;
+    }
+}
+
+status virtio_alloc_virtqueue(vtdev dev, const char *name, int idx,
+                             struct virtqueue **result)
+{
+    switch (dev->transport) {
+    case VTIO_TRANSPORT_PCI:
+        return vtpci_alloc_virtqueue((vtpci)dev, name, idx, result);
+    default:
+        return timm("status", "unknown transport %d", dev->transport);
+    }
+}

--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -1,11 +1,14 @@
 #include <kernel.h>
 
 #include "virtio_internal.h"
+#include "virtio_mmio.h"
 #include "virtio_pci.h"
 
 u32 vtdev_cfg_read_4(vtdev dev, u64 offset)
 {
     switch (dev->transport) {
+    case VTIO_TRANSPORT_MMIO:
+        return vtmmio_get_u32((vtmmio)dev, VTMMIO_OFFSET_CONFIG + offset);
     case VTIO_TRANSPORT_PCI:
         return pci_bar_read_4(&((vtpci)dev)->device_config, offset);
     default:
@@ -16,6 +19,9 @@ u32 vtdev_cfg_read_4(vtdev dev, u64 offset)
 void vtdev_cfg_read_mem(vtdev dev, void *dest, bytes len)
 {
     switch (dev->transport) {
+    case VTIO_TRANSPORT_MMIO:
+        runtime_memcpy(dest, ((vtmmio)dev)->vbase + VTMMIO_OFFSET_CONFIG, len);
+        break;
     case VTIO_TRANSPORT_PCI:
         for (int i = 0; i < len; i++)
             *((u8 *)dest + i) = pci_bar_read_1(&((vtpci)dev)->device_config, i);
@@ -28,6 +34,9 @@ void vtdev_cfg_read_mem(vtdev dev, void *dest, bytes len)
 void vtdev_set_status(vtdev dev, u8 status)
 {
     switch (dev->transport) {
+    case VTIO_TRANSPORT_MMIO:
+        vtmmio_set_status((vtmmio)dev, status);
+        break;
     case VTIO_TRANSPORT_PCI:
         vtpci_set_status((vtpci)dev, status);
         break;
@@ -40,6 +49,8 @@ status virtio_alloc_virtqueue(vtdev dev, const char *name, int idx,
                              struct virtqueue **result)
 {
     switch (dev->transport) {
+    case VTIO_TRANSPORT_MMIO:
+        return vtmmio_alloc_virtqueue((vtmmio)dev, name, idx, result);
     case VTIO_TRANSPORT_PCI:
         return vtpci_alloc_virtqueue((vtpci)dev, name, idx, result);
     default:

--- a/src/virtio/virtio.h
+++ b/src/virtio/virtio.h
@@ -4,3 +4,5 @@ void init_virtio_network(kernel_heaps kh);
 
 void virtio_register_scsi(kernel_heaps kh, storage_attach a);
 void virtio_register_blk(kernel_heaps kh, storage_attach a);
+
+void virtio_mmio_parse(kernel_heaps kh, const char *str, int len);

--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -24,7 +24,7 @@ typedef closure_type(vqfinish, void, u64);
 /* Status byte for guest to report progress. */
 #define VIRTIO_CONFIG_STATUS_RESET	0x00
 #define VIRTIO_CONFIG_STATUS_ACK	0x01
-#define VIRTIO_CONFIG_STATUS_DRIVER	0x03
+#define VIRTIO_CONFIG_STATUS_DRIVER	0x02
 #define VIRTIO_CONFIG_STATUS_DRIVER_OK	0x04
 #define VIRTIO_CONFIG_STATUS_FEATURE	0x08
 #define VIRTIO_CONFIG_STATUS_FAILED	0x80

--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -66,6 +66,7 @@ typedef struct vtdev {
     heap general;
 
     enum vtio_transport {
+        VTIO_TRANSPORT_MMIO,
         VTIO_TRANSPORT_PCI,
     } transport;
     vtdev_notify notify;

--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -1,5 +1,3 @@
-#include "virtio_pci.h"
-
 /* VirtIO device IDs */
 #define VIRTIO_ID_NETWORK       1
 #define VIRTIO_ID_BLOCK         2
@@ -58,9 +56,37 @@ typedef closure_type(vqfinish, void, u64);
 /* Modern device */
 #define VIRTIO_F_VERSION_1 U64_FROM_BIT(32)
 
-void vtpci_notify_virtqueue(vtpci sc, u16 queue, bytes notify_offset);
+typedef closure_type(vtdev_notify, void, u16 queue_index, bytes notify_offset);
 
-status virtqueue_alloc(vtpci dev,
+typedef struct vtdev {
+    u64 dev_features;              // device features
+    u64 features;                  // negotiated features
+
+    heap contiguous;
+    heap general;
+
+    enum vtio_transport {
+        VTIO_TRANSPORT_PCI,
+    } transport;
+    vtdev_notify notify;
+} *vtdev;
+
+u32 vtdev_cfg_read_4(vtdev dev, u64 offset);
+void vtdev_cfg_read_mem(vtdev dev, void *dest, bytes len);
+void vtdev_set_status(vtdev dev, u8 status);
+
+static inline void virtio_attach(heap h, heap page_allocator,
+                                 enum vtio_transport transport, vtdev d)
+{
+    d->general = h;
+    d->contiguous = page_allocator;
+    d->transport = transport;
+}
+
+status virtio_alloc_virtqueue(vtdev dev, const char *name, int idx,
+                              struct virtqueue **result);
+
+status virtqueue_alloc(vtdev dev,
                        const char *name,
                        u16 queue,
                        u16 size,

--- a/src/virtio/virtio_mmio.c
+++ b/src/virtio/virtio_mmio.c
@@ -1,0 +1,195 @@
+/* Specifications at
+ * http://docs.oasis-open.org/virtio/virtio/v1.0/cs04/virtio-v1.0-cs04.html,
+ * section 4.2 "Virtio Over MMIO". */
+
+#include <kernel.h>
+#include <apic.h>
+#include <page.h>
+
+#include "virtio_internal.h"
+#include "virtio_mmio.h"
+
+#define VTMMIO_INT_VRING    (1 << 0)
+#define VTMMIO_INT_CONFIG   (1 << 1)
+
+//#define VIRTIO_MMIO_DEBUG
+#ifdef VIRTIO_MMIO_DEBUG
+#define virtio_mmio_debug(x, ...) rprintf("VTMMIO: " x "\n", ##__VA_ARGS__)
+#else
+#define virtio_mmio_debug(x, ...)
+#endif
+
+static struct list vtmmio_devices = {
+        &vtmmio_devices, &vtmmio_devices
+};
+
+void virtio_mmio_parse(kernel_heaps kh, const char *str, int len)
+{
+    buffer b = alloca_wrap_buffer(str, len);
+    int optname_len = buffer_strchr(b, '=');
+    if (optname_len < 0)
+        return;
+    if ((optname_len == sizeof("device") - 1) &&
+            !buffer_memcmp(b, "device", optname_len)) {
+        /* Syntax: device=<memsize>@<membase>:<irq> */
+        buffer_consume(b, optname_len + 1);
+        u64 memsize;
+        if ((buffer_strchr(b, '@') < 0) || !parse_int(b, 10, &memsize))
+            return;
+        char suffix = (char)pop_u8(b);
+        if ((suffix == 'k') || (suffix == 'K'))
+            memsize *= KB;
+        else if ((suffix == 'm') || (suffix == 'M'))
+            memsize *= MB;
+        else if (suffix != '@')   /* unexpected character */
+            return;
+        if (suffix != '@')
+            buffer_consume(b, 1);
+        if (buffer_strchr(b, ':') < 0)
+            return;
+        u64 membase;
+        u64 irq;
+        if ((pop_u8(b) != '0') || (pop_u8(b) != 'x') ||
+                !parse_int(b, 16, &membase) || (pop_u8(b) != ':') ||
+                !parse_int(b, 10, &irq))
+            return;
+        virtio_mmio_debug("new device");
+        heap h = heap_general(kh);
+        vtmmio dev = allocate(h, sizeof(*dev));
+        assert(dev != INVALID_ADDRESS);
+        dev->membase = membase;
+        dev->memsize = memsize;
+        dev->irq = irq;
+        dev->vbase = allocate((heap)heap_virtual_huge(kh), memsize);
+        assert(dev->vbase != INVALID_ADDRESS);
+        map(u64_from_pointer(dev->vbase), membase, memsize, PAGE_DEV_FLAGS);
+        dev->irq_vector = 0;
+        dev->vq_handlers = allocate_vector(h, 2);
+        assert(dev->vq_handlers != INVALID_ADDRESS);
+        list_push_back(&vtmmio_devices, &dev->l);
+    }
+}
+
+void vtmmio_probe_devs(vtmmio_probe probe)
+{
+    list_foreach(&vtmmio_devices, e) {
+        vtmmio dev = struct_from_list(e, vtmmio, l);
+        if ((dev->memsize < VTMMIO_OFFSET_CONFIG) ||
+                (vtmmio_get_u32(dev, VTMMIO_OFFSET_MAGIC) != 0x74726976) ||
+                (vtmmio_get_u32(dev, VTMMIO_OFFSET_VERSION) != 2))
+            continue;
+        u8 status = vtmmio_get_status(dev);
+        if (status == VIRTIO_CONFIG_STATUS_RESET)
+            vtmmio_set_u32(dev, VTMMIO_OFFSET_STATUS, VIRTIO_CONFIG_STATUS_ACK);
+        if (!(status & VIRTIO_CONFIG_STATUS_DRIVER)) {
+            virtio_mmio_debug("probing device at 0x%lx(0x%lx), irq %d",
+                dev->membase, dev->memsize, dev->irq);
+            apply(probe, dev);
+        }
+    }
+}
+
+void vtmmio_set_status(vtmmio dev, u8 status)
+{
+    if (status != VIRTIO_CONFIG_STATUS_RESET)
+        status |= vtmmio_get_status(dev);
+    vtmmio_set_u32(dev, VTMMIO_OFFSET_STATUS, status);
+}
+
+static boolean vtmmio_negotatiate_features(vtmmio dev, u64 mask)
+{
+    vtdev virtio_dev = &dev->virtio_dev;
+    mask |= VIRTIO_F_VERSION_1;
+
+    vtmmio_set_u32(dev, VTMMIO_OFFSET_DEVFEATSEL, 1);
+    virtio_dev->dev_features = vtmmio_get_u32(dev, VTMMIO_OFFSET_DEVFEATURES);
+    vtmmio_set_u32(dev, VTMMIO_OFFSET_DEVFEATSEL, 0);
+    virtio_dev->dev_features = (virtio_dev->dev_features << 32) |
+            vtmmio_get_u32(dev, VTMMIO_OFFSET_DEVFEATURES);
+    virtio_mmio_debug("device features 0x%lx, mask 0x%lx",
+                      virtio_dev->dev_features, mask);
+    if (!(virtio_dev->dev_features & VIRTIO_F_VERSION_1)) {
+        msg_err("unsupported device features 0x%lx for device at 0x%x\n",
+            virtio_dev->dev_features, dev->membase);
+        return false;
+    }
+    virtio_dev->features = virtio_dev->dev_features & mask;
+    vtmmio_set_u32(dev, VTMMIO_OFFSET_DRVFEATSEL, 0);
+    vtmmio_set_u32(dev, VTMMIO_OFFSET_DRVFEATURES, (u32)virtio_dev->features);
+    vtmmio_set_u32(dev, VTMMIO_OFFSET_DRVFEATSEL, 1);
+    vtmmio_set_u32(dev, VTMMIO_OFFSET_DRVFEATURES,
+                   (u32)(virtio_dev->features >> 32));
+    vtmmio_set_status(dev, VIRTIO_CONFIG_STATUS_FEATURE);
+    return (vtmmio_get_status(dev) & VIRTIO_CONFIG_STATUS_FEATURE);
+}
+
+define_closure_function(1, 2, void, vtmmio_notify,
+                        vtmmio, dev,
+                        u16, queue_index, bytes, notify_offset)
+{
+    vtmmio_set_u32(bound(dev), notify_offset, queue_index);
+}
+
+boolean attach_vtmmio(heap h, heap page_allocator, vtmmio d, u64 feature_mask)
+{
+    virtio_mmio_debug("attaching device at 0x%lx, irq %d", d->membase, d->irq);
+    vtmmio_set_status(d, VIRTIO_CONFIG_STATUS_DRIVER);
+    if (!vtmmio_negotatiate_features(d, feature_mask)) {
+        msg_err("could not negotiate features for device at 0x%x\n",
+            d->membase);
+        return false;
+    }
+    init_closure(&d->notify, vtmmio_notify, d);
+    d->virtio_dev.notify = (vtdev_notify)&d->notify;
+    virtio_attach(h, page_allocator, VTIO_TRANSPORT_MMIO, &d->virtio_dev);
+    return true;
+}
+
+define_closure_function(1, 0, void, vtmmio_irq,
+                        vtmmio, dev)
+{
+    vtmmio dev = bound(dev);
+    u32 status = vtmmio_get_u32(dev, VTMMIO_OFFSET_INTSTATUS);
+    virtio_mmio_debug("int status 0x%x", status);
+    vtmmio_set_u32(dev, VTMMIO_OFFSET_INTACK, status);
+    if (status & VTMMIO_INT_VRING) {
+        thunk vq_handler;
+        vector_foreach(dev->vq_handlers, vq_handler) {
+            apply(vq_handler);
+        }
+    }
+}
+
+status vtmmio_alloc_virtqueue(vtmmio dev, const char *name, int idx,
+                              struct virtqueue **result)
+{
+    virtio_mmio_debug("allocating virtqueue %d (%s)", idx, name);
+    struct virtqueue *vq;
+    vtmmio_set_u32(dev, VTMMIO_OFFSET_QUEUESEL, idx);
+    assert(vtmmio_get_u32(dev, VTMMIO_OFFSET_QUEUEREADY) == 0);
+    u32 size = vtmmio_get_u32(dev, VTMMIO_OFFSET_QUEUENUMMAX);
+    assert(size > 0);
+    if (size > U16_MAX)
+        size = U16_MAX;
+    thunk handler;
+    status s = virtqueue_alloc(&dev->virtio_dev, name, idx, size,
+        VTMMIO_OFFSET_QUEUENOTIFY, PAGESIZE, &vq, &handler);
+    if (!is_ok(s))
+        return s;
+    if (!dev->irq_vector) {
+        dev->irq_vector = allocate_interrupt();
+        assert(dev->irq_vector != INVALID_PHYSICAL);
+        register_interrupt(dev->irq_vector,
+                           init_closure(&dev->irq_handler, vtmmio_irq, dev),
+                           name);
+        ioapic_set_int(dev->irq, dev->irq_vector);
+    }
+    vector_push(dev->vq_handlers, handler);
+    vtmmio_set_u32(dev, VTMMIO_OFFSET_QUEUENUM, size);
+    vtmmio_set_u64(dev, VTMMIO_OFFSET_QUEUEDESCLOW, virtqueue_desc_paddr(vq));
+    vtmmio_set_u64(dev, VTMMIO_OFFSET_QUEUEAVAILLOW, virtqueue_avail_paddr(vq));
+    vtmmio_set_u64(dev, VTMMIO_OFFSET_QUEUEUSEDLOW, virtqueue_used_paddr(vq));
+    vtmmio_set_u32(dev, VTMMIO_OFFSET_QUEUEREADY, 1);
+    *result = vq;
+    return STATUS_OK;
+}

--- a/src/virtio/virtio_mmio.h
+++ b/src/virtio/virtio_mmio.h
@@ -1,0 +1,64 @@
+#define VTMMIO_OFFSET_MAGIC             0x000
+#define VTMMIO_OFFSET_VERSION           0x004
+#define VTMMIO_OFFSET_DEVID             0x008
+#define VTMMIO_OFFSET_DEVFEATURES       0x010
+#define VTMMIO_OFFSET_DEVFEATSEL        0x014
+#define VTMMIO_OFFSET_DRVFEATURES       0x020
+#define VTMMIO_OFFSET_DRVFEATSEL        0x024
+#define VTMMIO_OFFSET_QUEUESEL          0x030
+#define VTMMIO_OFFSET_QUEUENUMMAX       0x034
+#define VTMMIO_OFFSET_QUEUENUM          0x038
+#define VTMMIO_OFFSET_QUEUEREADY        0x044
+#define VTMMIO_OFFSET_QUEUENOTIFY       0x050
+#define VTMMIO_OFFSET_INTSTATUS         0x060
+#define VTMMIO_OFFSET_INTACK            0x064
+#define VTMMIO_OFFSET_STATUS            0x070
+#define VTMMIO_OFFSET_QUEUEDESCLOW      0x080
+#define VTMMIO_OFFSET_QUEUEDESCHIGH     0x084
+#define VTMMIO_OFFSET_QUEUEAVAILLOW     0x090
+#define VTMMIO_OFFSET_QUEUEAVAILHIGH    0x094
+#define VTMMIO_OFFSET_QUEUEUSEDLOW      0x0A0
+#define VTMMIO_OFFSET_QUEUEUSEDHIGH     0x0A4
+#define VTMMIO_OFFSET_CONFIG            0x100
+
+declare_closure_struct(1, 2, void, vtmmio_notify,
+                       struct vtmmio_dev *, dev,
+                       u16, queue_index, bytes, notify_offset);
+
+declare_closure_struct(1, 0, void, vtmmio_irq,
+    struct vtmmio_dev *, dev);
+
+typedef struct vtmmio_dev {
+    struct vtdev virtio_dev; /* must be first */
+    struct list l;
+    u64 membase;
+    u64 memsize;
+    int irq;
+    void *vbase;
+    u64 irq_vector;
+    closure_struct(vtmmio_notify, notify);
+    closure_struct(vtmmio_irq, irq_handler);
+    vector vq_handlers;
+} *vtmmio;
+
+#define vtmmio_get_u32(dev, offset) (*((volatile u32 *)((dev)->vbase + offset)))
+
+#define vtmmio_set_u32(dev, offset, value)  do {    \
+    *(volatile u32 *)((dev)->vbase + offset) = value; \
+} while (0)
+
+static inline void vtmmio_set_u64(vtmmio dev, u64 offset, u64 value)
+{
+    vtmmio_set_u32(dev, offset, value);
+    vtmmio_set_u32(dev, offset + 4, value >> 32);
+}
+
+#define vtmmio_get_status(dev)  (u8)vtmmio_get_u32(dev, VTMMIO_OFFSET_STATUS)
+
+typedef closure_type(vtmmio_probe, void, vtmmio);
+
+void vtmmio_probe_devs(vtmmio_probe probe);
+void vtmmio_set_status(vtmmio dev, u8 status);
+boolean attach_vtmmio(heap h, heap page_allocator, vtmmio d, u64 feature_mask);
+status vtmmio_alloc_virtqueue(vtmmio dev, const char *name, int idx,
+                              struct virtqueue **result);

--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -44,6 +44,7 @@
 #include "netif/ethernet.h"
 #include "virtio_internal.h"
 #include "virtio_net.h"
+#include "virtio_pci.h"
 
 #include <io.h>
 
@@ -54,7 +55,7 @@
 #endif // defined(VIRTIO_NET_DEBUG)
 
 typedef struct vnet {
-    vtpci dev;
+    vtdev dev;
     u16 port;
     heap rxbuffers;
     bytes net_header_len;
@@ -181,8 +182,7 @@ static err_t virtioif_init(struct netif *netif)
     netif->linkoutput = low_level_output;
     netif->hwaddr_len = ETHARP_HWADDR_LEN;
     netif->status_callback = lwip_status_callback;
-    for (int i = 0; i < ETHER_ADDR_LEN; i++) 
-        netif->hwaddr[i] = pci_bar_read_1(&vn->dev->device_config, i);
+    vtdev_cfg_read_mem(vn->dev, netif->hwaddr, ETHER_ADDR_LEN);
     virtio_net_debug("%s: hwaddr %02x:%02x:%02x:%02x:%02x:%02x\n",
         __func__,
         netif->hwaddr[0], netif->hwaddr[1], netif->hwaddr[2],
@@ -207,32 +207,34 @@ static err_t virtioif_init(struct netif *netif)
     return ERR_OK;
 }
 
-static void virtio_net_attach(heap general, heap page_allocator, pci_dev d)
+static void virtio_net_attach(vtdev dev)
 {
     //u32 badness = VIRTIO_F_BAD_FEATURE | VIRTIO_NET_F_CSUM | VIRTIO_NET_F_GUEST_CSUM |
     //    VIRTIO_NET_F_GUEST_TSO4 | VIRTIO_NET_F_GUEST_TSO6 |  VIRTIO_NET_F_GUEST_ECN|
     //    VIRTIO_NET_F_GUEST_UFO | VIRTIO_NET_F_CTRL_VLAN | VIRTIO_NET_F_MQ;
 
-    vtpci dev = attach_vtpci(general, page_allocator, d, VIRTIO_NET_F_MAC);
-    vnet vn = allocate(dev->general, sizeof(struct vnet));
-    vn->n = allocate(dev->general, sizeof(struct netif));
-    vn->net_header_len = vtpci_is_modern(dev) || (dev->features & VIRTIO_NET_F_MRG_RXBUF) != 0 ?
+    heap h = dev->general;
+    heap contiguous = dev->contiguous;
+    vnet vn = allocate(h, sizeof(struct vnet));
+    vn->n = allocate(h, sizeof(struct netif));
+    vn->net_header_len = (dev->features & VIRTIO_F_VERSION_1) ||
+        (dev->features & VIRTIO_NET_F_MRG_RXBUF) != 0 ?
         sizeof(struct virtio_net_hdr_mrg_rxbuf) : sizeof(struct virtio_net_hdr);
     vn->rxbuflen = vn->net_header_len + sizeof(struct eth_hdr) + sizeof(struct eth_vlan_hdr) + 1500;
     virtio_net_debug("%s: net_header_len %d, rxbuflen %d\n", __func__, vn->net_header_len, vn->rxbuflen);
-    vn->rxbuffers = allocate_objcache(dev->general, page_allocator,
+    vn->rxbuffers = allocate_objcache(h, contiguous,
 				      vn->rxbuflen + sizeof(struct xpbuf), PAGESIZE_2M);
     /* rx = 0, tx = 1, ctl = 2 by 
        page 53 of http://docs.oasis-open.org/virtio/virtio/v1.0/cs01/virtio-v1.0-cs01.pdf */
     vn->dev = dev;
-    vtpci_alloc_virtqueue(dev, "virtio net tx", 1, &vn->txq);
-    vtpci_alloc_virtqueue(dev, "virtio net rx", 0, &vn->rxq);
+    virtio_alloc_virtqueue(dev, "virtio net tx", 1, &vn->txq);
+    virtio_alloc_virtqueue(dev, "virtio net rx", 0, &vn->rxq);
     // just need vn->net_header_len contig bytes really
-    vn->empty = allocate(dev->contiguous, dev->contiguous->pagesize);
+    vn->empty = allocate(contiguous, contiguous->pagesize);
     for (int i = 0; i < vn->net_header_len; i++)  ((u8 *)vn->empty)[i] = 0;
     vn->n->state = vn;
     // initialization complete
-    vtpci_set_status(dev, VIRTIO_CONFIG_STATUS_DRIVER_OK);
+    vtdev_set_status(dev, VIRTIO_CONFIG_STATUS_DRIVER_OK);
 
     netif_add(vn->n,
               0, 0, 0, 
@@ -241,19 +243,21 @@ static void virtio_net_attach(heap general, heap page_allocator, pci_dev d)
               ethernet_input);
 }
 
-closure_function(2, 1, boolean, virtio_net_probe,
+closure_function(2, 1, boolean, vtpci_net_probe,
                  heap, general, heap, page_allocator,
                  pci_dev, d)
 {
     if (!vtpci_probe(d, VIRTIO_ID_NETWORK))
         return false;
-
-    virtio_net_attach(bound(general), bound(page_allocator), d);
+    vtpci dev = attach_vtpci(bound(general), bound(page_allocator), d,
+        VIRTIO_NET_F_MAC);
+    virtio_net_attach(&dev->virtio_dev);
     return true;
 }
 
 void init_virtio_network(kernel_heaps kh)
 {
     heap h = heap_general(kh);
-    register_pci_driver(closure(h, virtio_net_probe, h, heap_backed(kh)));
+    heap page_allocator = heap_backed(kh);
+    register_pci_driver(closure(h, vtpci_net_probe, h, page_allocator));
 }

--- a/src/virtio/virtio_pci.h
+++ b/src/virtio/virtio_pci.h
@@ -47,7 +47,12 @@ enum {
     VTPCI_REG_MAX
 };
 
+declare_closure_struct(1, 2, void, vtpci_notify,
+                       struct vtpci *, dev,
+                       u16, queue_index, bytes, notify_offset);
+
 struct vtpci {
+    struct vtdev virtio_dev; /* must be first */
     struct pci_dev _dev;
     pci_dev dev;
     int regs[VTPCI_REG_MAX];
@@ -57,12 +62,9 @@ struct vtpci {
     struct pci_bar notify_config;  // notify config
     struct pci_bar device_config;  // device config
 
-    u64 dev_features;              // device features
-    u64 features;                  // negotiated features
-
-    heap contiguous;
-    heap general;
     struct virtio_feature_desc	*vtpci_child_feat_desc;
+
+    closure_struct(vtpci_notify, notify);
 
     int vtpci_nvqs;
     struct virtqueue *vtpci_vqs;

--- a/src/virtio/virtqueue.c
+++ b/src/virtio/virtqueue.c
@@ -88,7 +88,7 @@ typedef struct vqmsg {
 } *vqmsg;
     
 typedef struct virtqueue {
-    vtpci dev;
+    vtdev dev;
     const char *name;
     u16 entries;
     u16 queue_index;
@@ -229,7 +229,7 @@ closure_function(1, 0, void, virtqueue_service_vqmsgs,
     virtqueue_debug("%s exit\n", __func__);
 }
 
-status virtqueue_alloc(vtpci dev,
+status virtqueue_alloc(vtdev dev,
                        const char *name,
                        u16 queue,
                        u16 size,
@@ -316,7 +316,7 @@ static int virtqueue_notify(virtqueue vq)
     memory_barrier();
     int should_notify = (vq->used->flags & VRING_USED_F_NO_NOTIFY) == 0;
     if (should_notify)
-        vtpci_notify_virtqueue(vq->dev, vq->queue_index, vq->notify_offset);
+        apply(vq->dev->notify, vq->queue_index, vq->notify_offset);
     return should_notify;
 }
 

--- a/src/x86_64/def64.h
+++ b/src/x86_64/def64.h
@@ -11,6 +11,10 @@ typedef __uint128_t u128;
 typedef u64 word;
 typedef u64 bytes;
 
+#define U16_MAX 0xFFFF
+#define S16_MAX ((s16)(U16_MAX >> 1))
+#define S16_MIN (-S16_MAX - 1)
+
 #define U32_MAX (~0u)
 #define S32_MAX ((s32)(U32_MAX >> 1))
 #define S32_MIN (-S32_MAX - 1)

--- a/src/x86_64/kvm_platform.h
+++ b/src/x86_64/kvm_platform.h
@@ -12,6 +12,10 @@ static inline void QEMU_HALT(u8 code)
     out8(0x501, code);
 
     /* fallback (when no QEMU) */
+
+    /* Issue a CPU reset via port 0x64 of the PS/2 controller. */
+    out8(0x64, 0xfe);
+
     __asm__("cli");
     __asm__("hlt");
 

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -664,6 +664,7 @@ static u64 pt_2m_alloc(heap h, bytes size)
 /* this happens even before moving to the new stack, so ... be cool */
 id_heap init_page_tables(heap h, id_heap physical, range initial_phys)
 {
+    write_msr(EFER_MSR, read_msr(EFER_MSR) | EFER_NXE);
     spin_lock_init(&pt_lock);
     phys_internal = physical;
     id_heap i = allocate(h, sizeof(struct id_heap));

--- a/src/x86_64/page.h
+++ b/src/x86_64/page.h
@@ -12,6 +12,7 @@
 #define PAGE_PRESENT       0x0001
 
 #define PAGEMASK           MASK(PAGELOG)
+#define PAGEMASK_2M        MASK(PAGELOG_2M)
 #define PAGE_FLAGS_MASK    (PAGE_NO_EXEC | PAGEMASK)
 #define PAGE_PROT_FLAGS    (PAGE_NO_EXEC | PAGE_USER | PAGE_WRITABLE)
 #define PAGE_DEV_FLAGS     (PAGE_WRITABLE | PAGE_CACHE_DISABLE | PAGE_NO_EXEC)
@@ -68,7 +69,10 @@ boolean traverse_ptes(u64 vaddr, u64 length, entry_handler eh);
 void page_invalidate(u64 p, thunk completion);
 void flush_tlb();
 void init_flush();
+void *bootstrap_page_tables(heap initial);
 #ifdef STAGE3
+void map_setup_2mbpages(u64 v, physical p, int pages, u64 flags,
+                        u64 *pdpt, u64 *pdt);
 id_heap init_page_tables(heap h, id_heap physical, range initial_map);
 #else
 void init_page_tables(heap initial);

--- a/src/x86_64/pagecache.c
+++ b/src/x86_64/pagecache.c
@@ -1144,6 +1144,12 @@ pagecache_volume pagecache_allocate_volume(pagecache pc, u64 length, int block_o
     return pv;
 }
 
+void pagecache_dealloc_volume(pagecache_volume pv)
+{
+    list_delete(&pv->l);
+    deallocate(pv->pc->h, pv, sizeof(*pv));
+}
+
 static inline void page_list_init(struct pagelist *pl)
 {
     list_init(&pl->l);

--- a/src/x86_64/pagecache.h
+++ b/src/x86_64/pagecache.h
@@ -44,6 +44,7 @@ void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node
 void pagecache_node_add_shared_map(pagecache_node pn , range v /* bytes */, u64 node_offset);
 
 pagecache_volume pagecache_allocate_volume(pagecache pc, u64 length, int block_order);
+void pagecache_dealloc_volume(pagecache_volume pv);
 
 pagecache allocate_pagecache(heap general, heap contiguous, heap physical, u64 pagesize);
 

--- a/src/x86_64/region.h
+++ b/src/x86_64/region.h
@@ -61,15 +61,20 @@ static inline u64 allocate_region(heap h, bytes size)
     return result;
 }
 
+static inline void region_heap_init(region_heap rh, u64 pagesize, int type)
+{
+    rh->h.dealloc = leak;
+    rh->h.alloc = allocate_region;
+    rh->h.pagesize = pagesize;
+    rh->type = type;
+}
+
 static inline heap region_allocator(heap h, u64 pagesize, int type)
 {
     region_heap rh = allocate(h, sizeof(struct region_heap));
     if (rh == INVALID_ADDRESS)
         return INVALID_ADDRESS;
-    rh->h.dealloc = leak;
-    rh->h.alloc = allocate_region;    
-    rh->h.pagesize = pagesize;
-    rh->type = type;
+    region_heap_init(rh, pagesize, type);
     return (heap)rh;
 }
 

--- a/src/x86_64/service.c
+++ b/src/x86_64/service.c
@@ -481,6 +481,14 @@ static void init_kernel_heaps()
 // init linker set
 void init_service()
 {
+    u64 cr;
+    mov_from_cr("cr0", cr);
+    cr |= C0_MP;
+    cr &= ~C0_EM;
+    mov_to_cr("cr0", cr);
+    mov_from_cr("cr4", cr);
+    cr |= CR4_OSFXSR | CR4_OSXMMEXCPT | CR4_OSXSAVE;
+    mov_to_cr("cr4", cr);
     init_debug("init_service");
     init_kernel_heaps();
     u64 stack_size = 32*PAGESIZE;

--- a/src/x86_64/x86_64.h
+++ b/src/x86_64/x86_64.h
@@ -24,7 +24,14 @@
 #define GS_MSR           0xc0000101
 #define KERNEL_GS_MSR    0xc0000102
 
+#define C0_MP   0x00000002
+#define C0_EM   0x00000004
 #define C0_WP   0x00010000
+
+#define CR4_PAE         (1 << 5)
+#define CR4_OSFXSR      (1 << 9)
+#define CR4_OSXMMEXCPT  (1 << 10)
+#define CR4_OSXSAVE     (1 << 18)
 
 #define FLAG_INTERRUPT 9
 

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -62,6 +62,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/unix/unix.c \
 	$(SRCDIR)/unix/vdso.c \
 	$(SRCDIR)/unix/pipe.c \
+	$(SRCDIR)/virtio/virtio.c \
 	$(SRCDIR)/virtio/virtio_net.c \
 	$(SRCDIR)/virtio/virtio_pci.c \
 	$(SRCDIR)/virtio/virtio_storage.c \

--- a/stage3/Makefile
+++ b/stage3/Makefile
@@ -63,6 +63,7 @@ SRCS-stage3.img= \
 	$(SRCDIR)/unix/vdso.c \
 	$(SRCDIR)/unix/pipe.c \
 	$(SRCDIR)/virtio/virtio.c \
+	$(SRCDIR)/virtio/virtio_mmio.c \
 	$(SRCDIR)/virtio/virtio_net.c \
 	$(SRCDIR)/virtio/virtio_pci.c \
 	$(SRCDIR)/virtio/virtio_storage.c \
@@ -161,7 +162,7 @@ endif
 
 #CFLAGS+=	-DLWIPDIR_DEBUG -DEPOLL_DEBUG -DNETSYSCALL_DEBUG -DKERNEL_DEBUG
 AFLAGS+=	-felf64 -I$(OBJDIR)/
-LDFLAGS+=	$(KERNLDFLAGS) -T linker_script
+LDFLAGS+=	$(KERNLDFLAGS) --undefined=_start -T linker_script
 
 VDSO_SRCDIR=    $(SRCDIR)/x86_64
 VDSO_OBJDIR=    $(OBJDIR)/vdso

--- a/stage3/linker_script
+++ b/stage3/linker_script
@@ -1,16 +1,20 @@
 OUTPUT_FORMAT("elf64-x86-64")
 
-ENTRY(_start)
+ENTRY(_phys_start)
 
 SECTIONS
 {
     . = 0;
     AP_BOOT_PAGE = .;
 
+    /* Physical addresses are only relevant in case of direct stage3 load. */
+    LOAD_OFFSET = START - 0x200000;     /* 0x200000 equals KERNEL_BASE_PHYS */
+    _phys_start = _start - LOAD_OFFSET; /* entry point physical adddress */
+
     . = 0xffffffff80000000;
     START = .;
 
-    .start ALIGN(4096):
+    .start ALIGN(4096): AT(ADDR(.start) - LOAD_OFFSET)
     {
         *(.start)
     }
@@ -18,7 +22,7 @@ SECTIONS
     /* the default linker aligns the file and text without throwing
        away a page..but for today...*/
     text_start = .;
-    .text : ALIGN(4096)
+    .text ALIGN(4096): AT(ADDR(.text) - LOAD_OFFSET)
     {
         *(.text)
         *(.text.*)
@@ -36,30 +40,31 @@ SECTIONS
      * We could look at generating them automatically, but for now it's easy enough
      * to do it this way
      */
-    .vvar : ALIGN(4096)
+    .vvar ALIGN(4096): AT(ADDR(.vvar) - LOAD_OFFSET)
     {
         vvar_page = .; 
         __vdso_vdso_dat = vvar_page + 128;
     }
 
-    .rodata : ALIGN(4096)
+    .rodata ALIGN(4096): AT(ADDR(.rodata) - LOAD_OFFSET)
     {
         *(.rodata)
         *(.rodata.*)
     }
 
-    .data : ALIGN(4096)
+    .data ALIGN(4096): AT(ADDR(.data) - LOAD_OFFSET)
     {
         *(.data)
         *(.data.*)
     }
 
     PROVIDE(bss_start = .);
-    .bss  ALIGN(32):
+    .bss  ALIGN(32): AT(ADDR(.bss) - LOAD_OFFSET)
     {
         *(.bss)
         *(.bss.*)
         *(COMMON)
     }
     PROVIDE(bss_end = .);
+    END = .;
 }

--- a/test/unit/buffer_test.c
+++ b/test/unit/buffer_test.c
@@ -20,6 +20,7 @@ boolean basic_tests(heap h)
 {
     boolean failure = true;
     buffer wb = (buffer)0;
+    u32 test_int;
     char test_str[] =  "This is a test string";
     buffer b = allocate_buffer(h, 10);
     /*
@@ -38,10 +39,16 @@ boolean basic_tests(heap h)
         test_assert(pop_u8(b) == i);
     }
     buffer_write_le32(b, 0xdeadbeef);
+    test_int = 0xdeadbeef - 1;
+    test_assert(buffer_memcmp(b, &test_int, sizeof(test_int)) > 0);
+    test_int = 0xdeadbeef + 1;
+    test_assert(buffer_memcmp(b, &test_int, sizeof(test_int)) < 0);
     test_assert(buffer_read_le32(b) == 0xdeadbeef);
     push_varint(b, 0xdeadbeef);
     test_assert(pop_varint(b) == 0xdeadbeef);
     test_assert(buffer_length(b) == 0);
+    test_assert(buffer_memcmp(b, test_str, 0) == 0);
+    test_assert(buffer_strchr(b, '0') < 0);
 
     /* Buffer capacity */
     buffer_write_cstring(b, test_str);
@@ -49,6 +56,11 @@ boolean basic_tests(heap h)
     test_assert(buffer_set_capacity(b, b->length) == b->length);
     buffer_set_capacity(b, 3 * b->length);
     test_assert(buffer_compare_with_cstring(b, test_str));
+
+    test_assert(buffer_strcmp(b, test_str) == 0);
+    test_assert(buffer_memcmp(b, test_str, sizeof(test_str)) < 0);
+    test_assert(buffer_strchr(b, 't') == 10);
+    test_assert(buffer_strchr(b, 'u') < 0);
 
     /*
      * Validate wrap_buffer_cstring initialization, and contents


### PR DESCRIPTION
With this PR, the kernel supports being booted directly from the hypervisor, in 64-bit mode and with paging enabled (with the first GB of physical memory identity-mapped), without going through stage 1 and stage 2.
If the kernel detects that the standard Linux boot parameter structure is being passed to it at its entry point, it extracts memory and MMIO device information from this structure, sets up an initial set of page tables to map the kernel code address space, jumps to the virtual address space, then sets up the page tables in the same way as stage2 does, then continues the boot sequence as normal.
The entry point of the kernel ELF file is set to a physical address, instead of a virtual address, so that the kernel can be loaded in physical memory by a standard ELF loader.
VirtIO block and network device drivers now support MMIO transport in addition to PCI transport (Firecracker only exposes MMIO devices). Handling of interrupts from virtIO MMIO devices requires support for the I/O APIC, which is now initialized together with the local APIC. Memory space and interrupt numbers associated to MMIO devices are retrieved from the kernel command line passed by the hypervisor to the kernel at boot time.
The virtIO network device driver now handles also incoming packets with the NEEDS_CSUM flag set (violating the virtIO  standard, Firecracker sets this flag even if the VIRTIO_NET_F_GUEST_CSUM feature has not been negotiated).
To shut down the virtual machine with hypervisors other than QEMU, QEMU_HALT() now falls back to issuing a CPU reset command via the PS/2 controller (which is correctly emulated by Firecracker).
The code that handles the x86_64 page tables has been reorganized so that the kernel can bootstrap page mapping from scratch, without relying on the initial mappings set up by stage2.