### PR TITLE
Network socket ioctl: add support for FIONREAD command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ test test-noaccel: mkfs boot stage3
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fallocate fcntl fst getdents getrandom hw hws io_uring mkdir mmap pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fallocate fcntl fst getdents getrandom hw hws io_uring mkdir mmap netsock pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -152,7 +152,8 @@ struct flock {
 #define F_WRLCK         1
 #define F_UNLCK         2
 
-#define FIONBIO		0x5421
+#define FIONREAD        0x541b
+#define FIONBIO         0x5421
 #define FIONCLEX        0x5450
 #define FIOCLEX         0x5451
 

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -16,6 +16,7 @@ PROGRAMS= \
 	io_uring \
 	mkdir \
 	mmap \
+	netsock \
 	nullpage \
 	paging \
 	pipe \
@@ -131,6 +132,12 @@ SRCS-mkdir= \
 	$(CURDIR)/mkdir.c \
 	$(SRCDIR)/unix_process/ssp.c
 LDFLAGS-mkdir=		-static
+
+SRCS-netsock= \
+	$(CURDIR)/netsock.c \
+	$(SRCDIR)/unix_process/ssp.c
+LDFLAGS-netsock=	-static
+LIBS-netsock=		-lpthread
 
 SRCS-nullpage=		$(CURDIR)/nullpage.c
 # use -O0 so that clang does not generate UD2 instruction for the code with undefined behavior

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -1,0 +1,90 @@
+#include <netinet/in.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define NETSOCK_TEST_FIO_COUNT  8
+
+#define test_assert(expr) do { \
+    if (!(expr)) { \
+        printf("Error: %s -- failed at %s:%d\n", #expr, __FILE__, __LINE__); \
+        exit(EXIT_FAILURE); \
+    } \
+} while (0)
+
+static void *netsock_test_fionread_thread(void *arg)
+{
+    int port = (long)arg;
+    int fd;
+    struct sockaddr_in addr;
+    uint8_t buf[NETSOCK_TEST_FIO_COUNT];
+
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    test_assert(fd > 0);
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    test_assert(connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    test_assert(write(fd, buf, sizeof(buf)) == sizeof(buf));
+    return (void *)(long)fd;
+}
+
+static void netsock_test_fionread(void)
+{
+    int fd, conn_fd;
+    int nbytes;
+    struct sockaddr_in addr;
+    const int port = 1234;
+    pthread_t pt;
+    int ret;
+    void *thread_ret;
+    uint8_t buf[NETSOCK_TEST_FIO_COUNT];
+
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    test_assert(fd > 0);
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    test_assert(bind(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    test_assert((ioctl(fd, FIONREAD, &nbytes) == 0) && (nbytes == 0));
+    test_assert(listen(fd, 1) == 0);
+    ret = pthread_create(&pt, NULL, netsock_test_fionread_thread,
+        (void *)(long)port);
+    test_assert(ret == 0);
+
+    /* Wait for client to connect. */
+    conn_fd = accept(fd, NULL, NULL);
+    test_assert(conn_fd > 0);
+
+    /* Wait for client to send data. */
+    test_assert(pthread_join(pt, &thread_ret) == 0);
+
+    test_assert(ioctl(conn_fd, FIONREAD, &nbytes) == 0);
+    test_assert(nbytes == NETSOCK_TEST_FIO_COUNT);
+    test_assert(close((long)thread_ret) == 0);  /* TCP client socket */
+    test_assert(close(conn_fd) == 0);
+    test_assert(close(fd) == 0);
+
+    fd = socket(AF_INET, SOCK_DGRAM, 0);
+    test_assert(fd > 0);
+    test_assert(bind(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    test_assert((ioctl(fd, FIONREAD, &nbytes) == 0) && (nbytes == 0));
+    ret = sendto(fd, buf, sizeof(buf), 0, (struct sockaddr *)&addr,
+        sizeof(addr));
+    test_assert(ret == sizeof(buf));
+    test_assert((ioctl(fd, FIONREAD, &nbytes) == 0) && (nbytes == sizeof(buf)));
+    test_assert(close(fd) == 0);
+}
+
+int main(int argc, char **argv)
+{
+    setbuf(stdout, NULL);
+
+    netsock_test_fionread();
+    printf("Network socket tests OK\n");
+    return EXIT_SUCCESS;
+}

--- a/test/runtime/netsock.manifest
+++ b/test/runtime/netsock.manifest
@@ -1,0 +1,13 @@
+(
+    boot:(
+        children:(
+            kernel:(contents:(host:output/stage3/bin/stage3.img))
+        )
+    )
+    children:(
+        netsock:(contents:(host:output/test/runtime/bin/netsock))
+    )
+    program:/netsock
+    fault:t
+    environment:()
+)


### PR DESCRIPTION
This ioctl command returns the number of bytes available to be read from a socket.
A runtime test suite to exercise this feature (using the loopback interface) is also being added.

Closes #1036.