### PR TITLE
Fixed mincore handling of offsets into fat pages

### DIFF
--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -345,13 +345,13 @@ closure_function(3, 3, boolean, mincore_fill_vec,
     u64 pgoff, i;
 
     if (pt_entry_is_present(e)) {
-        if (addr < bound(base))
+        if (addr <= bound(base))
             pgoff = 0;
         else
             pgoff = ((addr - bound(base)) >> PAGELOG);
         if (pt_entry_is_fat(level, e)) {
-            u64 foff = (addr & PAGEMASK_2M) >> PAGELOG;
-            for (i = 0; (i < 512 - (pgoff ? 0 : foff)) && (pgoff + i < bound(nr_pgs)); i++)
+            u64 foff = pgoff ? 0 : (addr & PAGEMASK_2M) >> PAGELOG;
+            for (i = 0; (i < 512 - foff) && (pgoff + i < bound(nr_pgs)); i++)
                 bound(vec)[pgoff + i] = 1;
         } else if (pt_entry_is_pte(level, e)) {
             bound(vec)[pgoff] = 1;


### PR DESCRIPTION
During my testing for the eviction changes while I was looping the mmap test, I discovered that the mincore portion of the mmap test would fail infrequently. After some debugging I discovered that this happened when mincore was called on an address offset inside a fat page. The code handling the population of the mincore vector data didn't handle that case properly, so this change fixes that.
