### PR TITLE
iov_op(): add support for scatter gather I/O operations

### DIFF
--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -713,6 +713,14 @@ static inline void file_op_maybe_wake(thread t)
 void iov_op(fdesc f, boolean write, struct iovec *iov, int iovcnt, u64 offset,
             boolean blocking, io_completion completion);
 
+static inline u64 iov_total_len(struct iovec *iov, int iovcnt)
+{
+    u64 len = 0;
+    for (int i = 0; i < iovcnt; i++)
+        len += iov[i].iov_len;
+    return len;
+}
+
 #define resolve_fd_noret(__p, __fd) vector_get(__p->files, __fd)
 #define resolve_fd(__p, __fd) ({void *f ; if (!(f = resolve_fd_noret(__p, __fd))) return set_syscall_error(current, EBADF); f;})
 

--- a/test/runtime/io_uring.c
+++ b/test/runtime/io_uring.c
@@ -764,7 +764,7 @@ static void iour_test_iovec(void)
     int fd;
     struct iour iour;
     uint8_t read_buf[BUF_SIZE], write_buf[BUF_SIZE];
-    const int chunk_len = 64;
+    const int chunk_len = 8;
     const int chunk_count = BUF_SIZE / chunk_len;
     struct iovec iov[chunk_count];
     struct io_uring_cqe *cqe;


### PR DESCRIPTION
If the file descriptor on which a vector I/O operation is being invoked implements scatter/gather I/O, the kernel now uses this implementation, instead of invoking the linear read/write closures for each element in the I/O vector.
This PR also adds a scatter/gather write implementation for regular files.

Closes #1115.