### PR TITLE
 ATA PCI storage: add support for bus master DMA

### DIFF
--- a/src/drivers/ata-pci.c
+++ b/src/drivers/ata-pci.c
@@ -1,4 +1,7 @@
 #include <kernel.h>
+#include <page.h>
+#include <storage.h>
+#include <x86_64/apic.h>
 #include <x86_64/pci.h>
 #include "ata-pci.h"
 #include "ata.h"
@@ -36,6 +39,71 @@
 
 #define PCI_PRODUCT_PIIX4       0x7111
 
+#define ATA_PRIMARY     0
+#define ATA_SECONDARY   1
+
+#define PRDT_ENTRIES    256
+
+/* Allocate twice the nominal PRDT size so that we can align the PRDT to ensure
+ * it doesn't cross a 64K boundary. */
+#define PRDT_SIZE   (2 * PRDT_ENTRIES * sizeof(struct prd))
+
+#define PRD_LAST_ENTRY  (1 << 15)
+
+#define BMR_CHAN_OFFSET 0x08
+
+#define ATA_BMR_CMD(chan)       ((chan) * BMR_CHAN_OFFSET + 0x0)
+#define ATA_BMR_STATUS(chan)    ((chan) * BMR_CHAN_OFFSET + 0x2)
+#define ATA_BMR_PRDT(chan)      ((chan) * BMR_CHAN_OFFSET + 0x4)
+
+#define ATA_BMR_CMD_START   (1 << 0)
+#define ATA_BMR_CMD_READ    (1 << 3)
+
+#define ATA_BMR_STATUS_ERR  (1 << 1)
+#define ATA_BMR_STATUS_IRQ  (1 << 2)
+
+#define ATA_IRQ(chan)  (14 + (chan))
+
+struct prd {
+    u32 buf_addr;   /* physical address */
+    u16 byte_count;
+    u16 ctrl;
+} __attribute__((packed));
+
+declare_closure_struct(2, 3, void, ata_pci_io,
+                       struct ata_pci *, apci, boolean, write,
+                       void *, buf, range, blocks, status_handler, s);
+
+declare_closure_struct(1, 0, void, ata_pci_irq,
+                       struct ata_pci *, apci);
+
+declare_closure_struct(1, 0, void, ata_pci_service,
+                       struct ata_pci *, apci);
+
+typedef struct ata_pci {
+    heap h;
+    struct ata *ata;
+    struct prd *prdt;   /* physical region descriptor table */
+    u64 prdt_phys;
+    struct pci_bar bmr; /* bus master register */
+    closure_struct(ata_pci_io, read);
+    closure_struct(ata_pci_io, write);
+    block_io pio_read, pio_write;
+    closure_struct(ata_pci_irq, irq_handler);
+    closure_struct(ata_pci_service, service);
+    struct list reqs;
+    struct spinlock lock;
+} *ata_pci;
+
+typedef struct ata_pci_req {
+    struct list l;
+    boolean write;
+    void *buf;
+    range remain;
+    status_handler sh;
+    status s;
+} *ata_pci_req;
+
 #ifdef ATA_DEBUG
 static const char *ata_pcivendor2str(pci_dev d)
 {
@@ -68,19 +136,163 @@ static const char *ata_pcivendor2str(pci_dev d)
 }
 #endif // ATA_DEBUG
 
-static struct ata *ata_pci_alloc(heap general, pci_dev d)
+static ata_pci ata_pci_alloc(heap general, heap contiguous, pci_dev d)
 {
-    struct ata *dev = ata_alloc(general);
+    ata_pci apci = allocate(general, sizeof(*apci));
+    assert(apci != INVALID_ADDRESS);
+    apci->ata = ata_alloc(general);
+    apci->prdt = allocate(contiguous, PRDT_SIZE);
+    assert(apci->prdt != INVALID_ADDRESS);
     ata_debug("%s: %s ATA controller\n", __func__, ata_pcivendor2str(d));
-    return dev;
+    return apci;
 }
 
