### PR TITLE
pvscsi: fix double deallocation

### DIFF
--- a/src/vmware/pvscsi.c
+++ b/src/vmware/pvscsi.c
@@ -438,7 +438,6 @@ closure_function(1, 0, void, pvscsi_rx_service_bh, pvscsi, dev)
         if (!pvscsi_action_io(dev, hcb))
             break;
         list_delete(i);
-        pvscsi_hcb_dealloc(dev, hcb);
     }
     spin_unlock(&dev->queue_lock);
 }


### PR DESCRIPTION
only deallocate pvscsi_hcb after completion, not after enqueueing to request ring
