### PR TITLE
Storage: add support for multiple filesystem mounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ MKFS=		$(TOOLDIR)/mkfs
 BOOTIMG=	$(PLATFORMOBJDIR)/boot/boot.img
 KERNEL=		$(PLATFORMOBJDIR)/bin/kernel.img
 
-all: image
+all: image tools
 
-.PHONY: image release target distclean
+.PHONY: image release target tools distclean
 
 include rules.mk
 
@@ -53,6 +53,9 @@ release: mkfs
 
 target: contgen
 	$(Q) $(MAKE) -C test/runtime $(TARGET)
+
+tools:
+	$(Q) $(MAKE) -C $@
 
 distclean: clean
 	$(Q) $(RM) -rf $(VENDORDIR)

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -23,6 +23,7 @@ SRCS-kernel.img= \
 	$(SRCDIR)/kernel/pvclock.c \
 	$(SRCDIR)/kernel/schedule.c \
 	$(SRCDIR)/kernel/stage3.c \
+	$(SRCDIR)/kernel/storage.c \
 	$(SRCDIR)/kernel/symtab.c \
 	$(SRCDIR)/kernel/vdso-now.c \
 	$(SRCDIR)/net/direct.c \

--- a/platform/pc/boot/stage2.c
+++ b/platform/pc/boot/stage2.c
@@ -300,14 +300,12 @@ void newstack()
 
     setup_page_tables();
 
-    pagecache pc = allocate_pagecache(h, h, 0, PAGESIZE);
-    assert(pc != INVALID_ADDRESS);
+    init_pagecache(h, h, 0, PAGESIZE);
     create_filesystem(h,
                       SECTOR_SIZE,
                       infinity,
                       get_stage2_disk_read(h, fs_offset),
                       closure(h, stage2_empty_write),
-                      pc,
                       false,
                       closure(h, filesystem_initialized, h, heap_backed(&kh), bh));
     

--- a/src/kernel/pagecache.h
+++ b/src/kernel/pagecache.h
@@ -1,5 +1,3 @@
-typedef struct pagecache *pagecache;
-
 typedef struct pagecache_volume *pagecache_volume;
 
 typedef struct pagecache_node *pagecache_node;
@@ -14,11 +12,11 @@ void pagecache_sync_node(pagecache_node pn, status_handler complete);
 
 void pagecache_sync_volume(pagecache_volume pv, status_handler complete);
 
-void *pagecache_get_zero_page(pagecache pc);
+void *pagecache_get_zero_page();
 
-int pagecache_get_page_order(pagecache pc);
+int pagecache_get_page_order();
 
-u64 pagecache_drain(pagecache pc, u64 drain_bytes);
+u64 pagecache_drain(u64 drain_bytes);
 
 pagecache_node pagecache_allocate_node(pagecache_volume pv, sg_io fs_read, sg_io fs_write);
 
@@ -43,9 +41,7 @@ void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node
 
 void pagecache_node_add_shared_map(pagecache_node pn , range v /* bytes */, u64 node_offset);
 
-pagecache_volume pagecache_allocate_volume(pagecache pc, u64 length, int block_order);
+pagecache_volume pagecache_allocate_volume(u64 length, int block_order);
 void pagecache_dealloc_volume(pagecache_volume pv);
 
-pagecache allocate_pagecache(heap general, heap contiguous, heap physical, u64 pagesize);
-
-void deallocate_pagecache(pagecache pc);
+void init_pagecache(heap general, heap contiguous, heap physical, u64 pagesize);

