### PR TITLE
Refactor pause code in the scheduler

### DIFF
--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -97,6 +97,7 @@ static void init_cpuinfos(heap backed)
         ci->state = cpu_not_present;
         ci->have_kernel_lock = false;
         ci->frcount = 0;
+        ci->current_thread = INVALID_ADDRESS;
         /* frame and stacks */
         ci->kernel_context = allocate_kernel_context(backed);
         ci->exception_stack = allocate_stack(backed, EXCEPT_STACK_SIZE);

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -75,9 +75,6 @@ void resume_kernel_context(kernel_context c)
 {
     spare_kernel_context = current_cpu()->kernel_context;
     current_cpu()->kernel_context = c;
-    nanos_thread nt = pointer_from_u64(c->frame[FRAME_SYSCALL_THREAD]);
-    if (nt != INVALID_ADDRESS)
-        current_cpu()->current_thread = nt;
     frame_return(c->frame);
 }
 

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -75,6 +75,9 @@ void resume_kernel_context(kernel_context c)
 {
     spare_kernel_context = current_cpu()->kernel_context;
     current_cpu()->kernel_context = c;
+    nanos_thread nt = pointer_from_u64(c->frame[FRAME_SYSCALL_THREAD]);
+    if (nt != INVALID_ADDRESS)
+        current_cpu()->current_thread = nt;
     frame_return(c->frame);
 }
 

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -17,6 +17,10 @@ typedef struct kernel_context {
     u64 frame[0];
 } *kernel_context;
 
+typedef struct nanos_thread {
+    thunk pause;
+} *nanos_thread;
+
 typedef struct cpuinfo {
     /*** Fields accessed by low-level entry points. ***/
     /* Don't move these without updating gs-relative accesses in crt0.s ***/
@@ -49,7 +53,7 @@ typedef struct cpuinfo {
     /* Stack for interrupts */
     void *int_stack;
 
-    /* leaky unix stuff */
+    /* pointer to nanos_thread (and target OS dependent stuff) */
     void *current_thread;
 } *cpuinfo;
 

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -54,7 +54,7 @@ typedef struct cpuinfo {
     void *int_stack;
 
     /* pointer to nanos_thread (and target OS dependent stuff) */
-    void *current_thread;
+    nanos_thread current_thread;
 } *cpuinfo;
 
 #define cpu_not_present 0

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -138,7 +138,8 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
         nanos_thread nt = (nanos_thread)ci->current_thread;
         if (nt->pause)
             apply(nt->pause);
-        ci->current_thread = INVALID_ADDRESS;
+        /* XXX disable until we have a better solution for deferred processing */
+        //ci->current_thread = INVALID_ADDRESS;
     }
     disable_interrupts();
     sched_debug("runloop from %s b:%d r:%d t:%d i:%x lock:%d\n", state_strings[ci->state],

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -138,7 +138,7 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
         nanos_thread nt = ci->current_thread;
         if (nt->pause)
             apply(nt->pause);
-        //ci->current_thread = INVALID_ADDRESS;
+        ci->current_thread = INVALID_ADDRESS;
     }
     disable_interrupts();
     sched_debug("runloop from %s b:%d r:%d t:%d i:%x lock:%d\n", state_strings[ci->state],

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -131,7 +131,7 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
 
     if (ci->current_thread != INVALID_ADDRESS) {
         nanos_thread nt = (nanos_thread)ci->current_thread;
-        if (nt->pause)
+        if (nt->pause != INVALID_ADDRESS)
             apply(nt->pause);
         /* XXX disable until we have a better solution for deferred processing */
         //ci->current_thread = INVALID_ADDRESS;

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -134,6 +134,12 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
     cpuinfo ci = current_cpu();
     thunk t;
 
+    if (ci->current_thread && ci->current_thread != INVALID_ADDRESS) {
+        nanos_thread nt = ci->current_thread;
+        if (nt->pause)
+            apply(nt->pause);
+        //ci->current_thread = INVALID_ADDRESS;
+    }
     disable_interrupts();
     sched_debug("runloop from %s b:%d r:%d t:%d i:%x lock:%d\n", state_strings[ci->state],
                 queue_length(bhqueue), queue_length(runqueue), queue_length(thread_queue),
@@ -162,9 +168,6 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
 
     if (!shutting_down && (t = dequeue(thread_queue)) != INVALID_ADDRESS)
         run_thunk(t, cpu_user);
-// XXX redo with frame pause
-    if (ci->current_thread)
-        thread_pause(ci->current_thread);
 
     kernel_sleep();
 }    

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -162,9 +162,9 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
 
     if (!shutting_down && (t = dequeue(thread_queue)) != INVALID_ADDRESS)
         run_thunk(t, cpu_user);
-// XXX redo with frame pause
-    if (ci->current_thread)
-        thread_pause(ci->current_thread);
+
+    if ((t = pointer_from_u64(ci->running_frame[FRAME_PAUSE])) && t != INVALID_ADDRESS)
+        apply(t);
 
     kernel_sleep();
 }    

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -162,9 +162,9 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
 
     if (!shutting_down && (t = dequeue(thread_queue)) != INVALID_ADDRESS)
         run_thunk(t, cpu_user);
-
-    if ((t = pointer_from_u64(ci->running_frame[FRAME_PAUSE])) && t != INVALID_ADDRESS)
-        apply(t);
+// XXX redo with frame pause
+    if (ci->current_thread)
+        thread_pause(ci->current_thread);
 
     kernel_sleep();
 }    

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -134,8 +134,8 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
     cpuinfo ci = current_cpu();
     thunk t;
 
