### PR TITLE
Multi-volume support for AWS and ESXi

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -88,6 +88,7 @@ SRCS-kernel.img= \
 	$(SRCDIR)/vmware/vmxnet3_queue.c \
 	$(SRCDIR)/vmware/pvscsi.c \
 	$(SRCDIR)/xen/xen.c \
+	$(SRCDIR)/xen/xenblk.c \
 	$(SRCDIR)/xen/xennet.c \
 	$(SRCDIR)/hyperv/vmbus/hyperv.c \
 	$(SRCDIR)/hyperv/vmbus/vmbus.c \

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -462,7 +462,7 @@ static void __attribute__((noinline)) init_service_new_stack()
         init_vmxnet3_network(kh);
     }
 
-    init_storage(kh, sa, hyperv_storvsc_attached);
+    init_storage(kh, sa, !hyperv_storvsc_attached);
 
     init_debug("pci_discover (for virtio & ata)");
     pci_discover(); // do PCI discover again for other devices

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -446,6 +446,7 @@ static void __attribute__((noinline)) init_service_new_stack()
     if (xen_detected()) {
         init_debug("probing for Xen PV network...");
         init_xennet(kh);
+        init_xenblk(kh, sa);
         status s = xen_probe_devices();
         if (!is_ok(s))
             rprintf("xen probe failed: %v\n", s);
@@ -462,7 +463,7 @@ static void __attribute__((noinline)) init_service_new_stack()
         init_vmxnet3_network(kh);
     }
 
-    init_storage(kh, sa, !hyperv_storvsc_attached);
+    init_storage(kh, sa, !xen_detected() && !hyperv_storvsc_attached);
 
     init_debug("pci_discover (for virtio & ata)");
     pci_discover(); // do PCI discover again for other devices

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -222,7 +222,7 @@ closure_function(0, 3, void, attach_storage,
         deallocate(h, mbr, SECTOR_SIZE);
         return;
     }
-    apply(r, mbr, irange(0, SECTOR_SIZE), sh);
+    apply(r, mbr, irange(0, 1), sh);
 }
 
 static void read_kernel_syms()

--- a/src/drivers/ata-pci.c
+++ b/src/drivers/ata-pci.c
@@ -286,22 +286,14 @@ define_closure_function(1, 0, void, ata_pci_service,
     ata_pci_service_reqs(bound(apci));
 }
 