--- a/src/kernel/pagecache_internal.h
+++ b/src/kernel/pagecache_internal.h
@@ -4,7 +4,7 @@ typedef struct pagelist {
 } *pagelist;
 
 declare_closure_struct(1, 1, void, pagecache_scan_timer,
-                       pagecache, pc,
+                       struct pagecache *, pc,
                        u64, overruns /* ignored */);
 
 typedef struct pagecache {

--- a/src/kernel/storage.c
+++ b/src/kernel/storage.c
@@ -1,0 +1,237 @@
+#include <kernel.h>
+#include <pagecache.h>
+#include <storage.h>
+#include <tfs.h>
+#include <unix.h>
+
+typedef struct volume {
+    struct list l;
+    u8 uuid[UUID_LEN];
+    block_io r, w;
+    u64 size;
+    boolean mounting;
+    filesystem fs;
+    tuple mount_dir;
+} *volume;
+
+static struct {
+    heap h;
+    filesystem root_fs;
+    struct list volumes;
+    tuple mounts;
+    thunk mount_complete;
+    struct spinlock lock;
+} storage;
+
+//#define STORAGE_DEBUG
+#ifdef STORAGE_DEBUG
+#define storage_debug(x, ...) do {  \
+    rprintf("STORAGE: " x "\n", ##__VA_ARGS__); \
+} while(0)
+#else
+#define storage_debug(x, ...)
+#endif
+
+#define storage_lock()      u64 _irqflags = spin_lock_irq(&storage.lock)
+#define storage_unlock()    spin_unlock_irq(&storage.lock, _irqflags)
+
+/* Called with mutex locked. */
+static volume storage_get_volume(tuple root)
+{
+    list_foreach(&storage.volumes, e) {
+        volume v = struct_from_list(e, volume, l);
+        if (v->fs && (filesystem_getroot(v->fs) == root)) {
+            return v;
+        }
+    }
+    return 0;
+}
+
+static void storage_check_if_ready(void)
+{
+    boolean mounting = false;
+    thunk complete = 0;
+    storage_lock();
+    list_foreach(&storage.volumes, e) {
+        volume v = struct_from_list(e, volume, l);
+        if (v->mounting) {
+            mounting = true;
+            break;
+        }
+    }
+    if (!mounting) {
+        complete = storage.mount_complete;
+        storage.mount_complete = 0;
+    }
+    storage_unlock();
+    if (complete)
+        apply(complete);
+}
+
+static boolean volume_match(symbol s, volume v)
+{
+    /* UUID format in symbol string: 00112233-4455-6677-8899-aabbccddeeff */
+    buffer vol = symbol_string(s);
+    if (buffer_length(vol) != 2 * UUID_LEN + 4)
+        return false;
+    const char *b = buffer_ref(vol, 0);
+    return (!buf_hex_cmp(v->uuid, b, 4) && (b[8] == '-') &&
+            !buf_hex_cmp(v->uuid + 4, b + 9, 2) && (b[13] == '-') &&
+            !buf_hex_cmp(v->uuid + 6, b + 14, 2) && (b[18] == '-') &&
+            !buf_hex_cmp(v->uuid + 8, b + 19, 2) && (b[23] == '-') &&
+            !buf_hex_cmp(v->uuid + 10, b + 24, 6));
+}
+
+closure_function(2, 2, void, volume_link,
+                 volume, v, tuple, mount_dir,
+                 filesystem, fs, status, s)
+{
+    volume v = bound(v);
+    if (is_ok(s)) {
+        tuple mount_dir = bound(mount_dir);
+        tuple volume_root = filesystem_getroot(fs);
+        tuple mount = allocate_tuple();
+        table_set(mount, sym(root), volume_root);
+        table_set(mount, sym(no_encode), null_value); /* non-persistent entry */
+        table_set(mount_dir, sym(mount), mount);
+        v->fs = fs;
+        v->mount_dir = mount_dir;
+        storage_debug("volume mounted, mount directory %p, root %p", mount_dir,
+                      volume_root);
+    } else {
+        msg_err("cannot mount filesystem: %v\n", s);
+    }
+    v->mounting = false;
+    closure_finish();
+    timm_dealloc(s);
+    storage_check_if_ready();
+}
+
+static void volume_mount(volume v, buffer mount_point)
+{
+    tuple root = filesystem_getroot(storage.root_fs);
+    vector path = split(storage.h, mount_point, '/');
+    tuple mount_dir = resolve_path(root, path);
+    deallocate_vector(path);
+    if (!mount_dir || (mount_dir == root) || !children(mount_dir)) {
+        msg_err("invalid mount point %b\n", mount_point);
+        return;
+    }
+    filesystem_complete complete = closure(storage.h, volume_link,
+        v, mount_dir);
+    if (complete == INVALID_ADDRESS) {
+        msg_err("cannot allocate closure\n");
+        return;
+    }
+    storage_debug("mounting volume at %b", mount_point);
+    v->mounting = true;
+    create_filesystem(storage.h, SECTOR_SIZE, v->size, v->r, v->w, false,
+                      complete);
+}
+
+void init_volumes(heap h)
+{
+    storage.h = h;
+    list_init(&storage.volumes);
+    storage.root_fs = 0;
+    storage.mounts = 0;
+    storage.mount_complete = 0;
+    spin_lock_init(&storage.lock);
+}
+
+void storage_set_root_fs(filesystem root_fs)
+{
+    storage.root_fs = root_fs;
+}
+
+void storage_set_mountpoints(tuple mounts)
+{
+    storage_lock();
+    storage.mounts = mounts;
+    table_foreach(mounts, k, path) {
+        storage_debug("mount point for volume %b at %b", symbol_string(k),
+            path);
+        list_foreach(&storage.volumes, e) {
+            volume v = struct_from_list(e, volume, l);
+            if (volume_match(k, v))
+                volume_mount(v, path);
+        }
+    }
+    storage_unlock();
+}
+
+boolean volume_add(u8 *uuid, block_io r, block_io w, u64 size)
+{
+    storage_debug("new volume (%ld bytes)", size);
+    volume v = allocate(storage.h, sizeof(*v));
+    if (v == INVALID_ADDRESS)
+        return false;
+    runtime_memcpy(v->uuid, uuid, UUID_LEN);
+    v->r = r;
+    v->w = w;
+    v->size = size;
+    v->mounting = false;
+    v->fs = 0;
+    v->mount_dir = 0;
+    storage_lock();
+    list_push_back(&storage.volumes, &v->l);
+    if (storage.mounts)
+        table_foreach(storage.mounts, k, path) {
+            if (volume_match(k, v)) {
+                volume_mount(v, path);
+                break;
+            }
+        }
+    storage_unlock();
+    return true;
+}
+
+void storage_when_ready(thunk complete)
+{
+    storage.mount_complete = complete;
+    storage_check_if_ready();
+}
+
+void storage_sync(status_handler sh)
+{
+    storage_debug("sync (%F)", sh);
+    merge m = allocate_merge(storage.h, sh);
+    status_handler complete = apply_merge(m);
+    filesystem_sync(storage.root_fs, apply_merge(m));
+    storage_lock();
+    list_foreach(&storage.volumes, e) {
+        volume v = struct_from_list(e, volume, l);
+        if (v->fs) {
+            storage_debug("syncing mounted filesystem %p", v->fs);
+            filesystem_sync(v->fs, apply_merge(m));
+        }
+    }
+    storage_unlock();
+    apply(complete, STATUS_OK);
+}
+
+filesystem storage_get_fs(tuple root)
+{
+    filesystem fs;
+    storage_lock();
+    volume v = storage_get_volume(root);
+    if (v)
+        fs = v->fs;
+    else
+        fs = 0;
+    storage_unlock();
+    return fs;
+}
+
+tuple storage_get_mountpoint(tuple root)
+{
+    tuple mount_dir;
+    storage_lock();
+    volume v = storage_get_volume(root);
+    if (v)
+        mount_dir = v->mount_dir;
+    else
+        mount_dir = 0;
+    storage_unlock();
+    return mount_dir;
+}

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -251,6 +251,8 @@ void print_hex_buffer(buffer s, buffer b);
 
 void print_byte(buffer b, u8 f);
 
+void print_uuid(buffer b, u8 *uuid);
+
 static inline void deallocate_buffer(buffer b)
 {
     heap h = b->h;

--- a/src/runtime/extra_prints.c
+++ b/src/runtime/extra_prints.c
@@ -33,6 +33,17 @@ void print_hex_buffer(buffer s, buffer b)
     push_u8(s, '\n');
 }
 
+void print_uuid(buffer b, u8 *uuid)
+{
+    /* UUID format: 00112233-4455-6677-8899-aabbccddeeff */
+    for (int i = 0; i < 4; i++)
+        bprintf(b, "%02x", uuid[i]);
+    bprintf(b, "-%02x%02x-%02x%02x-%02x%02x-", uuid[4], uuid[5], uuid[6],
+            uuid[7], uuid[8], uuid[9]);
+    for (int i = 10; i < 16; i++)
+        bprintf(b, "%02x", uuid[i]);
+}
+
 /* just a little tool for debugging */
 void print_csum_buffer(buffer s, buffer b)
 {

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -25,6 +25,8 @@ typedef u64 timestamp;
 #define MB (KB*KB)
 #define GB (KB*MB)
 
+#define UUID_LEN    16
+
 void console_write(const char *s, bytes count);
 
 void print_u64(u64 s);

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -56,3 +56,15 @@ static inline void partition_write(struct partition_entry *e, boolean active,
     e->lba_start = offset / SECTOR_SIZE;
     e->nsectors = size / SECTOR_SIZE;
 }
+
+struct filesystem;
+
+void init_volumes(heap h);
+void storage_set_root_fs(struct filesystem *root_fs);
+void storage_set_mountpoints(tuple mounts);
+boolean volume_add(u8 *uuid, block_io r, block_io w, u64 size);
+void storage_when_ready(thunk complete);
+void storage_sync(status_handler sh);
+
+struct filesystem *storage_get_fs(tuple root);
+tuple storage_get_mountpoint(tuple root);

--- a/src/runtime/text.h
+++ b/src/runtime/text.h
@@ -11,6 +11,25 @@ static inline s8 digit_of(character x)
     return(-1);
 }
 
+static inline int byte_from_hex(character msn, character lsn)
+{
+    s8 n1, n2;
+    if (((n1 = digit_of(msn)) < 0) || ((n2 = digit_of(lsn)) < 0))
+        return -1;
+    return ((n1 << 4) | n2);
+}
+
+static inline int buf_hex_cmp(const u8 *buf, const char *hex, bytes n)
+{
+    for (bytes i = 0; i < n; i++) {
+        int b = byte_from_hex(hex[2 * i], hex[2 * i + 1]);
+        if (b < 0)
+            return b;
+        else if ((u8)b != buf[i])
+            return (buf[i] - b);
+    }
+    return 0;
+}
 
 static inline bytes utf8_length(unsigned char x)
 {

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -1142,7 +1142,6 @@ void create_filesystem(heap h,
                        u64 size,
                        block_io read,
                        block_io write,
-                       pagecache pc,
                        boolean initialize,
                        filesystem_complete complete)
 {
@@ -1153,16 +1152,15 @@ void create_filesystem(heap h,
     if (!ignore_io_status)
         ignore_io_status = closure(h, ignore_io);
     fs->files = allocate_table(h, identity_key, pointer_equal);
-    fs->zero_page = pagecache_get_zero_page(pc);
+    fs->zero_page = pagecache_get_zero_page();
     assert(fs->zero_page);
     fs->r = read;
-    fs->pc = pc;
     fs->root = 0;
-    fs->page_order = pagecache_get_page_order(pc);
+    fs->page_order = pagecache_get_page_order();
     fs->size = size;
     assert((blocksize & (blocksize - 1)) == 0);
     fs->blocksize_order = find_order(blocksize);
-    fs->pv = pagecache_allocate_volume(pc, size, fs->blocksize_order);
+    fs->pv = pagecache_allocate_volume(size, fs->blocksize_order);
     assert(fs->pv != INVALID_ADDRESS);
 #ifndef TFS_READ_ONLY
     fs->w = write;

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -1137,6 +1137,11 @@ closure_function(2, 1, void, log_complete,
 closure_function(0, 2, void, ignore_io,
                  status, s, bytes, length) {}
 
+void filesystem_get_uuid(filesystem fs, u8 *uuid)
+{
+    runtime_memcpy(uuid, fs->uuid, UUID_LEN);
+}
+
 void create_filesystem(heap h,
                        u64 blocksize,
                        u64 size,

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -18,6 +18,8 @@ extern io_status_handler ignore_io_status;
 #define MIN_EXTENT_SIZE PAGESIZE
 #define MAX_EXTENT_SIZE (1 * MB)
 
+void filesystem_get_uuid(filesystem fs, u8 *uuid);
+
 void create_filesystem(heap h,
                        u64 blocksize,
                        u64 size,

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -23,7 +23,6 @@ void create_filesystem(heap h,
                        u64 size,
                        block_io read,
                        block_io write,
-                       pagecache pc,
                        boolean initialize,
                        filesystem_complete complete);
 void destroy_filesystem(filesystem fs);

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -18,6 +18,7 @@ extern io_status_handler ignore_io_status;
 #define MIN_EXTENT_SIZE PAGESIZE
 #define MAX_EXTENT_SIZE (1 * MB)
 
+boolean filesystem_probe(u8 *first_sector, u8 *uuid);
 void filesystem_get_uuid(filesystem fs, u8 *uuid);
 
 void create_filesystem(heap h,

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -23,7 +23,6 @@ typedef struct filesystem {
     void *zero_page;
     block_io r;
     block_io w;
-    pagecache pc;
     pagecache_volume pv;
     log tl;
     log temp_log;

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -6,7 +6,7 @@
 #include <pagecache.h>
 #include <tfs.h>
 
-#define TFS_VERSION 0x00000002
+#define TFS_VERSION 0x00000003
 
 typedef struct log *log;
 
@@ -17,6 +17,7 @@ typedef struct filesystem {
     int blocksize_order;
     int alignment_order;        /* in blocks */
     int page_order;
+    u8 uuid[UUID_LEN];
     table files; // maps tuple to fsfile
     closure_type(log, void, tuple);
     heap dma;

--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -830,6 +830,16 @@ static void log_read(log tl, status_handler sh)
     apply(ext->read, sg, r, tlc);
 }
 
+boolean filesystem_probe(u8 *first_sector, u8 *uuid)
+{
+    u64 len;
+    status s = log_hdr_parse(alloca_wrap_buffer(first_sector, SECTOR_SIZE),
+        true, &len, uuid);
+    boolean success = is_ok(s);
+    timm_dealloc(s);
+    return success;
+}
+
 log log_create(heap h, filesystem fs, boolean initialize, status_handler sh)
 {
     tlog_debug("log_create: heap %p, fs %p, sh %p\n", h, fs, sh);

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -193,7 +193,7 @@ process exec_elf(buffer ex, process kp)
     unix_heaps uh = kp->uh;
     kernel_heaps kh = (kernel_heaps)uh;
     tuple root = kp->process_root;
-    filesystem fs = kp->fs;
+    filesystem fs = kp->root_fs;
     process proc = create_process(uh, root, fs);
     thread t = create_thread(proc);
     tuple interp = 0;

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -125,11 +125,11 @@ void register_special_files(process p)
     heap h = heap_general((kernel_heaps)p->uh);
 
     tuple proc_self;
-    int ret = resolve_cstring(p->cwd, "/proc/self/exe", 0, &proc_self);
+    int ret = resolve_cstring(0, p->cwd, "/proc/self/exe", 0, &proc_self);
     if (ret == -ENOENT) {
         if (!proc_self) {
-            filesystem_mkdirpath(p->fs, 0, "/proc/self", true);
-            assert(resolve_cstring(p->cwd, "/proc/self", &proc_self, 0) == 0);
+            filesystem_mkdirpath(p->root_fs, 0, "/proc/self", true);
+            assert(resolve_cstring(0, p->cwd, "/proc/self", &proc_self, 0) == 0);
         }
         assert(proc_self);
         value program = table_find(p->process_root, sym(program));
@@ -137,7 +137,7 @@ void register_special_files(process p)
         buffer b = clone_buffer(h, program);
         assert(b != INVALID_ADDRESS);
         buffer_write_byte(b, '\0'); /* append string terminator character */
-        filesystem_symlink(p->fs, proc_self, "exe", buffer_ref(b, 0));
+        filesystem_symlink(p->root_fs, proc_self, "exe", buffer_ref(b, 0));
         deallocate_buffer(b);
     }
 
@@ -148,10 +148,10 @@ void register_special_files(process p)
         tuple entry = allocate_tuple();
         buffer b = wrap_buffer(h, sf, sizeof(*sf));
         table_set(entry, sym(special), b);
-        filesystem_mkentry(p->fs, 0, sf->path, entry, false, true);
+        filesystem_mkentry(p->root_fs, 0, sf->path, entry, false, true);
     }
 
-    filesystem_mkdirpath(p->fs, 0, "/sys/devices/system/cpu/cpu0", false);
+    filesystem_mkdirpath(p->root_fs, 0, "/sys/devices/system/cpu/cpu0", false);
 }
 
 static special_file *

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1,5 +1,6 @@
 #include <unix_internal.h>
 #include <filesystem.h>
+#include <storage.h>
 
 // lifted from linux UAPI
 #define DT_UNKNOWN	0
@@ -210,43 +211,37 @@ static int file_get_path(tuple n, char *buf, u64 len)
     }
     buf[0] = '\0';
     int cur_len = 1;
+    tuple p;
     buffer tmpbuf = little_stack_buffer(NAME_MAX + 1);
 next:
+    n = lookup_follow_mounts(0, n, sym_this(".."), &p);
+    assert(n);
+    if (n == p) {   /* this is the root directory */
+        if (cur_len == 1) {
+            buf[0] = '/';
+            buf[1] = '\0';
+            cur_len = 2;
+        }
+        c = 0;
+    } else {
+        c = children(n);
+    }
+    if (!c)
+        goto done;
     table_foreach(c, k, v) {
-        char *name = cstring(symbol_string(k), tmpbuf);
-        if (!runtime_strcmp(name, "..")) {
-            if (v == n) {   /* this is the root directory */
-                if (cur_len == 1) {
-                    buf[0] = '/';
-                    buf[1] = '\0';
-                    cur_len = 2;
-                }
-                c = 0;
-            }
-            else {
-                c = children(v);
-            }
-            if (!c) {
-                goto done;
-            }
-            table_foreach(c, k, v) {
-                if (v == n) {
-                    char *name = cstring(symbol_string(k), tmpbuf);
-                    int name_len = runtime_strlen(name);
-                    if (len < 1 + name_len + cur_len) {
-                        return -1;
-                    }
-                    runtime_memcpy(buf + 1 + name_len, buf, cur_len);
-                    buf[0] = '/';
-                    runtime_memcpy(buf + 1, name, name_len);
-                    cur_len += 1 + name_len;
-                    break;
-                }
-            }
-            n = v;
-            goto next;
+        if (v == p) {
+            char *name = cstring(symbol_string(k), tmpbuf);
+            int name_len = runtime_strlen(name);
+            if (len < 1 + name_len + cur_len)
+                return -1;
+            runtime_memcpy(buf + 1 + name_len, buf, cur_len);
+            buf[0] = '/';
+            runtime_memcpy(buf + 1, name, name_len);
+            cur_len += 1 + name_len;
+            break;
         }
     }
+    goto next;
 done:
     return cur_len;
 }
@@ -256,12 +251,12 @@ static inline boolean filepath_is_ancestor(tuple wd1, const char *fp1,
         tuple wd2, const char *fp2)
 {
     tuple t1;
-    int ret = resolve_cstring(wd1, fp1, &t1, 0);
+    int ret = resolve_cstring(0, wd1, fp1, &t1, 0);
     if (ret) {
         return false;
     }
     tuple p2;
-    ret = resolve_cstring(wd2, fp2, 0, &p2);
+    ret = resolve_cstring(0, wd2, fp2, 0, &p2);
     if ((ret && (ret != -ENOENT)) || !p2) {
         return false;
     }
@@ -656,7 +651,7 @@ static sysreturn sendfile(int out_fd, int in_fd, int *offset, bytes count)
 static void begin_file_read(thread t, file f)
 {
     if ((f->length > 0) && !(f->f.flags & O_NOATIME)) {
-        filesystem_update_atime(t->p->fs, file_get_meta(f));
+        filesystem_update_atime(f->fs, fsfile_get_meta(f->fsf));
     }
     file_op_begin(t);
 }
@@ -760,7 +755,7 @@ closure_function(2, 6, sysreturn, file_sg_read,
 static void begin_file_write(thread t, file f, u64 len)
 {
     if (len > 0)
-        filesystem_update_mtime(t->p->fs, file_get_meta(f));
+        filesystem_update_mtime(f->fs, fsfile_get_meta(f->fsf));
     file_op_begin(t);
 }
 
@@ -956,7 +951,8 @@ boolean validate_user_string(const char *name)
     return false;
 }
 
-sysreturn open_internal(tuple cwd, const char *name, int flags, int mode)
+sysreturn open_internal(filesystem fs, tuple cwd, const char *name, int flags,
+                        int mode)
 {
     heap h = heap_general(get_kernel_heaps());
     unix_heaps uh = get_unix_heaps();
@@ -968,21 +964,21 @@ sysreturn open_internal(tuple cwd, const char *name, int flags, int mode)
         return -EFAULT;
 
     if (flags & O_NOFOLLOW) {
-        ret = resolve_cstring(cwd, name, &n, &parent);
+        ret = resolve_cstring(&fs, cwd, name, &n, &parent);
         if (!ret && is_symlink(n) && !(flags & O_PATH)) {
             ret = -ELOOP;
         }
     } else {
-        ret = resolve_cstring_follow(cwd, name, &n, &parent);
+        ret = resolve_cstring_follow(&fs, cwd, name, &n, &parent);
     }
     if ((flags & O_CREAT)) {
         if (!ret && (flags & O_EXCL)) {
             thread_log(current, "\"%s\" opened with O_EXCL but already exists", name);
             return set_syscall_error(current, EEXIST);
         } else if ((ret == -ENOENT) && parent) {
-            n = filesystem_creat(current->p->fs, parent, filename_from_path(name));
+            n = filesystem_creat(fs, parent, filename_from_path(name));
             if (n) {
-                filesystem_update_mtime(current->p->fs, parent);
+                filesystem_update_mtime(fs, parent);
                 ret = 0;
             } else {
                 ret = -ENOMEM;
@@ -1000,7 +996,7 @@ sysreturn open_internal(tuple cwd, const char *name, int flags, int mode)
 
     int type = file_type_from_tuple(n);
     if (type == FDESC_TYPE_REGULAR) {
-        fsf = fsfile_from_node(current->p->fs, n);
+        fsf = fsfile_from_node(fs, n);
         assert(fsf);
         length = fsfile_get_length(fsf);
     }
@@ -1026,6 +1022,7 @@ sysreturn open_internal(tuple cwd, const char *name, int flags, int mode)
     f->f.close = closure(h, file_close, f, fsf);
     f->f.events = closure(h, file_events, f);
     f->f.flags = flags;
+    f->fs = fs;
     if (type == FDESC_TYPE_REGULAR) {
         f->fsf = fsf;
         f->fs_read = fsfile_get_reader(fsf);
@@ -1056,7 +1053,8 @@ sysreturn open_internal(tuple cwd, const char *name, int flags, int mode)
 sysreturn open(const char *name, int flags, int mode)
 {
     thread_log(current, "open: \"%s\", flags %x, mode %x", name, flags, mode);
-    return open_internal(current->p->cwd, name, flags, mode);
+    return open_internal(current->p->cwd_fs, current->p->cwd, name, flags,
+        mode);
 }
 
 sysreturn dup(int fd)
@@ -1109,18 +1107,19 @@ sysreturn dup3(int oldfd, int newfd, int flags)
     return dup2(oldfd, newfd);
 }
 
-static sysreturn mkdir_internal(tuple cwd, const char *pathname, int mode)
+static sysreturn mkdir_internal(filesystem fs, tuple cwd, const char *pathname,
+                                int mode)
 {
     tuple parent;
-    int ret = resolve_cstring(cwd, pathname, 0, &parent);
+    int ret = resolve_cstring(&fs, cwd, pathname, 0, &parent);
     if ((ret != -ENOENT) || !parent) {
         return set_syscall_return(current, ret);
     }
     buffer b = little_stack_buffer(NAME_MAX + 1);
     if (!dirname_from_path(b, pathname))
         return -ENAMETOOLONG;
-    if (filesystem_mkdir(current->p->fs, parent, (char *)buffer_ref(b, 0))) {
-        filesystem_update_mtime(current->p->fs, parent);
+    if (filesystem_mkdir(fs, parent, (char *)buffer_ref(b, 0))) {
+        filesystem_update_mtime(fs, parent);
         return 0;
     } else {
         return -ENOSPC;
@@ -1132,7 +1131,7 @@ sysreturn mkdir(const char *pathname, int mode)
     if (!validate_user_string(pathname))
         return -EFAULT;
     thread_log(current, "mkdir: \"%s\", mode 0x%x", pathname, mode);
-    return mkdir_internal(current->p->cwd, pathname, mode);
+    return mkdir_internal(current->p->cwd_fs, current->p->cwd, pathname, mode);
 }
 
 /*
@@ -1152,16 +1151,18 @@ sysreturn mkdirat(int dirfd, char *pathname, int mode)
     if (!validate_user_string(pathname))
         return -EFAULT;
     thread_log(current, "mkdirat: \"%s\", dirfd %d, mode 0x%x", pathname, dirfd, mode);
+    filesystem fs;
     tuple cwd;
-    cwd = resolve_dir(dirfd, pathname);
+    cwd = resolve_dir(fs, dirfd, pathname);
 
-    return mkdir_internal(cwd, pathname, mode);
+    return mkdir_internal(fs, cwd, pathname, mode);
 }
 
 sysreturn creat(const char *pathname, int mode)
 {
     thread_log(current, "creat: \"%s\", mode 0x%x", pathname, mode);
-    return open_internal(current->p->cwd, pathname, O_CREAT|O_WRONLY|O_TRUNC, mode);
+    return open_internal(current->p->cwd_fs, current->p->cwd, pathname,
+        O_CREAT|O_WRONLY|O_TRUNC, mode);
 }
 
 sysreturn getrandom(void *buf, u64 buflen, unsigned int flags)
@@ -1197,7 +1198,7 @@ static int try_write_dirent(tuple root, struct linux_dirent *dirp, char *p,
             return -1;
         } else {
             tuple n;
-            resolve_cstring(root, p, &n, 0);
+            resolve_cstring(0, root, p, &n, 0);
             // include the entry in the buffer
             runtime_memset((u8*)dirp, 0, reclen);
             dirp->d_ino = u64_from_pointer(n);
@@ -1240,7 +1241,7 @@ sysreturn getdents(int fd, struct linux_dirent *dirp, unsigned int count)
     }
 
 done:
-    filesystem_update_atime(current->p->fs, file_get_meta(f));
+    filesystem_update_atime(f->fs, file_get_meta(f));
     f->offset = read_sofar;
     if (r < 0 && written_sofar == 0)
         return -EINVAL;
@@ -1263,7 +1264,7 @@ static int try_write_dirent64(tuple root, struct linux_dirent64 *dirp, char *p,
             return -1;
         } else {
             tuple n;
-            resolve_cstring(root, p, &n, 0);
+            resolve_cstring(0, root, p, &n, 0);
             // include the entry in the buffer
             runtime_memset((u8*)dirp, 0, reclen);
             dirp->d_ino = u64_from_pointer(n);
@@ -1306,7 +1307,7 @@ sysreturn getdents64(int fd, struct linux_dirent64 *dirp, unsigned int count)
     }
 
 done:
-    filesystem_update_atime(current->p->fs, file_get_meta(f));
+    filesystem_update_atime(f->fs, file_get_meta(f));
     f->offset = read_sofar;
     if (r < 0 && written_sofar == 0)
         return -EINVAL;
@@ -1317,17 +1318,19 @@ done:
 sysreturn chdir(const char *path)
 {
     int ret;
+    filesystem fs = current->p->cwd_fs;
     tuple n;
 
     if (!validate_user_string(path))
         return set_syscall_error(current, EFAULT);
-    ret = resolve_cstring_follow(current->p->cwd, path, &n, 0);
+    ret = resolve_cstring_follow(&fs, current->p->cwd, path, &n, 0);
     if (ret) {
         return set_syscall_return(current, ret);
     }
     if (!is_dir(n)) {
         return set_syscall_error(current, ENOENT);
     }
+    current->p->cwd_fs = fs;
     current->p->cwd = n;
     return set_syscall_return(current, 0);
 }
@@ -1339,11 +1342,12 @@ sysreturn fchdir(int dirfd)
     if (!children)
         return set_syscall_error(current, -ENOTDIR);
 
+    current->p->cwd_fs = f->fs;
     current->p->cwd = file_get_meta(f);
     return set_syscall_return(current, 0);
 }
 
-static sysreturn truncate_internal(file f, tuple t, long length)
+static sysreturn truncate_internal(filesystem fs, file f, tuple t, long length)
 {
     if (is_dir(t)) {
         return set_syscall_error(current, EISDIR);
@@ -1351,18 +1355,18 @@ static sysreturn truncate_internal(file f, tuple t, long length)
     if (length < 0) {
         return set_syscall_error(current, EINVAL);
     }
-    fsfile fsf = fsfile_from_node(current->p->fs, t);
+    fsfile fsf = fsfile_from_node(fs, t);
     if (!fsf) {
         return set_syscall_error(current, ENOENT);
     }
     if (length == fsfile_get_length(fsf))
         return 0;
-    fs_status s = filesystem_truncate(current->p->fs, fsf, length);
+    fs_status s = filesystem_truncate(fs, fsf, length);
     if (s == FS_STATUS_OK) {
         truncate_file_maps(current->p, fsf, length);
         if (f)
             f->length = length;
-        filesystem_update_mtime(current->p->fs, t);
+        filesystem_update_mtime(fs, t);
     }
     return sysreturn_from_fs_status(s);
 }
@@ -1373,11 +1377,12 @@ sysreturn truncate(const char *path, long length)
         return -EFAULT;
     thread_log(current, "%s \"%s\" %d", __func__, path, length);
     tuple t;
-    int ret = resolve_cstring_follow(current->p->cwd, path, &t, 0);
+    filesystem fs = current->p->cwd_fs;
+    int ret = resolve_cstring_follow(&fs, current->p->cwd, path, &t, 0);
     if (ret) {
         return set_syscall_return(current, ret);
     }
-    return truncate_internal(0, t, length);
+    return truncate_internal(fs, 0, t, length);
 }
 
 sysreturn ftruncate(int fd, long length)
@@ -1388,23 +1393,15 @@ sysreturn ftruncate(int fd, long length)
             (f->f.type != FDESC_TYPE_REGULAR)) {
         return set_syscall_error(current, EINVAL);
     }
-    return truncate_internal(f, file_get_meta(f), length);
+    return truncate_internal(f->fs, f, file_get_meta(f), length);
 }
 
-closure_function(4, 1, void, sync_complete,
-                 filesystem, fs, thread, t, pagecache_node, pn, boolean, fs_flushed,
+closure_function(1, 1, void, sync_complete,
+                 thread, t,
                  status, s)
 {
     thread t = bound(t);
-    thread_log(current, "%s: status %v, fs_flushed %d", __func__, s, bound(fs_flushed));
-    if (is_ok(s) && !bound(fs_flushed)) {
-        bound(fs_flushed) = true;
-        if (bound(pn))
-            pagecache_sync_node(bound(pn), (status_handler)closure_self());
-        else
-            pagecache_sync_volume(filesystem_get_pagecache_volume(bound(fs)), (status_handler)closure_self());
-        return;
-    }
+    thread_log(current, "%s: status %v", __func__, s);
     set_syscall_return(t, is_ok(s) ? 0 : -EIO);
     file_op_maybe_wake(t);
     closure_finish();
@@ -1412,9 +1409,12 @@ closure_function(4, 1, void, sync_complete,
 
 sysreturn sync(void)
 {
+    status_handler sh = closure(heap_general(get_kernel_heaps()), sync_complete,
+        current);
+    if (sh == INVALID_ADDRESS)
+        return -ENOMEM;
     file_op_begin(current);
-    filesystem_flush(current->p->fs, closure(heap_general(get_kernel_heaps()),
-                                             sync_complete, current->p->fs, current, 0, false));
+    storage_sync(sh);
     return file_op_maybe_sleep(current);
 }
 
@@ -1433,9 +1433,10 @@ sysreturn fsync(int fd)
     case FDESC_TYPE_REGULAR:
         assert(((file)f)->fsf);
         file_op_begin(current);
-        filesystem_flush(current->p->fs,
-                         closure(heap_general(get_kernel_heaps()), sync_complete, current->p->fs,
-                                 current, fsfile_get_cachenode(((file)f)->fsf), false));
+        filesystem_sync_node(((file)f)->fs,
+                             fsfile_get_cachenode(((file)f)->fsf),
+                             closure(heap_general(get_kernel_heaps()),
+                                 sync_complete, current));
         return file_op_maybe_sleep(current);
     case FDESC_TYPE_DIRECTORY:
     case FDESC_TYPE_SYMLINK:
@@ -1455,7 +1456,7 @@ sysreturn access(const char *name, int mode)
     if (!validate_user_string(name))
         return -EFAULT;
     thread_log(current, "access: \"%s\", mode %d", name, mode);
-    int ret = resolve_cstring_follow(current->p->cwd, name, 0, 0);
+    int ret = resolve_cstring_follow(0, current->p->cwd, name, 0, 0);
     if (ret) {
         return set_syscall_return(current, ret);
     }
@@ -1479,13 +1480,14 @@ sysreturn openat(int dirfd, const char *name, int flags, int mode)
     if (name == 0)
         return set_syscall_error(current, EINVAL);
 
+    filesystem fs;
     tuple cwd;
-    cwd = resolve_dir(dirfd, name);
+    cwd = resolve_dir(fs, dirfd, name);
 
-    return open_internal(cwd, name, flags, mode);
+    return open_internal(fs, cwd, name, flags, mode);
 }
 
-static void fill_stat(int type, tuple n, struct stat *s)
+static void fill_stat(int type, filesystem fs, tuple n, struct stat *s)
 {
     zero(s, sizeof(struct stat));
     switch (type) {
@@ -1514,16 +1516,16 @@ static void fill_stat(int type, tuple n, struct stat *s)
     }
     s->st_ino = u64_from_pointer(n);
     if (type == FDESC_TYPE_REGULAR) {
-        fsfile f = fsfile_from_node(current->p->fs, n);
+        fsfile f = fsfile_from_node(fs, n);
         if (f)
             s->st_size = fsfile_get_length(f);
     }
     if (n) {
         struct timespec ts;
-        timespec_from_time(&ts, filesystem_get_atime(current->p->fs, n));
+        timespec_from_time(&ts, filesystem_get_atime(fs, n));
         s->st_atime = ts.tv_sec;
         s->st_atime_nsec = ts.tv_nsec;
-        timespec_from_time(&ts, filesystem_get_mtime(current->p->fs, n));
+        timespec_from_time(&ts, filesystem_get_mtime(fs, n));
         s->st_mtime = ts.tv_sec;
         s->st_mtime_nsec = ts.tv_nsec;
     }
@@ -1537,23 +1539,26 @@ static sysreturn fstat(int fd, struct stat *s)
     if (!validate_user_memory(s, sizeof(struct stat), true))
         return -EFAULT;
     fdesc f = resolve_fd(current->p, fd);
+    filesystem fs;
     tuple n;
     switch (f->type) {
     case FDESC_TYPE_REGULAR:
     case FDESC_TYPE_DIRECTORY:
     case FDESC_TYPE_SPECIAL:
     case FDESC_TYPE_SYMLINK:
+        fs = ((file)f)->fs;
         n = file_get_meta((file)f);
         break;
     default:
+        fs = 0;
         n = 0;
         break;
     }
-    fill_stat(f->type, n, s);
+    fill_stat(f->type, fs, n, s);
     return 0;
 }
 
-static sysreturn stat_internal(tuple cwd, const char *name, boolean follow,
+static sysreturn stat_internal(filesystem fs, tuple cwd, const char *name, boolean follow,
         struct stat *buf)
 {
     tuple n;
@@ -1564,28 +1569,28 @@ static sysreturn stat_internal(tuple cwd, const char *name, boolean follow,
         return -EFAULT;
 
     if (!follow) {
-        ret = resolve_cstring(cwd, name, &n, 0);
+        ret = resolve_cstring(&fs, cwd, name, &n, 0);
     } else {
-        ret = resolve_cstring_follow(cwd, name, &n, 0);
+        ret = resolve_cstring_follow(&fs, cwd, name, &n, 0);
     }
     if (ret) {
         return set_syscall_return(current, ret);
     }
 
-    fill_stat(file_type_from_tuple(n), n, buf);
+    fill_stat(file_type_from_tuple(n), fs, n, buf);
     return 0;
 }
 
 static sysreturn stat(const char *name, struct stat *buf)
 {
     thread_log(current, "stat: \"%s\", buf %p", name, buf);
-    return stat_internal(current->p->cwd, name, true, buf);
+    return stat_internal(current->p->cwd_fs, current->p->cwd, name, true, buf);
 }
 
 static sysreturn lstat(const char *name, struct stat *buf)
 {
     thread_log(current, "lstat: \"%s\", buf %p", name, buf);
-    return stat_internal(current->p->cwd, name, false, buf);
+    return stat_internal(current->p->cwd_fs, current->p->cwd, name, false, buf);
 }
 
 static sysreturn newfstatat(int dfd, const char *name, struct stat *s, int flags)
@@ -1599,8 +1604,9 @@ static sysreturn newfstatat(int dfd, const char *name, struct stat *s, int flags
         return fstat(dfd, s);
 
     // Else, if we have a fd of a directory, resolve name to it.
-    tuple n = resolve_dir(dfd, name);
-    return stat_internal(n, name, !(flags & AT_SYMLINK_NOFOLLOW), s);
+    filesystem fs;
+    tuple n = resolve_dir(fs, dfd, name);
+    return stat_internal(fs, n, name, !(flags & AT_SYMLINK_NOFOLLOW), s);
 }
 
 sysreturn lseek(int fd, s64 offset, int whence)
@@ -1779,14 +1785,14 @@ static sysreturn brk(void *x)
     return sysreturn_from_pointer(p->brk);
 }
 
-static sysreturn readlink_internal(tuple cwd, const char *pathname, char *buf,
+static sysreturn readlink_internal(filesystem fs, tuple cwd, const char *pathname, char *buf,
         u64 bufsiz)
 {
     if (!validate_user_string(pathname) || !validate_user_memory(buf, bufsiz, true)) {
         return set_syscall_error(current, EFAULT);
     }
     tuple n;
-    int ret = resolve_cstring(cwd, pathname, &n, 0);
+    int ret = resolve_cstring(&fs, cwd, pathname, &n, 0);
     if (ret) {
         return set_syscall_return(current, ret);
     }
@@ -1799,46 +1805,48 @@ static sysreturn readlink_internal(tuple cwd, const char *pathname, char *buf,
         len = bufsiz;
     }
     runtime_memcpy(buf, buffer_ref(target, 0), len);
-    filesystem_update_atime(current->p->fs, n);
+    filesystem_update_atime(fs, n);
     return set_syscall_return(current, len);
 }
 
 sysreturn readlink(const char *pathname, char *buf, u64 bufsiz)
 {
     thread_log(current, "readlink: \"%s\"", pathname);
-    return readlink_internal(current->p->cwd, pathname, buf, bufsiz);
+    return readlink_internal(current->p->cwd_fs, current->p->cwd, pathname, buf,
+        bufsiz);
 }
 
 sysreturn readlinkat(int dirfd, const char *pathname, char *buf, u64 bufsiz)
 {
     thread_log(current, "readlinkat: \"%s\", dirfd %d", pathname, dirfd);
-    tuple cwd = resolve_dir(dirfd, pathname);
-    return readlink_internal(cwd, pathname, buf, bufsiz);
+    filesystem fs;
+    tuple cwd = resolve_dir(fs, dirfd, pathname);
+    return readlink_internal(fs, cwd, pathname, buf, bufsiz);
 }
 
-static sysreturn unlink_internal(tuple cwd, const char *pathname)
+static sysreturn unlink_internal(filesystem fs, tuple cwd, const char *pathname)
 {
     tuple n;
     tuple parent;
-    int ret = resolve_cstring(cwd, pathname, &n, &parent);
+    int ret = resolve_cstring(&fs, cwd, pathname, &n, &parent);
     if (ret) {
         return set_syscall_return(current, ret);
     }
     if (is_dir(n)) {
         return set_syscall_error(current, EISDIR);
     }
-    fs_status s = filesystem_delete(current->p->fs, parent,
+    fs_status s = filesystem_delete(fs, parent,
         lookup_sym(parent, n));
     if (s == FS_STATUS_OK)
-        filesystem_update_mtime(current->p->fs, parent);
+        filesystem_update_mtime(fs, parent);
     return sysreturn_from_fs_status(s);
 }
 
-static sysreturn rmdir_internal(tuple cwd, const char *pathname)
+static sysreturn rmdir_internal(filesystem fs, tuple cwd, const char *pathname)
 {
     tuple n;
     tuple parent;
-    int ret = resolve_cstring(cwd, pathname, &n, &parent);
+    int ret = resolve_cstring(&fs, cwd, pathname, &n, &parent);
     if (ret) {
         return set_syscall_return(current, ret);
     }
@@ -1855,10 +1863,10 @@ static sysreturn rmdir_internal(tuple cwd, const char *pathname)
             return set_syscall_error(current, ENOTEMPTY);
         }
     }
-    fs_status s = filesystem_delete(current->p->fs, parent,
+    fs_status s = filesystem_delete(fs, parent,
         lookup_sym(parent, n));
     if (s == FS_STATUS_OK)
-        filesystem_update_mtime(current->p->fs, parent);
+        filesystem_update_mtime(fs, parent);
     return sysreturn_from_fs_status(s);
 }
 
@@ -1867,7 +1875,7 @@ sysreturn unlink(const char *pathname)
     if (!validate_user_string(pathname))
         return -EFAULT;
     thread_log(current, "unlink %s", pathname);
-    return unlink_internal(current->p->cwd, pathname);
+    return unlink_internal(current->p->cwd_fs, current->p->cwd, pathname);
 }
 
 sysreturn unlinkat(int dirfd, const char *pathname, int flags)
@@ -1878,12 +1886,13 @@ sysreturn unlinkat(int dirfd, const char *pathname, int flags)
     if (flags & ~AT_REMOVEDIR) {
         return set_syscall_error(current, EINVAL);
     }
-    tuple cwd = resolve_dir(dirfd, pathname);
+    filesystem fs;
+    tuple cwd = resolve_dir(fs, dirfd, pathname);
     if (flags & AT_REMOVEDIR) {
-        return rmdir_internal(cwd, pathname);
+        return rmdir_internal(fs, cwd, pathname);
     }
     else {
-        return unlink_internal(cwd, pathname);
+        return unlink_internal(fs, cwd, pathname);
     }
 }
 
@@ -1892,11 +1901,12 @@ sysreturn rmdir(const char *pathname)
     if (!validate_user_string(pathname))
         return -EFAULT;
     thread_log(current, "rmdir %s", pathname);
-    return rmdir_internal(current->p->cwd, pathname);
+    return rmdir_internal(current->p->cwd_fs, current->p->cwd, pathname);
 }
 
-static sysreturn rename_internal(tuple oldwd, const char *oldpath, tuple newwd,
-        const char *newpath)
+static sysreturn rename_internal(filesystem oldfs, tuple oldwd,
+                                 const char *oldpath, filesystem newfs,
+                                 tuple newwd, const char *newpath)
 {
     if (!oldpath[0] || !newpath[0]) {
         return set_syscall_error(current, ENOENT);
@@ -1904,18 +1914,20 @@ static sysreturn rename_internal(tuple oldwd, const char *oldpath, tuple newwd,
     int ret;
     tuple old;
     tuple oldparent;
-    ret = resolve_cstring(oldwd, oldpath, &old, &oldparent);
+    ret = resolve_cstring(&oldfs, oldwd, oldpath, &old, &oldparent);
     if (ret) {
         return set_syscall_return(current, ret);
     }
     tuple new, newparent;
-    ret = resolve_cstring(newwd, newpath, &new, &newparent);
+    ret = resolve_cstring(&newfs, newwd, newpath, &new, &newparent);
     if (ret && (ret != -ENOENT)) {
         return set_syscall_return(current, ret);
     }
     if (!newparent) {
         return set_syscall_error(current, ENOENT);
     }
+    if (oldfs != newfs)
+        return -EXDEV;
     if (!ret && is_dir(new)) {
         if (!is_dir(old)) {
             return set_syscall_error(current, EISDIR);
@@ -1939,11 +1951,11 @@ static sysreturn rename_internal(tuple oldwd, const char *oldpath, tuple newwd,
     }
     if ((newparent == oldparent) && (new == old))
         return 0;
-    fs_status s = filesystem_rename(current->p->fs, oldparent,
+    fs_status s = filesystem_rename(oldfs, oldparent,
         lookup_sym(oldparent, old), newparent, filename_from_path(newpath));
     if (s == FS_STATUS_OK) {
-        filesystem_update_mtime(current->p->fs, oldparent);
-        filesystem_update_mtime(current->p->fs, newparent);
+        filesystem_update_mtime(oldfs, oldparent);
+        filesystem_update_mtime(newfs, newparent);
     }
     return sysreturn_from_fs_status(s);
 }
@@ -1953,7 +1965,8 @@ sysreturn rename(const char *oldpath, const char *newpath)
     if (!validate_user_string(oldpath) || !validate_user_string(newpath))
         return -EFAULT;
     thread_log(current, "rename \"%s\" \"%s\"", oldpath, newpath);
-    return rename_internal(current->p->cwd, oldpath, current->p->cwd, newpath);
+    return rename_internal(current->p->cwd_fs, current->p->cwd, oldpath,
+        current->p->cwd_fs, current->p->cwd, newpath);
 }
 
 sysreturn renameat(int olddirfd, const char *oldpath, int newdirfd,
@@ -1963,9 +1976,10 @@ sysreturn renameat(int olddirfd, const char *oldpath, int newdirfd,
         return -EFAULT;
     thread_log(current, "renameat %d \"%s\" %d \"%s\"", olddirfd, oldpath,
             newdirfd, newpath);
-    tuple oldwd = resolve_dir(olddirfd, oldpath);
-    tuple newwd = resolve_dir(newdirfd, newpath);
-    return rename_internal(oldwd, oldpath, newwd, newpath);
+    filesystem oldfs, newfs;
+    tuple oldwd = resolve_dir(oldfs, olddirfd, oldpath);
+    tuple newwd = resolve_dir(newfs, newdirfd, newpath);
+    return rename_internal(oldfs, oldwd, oldpath, newfs, newwd, newpath);
 }
 
 sysreturn renameat2(int olddirfd, const char *oldpath, int newdirfd,
@@ -1979,8 +1993,9 @@ sysreturn renameat2(int olddirfd, const char *oldpath, int newdirfd,
             ((flags & RENAME_EXCHANGE) && (flags & RENAME_NOREPLACE))) {
         return set_syscall_error(current, EINVAL);
     }
-    tuple oldwd = resolve_dir(olddirfd, oldpath);
-    tuple newwd = resolve_dir(newdirfd, newpath);
+    filesystem oldfs, newfs;
+    tuple oldwd = resolve_dir(oldfs, olddirfd, oldpath);
+    tuple newwd = resolve_dir(newfs, newdirfd, newpath);
     if (flags & RENAME_EXCHANGE) {
         if (filepath_is_ancestor(oldwd, oldpath, newwd, newpath) ||
                 filepath_is_ancestor(newwd, newpath, oldwd, oldpath)) {
@@ -1989,30 +2004,32 @@ sysreturn renameat2(int olddirfd, const char *oldpath, int newdirfd,
         int ret;
         tuple old, new;
         tuple oldparent, newparent;
-        ret = resolve_cstring(oldwd, oldpath, &old, &oldparent);
+        ret = resolve_cstring(&oldfs, oldwd, oldpath, &old, &oldparent);
         if (ret) {
             return set_syscall_return(current, ret);
         }
-        ret = resolve_cstring(newwd, newpath, &new, &newparent);
+        ret = resolve_cstring(&newfs, newwd, newpath, &new, &newparent);
         if (ret) {
             return set_syscall_return(current, ret);
         }
+        if (oldfs != newfs)
+            return -EXDEV;
         if ((newparent == oldparent) && (new == old))
             return 0;
-        fs_status s = filesystem_exchange(current->p->fs, oldparent,
+        fs_status s = filesystem_exchange(oldfs, oldparent,
             lookup_sym(oldparent, old), newparent, lookup_sym(newparent, new));
         if (s == FS_STATUS_OK) {
-            filesystem_update_mtime(current->p->fs, oldparent);
-            filesystem_update_mtime(current->p->fs, newparent);
+            filesystem_update_mtime(oldfs, oldparent);
+            filesystem_update_mtime(newfs, newparent);
         }
         return sysreturn_from_fs_status(s);
     }
     else {
         if ((flags & RENAME_NOREPLACE) &&
-                !resolve_cstring(newwd, newpath, 0, 0)) {
+                !resolve_cstring(0, newwd, newpath, 0, 0)) {
             return set_syscall_error(current, EEXIST);
         }
-        return rename_internal(oldwd, oldpath, newwd, newpath);
+        return rename_internal(oldfs, oldwd, oldpath, newfs, newwd, newpath);
     }
 }
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -294,7 +294,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
         p->virtual = p->virtual_page = p->virtual32 = 0;
         p->vareas = p->vmaps = INVALID_ADDRESS;
     }
-    p->fs = fs;
+    p->root_fs = p->cwd_fs = fs;
     p->cwd = root;
     p->process_root = root;
     p->fdallocator = create_id_heap(h, h, 0, infinity, 1);

--- a/src/unix/unix.h
+++ b/src/unix/unix.h
@@ -8,6 +8,9 @@ process create_process(unix_heaps uh, tuple root, filesystem fs);
 thread create_thread(process p);
 process exec_elf(buffer ex, process kernel_process);
 
+void filesystem_sync(filesystem fs, status_handler sh);
+void filesystem_sync_node(filesystem fs, pagecache_node pn, status_handler sh);
+
 void thread_enter_user(thread out, thread in);
 void thread_enter_system(thread t);
 void thread_pause(thread t);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -307,6 +307,7 @@ typedef struct fdesc {
 
 struct file {
     struct fdesc f;             /* must be first */
+    filesystem fs;
     union {
         struct {
             fsfile fsf;         /* fsfile for regular files */
@@ -379,7 +380,8 @@ typedef struct process {
     id_heap           virtual_page; /* pagesized, default for mmaps */
     id_heap           virtual32; /* for tracking low 32-bit space and MAP_32BIT maps */
     id_heap           fdallocator;
-    filesystem        fs;       /* XXX should be underneath tuple operators */
+    filesystem        root_fs;
+    filesystem        cwd_fs;
     tuple             process_root;
     tuple             cwd;
     table             futices;

--- a/test/runtime/rename.c
+++ b/test/runtime/rename.c
@@ -116,6 +116,10 @@ int main(int argc, char **argv)
 
     test_assert((rename("/dir1", "/dir1/dir2") < 0) && (errno == EINVAL));
 
+    test_assert(mkdir("dir1/dir2", 0) == 0);
+    test_assert(chdir("dir1/dir2") == 0);
+    test_assert(rename("..", "dir3") < 0);
+
     fd1 = open("/my_file", O_CREAT, S_IRWXU);
     test_assert(fd1 >= 0);
     close(fd1);

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -152,7 +152,7 @@ static u64 get_fs_offset(descriptor fd)
 
     struct partition_entry *rootfs_part = partition_get(buf, PARTITION_ROOTFS);
 
-    if (rootfs_part->lba_start == 0 ||
+    if (!rootfs_part || rootfs_part->lba_start == 0 ||
             rootfs_part->nsectors == 0) {
         // probably raw filesystem
         return 0;

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -199,14 +199,12 @@ int main(int argc, char **argv)
     }
 
     heap h = init_process_runtime();
-    pagecache pc = allocate_pagecache(h, h, 0, PAGESIZE);
-    assert(pc != INVALID_ADDRESS);
+    init_pagecache(h, h, 0, PAGESIZE);
     create_filesystem(h,
                       SECTOR_SIZE,
                       infinity,
                       closure(h, bread, fd, get_fs_offset(fd)),
                       0, /* no write */
-                      pc,
                       false,
                       closure(h, fsc, h, target_dir, options));
     return EXIT_SUCCESS;

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -117,8 +117,13 @@ closure_function(3, 2, void, fsc,
         exit(EXIT_FAILURE);
     }
 
+    u8 uuid[UUID_LEN];
+    filesystem_get_uuid(fs, uuid);
     tuple root = filesystem_getroot(fs);
     buffer rb = allocate_buffer(h, PAGESIZE);
+    bprintf(rb, "UUID: ");
+    print_uuid(rb, uuid);
+    bprintf(rb, "\nmetadata ");
     print_root(rb, root);
     buffer_print(rb);
     rprintf("\n");

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -214,8 +214,12 @@ closure_function(4, 2, void, fsc,
     vector worklist = allocate_vector(h, 10);
     tuple md = translate(h, worklist, bound(target_root), fs, root, closure(h, err));
 
-    rprintf("metadata ");
     buffer b = allocate_buffer(transient, 64);
+    u8 uuid[UUID_LEN];
+    filesystem_get_uuid(fs, uuid);
+    bprintf(b, "UUID: ");
+    print_uuid(b, uuid);
+    bprintf(b, "\nmetadata ");
     print_tuple(b, md);
     buffer_print(b);
     deallocate_buffer(b);

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -413,6 +413,7 @@ int main(int argc, char **argv)
     // this can be streaming
     parser_feed (p, read_stdin(h));
 
+    init_pagecache(h, h, 0, PAGESIZE);
     mkfs_write_status = closure(h, mkfs_write_handler);
 
     if (root) {
@@ -454,10 +455,8 @@ int main(int argc, char **argv)
         }
         if (!boot)
             halt("kernel or boot FS not specified\n");
-        pagecache pc = allocate_pagecache(h, h, 0, PAGESIZE);
-        assert(pc != INVALID_ADDRESS);
         create_filesystem(h, SECTOR_SIZE, BOOTFS_SIZE, 0,
-                          closure(h, bwrite, out, offset), pc,
+                          closure(h, bwrite, out, offset),
                           true, closure(h, fsc, h, out, boot, target_root));
         offset += BOOTFS_SIZE;
 
@@ -465,14 +464,11 @@ int main(int argc, char **argv)
         table_set(root, sym(boot), 0);
     }
 
-    pagecache pc = allocate_pagecache(h, h, 0, PAGESIZE);
-    assert(pc != INVALID_ADDRESS);
     create_filesystem(h,
                       SECTOR_SIZE,
                       infinity,
                       0, /* no read -> new fs */
                       closure(h, bwrite, out, offset),
-                      pc,
                       true,
                       closure(h, fsc, h, out, root, target_root));
 


### PR DESCRIPTION
Multiple filesystems can now be mounted by specifying a "mounts" entry in the root tuple of the manifest file. This entry is a tuple containing one entry for each mount, with format <uuid>:<mountpoint>, where <uuid> is a volume identifier (which corresponds to the UUID of the filesystem contained in the volume) and <mountpoint> is the path of the directory in which the filesystem is to be mounted (this directory must exist in the root filesystem). Example to mount 2 filesystems (one at /mnt and the other at /mnt2):
mounts:(
  2b8750f4-07f2-2584-7dcc-892b3b52bd07:/mnt
  f6f1d240-6b80-2f01-3a87-186b64b7caa6:/mnt2
)
The UUID is assigned to a given filesystem when the filesystem is created by the mkfs tool, and its value is displayed in the terminal output by this tool (as well as by the dump tool).
In order to create a (non-bootable) filesystem to be used for a volume, the mkfs tool must be invoked without passing a boot image or a kernel image. To create an empty filesystem:
mkfs -e my_volume.raw
To create a non-empty filesystem:
mkfs my_volume.raw < my_volume.manifest
The manifest file in the above command must contain all the files and folders that need to go in the filesystem.

The kernel probes any detected storage devices at boot time: if a device contains an MBR with a partition table, then it is assumed to be the root volume, otherwise if a filesystem is detected in the first disk sector and its UUID corresponds to one of the mount entries, it is mounted; if no MBR and no filesystem is found, then the storage device is ignored.
If one or more filesystems are detected and need to be mounted, the kernel waits for the mount operations to complete before starting the user process.
At runtime, the filesystem corresponding to each open file is referenced in the new "fs" field of struct file.
The virtIO SCSI driver has been modified to be able to handle multiple SCSI targets (which are used on a Google Cloud instance
when multiple disks are attached).

Usage notes:

- Qemu: to specify additional volumes, for each volume add the following command line options:
`-drive if=none,id=hd<N>,format=raw,file=<volumeN.raw> -device scsi-hd,bus=scsi0.0,drive=hd<N>`
where `<N>` = 1,2,..., and `<volumeN.raw>` is the name of the file created via mkfs for the N-th volume

- Google Cloud Platform: change the volume.raw file name to disk.raw, compress it into a tar.gz file, then upload the tar.gz file to Google Cloud Storage; then, create a Compute Engine image by specifying "Cloud storage file" as image source, and selecting the tar.gz file; then, create a Compute Engine disk by specifying "Image" as source type, and selecting the image created above; then, to attach a disk to a VM instance, select the instance, select "Edit", go to the "Additional disks" section, select "Attach existing disk" and then select the disk created above.

- Firecracker: for each additional volume, add a JSON object to the "drives" array in the Firecracker configuration file, as shown in the example below:
```
    {
      "drive_id": "mntN",
      "path_on_host": "volumeN.raw",
      "is_root_device": false,
      "is_read_only": false
    }
```

- AWS: not supported yet