### PR TITLE
fix strict-aliasing warnings

### DIFF
--- a/src/hyperv/vmbus/vmbus.c
+++ b/src/hyperv/vmbus/vmbus.c
@@ -429,12 +429,12 @@ static boolean vmbus_connect(vmbus_dev dev, uint32_t version)
         kernel_delay(milliseconds(1));
     }
 
-    int done = ((const struct vmbus_chanmsg_connect_resp *)
-        msg->msg_data)->chm_done;
+    const struct vmbus_chanmsg_connect_resp *connect_resp =
+        (const struct vmbus_chanmsg_connect_resp *)msg->msg_data;
 
     vmbus_msghc_put(dev, mh);
 
-    return (done ? true : false);
+    return (connect_resp->chm_done ? true : false);
 }
 
 static boolean
@@ -459,9 +459,9 @@ static void
 vmbus_chanmsg_handle(vmbus_dev sc, const struct vmbus_message *msg)
 {
     vmbus_chanmsg_proc_t msg_proc;
-    uint32_t msg_type;
+    const struct vmbus_chanmsg_hdr *hdr = (const struct vmbus_chanmsg_hdr *)msg->msg_data;
+    uint32_t msg_type = hdr->chm_type;
 
-    msg_type = ((const struct vmbus_chanmsg_hdr *)msg->msg_data)->chm_type;
     if (msg_type >= VMBUS_CHANMSG_TYPE_MAX) {
         vmbus_debug("unknown message type 0x%x", msg_type);
         return;
@@ -609,7 +609,8 @@ vmbus_probe_channels(vmbus_dev dev, const list driver_list, list nodes)
             continue;
         }
 
-        u32 msg_type = ((const struct vmbus_chanmsg_hdr *)msg->msg_data)->chm_type;
+        const struct vmbus_chanmsg_hdr *hdr = (const struct vmbus_chanmsg_hdr *)msg->msg_data;
+        u32 msg_type = hdr->chm_type;
         /* Handle response */
         if (msg_type == VMBUS_CHANMSG_TYPE_CHOFFER) {
 

--- a/src/hyperv/vmbus/vmbus_chan.c
+++ b/src/hyperv/vmbus/vmbus_chan.c
@@ -274,8 +274,9 @@ vmbus_chan_open_br(struct vmbus_channel *chan, const struct vmbus_chan_br *cbr,
     }
     uint32_t status;
     if (msg != NULL) {
-        status = ((const struct vmbus_chanmsg_chopen_resp *)
-            msg->msg_data)->chm_status;
+        const struct vmbus_chanmsg_chopen_resp *chan_resp =
+            (const struct vmbus_chanmsg_chopen_resp *)msg->msg_data;
+        status = chan_resp->chm_status;
     } else {
         /* XXX any non-0 value is ok here. */
         status = 0xff;
@@ -307,7 +308,6 @@ vmbus_chan_gpadl_connect(struct vmbus_channel *chan, bus_addr_t paddr,
     vmbus_dev dev = chan->ch_vmbus;
     struct vmbus_msghc *mh;
     struct vmbus_chanmsg_gpadl_conn *req;
-    const struct vmbus_message *msg;
     uint32_t gpadl, status;
 
     assert(*gpadl0 == 0); //GPADL is not zero
@@ -390,9 +390,10 @@ vmbus_chan_gpadl_connect(struct vmbus_channel *chan, bus_addr_t paddr,
     }
     assert(page_count == 0); //invalid page count %d", page_count
 
-    msg = vmbus_msghc_wait_result(dev, mh);
-    status = ((const struct vmbus_chanmsg_gpadl_connresp *)
-        msg->msg_data)->chm_status;
+    const struct vmbus_message *msg = vmbus_msghc_wait_result(dev, mh);
+    const struct vmbus_chanmsg_gpadl_connresp *connresp =
+        (const struct vmbus_chanmsg_gpadl_connresp *)msg->msg_data;
+    status = connresp->chm_status;
 
     vmbus_msghc_put(dev, mh);
 
@@ -1011,9 +1012,8 @@ void
 vmbus_chan_msgproc(vmbus_dev sc, const struct vmbus_message *msg)
 {
     vmbus_chanmsg_proc_t msg_proc;
-    uint32_t msg_type;
-
-    msg_type = ((const struct vmbus_chanmsg_hdr *)msg->msg_data)->chm_type;
+    const struct vmbus_chanmsg_hdr *hdr = (const struct vmbus_chanmsg_hdr *)msg->msg_data;
+    uint32_t msg_type = hdr->chm_type;
     assert(msg_type < VMBUS_CHANMSG_TYPE_MAX); //"invalid message type %u", msg_type
 
     msg_proc = vmbus_chan_msgprocs[msg_type];


### PR DESCRIPTION
Fix master build failure under gcc Debian 6.3.0-18+deb9u1 due to strict aliasing violations:

```
CC      /share/src/nanovms/master02/output/stage3/src/hyperv/vmbus/vmbus.o                                                                                                                                                                     
CC      /share/src/nanovms/master02/output/stage3/src/hyperv/vmbus/vmbus_chan.o                                                                                                                                                                
/share/src/nanovms/master02/src/hyperv/vmbus/vmbus_chan.c: In function ‘vmbus_chan_open_br’:                                                                                                                                                   
/share/src/nanovms/master02/src/hyperv/vmbus/vmbus_chan.c:278:13: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]                                                                          
             msg->msg_data)->chm_status;                                                                                                                                                                                                       
             ^~~                                                                                                                                                                                                                               
/share/src/nanovms/master02/src/hyperv/vmbus/vmbus.c: In function ‘vmbus_connect’:                                                                                                                                                             
/share/src/nanovms/master02/src/hyperv/vmbus/vmbus.c:433:9: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]                                                                                
         msg->msg_data)->chm_done;                                                                                                                                                                                                             
         ^~~                                                                                                                                                                                                                                   
/share/src/nanovms/master02/src/hyperv/vmbus/vmbus.c: In function ‘vmbus_chanmsg_handle’:                                                                                                                                                      
/share/src/nanovms/master02/src/hyperv/vmbus/vmbus.c:464:31: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]                                                                               
     msg_type = ((const struct vmbus_chanmsg_hdr *)msg->msg_data)->chm_type;                                                                                                                                                                   
                               ^~~~~~~~~~~~~~~~~                                                                                                                                                                                               
/share/src/nanovms/master02/src/hyperv/vmbus/vmbus_chan.c: In function ‘vmbus_chan_gpadl_connect’:                                                                                                                                             
/share/src/nanovms/master02/src/hyperv/vmbus/vmbus_chan.c:395:9: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]                                                                           
         msg->msg_data)->chm_status;                                                                                                                                                                                                           
         ^~~                                                                                                                                                                                                                                   
/share/src/nanovms/master02/src/hyperv/vmbus/vmbus.c: In function ‘vmbus_probe_channels’:                                                                                                                                                      
/share/src/nanovms/master02/src/hyperv/vmbus/vmbus.c:612:39: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]                                                                               
         u32 msg_type = ((const struct vmbus_chanmsg_hdr *)msg->msg_data)->chm_type;                                                                                                                                                           
                                       ^~~~~~~~~~~~~~~~~                                                                                                                                                                                       
/share/src/nanovms/master02/src/hyperv/vmbus/vmbus_chan.c: In function ‘vmbus_chan_msgproc’:                                                                                                                                                   
/share/src/nanovms/master02/src/hyperv/vmbus/vmbus_chan.c:1016:31: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]                                                                         
     msg_type = ((const struct vmbus_chanmsg_hdr *)msg->msg_data)->chm_type;                                                                                                                                                                   
                               ^~~~~~~~~~~~~~~~~                                                                                                                                                                                               
cc1: all warnings being treated as errors
```