### PR TITLE
vm_exit(): optionally dump kernel and Unix heap statistics

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -10,6 +10,7 @@
 #include <page.h>
 #include <storage.h>
 #include <symtab.h>
+#include <unix.h>
 #include <virtio/virtio.h>
 #include <vmware/vmxnet3.h>
 #include <drivers/storage.h>
@@ -308,6 +309,14 @@ void vm_exit(u8 code)
         cpuinfo ci = cpuinfo_from_id(i);
         if (ci->frcount)
             rprintf("%d\t%ld\n", i, ci->frcount);
+    }
+#endif
+
+#ifdef DUMP_MEM_STATS
+    buffer b = allocate_buffer(heap_general(&heaps), 512);
+    if (b != INVALID_ADDRESS) {
+        dump_mem_stats(b);
+        buffer_print(b);
     }
 #endif
 

--- a/src/runtime/format.c
+++ b/src/runtime/format.c
@@ -51,6 +51,9 @@ void vbprintf(buffer d, buffer fmt, vlist *ap)
                     invalid_format(d, fmt, start_idx, idx);
                 else
                     s.modifier = c;
+        } else if (c == '%') {
+            push_character(d, c);
+            s.state = 0;
             } else {
 		if ((c > 32) && (c < 128) &&
                     FORMATTER(c).f &&

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -469,3 +469,33 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     msg_err("failed to allocate kernel objects\n");
     return INVALID_ADDRESS;
 }
+
+static void dump_heap_stats(buffer b, const char *name, heap h)
+{
+    bytes allocated = heap_allocated(h);
+    bytes total = heap_total(h);
+    if ((total != INVALID_PHYSICAL) && (total != 0)) {
+        bprintf(b, " %s: total %ld, allocated %ld (%d%%)\n", name, total,
+                allocated, 100 * allocated / total);
+    } else {
+        bprintf(b, " %s: allocated %ld\n", name, allocated);
+    }
+}
+
+void dump_mem_stats(buffer b)
+{
+    unix_heaps uh = get_unix_heaps();
+    kernel_heaps kh = &uh->kh;
+    bprintf(b, "Kernel heaps:\n");
+    dump_heap_stats(b, "general", heap_general(kh));
+    dump_heap_stats(b, "physical", (heap)heap_physical(kh));
+    dump_heap_stats(b, "virtual huge", (heap)heap_virtual_huge(kh));
+    dump_heap_stats(b, "virtual page", (heap)heap_virtual_page(kh));
+    bprintf(b, "Unix heaps:\n");
+    dump_heap_stats(b, "file cache", uh->file_cache);
+    dump_heap_stats(b, "epoll cache", uh->epoll_cache);
+    dump_heap_stats(b, "epollfd cache", uh->epollfd_cache);
+    dump_heap_stats(b, "epoll_blocked cache", uh->epoll_blocked_cache);
+    dump_heap_stats(b, "pipe cache", uh->pipe_cache);
+    dump_heap_stats(b, "socket cache", uh->socket_cache);
+}

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -421,6 +421,10 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
         goto alloc_fail;
     if (ftrace_init(uh, fs))
 	goto alloc_fail;
+#ifdef NET
+    if (!netsyscall_init(uh))
+        goto alloc_fail;
+#endif
 
     set_syscall_handler(syscall_enter);
     process kernel_process = create_process(uh, root, fs);
@@ -449,8 +453,6 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     init_syscalls();
     register_file_syscalls(linux_syscalls);
 #ifdef NET
-    if (!netsyscall_init(uh))
-	goto alloc_fail;
     register_net_syscalls(linux_syscalls);
 #endif
 

--- a/src/unix/unix.h
+++ b/src/unix/unix.h
@@ -8,6 +8,8 @@ process create_process(unix_heaps uh, tuple root, filesystem fs);
 thread create_thread(process p);
 process exec_elf(buffer ex, process kernel_process);
 
+void dump_mem_stats(buffer b);
+
 void filesystem_sync(filesystem fs, status_handler sh);
 void filesystem_sync_node(filesystem fs, pagecache_node pn, status_handler sh);
 


### PR DESCRIPTION
If the DUMP_MEM_STATS preprocessor define is present, just before shutting down the VM the kernel dumps on the serial terminal a usage summary for the kernel and Unix heaps.

Closes #272.