### PR TITLE
fix mac ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: 
           name: macbuild
           environment:
-            NANOS_TARGET_ROOT: target-root
+            NANOS_TARGET_ROOT: $HOME/project/target-root
           command: |
             OPS_DIR=$HOME/.ops
             PATH=$HOME/.ops/bin:$PATH
@@ -81,13 +81,13 @@ jobs:
       - run: 
           name: macbuild
           environment:
-            NANOS_TARGET_ROOT: target-root
+            NANOS_TARGET_ROOT: $HOME/project/target-root
           command: make
       - run: brew upgrade python
       - run: curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-240.0.0-darwin-x86_64.tar.gz
       - run: tar xzf google-cloud-sdk*.tar.gz
       - run: ./google-cloud-sdk/install.sh -q
-      - run: source /Users/distiller/project/google-cloud-sdk/path.bash.inc && echo export PATH=$PATH > $BASH_ENV
+      - run: source $HOME/project/google-cloud-sdk/path.bash.inc && echo export PATH=$PATH > $BASH_ENV
       - run: echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
       - run: sudo gcloud config set project ${GOOGLE_PROJECT_ID}
       - run: gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}

--- a/src/hyperv/include/atomic.h
+++ b/src/hyperv/include/atomic.h
@@ -26,6 +26,7 @@ atomic_testandset32(volatile u32 *p, u32 v)
 {
         u8 res;
 
+#ifdef __GCC_ASM_FLAG_OUTPUTS__
         __asm __volatile(
         "       " MPLOCKED "            "
         "       btsl    %2,%1 ;         "
@@ -34,6 +35,17 @@ atomic_testandset32(volatile u32 *p, u32 v)
           "+m" (*p)                     /* 1 */
         : "Ir" (v & 0x1f)               /* 2 */
         : "cc");
+#else
+        __asm __volatile(
+        "       " MPLOCKED "            "
+        "       btsl    %2,%1 ;         "
+	"       sbb     %0,%0 ;         "
+        "# atomic_testandset_int"
+        : "=r" (res),                   /* 0 */
+          "+m" (*p)                     /* 1 */
+        : "Ir" (v & 0x1f)               /* 2 */
+        : "cc");
+#endif
         return (res);
 }
 
@@ -54,6 +66,7 @@ atomic_testandclear64(volatile u64 *p, u32 v)
 {
     unsigned char res;
 
+#ifdef __GCC_ASM_FLAG_OUTPUTS__
     __asm __volatile(
     "   " MPLOCKED "        "
     "   btrq    %2,%1 ;     "
@@ -62,6 +75,17 @@ atomic_testandclear64(volatile u64 *p, u32 v)
       "+m" (*p)         /* 1 */
     : "Jr" ((u64)(v & 0x3f)) /* 2 */
     : "cc");
+#else
+    __asm __volatile(
+    "   " MPLOCKED "        "
+    "   btrq    %2,%1 ;     "
+    "   sbb     %0,%0 ;     "
+    "# atomic_testandclear64"
+    : "=r" (res),        /* 0 */
+      "+m" (*p)         /* 1 */
+    : "Jr" ((u64)(v & 0x3f)) /* 2 */
+    : "cc");
+#endif
     return (res);
 }
 
@@ -98,6 +122,7 @@ ATOMIC_ASM(subtract, 32,   "subl %1,%0",  "ir",  v);
  *
  * Returns 0 on failure, non-zero on success.
  */
+#ifdef __GCC_ASM_FLAG_OUTPUTS__
 #define ATOMIC_CMPSET(SIZE)                             \
 static __inline int                                     \
 atomic_cmpset##SIZE(volatile u##SIZE *dst, u##SIZE expect, u##SIZE src) \
@@ -115,6 +140,26 @@ atomic_cmpset##SIZE(volatile u##SIZE *dst, u##SIZE expect, u##SIZE src) \
         : "memory", "cc");                              \
         return (res);                                   \
 }
+#else
+#define ATOMIC_CMPSET(SIZE)                             \
+static __inline int                                     \
+atomic_cmpset##SIZE(volatile u##SIZE *dst, u##SIZE expect, u##SIZE src) \
+{                                                       \
+        int res;                                        \
+        __asm __volatile(                               \
+        "       " MPLOCKED "            "               \
+        "       cmpxchg %3,%1 ; "                       \
+	"       lahf ; "                                \
+	"       andq $0x4000,%%rax ; "                  \
+        "# atomic_cmpset_" #SIZE "      "               \
+        : "=a" (res),                   /* 0 */         \
+          "+m" (*dst),                  /* 1 */         \
+          "+a" (expect)                 /* 2 */         \
+        : "r" (src)                     /* 3 */         \
+        : "memory", "cc");                              \
+        return (res);                                   \
+}
+#endif
 
 ATOMIC_CMPSET(32);
 

--- a/src/x86_64/crt0.s
+++ b/src/x86_64/crt0.s
@@ -124,7 +124,7 @@ extern common_handler
         ; noreturn               
 %endmacro
 
-# just write a generic one that takes rax, rcx and arguments and stores in a u64[3]
+;; just write a generic one that takes rax, rcx and arguments and stores in a u64[3]
 global xsave_features
 xsave_features :
 	push rcx

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -353,7 +353,7 @@ all: $(PROGRAMS)
 include ../../rules.mk
 
 ifeq ($(UNAME_s),Darwin)
-CFLAGS+=	-target x86_64-elf --sysroot $(TARGET_ROOT)
+CFLAGS+=	-target x86_64-elf --sysroot $(TARGET_ROOT) -I $(TARGET_ROOT)/usr/include
 LD=		x86_64-elf-ld
 LDFLAGS+=	--sysroot=$(TARGET_ROOT)
 OBJS_BEGIN=	$(OBJS_CRTBEGIN)

--- a/test/runtime/writev.c
+++ b/test/runtime/writev.c
@@ -27,7 +27,7 @@
 int main()
 {
     struct iovec iovs[3];
-    size_t rv;
+    ssize_t rv;
     char buf[BUFLEN];
     char arr1[] = "This seems ", arr2[] = "to have ", arr3[] = "worked";
     char *str = "This seems to have worked";

--- a/test/unit/tuple_test.c
+++ b/test/unit/tuple_test.c
@@ -81,7 +81,7 @@ boolean encode_decode_test(heap h)
 
     buffer buf = allocate_buffer(h, 128);
     bprintf(buf, "%t", t4);
-    test_assert(strncmp(buf->contents, "(1:200)", buf->length) == 0);
+    test_assert(strncmp(buf->contents, "(1:200)", buffer_length(buf)) == 0);
 
     // update tuple by removing an entry
     encode_eav(b3, tdict1, t3, intern_u64(1), 0);


### PR DESCRIPTION
fix various bugs uncovered by mac nightly build:

- hyperv atomics used asm flags constraints (`@CC<cond>`)without checking for support; use alternate versions when `__GCC_ASM_FLAG_OUTPUTS__` is not defined
- missing include path for runtime tests
- use absolute path for NANOS_TARGET_ROOT
- wrong type in writev test caused always-true condition
- incorrect use of buf->length in tuple_test
- unsupported comment syntax in crt0.s

resolves #1227 