-    if (ci->current_thread && ci->current_thread != INVALID_ADDRESS) {
-        nanos_thread nt = ci->current_thread;
+    if (ci->current_thread != INVALID_ADDRESS) {
+        nanos_thread nt = (nanos_thread)ci->current_thread;
         if (nt->pause)
             apply(nt->pause);
         ci->current_thread = INVALID_ADDRESS;

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -1,11 +1,6 @@
 #include <kernel.h>
 #include <apic.h>
 
-// XXX these three should go away along with thread_pause below
-#include <pagecache.h>
-#include <tfs.h>
-#include <unix.h>
-
 
 /* Try to keep these within the confines of the runloop lock so we
    don't create too much of a mess. */

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -253,7 +253,7 @@ process exec_elf(buffer ex, process kp)
     assert(proc->heap_map != INVALID_ADDRESS);
     exec_debug("entry %p, brk %p (offset 0x%lx)\n", entry, proc->brk, brk_offset);
 
-    current_cpu()->current_thread = t;
+    current_cpu()->current_thread = (nanos_thread)t;
     build_exec_stack(proc, t, e, entry, load_range.start, root, aslr);
 
     if (table_find(proc->process_root, sym(ingest_program_symbols))) {

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -253,6 +253,7 @@ process exec_elf(buffer ex, process kp)
     assert(proc->heap_map != INVALID_ADDRESS);
     exec_debug("entry %p, brk %p (offset 0x%lx)\n", entry, proc->brk, brk_offset);
 
+    current_cpu()->current_thread = t;
     build_exec_stack(proc, t, e, entry, load_range.start, root, aslr);
 
     if (table_find(proc->process_root, sym(ingest_program_symbols))) {

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -661,6 +661,7 @@ closure_function(7, 1, void, file_read_complete,
                  status, s)
 {
     thread_log(bound(t), "%s: status %v", __func__, s);
+    current_cpu()->current_thread = (nanos_thread)bound(t);
     sysreturn rv;
     if (is_ok(s)) {
         file f = bound(f);
@@ -2423,6 +2424,7 @@ void syscall_debug(context f)
             thread_log(t, "syscall %d", call);
     }
     sysreturn (*h)(u64, u64, u64, u64, u64, u64) = s->handler;
+    current_cpu()->running_frame[FRAME_SYSCALL_THREAD] = u64_from_pointer(t);
     if (h) {
         thread_enter_system(t);
 
@@ -2436,6 +2438,7 @@ void syscall_debug(context f)
         else
             thread_log(t, "nosyscall %d", call);
     }
+    current_cpu()->running_frame[FRAME_SYSCALL_THREAD] = INVALID_PHYSICAL;
     t->syscall = -1;
     // i dont know that we actually want to defer the syscall return...its just easier for the moment to hew
     // to the general model and make exceptions later

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -661,7 +661,6 @@ closure_function(7, 1, void, file_read_complete,
                  status, s)
 {
     thread_log(bound(t), "%s: status %v", __func__, s);
-    current_cpu()->current_thread = (nanos_thread)bound(t);
     sysreturn rv;
     if (is_ok(s)) {
         file f = bound(f);
@@ -2424,7 +2423,6 @@ void syscall_debug(context f)
             thread_log(t, "syscall %d", call);
     }
     sysreturn (*h)(u64, u64, u64, u64, u64, u64) = s->handler;
-    current_cpu()->running_frame[FRAME_SYSCALL_THREAD] = u64_from_pointer(t);
     if (h) {
         thread_enter_system(t);
 
@@ -2438,7 +2436,6 @@ void syscall_debug(context f)
         else
             thread_log(t, "nosyscall %d", call);
     }
-    current_cpu()->running_frame[FRAME_SYSCALL_THREAD] = INVALID_PHYSICAL;
     t->syscall = -1;
     // i dont know that we actually want to defer the syscall return...its just easier for the moment to hew
     // to the general model and make exceptions later

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2412,39 +2412,39 @@ extern u64 kernel_lock;
 void syscall_debug(context f)
 {
     u64 call = f[FRAME_VECTOR];
-    thread t = current;
+    thread t = pointer_from_u64(f[FRAME_THREAD]);
     set_syscall_return(t, -ENOSYS);
 
     if (call >= sizeof(_linux_syscalls) / sizeof(_linux_syscalls[0])) {
         schedule_frame(f);
-        thread_log(current, "invalid syscall %d", call);
+        thread_log(t, "invalid syscall %d", call);
         runloop();
     }
     t->syscall = call;
     // should we cache this for performance?
-    void *debugsyscalls = table_find(current->p->process_root, sym(debugsyscalls));
-    struct syscall *s = current->p->syscalls + call;
+    void *debugsyscalls = table_find(t->p->process_root, sym(debugsyscalls));
+    struct syscall *s = t->p->syscalls + call;
     if (debugsyscalls) {
         if (s->name)
-            thread_log(current, s->name);
+            thread_log(t, s->name);
         else
-            thread_log(current, "syscall %d", call);
+            thread_log(t, "syscall %d", call);
     }
     sysreturn (*h)(u64, u64, u64, u64, u64, u64) = s->handler;
     if (h) {
-        thread_enter_system(current);
+        thread_enter_system(t);
 
         sysreturn rv = h(f[FRAME_RDI], f[FRAME_RSI], f[FRAME_RDX], f[FRAME_R10], f[FRAME_R8], f[FRAME_R9]);
-        set_syscall_return(current, rv);
+        set_syscall_return(t, rv);
         if (debugsyscalls)
-            thread_log(current, "direct return: %ld, rsp 0x%lx", rv, f[FRAME_RSP]);
+            thread_log(t, "direct return: %ld, rsp 0x%lx", rv, f[FRAME_RSP]);
     } else if (debugsyscalls) {
         if (s->name)
-            thread_log(current, "nosyscall %s", s->name);
+            thread_log(t, "nosyscall %s", s->name);
         else
-            thread_log(current, "nosyscall %d", call);
+            thread_log(t, "nosyscall %d", call);
     }
-    current->syscall = -1;
+    t->syscall = -1;
     // i dont know that we actually want to defer the syscall return...its just easier for the moment to hew
     // to the general model and make exceptions later
     schedule_frame(f);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -661,6 +661,7 @@ closure_function(7, 1, void, file_read_complete,
                  status, s)
 {
     thread_log(bound(t), "%s: status %v", __func__, s);
+    current_cpu()->current_thread = (nanos_thread)bound(t);
     sysreturn rv;
     if (is_ok(s)) {
         file f = bound(f);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -179,6 +179,12 @@ define_closure_function(1, 0, void, run_thread,
     run_thread_frame(t);
 }
 
+define_closure_function(1, 0, void, pause_thread,
+                        thread, t)
+{
+    thread_pause(bound(t));
+}
+
 define_closure_function(1, 0, void, run_sighandler,
                         thread, t)
 {
@@ -291,6 +297,7 @@ thread create_thread(process p)
     init_thread_fault_handler(t);
     setup_thread_frame(h, t->default_frame, t);
     t->default_frame[FRAME_RUN] = u64_from_pointer(init_closure(&t->run_thread, run_thread, t));
+    t->default_frame[FRAME_PAUSE] = u64_from_pointer(init_closure(&t->pause_thread, pause_thread, t));
     set_thread_frame(t, t->default_frame);
     
     t->sighandler_frame = allocate_frame(h);
@@ -366,6 +373,7 @@ void exit_thread(thread t)
     t->thread_bq = INVALID_ADDRESS;
 
     t->default_frame[FRAME_RUN] = INVALID_PHYSICAL;
+    t->default_frame[FRAME_PAUSE] = INVALID_PHYSICAL;
     t->default_frame[FRAME_QUEUE] = INVALID_PHYSICAL;
     t->sighandler_frame[FRAME_RUN] = INVALID_PHYSICAL;
     t->sighandler_frame[FRAME_QUEUE] = INVALID_PHYSICAL;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -179,12 +179,6 @@ define_closure_function(1, 0, void, run_thread,
     run_thread_frame(t);
 }
 
-define_closure_function(1, 0, void, pause_thread,
-                        thread, t)
-{
-    thread_pause(bound(t));
-}
-
 define_closure_function(1, 0, void, run_sighandler,
                         thread, t)
 {
@@ -297,7 +291,6 @@ thread create_thread(process p)
     init_thread_fault_handler(t);
     setup_thread_frame(h, t->default_frame, t);
     t->default_frame[FRAME_RUN] = u64_from_pointer(init_closure(&t->run_thread, run_thread, t));
-    t->default_frame[FRAME_PAUSE] = u64_from_pointer(init_closure(&t->pause_thread, pause_thread, t));
     set_thread_frame(t, t->default_frame);
     
     t->sighandler_frame = allocate_frame(h);
@@ -373,7 +366,6 @@ void exit_thread(thread t)
     t->thread_bq = INVALID_ADDRESS;
 
     t->default_frame[FRAME_RUN] = INVALID_PHYSICAL;
-    t->default_frame[FRAME_PAUSE] = INVALID_PHYSICAL;
     t->default_frame[FRAME_QUEUE] = INVALID_PHYSICAL;
     t->sighandler_frame[FRAME_RUN] = INVALID_PHYSICAL;
     t->sighandler_frame[FRAME_QUEUE] = INVALID_PHYSICAL;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -201,6 +201,7 @@ static void setup_thread_frame(heap h, context frame, thread t)
     frame[FRAME_IS_SYSCALL] = 1;
     frame[FRAME_CS] = 0x2b; // where is this defined?
     frame[FRAME_THREAD] = u64_from_pointer(t);
+    frame[FRAME_SYSCALL_THREAD] = INVALID_PHYSICAL;
 }
 
 void thread_sleep_interruptible(void)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -201,7 +201,6 @@ static void setup_thread_frame(heap h, context frame, thread t)
     frame[FRAME_IS_SYSCALL] = 1;
     frame[FRAME_CS] = 0x2b; // where is this defined?
     frame[FRAME_THREAD] = u64_from_pointer(t);
-    frame[FRAME_SYSCALL_THREAD] = INVALID_PHYSICAL;
 }
 
 void thread_sleep_interruptible(void)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -179,6 +179,12 @@ define_closure_function(1, 0, void, run_thread,
     run_thread_frame(t);
 }
 
+define_closure_function(1, 0, void, pause_thread,
+                        thread, t)
+{
+    thread_pause(bound(t));
+}
+
 define_closure_function(1, 0, void, run_sighandler,
                         thread, t)
 {
@@ -298,6 +304,7 @@ thread create_thread(process p)
     setup_thread_frame(h, t->sighandler_frame, t);
     t->sighandler_frame[FRAME_RUN] = u64_from_pointer(init_closure(&t->run_sighandler, run_sighandler, t));
 
+    t->thrd.pause = init_closure(&t->pause_thread, pause_thread, t);
     // xxx another max 64
     t->affinity.mask[0] = MASK(total_processors);
     t->blocked_on = 0;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -153,7 +153,7 @@ static inline void run_thread_frame(thread t)
     check_stop_conditions(t);
     kern_lock(); // xx - make thread entry a separate exclusion region for performance
     thread old = current;
-    current_cpu()->current_thread = t;
+    current_cpu()->current_thread = (nanos_thread)t;
     ftrace_thread_switch(old, current);    /* ftrace needs to know about the switch event */
     thread_enter_user(t);
 
@@ -177,7 +177,7 @@ define_closure_function(1, 0, void, run_thread,
                         thread, t)
 {
     thread t = bound(t);
-    current_cpu()->current_thread = t;
+    current_cpu()->current_thread = (nanos_thread)t;
     dispatch_signals(t);
     run_thread_frame(t);
 }
@@ -265,7 +265,7 @@ define_closure_function(1, 0, void, free_thread,
 
 define_closure_function(1, 0, void, resume_syscall, thread, t)
 {
-    current_cpu()->current_thread = bound(t);
+    current_cpu()->current_thread = (nanos_thread)bound(t);
     thread_resume(bound(t));
     syscall_debug(thread_frame(bound(t)));
 }
@@ -386,7 +386,7 @@ void exit_thread(thread t)
     ftrace_thread_deinit(t, dummy_thread);
 
     /* replace references to thread with placeholder */
-    current_cpu()->current_thread = dummy_thread;
+    current_cpu()->current_thread = (nanos_thread)dummy_thread;
     set_running_frame(dummy_thread->default_frame);
     refcount_release(&t->refcount);
 }

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -101,6 +101,8 @@ void register_thread_syscalls(struct syscall *map)
 
 void thread_log_internal(thread t, const char *desc, ...)
 {
+    if (t == INVALID_ADDRESS)
+        return;
     if (table_find(t->p->process_root, sym(trace))) {
         if (syscall_notrace(t->syscall))
             return;
@@ -124,7 +126,7 @@ static inline void check_stop_conditions(thread t)
     boolean in_sighandler = thread_frame(t) == t->sighandler_frame;
     /* rather abrupt to just halt...this should go do dump or recovery */
     if (pending & mask_from_sig(SIGSEGV)) {
-        void * handler = sigaction_from_sig(SIGSEGV)->sa_handler;
+        void * handler = sigaction_from_sig(t, SIGSEGV)->sa_handler;
 
         /* Terminate on uncaught SIGSEGV, or if triggered by signal handler. */
         if (in_sighandler || (handler == SIG_IGN || handler == SIG_DFL)) {
@@ -153,7 +155,7 @@ static inline void run_thread_frame(thread t)
     thread old = current;
     current_cpu()->current_thread = t;
     ftrace_thread_switch(old, current);    /* ftrace needs to know about the switch event */
-    thread_enter_user(old, t);
+    thread_enter_user(t);
 
     /* cover wake-before-sleep situations (e.g. sched yield, fs ops that don't go to disk, etc.) */
     t->blocked_on = 0;
@@ -175,6 +177,7 @@ define_closure_function(1, 0, void, run_thread,
                         thread, t)
 {
     thread t = bound(t);
+    current_cpu()->current_thread = t;
     dispatch_signals(t);
     run_thread_frame(t);
 }
@@ -231,8 +234,8 @@ void thread_yield(void)
 void thread_wakeup(thread t)
 {
     thread_log(current, "%s: %ld->%ld blocked_on %s, RIP=0x%lx", __func__, current->tid, t->tid,
-               t->blocked_on ? (t->blocked_on != INVALID_ADDRESS ? blockq_name(t->blocked_on) : "uninterruptible") :
-               "(null)", thread_frame(t)[FRAME_RIP]);
+            t->blocked_on ? (t->blocked_on != INVALID_ADDRESS ? blockq_name(t->blocked_on) : "uninterruptible") :
+            "(null)", thread_frame(t)[FRAME_RIP]);
     assert(t->blocked_on);
     t->blocked_on = 0;
     t->syscall = -1;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -132,12 +132,7 @@ define_closure_function(1, 1, context, default_fault_handler,
        for kernel page faults on user pages. If we were ever to
        support multiple processes, we may need to install current when
        resuming deferred processing. */
-    // XXX This seems too hacky
-    process p;
-    if (current == INVALID_ADDRESS)
-        p = bound(t)->p;
-    else
-        p = current->p;
+    process p = current->p;
 
     u64 vaddr = fault_address(frame);
     if (frame[FRAME_VECTOR] == 0) {

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -465,7 +465,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
         sizeof(dummy_thread->name));
 
     for (int i = 0; i < MAX_CPUS; i++)
-        cpuinfo_from_id(i)->current_thread = dummy_thread;
+        cpuinfo_from_id(i)->current_thread = (nanos_thread)dummy_thread;
 
     /* XXX remove once we have http PUT support */
     ftrace_enable();

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -120,9 +120,7 @@ define_closure_function(1, 1, context, default_fault_handler,
        for kernel page faults on user pages. If we were ever to
        support multiple processes, we may need to install current when
        resuming deferred processing. */
-    // XXX
-    if (current != bound(t))
-        log_printf("DEBUGGG", "current and bound don't match: %p != %p\n", current, bound(t));
+    // XXX This seems too hacky
     process p;
     if (current == INVALID_ADDRESS)
         p = bound(t)->p;

--- a/src/unix/unix.h
+++ b/src/unix/unix.h
@@ -8,7 +8,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs);
 thread create_thread(process p);
 process exec_elf(buffer ex, process kernel_process);
 
-void thread_enter_user(thread out, thread in);
+void thread_enter_user(thread in);
 void thread_enter_system(thread t);
 void thread_pause(thread t);
 void thread_resume(thread t);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -196,8 +196,6 @@ declare_closure_struct(1, 0, void, resume_syscall,
                        thread, t);
 declare_closure_struct(1, 0, void, run_thread,
                        thread, t);
-declare_closure_struct(1, 0, void, pause_thread,
-                        thread, t);
 declare_closure_struct(1, 0, void, run_sighandler,
                        thread, t);
 declare_closure_struct(1, 1, context, default_fault_handler,
@@ -236,7 +234,6 @@ typedef struct thread {
     struct refcount refcount;
     closure_struct(free_thread, free);
     closure_struct(run_thread, run_thread);
-    closure_struct(pause_thread, pause_thread);
     closure_struct(run_sighandler, run_sighandler);
     closure_struct(default_fault_handler, fault_handler);
     closure_struct(thread_demand_file_page, demand_file_page);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -415,15 +415,21 @@ typedef struct sigaction *sigaction;
 
 extern thread dummy_thread;
 // seems like we could extract this from the frame or remove the thread entry in the frame
-//#define current ((thread)(current_cpu()->current_thread))
+#ifdef CURRENT_DEBUG
 #define current _current(__func__)
 static inline thread _current(const char *caller) {
-    if (current_cpu()->current_thread == INVALID_ADDRESS && runtime_strcmp("run_thread_frame", caller) != 0 && runtime_strcmp("thread_wakeup", caller) != 0) {
+    if (current_cpu()->current_thread == INVALID_ADDRESS &&
+      runtime_strcmp("run_thread_frame", caller) != 0 &&
+      runtime_strcmp("thread_wakeup", caller) != 0) {
         log_printf("CURRENT", "invalid address returned to caller '%s'\n", caller);
         print_stack_from_here();
     }
     return (thread)(current_cpu()->current_thread);
 }
+#else
+#define current ((thread)(current_cpu()->current_thread))
+#endif
+
 
 void init_thread_fault_handler(thread t);
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -196,6 +196,8 @@ declare_closure_struct(1, 0, void, resume_syscall,
                        thread, t);
 declare_closure_struct(1, 0, void, run_thread,
                        thread, t);
+declare_closure_struct(1, 0, void, pause_thread,
+                        thread, t);
 declare_closure_struct(1, 0, void, run_sighandler,
                        thread, t);
 declare_closure_struct(1, 1, context, default_fault_handler,
@@ -234,6 +236,7 @@ typedef struct thread {
     struct refcount refcount;
     closure_struct(free_thread, free);
     closure_struct(run_thread, run_thread);
+    closure_struct(pause_thread, pause_thread);
     closure_struct(run_sighandler, run_sighandler);
     closure_struct(default_fault_handler, fault_handler);
     closure_struct(thread_demand_file_page, demand_file_page);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -196,6 +196,8 @@ declare_closure_struct(1, 0, void, resume_syscall,
                        thread, t);
 declare_closure_struct(1, 0, void, run_thread,
                        thread, t);
+declare_closure_struct(1, 0, void, pause_thread,
+                        thread, t);
 declare_closure_struct(1, 0, void, run_sighandler,
                        thread, t);
 declare_closure_struct(1, 1, context, default_fault_handler,
@@ -215,6 +217,7 @@ declare_closure_struct(3, 1, void, thread_demand_file_page_complete,
 #define set_thread_frame(t, f) do { (t)->active_frame = (f); } while(0)
 
 typedef struct thread {
+    struct nanos_thread thrd;
     context default_frame;
     context sighandler_frame;
     context active_frame;         /* mux between default and sighandler */
@@ -234,6 +237,7 @@ typedef struct thread {
     struct refcount refcount;
     closure_struct(free_thread, free);
     closure_struct(run_thread, run_thread);
+    closure_struct(pause_thread, pause_thread);
     closure_struct(run_sighandler, run_sighandler);
     closure_struct(default_fault_handler, fault_handler);
     closure_struct(thread_demand_file_page, demand_file_page);

--- a/src/x86_64/frame.h
+++ b/src/x86_64/frame.h
@@ -45,7 +45,6 @@
 #define FRAME_FULL 34 
 #define FRAME_THREAD 35
 #define FRAME_HEAP 36
-#define FRAME_PAUSE 37
-#define FRAME_MAX 38
+#define FRAME_MAX 37
 #define FRAME_EXTENDED_SAVE 40
 

--- a/src/x86_64/frame.h
+++ b/src/x86_64/frame.h
@@ -45,6 +45,8 @@
 #define FRAME_FULL 34 
 #define FRAME_THREAD 35
 #define FRAME_HEAP 36
-#define FRAME_MAX 37
+#define FRAME_SYSCALL_THREAD 37
+#define FRAME_MAX 38
+
 #define FRAME_EXTENDED_SAVE 40
 

--- a/src/x86_64/frame.h
+++ b/src/x86_64/frame.h
@@ -45,8 +45,6 @@
 #define FRAME_FULL 34 
 #define FRAME_THREAD 35
 #define FRAME_HEAP 36
-#define FRAME_SYSCALL_THREAD 37
-#define FRAME_MAX 38
-
+#define FRAME_MAX 37
 #define FRAME_EXTENDED_SAVE 40
 

--- a/src/x86_64/frame.h
+++ b/src/x86_64/frame.h
@@ -45,6 +45,7 @@
 #define FRAME_FULL 34 
 #define FRAME_THREAD 35
 #define FRAME_HEAP 36
-#define FRAME_MAX 37
+#define FRAME_PAUSE 37
+#define FRAME_MAX 38
 #define FRAME_EXTENDED_SAVE 40
 


### PR DESCRIPTION
This branch addresses the leaky unix stuff described in #1254. It cleans up the handling of 'current' in the scheduler and unix code by changing current_thread to a generic thread struct with generic methods (like pause). Additionally, some problematic usage of current has been cleaned up (now that current_thread is invalidated on runloop entry).