### PR TITLE
Refactor pagecache evict

### DIFF
--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -261,7 +261,6 @@ static boolean realloc_pagelocked(pagecache pc, pagecache_page pp)
     }
     assert(pp->refcount.c == 0);
     refcount_reserve(&pp->refcount);
-    assert(pp->refcount.c == 1);
     pp->write_count = 0;
     #ifdef KERNEL
     pp->phys = physical_from_virtual(pp->kvirt);

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -282,8 +282,8 @@ static boolean touch_or_fill_page_nodelocked(pagecache_node pn, pagecache_page p
     case PAGECACHE_PAGESTATE_READING:
         if (m) {
             enqueue_page_completion_statelocked(pc, pp, apply_merge(m));
-            refcount_reserve(&pp->refcount);
         }
+        refcount_reserve(&pp->refcount);
         pagecache_unlock_state(pc);
         return false;
     case PAGECACHE_PAGESTATE_FREE:
@@ -294,8 +294,8 @@ static boolean touch_or_fill_page_nodelocked(pagecache_node pn, pagecache_page p
         if (m) {
             enqueue_page_completion_statelocked(pc, pp, apply_merge(m));
             change_page_state_locked(pc, pp, PAGECACHE_PAGESTATE_READING);
-            refcount_reserve(&pp->refcount);
         }
+        refcount_reserve(&pp->refcount);
         pagecache_unlock_state(pc);
 
         if (m) {
@@ -1034,9 +1034,7 @@ boolean pagecache_node_do_page_cow(pagecache_node pn, u64 node_offset, u64 vaddr
 static void map_page(pagecache pc, pagecache_page pp, u64 vaddr, u64 flags)
 {
     assert(pp->refcount.c != 0);
-    refcount_reserve(&pp->refcount);
     assert(pp->kvirt != INVALID_ADDRESS);
-    assert(page_state(pp) != PAGECACHE_PAGESTATE_FREE);
     map(vaddr, pp->phys, cache_pagesize(pc), flags);
 }
 
@@ -1108,7 +1106,7 @@ closure_function(3, 3, boolean, pagecache_unmap_page_nodelocked,
         u64 phys = page_from_pte(old_entry);
         if (phys == pp->phys) {
             /* shared or cow */
-            assert(pp->refcount.c > 1);
+            assert(pp->refcount.c >= 1);
             refcount_release(&pp->refcount);
         } else {
             /* private copy */

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -337,10 +337,6 @@ static boolean touch_or_fill_page_nodelocked(pagecache_node pn, pagecache_page p
 define_closure_function(2, 0, void, pagecache_page_free,
                         pagecache, pc, pagecache_page, pp)
 {
-    /*  Since the page state is changed here, the caller must lock the
-        release of the refcount. However, the refcount is used on some
-        sgb's which can't control the page state lock. XXX */
-
     pagecache_page pp = bound(pp);
     pagecache_debug("%s: pp %p state %d\n", __func__, pp, page_state(pp));
     assert(pp->write_count == 0);
@@ -889,7 +885,6 @@ void pagecache_commit_dirty_pages(pagecache pc)
         sgb->buf = pp->kvirt;
         sgb->offset = 0;
         sgb->size = cache_pagesize(pc);
-        /* XXX possible source of trouble if sgb->refcount is released outside of state lock */
         sgb->refcount = &pp->refcount;
         refcount_reserve(&pp->refcount);
         change_page_state_locked(pc, pp, PAGECACHE_PAGESTATE_WRITING);

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -511,7 +511,7 @@ closure_function(5, 1, void, pagecache_write_sg_finish,
                 pagecache_page_queue_completions_locked(pc, pp, s);
             }
             pagecache_unlock_state(pc);
-// TODO            refcount_release(&pp->refcount);
+            refcount_release(&pp->refcount);
             pi++;
             pp = (pagecache_page)rbnode_get_next((rbnode)pp);
         } while (pi < end);
@@ -551,6 +551,7 @@ closure_function(5, 1, void, pagecache_write_sg_finish,
                 return;
             }
 
+            refcount_reserve(&pp->refcount);
             /* When writing a new page at the end of a node whose length is not block-aligned, zero
                the remaining portion of the last block. The filesystem will depend on this to properly
                implement file holes. */

--- a/src/kernel/pagecache_internal.h
+++ b/src/kernel/pagecache_internal.h
@@ -102,6 +102,7 @@ struct pagecache_page {
     u64 phys;                   /* physical address */
     vector completions;         /* status_handlers */
     closure_struct(pagecache_page_free, free);
+    boolean evicted;
 };
 
 static inline void pagecache_release_page(pagecache_page pp)


### PR DESCRIPTION
This change addresses issue #1253 by moving evicted pages to a free list when no longer used, but leaving their meta in the node's tree. When the page is accessed again, memory is reallocated. This change also fixes a missing reserve_refcount in map_pages.