### PR TITLE
vmap_update_protections: fix flags for newly allocated ranges

### DIFF
--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -460,7 +460,7 @@ closure_function(4, 1, void, vmap_update_protections_intersection,
         if (tail) {
             /* create node at tail end */
             assert(allocate_vmap(pvmap, irange(ri.end, rn.end),
-                                ivmap(newflags,
+                                ivmap(match->flags,
                                       node_offset + (ri.end - rn.start),
                                       match->cache_node)) != INVALID_ADDRESS);
         }


### PR DESCRIPTION
This PR fixes a regression introduced in commit 5a4247ea; if an mprotect syscall causes a new memory map range to be allocated at the tail of an existing mapping, its protection flags should be those of the existing mapping, rather than those being set for the memory range passed to mprotect().
The mmap runtime test suite is also being amended with a new set of tests that would have failed without this fix.