-closure_function(3, 1, boolean, ata_pci_probe,
-                 heap, general, storage_attach, a,
+void ata_pci_dealloc(heap general, heap contiguous, ata_pci apci)
+{
+    ata_debug("%s\n", __func__);
+    deallocate(contiguous, apci->prdt, PRDT_SIZE);
+    ata_dealloc(apci->ata);
+    deallocate(general, apci, sizeof(*apci));
+}
+
+static boolean ata_pci_service_req(ata_pci apci, ata_pci_req req)
+{
+    ata_debug("%s: %R %v\n", __func__, req->remain, req->s);
+    if (!is_ok(req->s))
+        goto done;
+    u64 byte_count = range_span(req->remain) * SECTOR_SIZE;
+    if (byte_count == 0)
+        goto done;
+    u64 buf_phys;
+    int prd_count = 0;
+    while (byte_count > 0 && prd_count < PRDT_ENTRIES) {
+        buf_phys = physical_from_virtual(req->buf);
+        if (buf_phys >= U64_FROM_BIT(32))
+            break;
+
+        /* Ensure the buffer doesn't cross a 64K boundary. */
+        u64 boundary = pad(buf_phys + 1, 64 * KB);
+        u64 len = MIN(byte_count, boundary - buf_phys);
+
+        ata_debug("%s: PRD address 0x%08x, len %ld\n", __func__, buf_phys, len);
+        req->buf += len;
+        byte_count -= len;
+        if (len == U64_FROM_BIT(16))
+            len = 0;
+        apci->prdt[prd_count].buf_addr = buf_phys;
+        apci->prdt[prd_count].byte_count = len;
+        apci->prdt[prd_count].ctrl = 0;
+        prd_count++;
+    }
+    if (prd_count > 0) {
+        apci->prdt[prd_count - 1].ctrl = PRD_LAST_ENTRY;
+        range blocks = irange(req->remain.start,
+            req->remain.end - byte_count / SECTOR_SIZE);
+        ata_debug("%s: starting DMA for %R\n", __func__, blocks);
+        pci_bar_write_4(&apci->bmr, ATA_BMR_PRDT(ATA_PRIMARY), apci->prdt_phys);
+        if (!ata_io_cmd_dma(apci->ata, req->write, blocks)) {
+            req->s = timm("result", "ATA command failed");
+            goto done;
+        }
+        req->remain = irange(blocks.end, req->remain.end);
+        write_barrier();
+        u8 cmd = ATA_BMR_CMD_START | (!req->write ? ATA_BMR_CMD_READ : 0);
+        pci_bar_write_1(&apci->bmr, ATA_BMR_CMD(ATA_PRIMARY), cmd);
+        return false;
+    }
+
+    /* Couldn't use DMA, fall back to PIO. */
+    apply(req->write ? apci->pio_write : apci->pio_read, req->buf, req->remain,
+            req->sh);
+    return true;
+
+done:
+    apply(req->sh, req->s);
+    return true;
+}
+
+static void ata_pci_service_reqs(ata_pci apci)
+{
+    u64 irqflags = spin_lock_irq(&apci->lock);
+    while (!list_empty(&apci->reqs)) {
+        ata_pci_req req = struct_from_list(list_begin(&apci->reqs), ata_pci_req,
+            l);
+        spin_unlock_irq(&apci->lock, irqflags);
+        if (ata_pci_service_req(apci, req)) {
+            irqflags = spin_lock_irq(&apci->lock);
+            list_delete(&req->l);
+            deallocate(apci->h, req, sizeof(*req));
+        } else {    /* request is in progress */
+            return;
+        }
+    }
+    spin_unlock_irq(&apci->lock, irqflags);
+}
+
+define_closure_function(2, 3, void, ata_pci_io,
+                        ata_pci, apci, boolean, write,
+                        void *, buf, range, blocks, status_handler, sh)
+{
+    ata_pci apci = bound(apci);
+    ata_pci_req req = allocate(apci->h, sizeof(*req));
+    if (req == INVALID_ADDRESS) {
+        apply(sh, timm("result", "request allocation failed"));
+        return;
+    }
+    req->write = bound(write);
+    req->buf = buf;
+    req->remain = blocks;
+    req->sh = sh;
+    req->s = STATUS_OK;
+    u64 irqflags = spin_lock_irq(&apci->lock);
+    boolean idle = list_empty(&apci->reqs);
+    list_push_back(&apci->reqs, &req->l);
+    spin_unlock_irq(&apci->lock, irqflags);
+    if (idle)
+        ata_pci_service_reqs(apci);
+}
+
+define_closure_function(1, 0, void, ata_pci_irq,
+                        ata_pci, apci)
+{
+    ata_pci apci = bound(apci);
+    pci_bar_write_1(&apci->bmr, ATA_BMR_CMD(ATA_PRIMARY), 0);
+    u8 status = pci_bar_read_1(&apci->bmr, ATA_BMR_STATUS(ATA_PRIMARY));
+    boolean error = ata_clear_irq(apci->ata);
+    ata_debug("%s: BMR status 0x%02x, ATA %s\n", __func__, status,
+              error ? "error" : "OK");
+    if (status & ATA_BMR_STATUS_ERR) {
+        /* Clear error status */
+        pci_bar_write_1(&apci->bmr, ATA_BMR_STATUS(ATA_PRIMARY),
+            ATA_BMR_STATUS_ERR);
+
+        error = true;
+    }
+    u64 irqflags = spin_lock_irq(&apci->lock);
+    if (!list_empty(&apci->reqs)) {
+        if (error) {
+            ata_pci_req req = struct_from_list(list_begin(&apci->reqs),
+                ata_pci_req, l);
+            req->s = timm("result", "I/O error");
+        }
+        enqueue(bhqueue, &apci->service);
+    }
+    spin_unlock_irq(&apci->lock, irqflags);
+}
+
+define_closure_function(1, 0, void, ata_pci_service,
+                        ata_pci, apci)
+{
+    ata_pci_service_reqs(bound(apci));
+}
+
+closure_function(4, 1, boolean, ata_pci_probe,
+                 heap, general, heap, contiguous, storage_attach, a,
                  boolean, hyperv_storvsc_attached,
                  pci_dev, d)
 {
     heap general = bound(general);
+    heap contiguous = bound(contiguous);
     if (pci_get_class(d) != PCIC_STORAGE || pci_get_subclass(d) != PCIS_STORAGE_IDE)
         return false;
 
@@ -91,22 +303,48 @@ closure_function(3, 1, boolean, ata_pci_probe,
         return false;
     }
 
-
-    struct ata *dev = ata_pci_alloc(general, d);
-    if (!ata_probe(dev)) {
-        ata_dealloc(dev);
+    ata_pci dev = ata_pci_alloc(general, contiguous, d);
+    if (!ata_probe(dev->ata)) {
+        ata_pci_dealloc(general, contiguous, dev);
         return false;
     }
 
+    /* Align the PRDT to ensure it doesn't cross a 64K boundary. */
+    dev->prdt_phys = physical_from_virtual(dev->prdt);
+    u64 boundary = pad(dev->prdt_phys, 64 * KB);
+    int align_offset =
+            (dev->prdt_phys + PRDT_ENTRIES * sizeof(struct prd) > boundary) ?
+                    boundary - dev->prdt_phys : 0;
+    dev->prdt_phys += align_offset;
+    assert(dev->prdt_phys < U64_FROM_BIT(32));
+    dev->prdt = pointer_from_u64(u64_from_pointer(dev->prdt) + align_offset);
+
+    dev->h = general;
+    pci_bar_init(d, &dev->bmr, 4, 0, -1);
+    pci_set_bus_master(d);
+    list_init(&dev->reqs);
+    spin_lock_init(&dev->lock);
+
     // attach
-    block_io in = create_ata_io(general, dev, ATA_READ48);
-    block_io out = create_ata_io(general, dev, ATA_WRITE48);
-    apply(bound(a), in, out, ata_get_capacity(dev));
+    init_closure(&dev->read, ata_pci_io, dev, false);
+    init_closure(&dev->write, ata_pci_io, dev, true);
+    dev->pio_read = create_ata_io(general, dev->ata, ATA_READ48);
+    dev->pio_write = create_ata_io(general, dev->ata, ATA_WRITE48);
+    init_closure(&dev->irq_handler, ata_pci_irq, dev);
+    init_closure(&dev->service, ata_pci_service, dev);
+    ata_clear_irq(dev->ata);
+    u64 irq = allocate_interrupt();
+    assert(irq != INVALID_PHYSICAL);
+    ioapic_set_int(ATA_IRQ(ATA_PRIMARY), irq);
+    register_interrupt(irq, (thunk)&dev->irq_handler, "ata pci");
+    apply(bound(a), (block_io)&dev->read, (block_io)&dev->write,
+          ata_get_capacity(dev->ata));
     return true;
 }
 
 void ata_pci_register(kernel_heaps kh, storage_attach a, boolean hyperv_storvsc_attached)
 {
     heap h = heap_general(kh);
-    register_pci_driver(closure(h, ata_pci_probe, h, a, hyperv_storvsc_attached));
+    register_pci_driver(closure(h, ata_pci_probe, h, heap_backed(kh), a,
+        hyperv_storvsc_attached));
 }

--- a/src/drivers/ata.h
+++ b/src/drivers/ata.h
@@ -90,4 +90,6 @@ u64 ata_get_capacity(struct ata *);
 #define ATA_SET_MAX_ADDRESS             0xf9    /* set max address */
 
 void ata_io_cmd(void *dev, int cmd, void *buf, range blocks, status_handler s);
+boolean ata_io_cmd_dma(void *dev, boolean write, range blocks);
+boolean ata_clear_irq(void *dev);
 block_io create_ata_io(heap h, void * dev, int cmd);

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -254,9 +254,9 @@ void print_byte(buffer b, u8 f);
 static inline void deallocate_buffer(buffer b)
 {
     heap h = b->h;
-    deallocate(h, b->contents, b->length);
     if (!b->wrapped)
-        deallocate(h, b, sizeof(struct buffer));
+        deallocate(h, b->contents, b->length);
+    deallocate(h, b, sizeof(struct buffer));
 }
 
 static inline void copy_descriptor(buffer d, buffer s)

--- a/src/runtime/status.h
+++ b/src/runtime/status.h
@@ -34,6 +34,12 @@ static inline tuple timm_internal(tuple t, char *first, ...)
     return t;
 }
 
+static inline void timm_dealloc(tuple t)
+{
+    if (t != STATUS_OK)
+        destruct_tuple(t);
+}
+
 // fix for zero argument case
 #define timm(first, ...)  timm_internal(STATUS_OK, first, __VA_ARGS__, INVALID_ADDRESS)
 #define timm_append(s, first, ...)  timm_internal(s, first, __VA_ARGS__, INVALID_ADDRESS)

--- a/src/runtime/tuple.c
+++ b/src/runtime/tuple.c
@@ -39,6 +39,20 @@ tuple allocate_tuple()
     return tag(allocate_table(theap, key_from_symbol, pointer_equal), tag_tuple);
 }
 
