### PR TITLE
CircleCI: bump golang version in Docker image to Go 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.14
     steps:
       - checkout
       - run: sudo apt-get update
@@ -19,7 +19,7 @@ jobs:
 
   nightly-build:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.14
     steps:
       - checkout
       - run: sudo apt-get update

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Makefile.local
 /TAGS
 
 # test artifacts
+/test/go/go.sum
 /test/go/instance.img
 /test/go/image*
 /test/go/.staging/*

--- a/test/go/go.mod
+++ b/test/go/go.mod
@@ -1,0 +1,5 @@
+module github.com/nanovms/nanos/test/go
+
+go 1.13
+
+require github.com/nanovms/ops v0.0.0-20200723220750-5b6024c6dc1b


### PR DESCRIPTION
This fixes the CI failures triggered by the addition of Azure support to ops (the Azure SDK for Go requires Go 1.13 or newer).
A go.mod file is being added to test/go/ because it is needed with Go 1.13 or newer in order for the github.com/nanovms/ops/lepton dependency to be resolved by "go build".
The go.sum file that is created by "go build" is being gitignored.