### PR TITLE
File I/O: add read-ahead functionality

### DIFF
--- a/src/kernel/pagecache.h
+++ b/src/kernel/pagecache.h
@@ -33,6 +33,8 @@ boolean pagecache_map_page_if_filled(pagecache_node pn, u64 node_offset, u64 vad
 
 boolean pagecache_node_do_page_cow(pagecache_node pn, u64 node_offset, u64 vaddr, u64 flags);
 
+void pagecache_node_fetch_pages(pagecache_node pn, range r /* bytes */);
+
 void pagecache_node_scan_and_commit_shared_pages(pagecache_node pn, range q /* bytes */);
 
 void pagecache_node_close_shared_pages(pagecache_node pn, range q /* bytes */);

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -116,6 +116,11 @@ static inline int filesystem_get_tuple(const char *path, tuple *t)
     return resolve_cstring(0, current->p->cwd, path, t, 0);
 }
 
+/* Perform read-ahead following a userspace read request.
+ * offset and len arguments refer to the byte range being read from userspace,
+ * not to the range to be read ahead. */
+void file_readahead(file f, u64 offset, u64 len);
+
 sysreturn symlink(const char *target, const char *linkpath);
 sysreturn symlinkat(const char *target, int dirfd, const char *linkpath);
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -718,6 +718,7 @@ closure_function(2, 6, sysreturn, file_read,
     begin_file_read(t, f);
     apply(f->fs_read, sg, irangel(offset, length), closure(h, file_read_complete, t, sg, dest, length,
                                                            f, is_file_offset, completion));
+    file_readahead(f, offset, length);
     /* possible direct return in top half */
     return bh ? SYSRETURN_CONTINUE_BLOCKING : file_op_maybe_sleep(t);
 }
@@ -762,6 +763,7 @@ closure_function(2, 6, sysreturn, file_sg_read,
     begin_file_read(t, f);
     apply(f->fs_read, sg, irangel(offset, length), closure(h, file_sg_read_complete,
                                                            t, f, sg, is_file_offset, completion));
+    file_readahead(f, offset, length);
   out:
     /* possible direct return in top half */
     return bh ? SYSRETURN_CONTINUE_BLOCKING : file_op_maybe_sleep(t);
@@ -1056,6 +1058,7 @@ sysreturn open_internal(filesystem fs, tuple cwd, const char *name, int flags,
         assert(f->fs_read);
         f->fs_write = fsfile_get_writer(fsf);
         assert(f->fs_write);
+        f->fadv = POSIX_FADV_NORMAL;
     } else {
         f->meta = n;
     }

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -203,9 +203,8 @@ declare_closure_struct(1, 0, void, run_sighandler,
 declare_closure_struct(1, 1, context, default_fault_handler,
                        thread, t,
                        context, frame);
-declare_closure_struct(7, 0, void, thread_demand_file_page,
-                       thread, t, context, frame, pagecache_node, pn, u64, node_offset,
-                       u64, page_addr, u64, flags, boolean, shared);
+declare_closure_struct(5, 0, void, thread_demand_file_page,
+                       thread, t, struct vmap *, vm, u64, node_offset, u64, page_addr, u64, flags);
 declare_closure_struct(3, 1, void, thread_demand_file_page_complete,
                        thread, t, context, frame, u64, vaddr,
                        status, s);
@@ -309,6 +308,8 @@ typedef struct fdesc {
 
 #define IOV_MAX 1024
 
+#define FILE_READAHEAD_DEFAULT  (128 * KB)
+
 struct file {
     struct fdesc f;             /* must be first */
     filesystem fs;
@@ -317,6 +318,7 @@ struct file {
             fsfile fsf;         /* fsfile for regular files */
             sg_io fs_read;
             sg_io fs_write;
+            int fadv;           /* posix_fadvise advice */
         };
         tuple meta;             /* meta tuple for others */
     };


### PR DESCRIPTION
The new pagecache_node_fetch_pages() function populates the page cache with the supplied byte range from the supplied node. This function is called to implement a read-ahead functionality, both when a user-space read request is received, and when a page fault requiring I/O from disk occurs.
The default read-ahead size is 128 kB (same as Linux). The fadvise64() syscall can be used to change the default read-ahead
behavior following userspace read requests (POSIX_FADV_RANDOM disables read-ahead, POSIX_FADV_SEQUENTIAL doubles the read-ahead size).
Simple benchmark results when read-ahead is used:
- a sequence of file reads with 4KB chunks on a multi-MB file is around 2 times faster
- sequential access to file-backed memory (accessing 1 byte every 4KB) with a multi-MB file is around 2.5 times faster

Closes #1268.