+void destruct_tuple(tuple t)
+{
+    table_foreach(t, k, v) {
+        (void)k;
+        if (!v)
+            continue;
+        if (tagof(v) == tag_tuple)
+            destruct_tuple(v);
+        else
+            deallocate_buffer(v);
+    }
+    deallocate_tuple(t);
+}
+
 // header: immediate(1)
 //         type(1)
 //         varint encoded unsigned

--- a/src/runtime/tuple.h
+++ b/src/runtime/tuple.h
@@ -17,6 +17,8 @@ static inline void clear_tuple(tuple t)
     table_clear(t);
 }
 
+void destruct_tuple(tuple t);
+
 void encode_tuple(buffer dest, table dictionary, tuple t);
 
 

--- a/test/unit/buffer_test.c
+++ b/test/unit/buffer_test.c
@@ -62,6 +62,9 @@ boolean basic_tests(heap h)
     test_assert(buffer_strchr(b, 't') == 10);
     test_assert(buffer_strchr(b, 'u') < 0);
 
+    /* Create and then deallocate a wrapped buffer. */
+    deallocate_buffer(wrap_buffer_cstring(h, test_str));
+
     /*
      * Validate wrap_buffer_cstring initialization, and contents
      */

--- a/test/unit/tuple_test.c
+++ b/test/unit/tuple_test.c
@@ -35,6 +35,7 @@ boolean all_tests(heap h)
     }
     tuple t2 = tuple_from_vector(v1);
     test_assert(table_elements(t2) == COUNT_ELM);//rprintf("%t\n", t2);