-closure_function(4, 1, boolean, ata_pci_probe,
+closure_function(3, 1, boolean, ata_pci_probe,
                  heap, general, heap, contiguous, storage_attach, a,
-                 boolean, hyperv_storvsc_attached,
                  pci_dev, d)
 {
     heap general = bound(general);
     heap contiguous = bound(contiguous);
     if (pci_get_class(d) != PCIC_STORAGE || pci_get_subclass(d) != PCIS_STORAGE_IDE)
         return false;
-
-    if (bound(hyperv_storvsc_attached) &&
-        pci_get_vendor(d) == ATA_INTEL_ID &&
-        pci_get_device(d) == PCI_PRODUCT_PIIX4) {
-        ata_debug("HyperV storvsc attached: ignore simulated ATA controller\n");
-        return false;
-    }
 
     ata_pci dev = ata_pci_alloc(general, contiguous, d);
     if (!ata_probe(dev->ata)) {
@@ -342,9 +334,8 @@ closure_function(4, 1, boolean, ata_pci_probe,
     return true;
 }
 
-void ata_pci_register(kernel_heaps kh, storage_attach a, boolean hyperv_storvsc_attached)
+void ata_pci_register(kernel_heaps kh, storage_attach a)
 {
     heap h = heap_general(kh);
-    register_pci_driver(closure(h, ata_pci_probe, h, heap_backed(kh), a,
-        hyperv_storvsc_attached));
+    register_pci_driver(closure(h, ata_pci_probe, h, heap_backed(kh), a));
 }

--- a/src/drivers/ata-pci.h
+++ b/src/drivers/ata-pci.h
@@ -1,3 +1,3 @@
 #include <drivers/storage.h>
 
-void ata_pci_register(kernel_heaps kh, storage_attach a, boolean hyperv_storvsc_attached);
+void ata_pci_register(kernel_heaps kh, storage_attach a);

--- a/src/drivers/storage.c
+++ b/src/drivers/storage.c
@@ -3,10 +3,11 @@
 #include <vmware/storage.h>
 #include <drivers/ata-pci.h>
 
-void init_storage(kernel_heaps kh, storage_attach a, boolean hyperv_storvsc_attached)
+void init_storage(kernel_heaps kh, storage_attach a, boolean enable_ata)
 {
     virtio_register_blk(kh, a);
     virtio_register_scsi(kh, a);
     pvscsi_register(kh, a);
-    ata_pci_register(kh, a, hyperv_storvsc_attached);
+    if (enable_ata)
+        ata_pci_register(kh, a);
 }

--- a/src/drivers/storage.h
+++ b/src/drivers/storage.h
@@ -1,3 +1,3 @@
 typedef closure_type(storage_attach, void, block_io, block_io, u64);
 
-void init_storage(kernel_heaps kh, storage_attach, boolean hyperv_storvsc_attached);
+void init_storage(kernel_heaps kh, storage_attach, boolean enable_ata);

--- a/src/kernel/xen_platform.h
+++ b/src/kernel/xen_platform.h
@@ -2,3 +2,4 @@ boolean xen_detect(kernel_heaps kh);
 boolean xen_detected(void);
 status xen_probe_devices(void);
 void init_xennet(kernel_heaps kh);
+void init_xenblk(kernel_heaps kh, storage_attach sa);

--- a/src/xen/public/io/blkif.h
+++ b/src/xen/public/io/blkif.h
@@ -1,0 +1,702 @@
+/******************************************************************************
+ * blkif.h
+ *
+ * Unified block-device I/O interface for Xen guest OSes.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Copyright (c) 2003-2004, Keir Fraser
+ * Copyright (c) 2012, Spectra Logic Corporation
+ */
+
+#ifndef __XEN_PUBLIC_IO_BLKIF_H__
+#define __XEN_PUBLIC_IO_BLKIF_H__
+
+#include "ring.h"
+#include "../grant_table.h"
+
+/*
+ * Front->back notifications: When enqueuing a new request, sending a
+ * notification can be made conditional on req_event (i.e., the generic
+ * hold-off mechanism provided by the ring macros). Backends must set
+ * req_event appropriately (e.g., using RING_FINAL_CHECK_FOR_REQUESTS()).
+ *
+ * Back->front notifications: When enqueuing a new response, sending a
+ * notification can be made conditional on rsp_event (i.e., the generic
+ * hold-off mechanism provided by the ring macros). Frontends must set
+ * rsp_event appropriately (e.g., using RING_FINAL_CHECK_FOR_RESPONSES()).
+ */
+
+#ifndef blkif_vdev_t
+#define blkif_vdev_t   uint16_t
+#endif
+#define blkif_sector_t uint64_t
+
+/*
+ * Feature and Parameter Negotiation
+ * =================================
+ * The two halves of a Xen block driver utilize nodes within the XenStore to
+ * communicate capabilities and to negotiate operating parameters.  This
+ * section enumerates these nodes which reside in the respective front and
+ * backend portions of the XenStore, following the XenBus convention.
+ *
+ * All data in the XenStore is stored as strings.  Nodes specifying numeric
+ * values are encoded in decimal.  Integer value ranges listed below are
+ * expressed as fixed sized integer types capable of storing the conversion
+ * of a properly formated node string, without loss of information.
+ *
+ * Any specified default value is in effect if the corresponding XenBus node
+ * is not present in the XenStore.
+ *
+ * XenStore nodes in sections marked "PRIVATE" are solely for use by the
+ * driver side whose XenBus tree contains them.
+ *
+ * XenStore nodes marked "DEPRECATED" in their notes section should only be
+ * used to provide interoperability with legacy implementations.
+ *
+ * See the XenBus state transition diagram below for details on when XenBus
+ * nodes must be published and when they can be queried.
+ *
+ *****************************************************************************
+ *                            Backend XenBus Nodes
+ *****************************************************************************
+ *
+ *------------------ Backend Device Identification (PRIVATE) ------------------
+ *
+ * mode
+ *      Values:         "r" (read only), "w" (writable)
+ *
+ *      The read or write access permissions to the backing store to be
+ *      granted to the frontend.
+ *
+ * params
+ *      Values:         string
+ *
+ *      A free formatted string providing sufficient information for the
+ *      hotplug script to attach the device and provide a suitable
+ *      handler (ie: a block device) for blkback to use.
+ *
+ * physical-device
+ *      Values:         "MAJOR:MINOR"
+ *      Notes: 11
+ *
+ *      MAJOR and MINOR are the major number and minor number of the
+ *      backing device respectively.
+ *
+ * physical-device-path
+ *      Values:         path string
+ *
+ *      A string that contains the absolute path to the disk image. On
+ *      NetBSD and Linux this is always a block device, while on FreeBSD
+ *      it can be either a block device or a regular file.
+ *
+ * type
+ *      Values:         "file", "phy", "tap"
+ *
+ *      The type of the backing device/object.
+ *
+ *
+ * direct-io-safe
+ *      Values:         0/1 (boolean)
+ *      Default Value:  0
+ *
+ *      The underlying storage is not affected by the direct IO memory
+ *      lifetime bug.  See:
+ *        http://lists.xen.org/archives/html/xen-devel/2012-12/msg01154.html
+ *
+ *      Therefore this option gives the backend permission to use
+ *      O_DIRECT, notwithstanding that bug.
+ *
+ *      That is, if this option is enabled, use of O_DIRECT is safe,
+ *      in circumstances where we would normally have avoided it as a
+ *      workaround for that bug.  This option is not relevant for all
+ *      backends, and even not necessarily supported for those for
+ *      which it is relevant.  A backend which knows that it is not
+ *      affected by the bug can ignore this option.
+ *
+ *      This option doesn't require a backend to use O_DIRECT, so it
+ *      should not be used to try to control the caching behaviour.
+ *
+ *--------------------------------- Features ---------------------------------
+ *
+ * feature-barrier
+ *      Values:         0/1 (boolean)
+ *      Default Value:  0
+ *
+ *      A value of "1" indicates that the backend can process requests
+ *      containing the BLKIF_OP_WRITE_BARRIER request opcode.  Requests
+ *      of this type may still be returned at any time with the
+ *      BLKIF_RSP_EOPNOTSUPP result code.
+ *
+ * feature-flush-cache
+ *      Values:         0/1 (boolean)
+ *      Default Value:  0
+ *
+ *      A value of "1" indicates that the backend can process requests
+ *      containing the BLKIF_OP_FLUSH_DISKCACHE request opcode.  Requests
+ *      of this type may still be returned at any time with the
+ *      BLKIF_RSP_EOPNOTSUPP result code.
+ *
+ * feature-discard
+ *      Values:         0/1 (boolean)
+ *      Default Value:  0
+ *
+ *      A value of "1" indicates that the backend can process requests
+ *      containing the BLKIF_OP_DISCARD request opcode.  Requests
+ *      of this type may still be returned at any time with the
+ *      BLKIF_RSP_EOPNOTSUPP result code.
+ *
+ * feature-persistent
+ *      Values:         0/1 (boolean)
+ *      Default Value:  0
+ *      Notes: 7
+ *
+ *      A value of "1" indicates that the backend can keep the grants used
+ *      by the frontend driver mapped, so the same set of grants should be
+ *      used in all transactions. The maximum number of grants the backend
+ *      can map persistently depends on the implementation, but ideally it
+ *      should be RING_SIZE * BLKIF_MAX_SEGMENTS_PER_REQUEST. Using this
+ *      feature the backend doesn't need to unmap each grant, preventing
+ *      costly TLB flushes. The backend driver should only map grants
+ *      persistently if the frontend supports it. If a backend driver chooses
+ *      to use the persistent protocol when the frontend doesn't support it,
+ *      it will probably hit the maximum number of persistently mapped grants
+ *      (due to the fact that the frontend won't be reusing the same grants),
+ *      and fall back to non-persistent mode. Backend implementations may
+ *      shrink or expand the number of persistently mapped grants without
+ *      notifying the frontend depending on memory constraints (this might
+ *      cause a performance degradation).
+ *
+ *      If a backend driver wants to limit the maximum number of persistently
+ *      mapped grants to a value less than RING_SIZE *
+ *      BLKIF_MAX_SEGMENTS_PER_REQUEST a LRU strategy should be used to
+ *      discard the grants that are less commonly used. Using a LRU in the
+ *      backend driver paired with a LIFO queue in the frontend will
+ *      allow us to have better performance in this scenario.
+ *
+ *----------------------- Request Transport Parameters ------------------------
+ *
+ * max-ring-page-order
+ *      Values:         <uint32_t>
+ *      Default Value:  0
+ *      Notes:          1, 3
+ *
+ *      The maximum supported size of the request ring buffer in units of
+ *      lb(machine pages). (e.g. 0 == 1 page,  1 = 2 pages, 2 == 4 pages,
+ *      etc.).
+ *
+ * max-ring-pages
+ *      Values:         <uint32_t>
+ *      Default Value:  1
+ *      Notes:          DEPRECATED, 2, 3
+ *
+ *      The maximum supported size of the request ring buffer in units of
+ *      machine pages.  The value must be a power of 2.
+ *
+ *------------------------- Backend Device Properties -------------------------
+ *
+ * discard-enable
+ *      Values:         0/1 (boolean)
+ *      Default Value:  1
+ *
+ *      This optional property, set by the toolstack, instructs the backend
+ *      to offer (or not to offer) discard to the frontend. If the property
+ *      is missing the backend should offer discard if the backing storage
+ *      actually supports it.
+ *
+ * discard-alignment
+ *      Values:         <uint32_t>
+ *      Default Value:  0
+ *      Notes:          4, 5
+ *
+ *      The offset, in bytes from the beginning of the virtual block device,
+ *      to the first, addressable, discard extent on the underlying device.
+ *
+ * discard-granularity
+ *      Values:         <uint32_t>
+ *      Default Value:  <"sector-size">
+ *      Notes:          4
+ *
+ *      The size, in bytes, of the individually addressable discard extents
+ *      of the underlying device.
+ *
+ * discard-secure
+ *      Values:         0/1 (boolean)
+ *      Default Value:  0
+ *      Notes:          10
+ *
+ *      A value of "1" indicates that the backend can process BLKIF_OP_DISCARD
+ *      requests with the BLKIF_DISCARD_SECURE flag set.
+ *
+ * info
+ *      Values:         <uint32_t> (bitmap)
+ *
+ *      A collection of bit flags describing attributes of the backing
+ *      device.  The VDISK_* macros define the meaning of each bit
+ *      location.
+ *
+ * sector-size
+ *      Values:         <uint32_t>
+ *
+ *      The logical sector size, in bytes, of the backend device.
+ *
+ * physical-sector-size
+ *      Values:         <uint32_t>
+ *
+ *      The physical sector size, in bytes, of the backend device.
+ *
+ * sectors
+ *      Values:         <uint64_t>
+ *
+ *      The size of the backend device, expressed in units of its logical
+ *      sector size ("sector-size").
+ *
+ *****************************************************************************
+ *                            Frontend XenBus Nodes
+ *****************************************************************************
+ *
+ *----------------------- Request Transport Parameters -----------------------
+ *
+ * event-channel
+ *      Values:         <uint32_t>
+ *
+ *      The identifier of the Xen event channel used to signal activity
+ *      in the ring buffer.
+ *
+ * ring-ref
+ *      Values:         <uint32_t>
+ *      Notes:          6
+ *
+ *      The Xen grant reference granting permission for the backend to map
+ *      the sole page in a single page sized ring buffer.
+ *
+ * ring-ref%u
+ *      Values:         <uint32_t>
+ *      Notes:          6
+ *
+ *      For a frontend providing a multi-page ring, a "number of ring pages"
+ *      sized list of nodes, each containing a Xen grant reference granting
+ *      permission for the backend to map the page of the ring located
+ *      at page index "%u".  Page indexes are zero based.
+ *
+ * protocol
+ *      Values:         string (XEN_IO_PROTO_ABI_*)
+ *      Default Value:  XEN_IO_PROTO_ABI_NATIVE
+ *
+ *      The machine ABI rules governing the format of all ring request and
+ *      response structures.
+ *
+ * ring-page-order
+ *      Values:         <uint32_t>
+ *      Default Value:  0
+ *      Maximum Value:  MAX(ffs(max-ring-pages) - 1, max-ring-page-order)
+ *      Notes:          1, 3
+ *
+ *      The size of the frontend allocated request ring buffer in units
+ *      of lb(machine pages). (e.g. 0 == 1 page, 1 = 2 pages, 2 == 4 pages,
+ *      etc.).
+ *
+ * num-ring-pages
+ *      Values:         <uint32_t>
+ *      Default Value:  1
+ *      Maximum Value:  MAX(max-ring-pages,(0x1 << max-ring-page-order))
+ *      Notes:          DEPRECATED, 2, 3
+ *
+ *      The size of the frontend allocated request ring buffer in units of
+ *      machine pages.  The value must be a power of 2.
+ *
+ * feature-persistent
+ *      Values:         0/1 (boolean)
+ *      Default Value:  0
+ *      Notes: 7, 8, 9
+ *
+ *      A value of "1" indicates that the frontend will reuse the same grants
+ *      for all transactions, allowing the backend to map them with write
+ *      access (even when it should be read-only). If the frontend hits the
+ *      maximum number of allowed persistently mapped grants, it can fallback
+ *      to non persistent mode. This will cause a performance degradation,
+ *      since the the backend driver will still try to map those grants
+ *      persistently. Since the persistent grants protocol is compatible with
+ *      the previous protocol, a frontend driver can choose to work in
+ *      persistent mode even when the backend doesn't support it.
+ *
+ *      It is recommended that the frontend driver stores the persistently
+ *      mapped grants in a LIFO queue, so a subset of all persistently mapped
+ *      grants gets used commonly. This is done in case the backend driver
+ *      decides to limit the maximum number of persistently mapped grants
+ *      to a value less than RING_SIZE * BLKIF_MAX_SEGMENTS_PER_REQUEST.
+ *
+ *------------------------- Virtual Device Properties -------------------------
+ *
+ * device-type
+ *      Values:         "disk", "cdrom", "floppy", etc.
+ *
+ * virtual-device
+ *      Values:         <uint32_t>
+ *
+ *      A value indicating the physical device to virtualize within the
+ *      frontend's domain.  (e.g. "The first ATA disk", "The third SCSI
+ *      disk", etc.)
+ *
+ *      See docs/misc/vbd-interface.txt for details on the format of this
+ *      value.
+ *
+ * Notes
+ * -----
+ * (1) Multi-page ring buffer scheme first developed in the Citrix XenServer
+ *     PV drivers.
+ * (2) Multi-page ring buffer scheme first used in some RedHat distributions
+ *     including a distribution deployed on certain nodes of the Amazon
+ *     EC2 cluster.
+ * (3) Support for multi-page ring buffers was implemented independently,
+ *     in slightly different forms, by both Citrix and RedHat/Amazon.
+ *     For full interoperability, block front and backends should publish
+ *     identical ring parameters, adjusted for unit differences, to the
+ *     XenStore nodes used in both schemes.
+ * (4) Devices that support discard functionality may internally allocate space
+ *     (discardable extents) in units that are larger than the exported logical
+ *     block size. If the backing device has such discardable extents the
+ *     backend should provide both discard-granularity and discard-alignment.
+ *     Providing just one of the two may be considered an error by the frontend.
+ *     Backends supporting discard should include discard-granularity and
+ *     discard-alignment even if it supports discarding individual sectors.
+ *     Frontends should assume discard-alignment == 0 and discard-granularity
+ *     == sector size if these keys are missing.
+ * (5) The discard-alignment parameter allows a physical device to be
+ *     partitioned into virtual devices that do not necessarily begin or
+ *     end on a discardable extent boundary.
+ * (6) When there is only a single page allocated to the request ring,
+ *     'ring-ref' is used to communicate the grant reference for this
+ *     page to the backend.  When using a multi-page ring, the 'ring-ref'
+ *     node is not created.  Instead 'ring-ref0' - 'ring-refN' are used.
+ * (7) When using persistent grants data has to be copied from/to the page
+ *     where the grant is currently mapped. The overhead of doing this copy
+ *     however doesn't suppress the speed improvement of not having to unmap
+ *     the grants.
+ * (8) The frontend driver has to allow the backend driver to map all grants
+ *     with write access, even when they should be mapped read-only, since
+ *     further requests may reuse these grants and require write permissions.
+ * (9) Linux implementation doesn't have a limit on the maximum number of
+ *     grants that can be persistently mapped in the frontend driver, but
+ *     due to the frontent driver implementation it should never be bigger
+ *     than RING_SIZE * BLKIF_MAX_SEGMENTS_PER_REQUEST.
+ *(10) The discard-secure property may be present and will be set to 1 if the
+ *     backing device supports secure discard.
+ *(11) Only used by Linux and NetBSD.
+ */
+
+/*
+ * Multiple hardware queues/rings:
+ * If supported, the backend will write the key "multi-queue-max-queues" to
+ * the directory for that vbd, and set its value to the maximum supported
+ * number of queues.
+ * Frontends that are aware of this feature and wish to use it can write the
+ * key "multi-queue-num-queues" with the number they wish to use, which must be
+ * greater than zero, and no more than the value reported by the backend in
+ * "multi-queue-max-queues".
+ *
+ * For frontends requesting just one queue, the usual event-channel and
+ * ring-ref keys are written as before, simplifying the backend processing
+ * to avoid distinguishing between a frontend that doesn't understand the
+ * multi-queue feature, and one that does, but requested only one queue.
+ *
+ * Frontends requesting two or more queues must not write the toplevel
+ * event-channel and ring-ref keys, instead writing those keys under sub-keys
+ * having the name "queue-N" where N is the integer ID of the queue/ring for
+ * which those keys belong. Queues are indexed from zero.
+ * For example, a frontend with two queues must write the following set of
+ * queue-related keys:
+ *
+ * /local/domain/1/device/vbd/0/multi-queue-num-queues = "2"
+ * /local/domain/1/device/vbd/0/queue-0 = ""
+ * /local/domain/1/device/vbd/0/queue-0/ring-ref = "<ring-ref#0>"
+ * /local/domain/1/device/vbd/0/queue-0/event-channel = "<evtchn#0>"
+ * /local/domain/1/device/vbd/0/queue-1 = ""
+ * /local/domain/1/device/vbd/0/queue-1/ring-ref = "<ring-ref#1>"
+ * /local/domain/1/device/vbd/0/queue-1/event-channel = "<evtchn#1>"
+ *
+ * It is also possible to use multiple queues/rings together with
+ * feature multi-page ring buffer.
+ * For example, a frontend requests two queues/rings and the size of each ring
+ * buffer is two pages must write the following set of related keys:
+ *
+ * /local/domain/1/device/vbd/0/multi-queue-num-queues = "2"
+ * /local/domain/1/device/vbd/0/ring-page-order = "1"
+ * /local/domain/1/device/vbd/0/queue-0 = ""
+ * /local/domain/1/device/vbd/0/queue-0/ring-ref0 = "<ring-ref#0>"
+ * /local/domain/1/device/vbd/0/queue-0/ring-ref1 = "<ring-ref#1>"
+ * /local/domain/1/device/vbd/0/queue-0/event-channel = "<evtchn#0>"
+ * /local/domain/1/device/vbd/0/queue-1 = ""
+ * /local/domain/1/device/vbd/0/queue-1/ring-ref0 = "<ring-ref#2>"
+ * /local/domain/1/device/vbd/0/queue-1/ring-ref1 = "<ring-ref#3>"
+ * /local/domain/1/device/vbd/0/queue-1/event-channel = "<evtchn#1>"
+ *
+ */
+
+/*
+ * STATE DIAGRAMS
+ *
+ *****************************************************************************
+ *                                   Startup                                 *
+ *****************************************************************************
+ *
+ * Tool stack creates front and back nodes with state XenbusStateInitialising.
+ *
+ * Front                                Back
+ * =================================    =====================================
+ * XenbusStateInitialising              XenbusStateInitialising
+ *  o Query virtual device               o Query backend device identification
+ *    properties.                          data.
+ *  o Setup OS device instance.          o Open and validate backend device.
+ *                                       o Publish backend features and
+ *                                         transport parameters.
+ *                                                      |
+ *                                                      |
+ *                                                      V
+ *                                      XenbusStateInitWait
+ *
+ * o Query backend features and
+ *   transport parameters.
+ * o Allocate and initialize the
+ *   request ring.
+ * o Publish transport parameters
+ *   that will be in effect during
+ *   this connection.
+ *              |
+ *              |
+ *              V
+ * XenbusStateInitialised
+ *
+ *                                       o Query frontend transport parameters.
+ *                                       o Connect to the request ring and
+ *                                         event channel.
+ *                                       o Publish backend device properties.
+ *                                                      |
+ *                                                      |
+ *                                                      V
+ *                                      XenbusStateConnected
+ *
+ *  o Query backend device properties.
+ *  o Finalize OS virtual device
+ *    instance.
+ *              |
+ *              |
+ *              V
+ * XenbusStateConnected
+ *
+ * Note: Drivers that do not support any optional features, or the negotiation
+ *       of transport parameters, can skip certain states in the state machine:
+ *
+ *       o A frontend may transition to XenbusStateInitialised without
+ *         waiting for the backend to enter XenbusStateInitWait.  In this
+ *         case, default transport parameters are in effect and any
+ *         transport parameters published by the frontend must contain
+ *         their default values.
+ *
+ *       o A backend may transition to XenbusStateInitialised, bypassing
+ *         XenbusStateInitWait, without waiting for the frontend to first
+ *         enter the XenbusStateInitialised state.  In this case, default
+ *         transport parameters are in effect and any transport parameters
+ *         published by the backend must contain their default values.
+ *
+ *       Drivers that support optional features and/or transport parameter
+ *       negotiation must tolerate these additional state transition paths.
+ *       In general this means performing the work of any skipped state
+ *       transition, if it has not already been performed, in addition to the
+ *       work associated with entry into the current state.
+ */
+
+/*
+ * REQUEST CODES.
+ */
+#define BLKIF_OP_READ              0
+#define BLKIF_OP_WRITE             1
+/*
+ * All writes issued prior to a request with the BLKIF_OP_WRITE_BARRIER
+ * operation code ("barrier request") must be completed prior to the
+ * execution of the barrier request.  All writes issued after the barrier
+ * request must not execute until after the completion of the barrier request.
+ *
+ * Optional.  See "feature-barrier" XenBus node documentation above.
+ */
+#define BLKIF_OP_WRITE_BARRIER     2
+/*
+ * Commit any uncommitted contents of the backing device's volatile cache
+ * to stable storage.
+ *
+ * Optional.  See "feature-flush-cache" XenBus node documentation above.
+ */
+#define BLKIF_OP_FLUSH_DISKCACHE   3
+/*
+ * Used in SLES sources for device specific command packet
+ * contained within the request. Reserved for that purpose.
+ */
+#define BLKIF_OP_RESERVED_1        4
+/*
+ * Indicate to the backend device that a region of storage is no longer in
+ * use, and may be discarded at any time without impact to the client.  If
+ * the BLKIF_DISCARD_SECURE flag is set on the request, all copies of the
+ * discarded region on the device must be rendered unrecoverable before the
+ * command returns.
+ *
+ * This operation is analogous to performing a trim (ATA) or unamp (SCSI),
+ * command on a native device.
+ *
+ * More information about trim/unmap operations can be found at:
+ * http://t13.org/Documents/UploadedDocuments/docs2008/
+ *     e07154r6-Data_Set_Management_Proposal_for_ATA-ACS2.doc
+ * http://www.seagate.com/staticfiles/support/disc/manuals/
+ *     Interface%20manuals/100293068c.pdf
+ *
+ * Optional.  See "feature-discard", "discard-alignment",
+ * "discard-granularity", and "discard-secure" in the XenBus node
+ * documentation above.
+ */
+#define BLKIF_OP_DISCARD           5
+
+/*
+ * Recognized if "feature-max-indirect-segments" in present in the backend
+ * xenbus info. The "feature-max-indirect-segments" node contains the maximum
+ * number of segments allowed by the backend per request. If the node is
+ * present, the frontend might use blkif_request_indirect structs in order to
+ * issue requests with more than BLKIF_MAX_SEGMENTS_PER_REQUEST (11). The
+ * maximum number of indirect segments is fixed by the backend, but the
+ * frontend can issue requests with any number of indirect segments as long as
+ * it's less than the number provided by the backend. The indirect_grefs field
+ * in blkif_request_indirect should be filled by the frontend with the
+ * grant references of the pages that are holding the indirect segments.
+ * These pages are filled with an array of blkif_request_segment that hold the
+ * information about the segments. The number of indirect pages to use is
+ * determined by the number of segments an indirect request contains. Every
+ * indirect page can contain a maximum of
+ * (PAGE_SIZE / sizeof(struct blkif_request_segment)) segments, so to
+ * calculate the number of indirect pages to use we have to do
+ * ceil(indirect_segments / (PAGE_SIZE / sizeof(struct blkif_request_segment))).
+ *
+ * If a backend does not recognize BLKIF_OP_INDIRECT, it should *not*
+ * create the "feature-max-indirect-segments" node!
+ */
+#define BLKIF_OP_INDIRECT          6
+
+/*
+ * Maximum scatter/gather segments per request.
+ * This is carefully chosen so that sizeof(blkif_ring_t) <= PAGE_SIZE.
+ * NB. This could be 12 if the ring indexes weren't stored in the same page.
+ */
+#define BLKIF_MAX_SEGMENTS_PER_REQUEST 11
+
+/*
+ * Maximum number of indirect pages to use per request.
+ */
+#define BLKIF_MAX_INDIRECT_PAGES_PER_REQUEST 8
+
+/*
+ * NB. first_sect and last_sect in blkif_request_segment, as well as
+ * sector_number in blkif_request, are always expressed in 512-byte units.
+ * However they must be properly aligned to the real sector size of the
+ * physical disk, which is reported in the "physical-sector-size" node in
+ * the backend xenbus info. Also the xenbus "sectors" node is expressed in
+ * 512-byte units.
+ */
+struct blkif_request_segment {
+    grant_ref_t gref;        /* reference to I/O buffer frame        */
+    /* @first_sect: first sector in frame to transfer (inclusive).   */
+    /* @last_sect: last sector in frame to transfer (inclusive).     */
+    uint8_t     first_sect, last_sect;
+};
+
+/*
+ * Starting ring element for any I/O request.
+ */
+struct blkif_request {
+    uint8_t        operation;    /* BLKIF_OP_???                         */
+    uint8_t        nr_segments;  /* number of segments                   */
+    blkif_vdev_t   handle;       /* only for read/write requests         */
+    uint64_t       id;           /* private guest value, echoed in resp  */
+    blkif_sector_t sector_number;/* start sector idx on disk (r/w only)  */
+    struct blkif_request_segment seg[BLKIF_MAX_SEGMENTS_PER_REQUEST];
+};
+typedef struct blkif_request blkif_request_t;
+
+/*
+ * Cast to this structure when blkif_request.operation == BLKIF_OP_DISCARD
+ * sizeof(struct blkif_request_discard) <= sizeof(struct blkif_request)
+ */
+struct blkif_request_discard {
+    uint8_t        operation;    /* BLKIF_OP_DISCARD                     */
+    uint8_t        flag;         /* BLKIF_DISCARD_SECURE or zero         */
+#define BLKIF_DISCARD_SECURE (1<<0)  /* ignored if discard-secure=0      */
+    blkif_vdev_t   handle;       /* same as for read/write requests      */
+    uint64_t       id;           /* private guest value, echoed in resp  */
+    blkif_sector_t sector_number;/* start sector idx on disk             */
+    uint64_t       nr_sectors;   /* number of contiguous sectors to discard*/
+};
+typedef struct blkif_request_discard blkif_request_discard_t;
+
+struct blkif_request_indirect {
+    uint8_t        operation;    /* BLKIF_OP_INDIRECT                    */
+    uint8_t        indirect_op;  /* BLKIF_OP_{READ/WRITE}                */
+    uint16_t       nr_segments;  /* number of segments                   */
+    uint64_t       id;           /* private guest value, echoed in resp  */
+    blkif_sector_t sector_number;/* start sector idx on disk (r/w only)  */
+    blkif_vdev_t   handle;       /* same as for read/write requests      */
+    grant_ref_t    indirect_grefs[BLKIF_MAX_INDIRECT_PAGES_PER_REQUEST];
+#ifdef __i386__
+    uint64_t       pad;          /* Make it 64 byte aligned on i386      */
+#endif
+};
+typedef struct blkif_request_indirect blkif_request_indirect_t;
+
+struct blkif_response {
+    uint64_t        id;              /* copied from request */
+    uint8_t         operation;       /* copied from request */
+    int16_t         status;          /* BLKIF_RSP_???       */
+};
+typedef struct blkif_response blkif_response_t;
+
+/*
+ * STATUS RETURN CODES.
+ */
+ /* Operation not supported (only happens on barrier writes). */
+#define BLKIF_RSP_EOPNOTSUPP  -2
+ /* Operation failed for some unspecified reason (-EIO). */
+#define BLKIF_RSP_ERROR       -1
+ /* Operation completed successfully. */
+#define BLKIF_RSP_OKAY         0
+
+/*
+ * Generate blkif ring structures and types.
+ */
+DEFINE_RING_TYPES(blkif, struct blkif_request, struct blkif_response);
+
+#define VDISK_CDROM        0x1
+#define VDISK_REMOVABLE    0x2
+#define VDISK_READONLY     0x4
+
+#endif /* __XEN_PUBLIC_IO_BLKIF_H__ */
+
+/*
+ * Local variables:
+ * mode: C
+ * c-file-style: "BSD"
+ * c-basic-offset: 4
+ * tab-width: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/src/xen/public/io/protocols.h
+++ b/src/xen/public/io/protocols.h
@@ -1,0 +1,42 @@
+/******************************************************************************
+ * protocols.h
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ * Copyright (c) 2008, Keir Fraser
+ */
+
+#ifndef __XEN_PROTOCOLS_H__
+#define __XEN_PROTOCOLS_H__
+
+#define XEN_IO_PROTO_ABI_X86_32     "x86_32-abi"
+#define XEN_IO_PROTO_ABI_X86_64     "x86_64-abi"
+#define XEN_IO_PROTO_ABI_ARM        "arm-abi"
+
+#if defined(__i386__)
+# define XEN_IO_PROTO_ABI_NATIVE XEN_IO_PROTO_ABI_X86_32
+#elif defined(__x86_64__)
+# define XEN_IO_PROTO_ABI_NATIVE XEN_IO_PROTO_ABI_X86_64
+#elif defined(__arm__) || defined(__aarch64__)
+# define XEN_IO_PROTO_ABI_NATIVE XEN_IO_PROTO_ABI_ARM
+#else
+# error arch fixup needed here
+#endif
+
+#endif

--- a/src/xen/xen_internal.h
+++ b/src/xen/xen_internal.h
@@ -24,6 +24,17 @@ typedef s64 int64_t;
 #include "grant_table.h"
 #include "io/xenbus.h"
 
+#define memset runtime_memset
+#define xen_wmb write_barrier
+#define xen_mb memory_barrier
+
+typedef struct xen_dev {
+    int if_id;
+    domid_t backend_id;
+    buffer frontend;
+    buffer backend;
+} *xen_dev;
+
 status xen_allocate_evtchn(domid_t other_id, evtchn_port_t *evtchn);
 void xen_register_evtchn_handler(evtchn_port_t evtchn, thunk handler);
 int xen_notify_evtchn(evtchn_port_t evtchn);
@@ -40,6 +51,8 @@ status xenstore_sync_request(u32 tx_id, enum xsd_sockmsg_type type, buffer reque
 status xenstore_sync_printf(u32 tx_id, buffer path, const char *node, const char *format, ...);
 status xenstore_transaction_start(u32 *tx_id);
 status xenstore_transaction_end(u32 tx_id, boolean abort);
+
+status xendev_attach(xen_dev xd, int id, buffer frontend, tuple meta);
 
 typedef closure_type(xen_device_probe, boolean, int, buffer, tuple);
 void register_xen_driver(const char * name, xen_device_probe probe);

--- a/src/xen/xenblk.c
+++ b/src/xen/xenblk.c
@@ -1,0 +1,449 @@
+#include <kernel.h>
+#include <drivers/storage.h>
+#include <page.h>
+#include <storage.h>
+
+#include "xen_internal.h"
+
+#include "io/blkif.h"
+#include "io/protocols.h"
+
+#define XENBLK_RING_SIZE                                                \
+  (__RD32(((PAGESIZE) - __builtin_offsetof(struct blkif_sring, ring)) / \
+          sizeof(((struct blkif_sring *)0)->ring[0])))
+#define XENBLK_SECTORS_PER_PAGE (PAGESIZE / SECTOR_SIZE)
+
+//#define XENBLK_DEBUG
+#ifdef XENBLK_DEBUG
+#define xenblk_debug(x, ...) do {rprintf("XBLK: " x "\n", ##__VA_ARGS__);} while(0)
+#else
+#define xenblk_debug(x, ...)
+#endif
+
+typedef struct xenblk_dev *xenblk_dev;
+
+declare_closure_struct(2, 3, void, xenblk_io,
+                       xenblk_dev, xbd, boolean, write,
+                       void *, buf, range, blocks, status_handler, sh);
+
+declare_closure_struct(1, 0, void, xenblk_event_handler,
+                       xenblk_dev, xbd);
+
+declare_closure_struct(1, 0, void, xenblk_bh_service,
+                       xenblk_dev, xbd);
+
+struct xenblk_dev {
+    struct xen_dev dev;
+    heap h;
+    heap contiguous;
+    u64 capacity;
+    blkif_front_ring_t ring;
+    grant_ref_t ring_gntref;
+    evtchn_port_t evtchn;
+    closure_struct(xenblk_io, read);
+    closure_struct(xenblk_io, write);
+    closure_struct(xenblk_event_handler, event_handler);
+    closure_struct(xenblk_bh_service, bh_service);
+    vector rreqs;   /* xenblk_ring_req */
+    struct list pending, done, free;    /* xenblk_req */
+    struct list free_rreqs; /* xenblk_ring_req */
+    struct spinlock lock;
+};
+
+typedef struct xenblk_req {
+    struct list l;
+    u8 operation;   /* BLKIF_OP_xxx */
+    void *buf;
+    range remain;
+    u64 pending;
+    status_handler sh;
+    status s;
+} *xenblk_req;
+
+typedef struct xenblk_ring_req {
+    struct list l;
+    u64 id;
+    xenblk_req req;
+    u8 segments;
+    grant_ref_t grefs[BLKIF_MAX_SEGMENTS_PER_REQUEST];
+} *xenblk_ring_req;
+
+static xenblk_req xenblk_get_req(xenblk_dev xbd)
+{
+    xenblk_req req;
+    spin_lock(&xbd->lock);
+    list l = list_get_next(&xbd->free);
+    if (l) {
+        list_delete(l);
+        req = struct_from_list(l, xenblk_req, l);
+    } else {
+        xenblk_debug("new request allocation");
+        req = allocate(xbd->h, sizeof(*req));
+        if (req == INVALID_ADDRESS)
+            req = 0;
+    }
+    spin_unlock(&xbd->lock);
+    return req;
+}
+
+static xenblk_ring_req xenblk_get_rreq(xenblk_dev xbd)
+{
+    u64 irqflags = spin_lock_irq(&xbd->lock);
+    list l = list_get_next(&xbd->free_rreqs);
+    if (l) {
+        list_delete(l);
+        spin_unlock_irq(&xbd->lock, irqflags);
+        return struct_from_list(l, xenblk_ring_req, l);
+    }
+    xenblk_debug("new ring request allocation");
+    xenblk_ring_req req = allocate(xbd->h, sizeof(*req));
+    if (req != INVALID_ADDRESS) {
+        req->id = vector_length(xbd->rreqs);
+        vector_push(xbd->rreqs, req);
+    } else {
+        req = 0;
+    }
+    spin_unlock_irq(&xbd->lock, irqflags);
+    return req;
+}
+
+/* Called with the mutex locked. */
+static void xenblk_service_pending(xenblk_dev xbd)
+{
+    RING_IDX prod = xbd->ring.req_prod_pvt;
+    RING_IDX prod_end = xbd->ring.rsp_cons + XENBLK_RING_SIZE;
+    xenblk_debug("%s: prod %d, prod_end %d", __func__, prod, prod_end);
+    while (prod < prod_end) {
+        blkif_request_t *req = RING_GET_REQUEST(&xbd->ring, prod);
+        list l = list_get_next(&xbd->pending);
+        if (!l) {
+            xenblk_debug("pending empty");
+            break;
+        }
+        xenblk_req xbreq = struct_from_list(l, xenblk_req, l);
+        xenblk_debug(" sectors %R", xbreq->remain);
+        xenblk_ring_req rreq = xenblk_get_rreq(xbd);
+        if (!rreq) {
+            xenblk_debug("no available requests");
+            break;
+        }
+        rreq->req = xbreq;
+        rreq->segments = 0;
+        req->operation = xbreq->operation;
+        req->handle = xbd->dev.if_id;
+        req->id = rreq->id;
+        req->sector_number = xbreq->remain.start;
+        req->nr_segments = 0;
+        boolean out_of_grants = false;
+        do {
+            u64 sectors = range_span(xbreq->remain);
+            if (sectors == 0) {
+                list_delete(l);
+                break;
+            }
+            struct blkif_request_segment *seg = &req->seg[req->nr_segments];
+            u64 phys = physical_from_virtual(xbreq->buf);
+            assert(phys != INVALID_PHYSICAL);
+            seg->gref = xen_grant_page_access(xbd->dev.backend_id, phys,
+                req->operation == BLKIF_OP_WRITE);
+            if (!seg->gref) {
+                out_of_grants = true;
+                break;
+            }
+            rreq->grefs[req->nr_segments] = seg->gref;
+            seg->first_sect = (phys & MASK(PAGELOG)) >> SECTOR_OFFSET;
+            if (seg->first_sect + sectors > XENBLK_SECTORS_PER_PAGE)
+                sectors = XENBLK_SECTORS_PER_PAGE - seg->first_sect;
+            seg->last_sect = seg->first_sect + sectors - 1;
+            xenblk_debug("  segment %d [%d, %d]", req->nr_segments,
+                         seg->first_sect, seg->last_sect);
+            xbreq->remain.start += sectors;
+            xbreq->buf += sectors * SECTOR_SIZE;
+        } while (++req->nr_segments < BLKIF_MAX_SEGMENTS_PER_REQUEST);
+        if (req->nr_segments > 0) {
+            rreq->segments = req->nr_segments;
+            xbreq->pending++;
+            prod++;
+        }
+        if (out_of_grants)
+            break;
+    }
+    xbd->ring.req_prod_pvt = prod;
+    int notify;
+    RING_PUSH_REQUESTS_AND_CHECK_NOTIFY(&xbd->ring, notify);
+    if (notify)
+        xen_notify_evtchn(xbd->evtchn);
+}
+
+/* Called with the mutex locked. */
+static void xenblk_service_ring(xenblk_dev xbd)
+{
+    int more;
+
+    do {
+        RING_IDX cons = xbd->ring.rsp_cons;
+        RING_IDX prod = xbd->ring.sring->rsp_prod;
+        read_barrier();
+        xenblk_debug("%s: cons %d, prod %d", __func__, cons, prod);
+        while (cons < prod) {
+            blkif_response_t *resp = RING_GET_RESPONSE(&xbd->ring, cons);
+            xenblk_ring_req rreq = vector_get(xbd->rreqs, resp->id);
+            assert(rreq);
+            for (u8 segment = 0; segment < rreq->segments; segment++)
+                xen_revoke_page_access(rreq->grefs[segment]);
+            list_insert_before(list_begin(&xbd->free_rreqs), &rreq->l);
+            xenblk_req req = rreq->req;
+            if ((resp->status != BLKIF_RSP_OKAY) && (req->s == STATUS_OK)) {
+                req->s = timm("result", "xenblk error %d", resp->status);
+            }
+            if ((--req->pending == 0) && (range_span(req->remain) == 0))
+                list_push_back(&xbd->done, &req->l);
+            cons++;
+        }
+        xbd->ring.rsp_cons = cons;
+        RING_FINAL_CHECK_FOR_RESPONSES(&xbd->ring, more);
+    } while (more);
+}
+
+define_closure_function(2, 3, void, xenblk_io,
+                        xenblk_dev, xbd, boolean, write,
+                        void *, buf, range, blocks, status_handler, sh)
+{
+    xenblk_dev xbd = bound(xbd);
+    boolean write = bound(write);
+    xenblk_debug("[%d] %s %R", xbd->dev.if_id, write ? "write" : "read",
+            blocks);
+    xenblk_req req = xenblk_get_req(xbd);
+    if (!req) {
+        apply(sh, timm("result", "request allocation failed"));
+        return;
+    }
+    req->operation = write ? BLKIF_OP_WRITE : BLKIF_OP_READ;
+    req->buf = buf;
+    req->remain = blocks;
+    req->pending = 0;
+    req->sh = sh;
+    req->s = STATUS_OK;
+    u64 irqflags = spin_lock_irq(&xbd->lock);
+    list_push_back(&xbd->pending, &req->l);
+    xenblk_service_pending(xbd);
+    spin_unlock_irq(&xbd->lock, irqflags);
+}
+
+define_closure_function(1, 0, void, xenblk_event_handler,
+                        xenblk_dev, xbd)
+{
+    xenblk_dev xbd = bound(xbd);
+    xenblk_debug("[%d] %s", xbd->dev.if_id, __func__);
+    spin_lock(&xbd->lock);
+    boolean done_empty = list_empty(&xbd->done);
+    xenblk_service_ring(xbd);
+    xenblk_service_pending(xbd);
+    if (done_empty && !list_empty(&xbd->done))
+        enqueue(bhqueue, &xbd->bh_service);
+    spin_unlock(&xbd->lock);
+    assert(xen_unmask_evtchn(xbd->evtchn) == 0);
+}
+
+define_closure_function(1, 0, void, xenblk_bh_service,
+                        xenblk_dev, xbd)
+{
+    xenblk_dev xbd = bound(xbd);
+    xenblk_debug("[%d] %s", xbd->dev.if_id, __func__);
+    list l;
+    u64 irqflags = spin_lock_irq(&xbd->lock);
+    while ((l = list_get_next(&xbd->done))) {
+        list_delete(l);
+        spin_unlock_irq(&xbd->lock, irqflags);
+        xenblk_req req = struct_from_list(l, xenblk_req, l);
+        apply(req->sh, req->s);
+        irqflags = spin_lock_irq(&xbd->lock);
+        list_insert_before(list_begin(&xbd->free), l);
+    }
+    spin_unlock(&xbd->lock);
+}
+
+#define XENBLK_INFORM_BACKEND_RETRIES   64
+
+static status xenblk_inform_backend(xenblk_dev xbd)
+{
+    status s = STATUS_OK;
+    xen_dev xd = &xbd->dev;
+    xenblk_debug("%s: dev id %d", __func__, xd->if_id);
+    u32 tx_id;
+    char *node;
+    int retries = XENBLK_INFORM_BACKEND_RETRIES;
+
+  again:
+    s = xenstore_transaction_start(&tx_id);
+    if (!is_ok(s))
+        return s;
+    node = "protocol";
+    s = xenstore_sync_printf(tx_id, xd->frontend, node, "%s",
+        XEN_IO_PROTO_ABI_NATIVE);
+    if (!is_ok(s))
+        goto abort;
+    node = "ring-ref";
+    s = xenstore_sync_printf(tx_id, xd->frontend, node, "%d", xbd->ring_gntref);
+    if (!is_ok(s))
+        goto abort;
+    node = "event-channel";
+    s = xenstore_sync_printf(tx_id, xd->frontend, node, "%d", xbd->evtchn);
+    if (!is_ok(s))
+        goto abort;
+    s = xenstore_transaction_end(tx_id, false);
+    if (!is_ok(s)) {
+        value v = table_find(s, sym(errno));
+        if (v) {
+            if (!buffer_strcmp((buffer)v, "EAGAIN")) {
+                deallocate_tuple(s);
+                if (retries-- == 0)
+                    return timm("result", "%s failed after %d tries", __func__,
+                        XENBLK_INFORM_BACKEND_RETRIES);
+                goto again;
+            }
+        }
+        return timm_up(s, "result", "%s: transaction end failed", __func__);
+    }
+    return xenbus_set_state(0, xd->frontend, XenbusStateInitialised);
+  abort:
+    xenstore_transaction_end(tx_id, true);
+    return timm_up(s, "result", "%s: transaction aborted; step \"%s\" failed",
+                   __func__, node);
+}
+
+static status xenblk_enable(xenblk_dev xbd)
+{
+    xen_dev xd = &xbd->dev;
+    blkif_sring_t *ring = allocate_zero(xbd->contiguous, PAGESIZE);
+    if (ring == INVALID_ADDRESS)
+        return timm("result", "cannot allocate ring");
+    SHARED_RING_INIT(ring);
+    FRONT_RING_INIT(&xbd->ring, ring, PAGESIZE);
+    status s;
+    xbd->ring_gntref = xen_grant_page_access(xd->backend_id,
+        physical_from_virtual(ring), false);
+    if (xbd->ring_gntref == 0) {
+        s = timm("result", "failed to obtain grant reference for ring");
+        goto out_dealloc;
+    }
+    s = xen_allocate_evtchn(xd->backend_id, &xbd->evtchn);
+    if (!is_ok(s))
+        goto out_revoke;
+    init_closure(&xbd->bh_service, xenblk_bh_service, xbd);
+    xen_register_evtchn_handler(xbd->evtchn, init_closure(&xbd->event_handler,
+        xenblk_event_handler, xbd));
+    s = xenblk_inform_backend(xbd);
+    if (!is_ok(s))
+        goto out_revoke;
+    XenbusState backend_state = XenbusStateUnknown;
+    for (int retries = 0; retries < 8; retries++) {
+        s = xenbus_get_state(xd->backend, &backend_state);
+        if (!is_ok(s)) {
+            s = timm_up(s, "result", "cannot read backend state");
+            goto out_revoke;
+        }
+        if (backend_state == XenbusStateConnected)
+            break;
+        kernel_delay(milliseconds(1 << retries));
+    }
+    if (backend_state != XenbusStateConnected) {
+        s = timm("result", "backend not connected");
+        goto out_revoke;
+    }
+    u64 sector_size;
+    s = xenstore_read_u64(0, xd->backend, "sector-size", &sector_size);
+    if (!is_ok(s)) {
+        s = timm_up(s, "result", "cannot read sector size");
+        goto out_revoke;
+    } else if (sector_size != SECTOR_SIZE) {
+        s = timm("result", "unsupported sector size %ld", sector_size);
+        goto out_revoke;
+    }
+    s = xenstore_read_u64(0, xd->backend, "physical-sector-size",
+        &sector_size);
+    if (!is_ok(s)) {
+        /* physical sector size is the same as logical sector size */
+        timm_dealloc(s);
+    } else if (sector_size != SECTOR_SIZE) {
+        s = timm("result", "unsupported physical sector size %ld", sector_size);
+        goto out_revoke;
+    }
+    u64 sectors;
+    s = xenstore_read_u64(0, xd->backend, "sectors", &sectors);
+    if (!is_ok(s)) {
+        s = timm_up(s, "result", "cannot read number of sectors");
+        goto out_revoke;
+    }
+    xbd->capacity = sector_size * sectors;
+    s = xenbus_set_state(0, xd->frontend, XenbusStateConnected);
+    if (!is_ok(s)) {
+        s = timm_up(s, "result", "cannot set frontend state to connected");
+        goto out_revoke;
+    }
+    int rv = xen_unmask_evtchn(xbd->evtchn);
+    if (rv < 0) {
+        s = timm("result", "failed to unmask event channel %d: rv %d",
+            xbd->evtchn, rv);
+        goto out_revoke;
+    }
+    return STATUS_OK;
+  out_revoke:
+    xen_revoke_page_access(xbd->ring_gntref);
+  out_dealloc:
+    deallocate(xbd->contiguous, ring, PAGESIZE);
+    return s;
+}
+
+closure_function(2, 3, boolean, xenblk_probe,
+                 kernel_heaps, kh, storage_attach, sa,
+                 int, id, buffer, frontend, tuple, meta)
+{
+    xenblk_debug("probe for id %d, frontend %b, meta %v", id, frontend, meta);
+    kernel_heaps kh = bound(kh);
+    heap h = heap_general(kh);
+    xenblk_dev xbd = allocate(h, sizeof(*xbd));
+    if (xbd == INVALID_ADDRESS) {
+        msg_err("%s: cannot allocate device structure\n", __func__);
+        return false;
+    }
+    xen_dev xd = &xbd->dev;
+    xbd->h = h;
+    xbd->contiguous = heap_backed(kh);
+    status s = xendev_attach(xd, id, frontend, meta);
+    if (!is_ok(s)) {
+        msg_err("%s: cannot attach Xen device: %v\n", __func__, s);
+        timm_dealloc(s);
+        goto dealloc_xbd;
+    }
+    xbd->rreqs = allocate_vector(h, XENBLK_RING_SIZE);
+    if (xbd->rreqs == INVALID_ADDRESS) {
+        msg_err("%s: cannot allocate request vector\n", __func__);
+        goto dealloc_xbd;
+    }
+    list_init(&xbd->pending);
+    list_init(&xbd->done);
+    list_init(&xbd->free);
+    list_init(&xbd->free_rreqs);
+    spin_lock_init(&xbd->lock);
+    s = xenblk_enable(xbd);
+    if (!is_ok(s)) {
+        msg_err("%s: cannot enable device: %v\n", __func__, s);
+        timm_dealloc(s);
+        goto dealloc_reqs;
+    }
+    xenblk_debug("attaching disk, capacity %ld bytes", xbd->capacity);
+    apply(bound(sa), init_closure(&xbd->read, xenblk_io, xbd, false),
+          init_closure(&xbd->write, xenblk_io, xbd, true), xbd->capacity);
+    return true;
+  dealloc_reqs:
+    deallocate_vector(xbd->rreqs);
+  dealloc_xbd:
+    deallocate(h, xbd, sizeof(*xbd));
+    return false;
+}
+
+void init_xenblk(kernel_heaps kh, storage_attach sa)
+{
+    register_xen_driver("vbd", closure(heap_general(kh), xenblk_probe, kh, sa));
+}


### PR DESCRIPTION
For AWS instances, multi-volume support is being added by using the Xen paravirtualized block device driver instead of the ATA PCI driver.
For the ESXi platform, the PVSCSI driver has been enhanced to support more than one disk.