### PR TITLE
Implement protection against arbitrary code execution

### DIFF
--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -181,6 +181,8 @@ closure_function(3, 0, void, startup,
     value p = table_find(root, sym(program));
     assert(p);
     tuple pro = resolve_path(root, split(general, p, '/'));
+    if (table_find(root, sym(exec_protection)))
+        table_set(pro, sym(exec), null_value);  /* set executable flag */
     init_network_iface(root);
     filesystem_read_entire(fs, pro, heap_backed(kh), pg, closure(general, read_program_fail));
     closure_finish();

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1720,7 +1720,7 @@ closure_function(5, 1, sysreturn, accept_bh,
         goto out;
     }
 
-    child->sock.f.flags = bound(flags);
+    child->sock.f.flags |= bound(flags);
     if (bound(addr))
         remote_sockaddr(child, bound(addr), bound(addrlen));
 

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -34,7 +34,7 @@ static void build_exec_stack(process p, thread t, Elf64_Ehdr * e, void *start,
 
     assert(id_heap_set_area(p->virtual32, stack_start, PROCESS_STACK_SIZE, true, true));
     p->stack_map = allocate_vmap(p->vmaps, irangel(stack_start, PROCESS_STACK_SIZE),
-                                 ivmap(VMAP_FLAG_WRITABLE, 0, 0));
+                                 ivmap(VMAP_FLAG_WRITABLE, 0, 0, 0));
     assert(p->stack_map != INVALID_ADDRESS);
 
     u64 * s = pointer_from_u64(stack_start);
@@ -158,7 +158,7 @@ closure_function(2, 4, void, exec_elf_map,
     boolean is_bss = paddr == INVALID_PHYSICAL;
     exec_debug("%s: add to vmap: %R vmflags 0x%lx%s\n",
                __func__, r, vmflags, is_bss ? " bss" : "");
-    assert(allocate_vmap(bound(p)->vmaps, r, ivmap(vmflags, 0, 0)) != INVALID_ADDRESS);
+    assert(allocate_vmap(bound(p)->vmaps, r, ivmap(vmflags, 0, 0, 0)) != INVALID_ADDRESS);
     if (is_bss) {
         /* bss */
         paddr = allocate_u64((heap)heap_physical(kh), size);
@@ -249,7 +249,8 @@ process exec_elf(buffer ex, process kp)
     u64 brk = pad(load_range.end, PAGESIZE) + brk_offset;
     proc->brk = pointer_from_u64(brk);
     proc->heap_base = brk;
-    proc->heap_map = allocate_vmap(proc->vmaps, irange(brk, brk), ivmap(VMAP_FLAG_WRITABLE, 0, 0));
+    proc->heap_map = allocate_vmap(proc->vmaps, irange(brk, brk),
+        ivmap(VMAP_FLAG_WRITABLE, 0, 0, 0));
     assert(proc->heap_map != INVALID_ADDRESS);
     exec_debug("entry %p, brk %p (offset 0x%lx)\n", entry, proc->brk, brk_offset);
 

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -380,6 +380,8 @@ sysreturn fallocate(int fd, int mode, long offset, long len)
         default:
             return -ENODEV;
         }
+    } else if (!fdesc_is_writable(desc)) {
+        return -EBADF;
     }
 
     heap h = heap_general(get_kernel_heaps());

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -590,6 +590,9 @@ static void iour_rw(io_uring iour, fdesc f, boolean write, void *addr, u32 len,
     io_completion completion = 0;
     if (!op) {
         err = -EOPNOTSUPP;
+    } else if ((write && !fdesc_is_writable(f)) ||
+            (!write && !fdesc_is_readable(f))) {
+        err = -EBADF;
     } else {
         completion = closure(iour->h, iour_rw_complete, iour, f, user_data);
         if (completion == INVALID_ADDRESS)

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -66,7 +66,7 @@ static inline int socket_init(process p, heap h, int domain, int type, u32 flags
         goto err_tx;
     }
     init_fdesc(h, &s->f, FDESC_TYPE_SOCKET);
-    s->f.flags = flags;
+    s->f.flags = (flags & ~O_ACCMODE) | O_RDWR;
     s->domain = domain;
     s->type = type;
     s->h = h;

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -113,6 +113,7 @@ typedef struct iovec {
 #define O_RDONLY	00000000
 #define O_WRONLY	00000001
 #define O_RDWR		00000002
+#define O_ACCMODE	00000003
 #define O_CREAT		00000100
 #define O_EXCL          00000200
 #define O_NOCTTY        00000400
@@ -139,6 +140,12 @@ typedef struct iovec {
 #define F_DUPFD_CLOEXEC (F_LINUX_SPECIFIC_BASE + 6)
 #define F_SETPIPE_SZ    (F_LINUX_SPECIFIC_BASE + 7)
 #define F_GETPIPE_SZ    (F_LINUX_SPECIFIC_BASE + 8)
+
+/* Values for 'mode' argument of access/faccessat syscalls */
+#define F_OK    0x0
+#define X_OK    0x1
+#define W_OK    0x2
+#define R_OK    0x4
 
 struct flock {
     s16 l_type;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -428,6 +428,11 @@ extern thread dummy_thread;
 
 void init_thread_fault_handler(thread t);
 
+static inline boolean proc_is_exec_protected(process p)
+{
+    return !!table_find(p->process_root, sym(exec_protection));
+}
+
 static inline fsfile file_get_fsfile(file f)
 {
     return f->fsf;
@@ -450,11 +455,19 @@ static inline boolean fdesc_is_writable(fdesc f)
 
 static inline u32 anon_perms(process p)
 {
+    if (proc_is_exec_protected(p))
+        return (ACCESS_PERM_READ | ACCESS_PERM_WRITE);
     return ACCESS_PERM_ALL;
 }
 
 static inline u32 file_meta_perms(process p, tuple m)
 {
+    if (proc_is_exec_protected(p)) {
+        if (table_find(m, sym(exec)))
+            return (ACCESS_PERM_READ | ACCESS_PERM_EXEC);
+        else
+            return (ACCESS_PERM_READ | ACCESS_PERM_WRITE);
+    }
     return ACCESS_PERM_ALL;
 }
 

--- a/test/runtime/fallocate.c
+++ b/test/runtime/fallocate.c
@@ -26,6 +26,12 @@ int main(int argc, char **argv)
 
     test_assert((fallocate(0, 0, 0, 1) == -1) && (errno == ESPIPE));
 
+    fd = open("my_file", O_RDONLY | O_CREAT, S_IRWXU);
+    test_assert(fd > 0);
+    test_assert(fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, 1) == -1);
+    test_assert(errno == EBADF);    /* the file is open in read-only mode */
+    test_assert(close(fd) == 0);
+
     fd = open("my_file", O_RDWR | O_CREAT, S_IRWXU);
     test_assert(fd > 0);
     test_assert(fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, 1) == 0);

--- a/test/runtime/fcntl.c
+++ b/test/runtime/fcntl.c
@@ -12,6 +12,22 @@
     } \
 } while (0)
 
+static void test_access_mode(int fd)
+{
+    int old_flags, access_mode, new_flags;
+
+    old_flags = fcntl(fd, F_GETFL);
+    test_assert(old_flags >= 0);
+    access_mode = old_flags & O_ACCMODE;
+
+    /* Try to change file access mode and verify that it does not change. */
+    access_mode = (access_mode == O_RDWR) ? O_RDONLY : O_RDWR;
+    new_flags = (old_flags & ~O_ACCMODE) | access_mode;
+    test_assert(fcntl(fd, F_SETFL, new_flags) == 0);
+    new_flags = fcntl(fd, F_GETFL);
+    test_assert((new_flags & O_ACCMODE) == (old_flags & O_ACCMODE));
+}
+
 /* covers F_GETLK, F_SETLK, F_SETLKW; expect = 0 for success, errno otherwise */
 void test_lk(int fd, int cmd, struct flock *lock, int expect)
 {
@@ -59,6 +75,8 @@ int main(int argc, char **argv)
 {
     struct flock lock;
     int fd = open("test", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+
+    test_access_mode(fd);
 
     lock.l_type   = F_WRLCK;
     lock.l_start  = 0;

--- a/test/runtime/mmap.c
+++ b/test/runtime/mmap.c
@@ -681,6 +681,14 @@ void mprotect_test(void)
     u8 *addr;
     int ret;
 
+    if (mprotect(0, PAGESIZE, PROT_READ) == 0) {
+        fprintf(stderr, "%s: could enable read access to zero page\n",
+            __func__);
+        exit(EXIT_FAILURE);
+    } else if (errno != ENOMEM) {
+        handle_err("mprotect() to zero page: unexpected error");
+    }
+
     addr = mmap(NULL, 5 * PAGESIZE, PROT_READ | PROT_WRITE,
             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (addr == MAP_FAILED)
@@ -909,6 +917,22 @@ static void filebacked_test(heap h)
     munmap(p + PAGESIZE, PAGESIZE);
     munmap(p + (PAGESIZE * 3), PAGESIZE);
     close(fd);
+
+    fd = open("mapfile", O_RDONLY);
+    if (fd < 0)
+        handle_err("open read-only file");
+    if (mmap(NULL, PAGESIZE, PROT_WRITE, MAP_SHARED, fd, 0) != MAP_FAILED) {
+        fprintf(stderr, "%s: could mmap read-only file with write access\n",
+            __func__);
+        exit(EXIT_FAILURE);
+    }
+    p = mmap(NULL, PAGESIZE, PROT_WRITE, MAP_PRIVATE, fd, 0);
+    if (p == MAP_FAILED)
+        handle_err("set up private mmap with read-only file");
+    __munmap(p, PAGESIZE);
+    if (close(fd) < 0)
+        handle_err("close read-only file");
+
     printf("** all file-backed tests passed\n");
 }
 

--- a/test/runtime/mmap.manifest
+++ b/test/runtime/mmap.manifest
@@ -13,5 +13,6 @@
     fault:t
     arguments:[/mmap, basic]
     environment:(USER:bobby PWD:/)
+    exec_protection:t
     imagesize:30M
 )

--- a/test/runtime/readv.c
+++ b/test/runtime/readv.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -60,6 +61,28 @@ int main()
     }
     int curpos = rv;
     EXPECT_LONG_EQUAL(startpos + bytes_read, curpos);
+
+    if (close(fd) < 0) {
+        perror("close");
+        exit(EXIT_FAILURE);
+    }
+
+    fd = open("hello", O_WRONLY);
+    if (fd < 0) {
+        perror("open write-only");
+        exit(EXIT_FAILURE);
+    }
+    if (readv(fd, iovs, 3) != -1) {
+        printf("Could readv from write-only file\n");
+        exit(EXIT_FAILURE);
+    } else if (errno != EBADF) {
+        perror("readv from write-only file: unexpected error");
+        exit(EXIT_FAILURE);
+    }
+    if (close(fd) < 0) {
+        perror("close write-only");
+        exit(EXIT_FAILURE);
+    }
 
     printf("readv test PASSED\n");
 

--- a/test/runtime/sendfile.c
+++ b/test/runtime/sendfile.c
@@ -35,6 +35,42 @@ int main(int argc, char *argv[])
     char buf[BUF_LEN];
     char cmp_buf[BUF_LEN];
 
+    fd_in = open("infile", O_WRONLY);
+    if (fd_in < 0)
+        sf_err_goto(err_fdin, "open write-only: %s\n", strerror(errno));
+    fd_out = open("outfile", O_RDWR);
+    if (fd_out < 0)
+        sf_err_goto(err_fdout, "open outfile: %s\n", strerror(errno));
+    ret = sendfile(fd_out, fd_in, NULL, BUF_LEN);
+    if (ret != -1)
+        sf_err_goto(err_fop, "could sendfile() %d bytes from write-only file\n",
+            ret);
+    else if (errno != EBADF)
+        sf_err_goto(err_fdout, "[line %d] unexpected error: %s\n",  __LINE__,
+            strerror(errno));
+    if (close(fd_out) < 0)
+        sf_err_goto(err_fdout, "close outfile: %s\n", strerror(errno));
+    if (close(fd_in) < 0)
+        sf_err_goto(err_fdin, "close infile: %s\n", strerror(errno));
+
+    fd_in = open("infile", O_RDWR);
+    if (fd_in < 0)
+        sf_err_goto(err_fdin, "open infile: %s\n", strerror(errno));
+    fd_out = open("outfile", O_RDONLY);
+    if (fd_out < 0)
+        sf_err_goto(err_fdout, "open read-only: %s\n", strerror(errno));
+    ret = sendfile(fd_out, fd_in, NULL, BUF_LEN);
+    if (ret != -1)
+        sf_err_goto(err_fop, "could sendfile() %d bytes to read-only file\n",
+            ret);
+    else if (errno != EBADF)
+        sf_err_goto(err_fdout, "[line %d] unexpected error: %s\n",  __LINE__,
+            strerror(errno));
+    if (close(fd_out) < 0)
+        sf_err_goto(err_fdout, "close outfile: %s\n", strerror(errno));
+    if (close(fd_in) < 0)
+        sf_err_goto(err_fdin, "close infile: %s\n", strerror(errno));
+
     fd_in = open("infile", O_RDWR);
     if (fd_in == -1)
         sf_err_goto(err_fdin, "error %d opeing sendfile_test\n", errno);

--- a/test/runtime/write.manifest
+++ b/test/runtime/write.manifest
@@ -10,5 +10,6 @@
     fault:t
 #    arguments:[write -p]
     environment:(USER:bobby PWD:/)
+    exec_protection:t
     imagesize:30M
 )

--- a/test/runtime/writev.c
+++ b/test/runtime/writev.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
@@ -101,6 +102,23 @@ int main()
     }
 
     close(fd);
+
+    fd = open("hello", O_RDONLY);
+    if (fd < 0) {
+        perror("open read-only");
+        exit(EXIT_FAILURE);
+    }
+    if (writev(fd, iovs, 3) != -1) {
+        printf("Could writev to read-only file\n");
+        exit(EXIT_FAILURE);
+    } else if (errno != EBADF) {
+        perror("writev to read-only file: unexpected error");
+        exit(EXIT_FAILURE);
+    }
+    if (close(fd) < 0) {
+        perror("close read-only");
+        exit(EXIT_FAILURE);
+    }
 
     printf("write test passed\n");
 


### PR DESCRIPTION
This PR implements an "exec protection" feature that, if enabled, prevents the kernel from executing any code outside the main program executable and other "trusted" files explicitly marked as executable. This feature is enabled by adding an "exec_protection" symbol to the root tuple in the manifest file; then, any files containing executable code that need to be executed by the application (usually, shared libraries) need to marked in the manifest file with an "exec" symbol. It is not necessary to add the "exec" symbol to the main program, since this is always considered as a "trusted" executable file.
Example of a manifest file with exec protection enabled and with one shared library:
(
  children:(
    my_app:(contents:(host:bin/my_app))
    lib64:(children:(ld-linux-x86-64.so.2:(contents:(host:/lib64/ld-linux-x86-64.so.2))))
    lib:(children:(x86_64-linux-gnu:(children:(libc.so.6:(exec:t contents:(host:/lib/x86_64-linux-gnu/libc.so.6))))))
  )
  program:/my_app
  environment:(USER:bobby PWD:/)
  exec_protection:t
)

(Note the exec symbol in the libc.so.6 shared library, without which the application would fail to start, with an error such as "error while loading shared libraries: libc.so.6: failed to map segment from shared object".)

The application cannot modify the executable files and cannot create new executable files.