+    destruct_tuple(t2);
     deallocate_vector(v1);
 
     // value <-> U64
@@ -55,6 +56,7 @@ boolean all_tests(heap h)
 
     failure = false;
 fail:
+    destruct_tuple(t1);
     return failure;
 }
 
@@ -86,8 +88,10 @@ boolean encode_decode_test(heap h)
     test_assert(decode_value(h, tdict2, b3) == t4);
     test_assert(!table_find(t4, intern_u64(1)));
 
+    destruct_tuple(t4);
     failure = false;
 fail:
+    destruct_tuple(t3);
     return failure;
 }
 
@@ -147,8 +151,10 @@ boolean encode_decode_lengthy_test(heap h)
     //rprintf("%t\n", t4);
     test_assert(t4->count == 1000);
 
+    destruct_tuple(t4);
     failure = false;
 fail:
+    destruct_tuple(t3);
     return failure;
 }
 


### PR DESCRIPTION
This PR changes the ATA PCI driver in order to use the more efficient DMA transfer mode instead of PIO. Since DMA transfers
can only occur on memory buffers whose addresses fit in 32-bit, the driver falls back to using PIO mode in case a given buffer cannot be used for DMA (which may happen if a machine uses more than 4 GB of memory).
The stage2 bootloader continues to use PIO mode, in order to avoid bloating the bootloader with the PCI support code.
Benchmarks on AWS run with the write runtime test show a performance increase of around 350% on a t2.micro instance, and of more than 400% on a t2.large instance:
t2.micro, PIO mode:
bulk write test, size 20480 KB:
   write   26.757145929s
   fsync   0.006090302s
    read   0.026496127s
   total   26.789732358s (764 KB/s)
