### PR TITLE
Added fadvise64 syscall stub and test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ test test-noaccel: mkfs image
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fallocate fcntl fst getdents getrandom hw hws io_uring mkdir mmap netsock pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst getdents getrandom hw hws io_uring mkdir mmap netsock pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -323,3 +323,29 @@ sysreturn fallocate(int fd, int mode, long offset, long len)
     }
     return file_op_maybe_sleep(current);
 }
+
+sysreturn fadvise64(int fd, s64 off, u64 len, int advice)
+{
+    fdesc desc = resolve_fd(current->p, fd);
+    if (desc->type != FDESC_TYPE_REGULAR) {
+        switch (desc->type) {
+        case FDESC_TYPE_PIPE:
+        case FDESC_TYPE_STDIO:
+            return -ESPIPE;
+        default:
+            return -EBADF;
+        }
+    }
+    switch (advice) {
+    case POSIX_FADV_NORMAL:
+    case POSIX_FADV_RANDOM:
+    case POSIX_FADV_SEQUENTIAL:
+    case POSIX_FADV_WILLNEED:
+    case POSIX_FADV_DONTNEED:
+    case POSIX_FADV_NOREUSE:
+        break;
+    default:
+        return -EINVAL;
+    }
+    return 0;
+}

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -117,3 +117,5 @@ sysreturn statfs(const char *path, struct statfs *buf);
 sysreturn fstatfs(int fd, struct statfs *buf);
 
 sysreturn fallocate(int fd, int mode, long offset, long len);
+
+sysreturn fadvise64(int fd, s64 off, u64 len, int advice);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -128,7 +128,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, remap_file_pages, 0);
     register_syscall(map, restart_syscall, 0);
     register_syscall(map, semtimedop, 0);
-    register_syscall(map, fadvise64, 0);
     register_syscall(map, clock_settime, 0);
     register_syscall(map, vserver, 0);
     register_syscall(map, mbind, 0);
@@ -2319,6 +2318,7 @@ void register_file_syscalls(struct syscall *map)
     register_syscall(map, dup3, dup3);
     register_syscall(map, fstat, fstat);
     register_syscall(map, fallocate, fallocate);
+    register_syscall(map, fadvise64, fadvise64);
     register_syscall(map, sendfile, sendfile);
     register_syscall(map, stat, stat);
     register_syscall(map, lstat, lstat);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -914,3 +914,11 @@ struct io_uring_params {
 #define FALLOC_FL_COLLAPSE_RANGE    0x08
 #define FALLOC_FL_ZERO_RANGE        0x10
 #define FALLOC_FL_INSERT_RANGE      0x20
+
+/* posix_fadvise advice types */
+#define POSIX_FADV_NORMAL       0
+#define POSIX_FADV_RANDOM       1
+#define POSIX_FADV_SEQUENTIAL   2
+#define POSIX_FADV_WILLNEED     3
+#define POSIX_FADV_DONTNEED     4
+#define POSIX_FADV_NOREUSE      5

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -6,6 +6,7 @@ PROGRAMS= \
 	epoll \
 	eventfd \
 	fallocate \
+	fadvise \
 	fcntl \
 	fst \
 	ftrace \
@@ -70,6 +71,12 @@ SRCS-fallocate= \
 	$(SRCDIR)/unix_process/ssp.c
 
 LDFLAGS-fallocate=	-static
+
+SRCS-fadvise= \
+	$(CURDIR)/fadvise.c \
+	$(SRCDIR)/unix_process/ssp.c
+
+LDFLAGS-fadvise=	-static
 
 SRCS-fcntl= \
 	$(CURDIR)/fcntl.c \

--- a/test/runtime/fadvise.c
+++ b/test/runtime/fadvise.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+
+/* fadvise stub test for parameters only */
+
+void test_fadvise(int fd, int64_t off, uint64_t len, int adv, int exp, char *name)
+{
+    int r = posix_fadvise(fd, off, len, adv);
+    if (r != exp) {
+        char b[256];
+        snprintf(b, sizeof b, "fadvise test '%s' did not get expected result: %d != %d",
+            name, r, exp);
+        perror(b);
+        exit(EXIT_FAILURE);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    int fd = open("test_fadvise", O_CREAT|O_RDWR, 0644);
+    if (fd < 0) {
+        perror("open");
+        exit(EXIT_FAILURE);
+    }
+    test_fadvise(fd, 0, 128, POSIX_FADV_SEQUENTIAL, 0, "set sequential");
+    test_fadvise(fd, 0, 128, POSIX_FADV_RANDOM, 0, "set random");
+    test_fadvise(fd, 0, 128, POSIX_FADV_NOREUSE, 0, "set noreuse");
+    test_fadvise(fd, 0, 128, POSIX_FADV_WILLNEED, 0, "set willneed");
+    test_fadvise(fd, 0, 128, POSIX_FADV_DONTNEED, 0, "set dontneed");
+    test_fadvise(fd, 0, 128, POSIX_FADV_NORMAL, 0, "set normal");
+    test_fadvise(fd, 0, 128, 9999, EINVAL, "use bad advice");
+    close(fd);
+    test_fadvise(fd, 0, 128, 9999, EBADF, "use bad fd");
+    printf("fadvise test passed\n");
+    exit(EXIT_SUCCESS);
+}

--- a/test/runtime/fadvise.manifest
+++ b/test/runtime/fadvise.manifest
@@ -1,0 +1,14 @@
+(
+    children:(
+              #user program
+	      fadvise:(contents:(host:output/test/runtime/bin/fadvise))
+	      )
+    # filesystem path to elf for kernel to run
+    program:/fadvise
+#    trace:t
+#    debugsyscalls:t
+#    futex_trace:t
+    fault:t
+    arguments:[fadvise]
+    environment:()
+)


### PR DESCRIPTION
Added a stub and a test for the fadvise64 syscall used by posix_fadvise, issue #1101 . This stub checks the fd and advice parameters and returns appropriate errors.