### PR TITLE
x86 HPET: add support for standard (I/O APIC) interrupt mapping

### DIFF
--- a/src/x86_64/apic.h
+++ b/src/x86_64/apic.h
@@ -66,6 +66,9 @@ void apic_ipi(u32 target, u64 flags, u8 vector);
 void apic_per_cpu_init(void);
 void apic_enable(void);
 
+void ioapic_set_int(unsigned int gsi, u64 v);
+boolean ioapic_int_is_free(unsigned int gsi);
+
 extern apic_iface apic_if;
 
 static inline u8 apic_id(void)


### PR DESCRIPTION
The current HPET driver configures the HPET interrupt mapping using the FSB option, without checking whether this option is actually supported. This prevents the HPET from generating timer interrupts in platforms (such as VMWare ESXi) where FSB mapping is not supported.
This PR adds a check for the FSB capability in the HPET timer configuration register, and sets up interrupt mapping based on this
capability: if FSB mapping is not supported, standard mapping (which routes interrupts to the I/O APIC) is set up instead.

Note: QEMU by default reports its HPET peripheral as not supporting FSB mapping, even though this feature is actually supported; for this reason, after this commit, when running on QEMU without KVM the kernel sets up the HPET using standard mapping instead of FSB mapping (when KVM is enabled this doesn't apply, since with KVM the kernel uses the TSC deadline timer instead of the HPET). In order to make QEMU report the FSB capability, the '-global hpet.msi=true' command line option needs to be passed to QEMU.