t2.micro, DMA mode:
bulk write test, size 20480 KB:
   write   0.010488796s
   fsync   5.957289999s
    read   0.031858582s
   total   5.999637377s (3413 KB/s)
t2.large, PIO mode:
bulk write test, size 20480 KB:
   write   26.502151852s
   fsync   0.004106176s
    read   0.025324654s
   total   26.531582682s (771 KB/s)
t2.large, DMA mode:
bulk write test, size 20480 KB:
   write   0.009317837s
   fsync   4.938269144s
    read   0.023180522s
   total   4.970767503s (4120 KB/s)

For reference, benchmarks run on Qemu (with '-device piix4-ide,id=ide -device ide-hd,drive=hd0,bus=ide.0') showed the following results:
PIO mode:
bulk write test, size 20480 KB:
   write   69.878560419s
   fsync   0.002487529s
    read   0.039719587s
   total   69.920767535s (292 KB/s)
DMA mode:
bulk write test, size 20480 KB:
   write   0.102844458s
   fsync   1.395770157s
    read   0.045169839s
   total   1.543784454s (13266 KB/s)

Qemu with a virtio-scsi disk (as set up by Ops) ran the benchmark with the following figures:
bulk write test, size 20480 KB:
   write   0.112496359s
   fsync   0.060424293s
    read   0.045857733s
   total   0.218778385s (93610 KB/s)

Closes #872.