### PR TITLE
Builddoc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Create a Chroot:
 mkdir target-root && cd target-root && wget
 https://storage.googleapis.com/testmisc/target-root.tar.gz && tar xzf target-root.tar.gz
 ```
+You should also set the environment variable NANOS_TARGET_ROOT to the path of 
+target-root created above in order to create the example and test images.
 
 #### To build:
 ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ https://storage.googleapis.com/testmisc/target-root.tar.gz && tar xzf target-roo
 
 #### To build:
 ```
-make run no-accel
+make run-noaccel
 ```
 
 ### Documentation


### PR DESCRIPTION
I updated the README with a couple things I had to figure out. Mainly, that you need to have NANOS_TARGET_ROOT set in order to create the images, but I didn't find that mentioned in the docs.