### PR TITLE
sigaction: add support for SA_RESTART flag

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1189,10 +1189,8 @@ closure_function(2, 1, sysreturn, connect_tcp_bh,
     assert(s->info.tcp.state == TCP_SOCK_OPEN);
     rv = lwip_to_errno(err);
   out:
-    if (flags & BLOCKQ_ACTION_BLOCKED)
-        thread_wakeup(t);
     closure_finish();
-    return set_syscall_return(t, rv);
+    return syscall_return(t, rv);
 }
 
 static err_t connect_tcp_complete(void* arg, struct tcp_pcb* tpcb, err_t err)
@@ -1478,11 +1476,8 @@ closure_function(7, 1, sysreturn, sendmmsg_tcp_bh,
         }
     }
 
-    if (bqflags & BLOCKQ_ACTION_BLOCKED)
-        thread_wakeup(t);
-
     closure_finish();
-    return set_syscall_return(t, rv);
+    return syscall_return(t, rv);
 }
 
 sysreturn sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
@@ -1733,9 +1728,7 @@ closure_function(5, 1, sysreturn, accept_bh,
 
     rv = child->sock.fd;
   out:
-    set_syscall_return(t, rv);
-    if (bqflags & BLOCKQ_ACTION_BLOCKED)
-        thread_wakeup(t);
+    syscall_return(t, rv);
 
     closure_finish();
     return rv;

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -378,7 +378,7 @@ static sysreturn sock_read_bh_internal(netsock s, thread t, void * dest,
     assert(s->sock.type == SOCK_STREAM || s->sock.type == SOCK_DGRAM);
 
     if (flags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
 
@@ -535,7 +535,7 @@ static sysreturn socket_write_tcp_bh_internal(netsock s, thread t, void * buf,
     assert(remain > 0);
 
     if (flags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
 
@@ -1182,7 +1182,7 @@ closure_function(2, 1, sysreturn, connect_tcp_bh,
         /* XXX spinlock */
         if (rv == 0) {
             s->info.tcp.state = TCP_SOCK_ABORTING_CONNECTION;
-            rv = -EINTR;
+            rv = -ERESTARTSYS;
         }
         goto out;
     }
@@ -1689,7 +1689,7 @@ closure_function(5, 1, sysreturn, accept_bh,
     sysreturn rv = 0;
 
     if (bqflags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
 

--- a/src/unix/aio.c
+++ b/src/unix/aio.c
@@ -266,7 +266,7 @@ closure_function(7, 1, sysreturn, io_getevents_bh,
     aio_ring ring = aio->ring;
     sysreturn rv;
     if (flags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -EINTR;
+        rv = (timeout == infinity) ? -ERESTARTSYS : -EINTR;
         goto out;
     }
 

--- a/src/unix/eventfd.c
+++ b/src/unix/eventfd.c
@@ -19,7 +19,7 @@ closure_function(5, 1, sysreturn, efd_read_bh,
     sysreturn rv = sizeof(efd->counter);
 
     if (flags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
 
@@ -70,7 +70,7 @@ closure_function(5, 1, sysreturn, efd_write_bh,
     u64 counter;
 
     if (flags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
 

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -260,8 +260,7 @@ closure_function(2, 2, void, fs_op_complete,
     thread_log(current, "%s: %d", __func__, ret);
 
     bound(f)->length = fsfile_get_length(fsf);
-    set_syscall_return(t, ret);
-    file_op_maybe_wake(t);
+    syscall_return(t, ret);
     closure_finish();
 }
 
@@ -406,7 +405,6 @@ sysreturn fallocate(int fd, int mode, long offset, long len)
     file f = (file) desc;
     filesystem fs = f->fs;
     tuple t = fsfile_get_meta(f->fsf);
-    file_op_begin(current);
     switch (mode) {
     case 0:
     case FALLOC_FL_KEEP_SIZE:
@@ -421,7 +419,7 @@ sysreturn fallocate(int fd, int mode, long offset, long len)
     default:
         set_syscall_error(current, EINVAL);
     }
-    return file_op_maybe_sleep(current);
+    return thread_maybe_sleep_uninterruptible(current);
 }
 
 sysreturn fadvise64(int fd, s64 off, u64 len, int advice)

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -114,9 +114,8 @@ closure_function(2, 1, sysreturn, futex_bh,
         rv = 0; /* no timer expire + not us --> actual wakeup */
 
     thread_log(t, "%s: struct futex: %p, flags 0x%lx, rv %ld\n", __func__, bound(f), flags, rv);
-    thread_wakeup(t);
     closure_finish();
-    return set_syscall_return(t, rv);
+    return syscall_return(t, rv);
 }
 
 static timestamp get_timeout_timestamp(int futex_op, u64 val2)

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -251,8 +251,7 @@ closure_function(3, 1, sysreturn, iour_close_bh,
     blockq bq = iour->bq;
     sysreturn rv;
     if (flags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -EINTR;
-        iour->shutdown = true;
+        rv = -ERESTARTSYS;
         goto out;
     }
     if (iour->noncancelable_ops != 0) {
@@ -1010,7 +1009,7 @@ simple_closure_function(7, 1, sysreturn, iour_getevents_bh,
     blockq bq = iour->bq;
     sysreturn rv;
     if (flags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
     iour_lock(iour);

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -146,7 +146,7 @@ closure_function(5, 1, sysreturn, pipe_read_bh,
     int rv;
 
     if (flags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
 
@@ -199,7 +199,7 @@ closure_function(5, 1, sysreturn, pipe_write_bh,
     pipe_file pf = bound(pf);
 
     if (flags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
 

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -379,14 +379,12 @@ closure_function(3, 1, sysreturn, epoll_wait_bh,
     epoll_debug("  continue blocking\n");
     return BLOCKQ_BLOCK_REQUIRED;
   out_wakeup:
-    if (flags & BLOCKQ_ACTION_BLOCKED)
-        thread_wakeup(t);
     unwrap_buffer(w->e->h, w->user_events);
     w->user_events = 0;
     epoll_debug("   pre refcnt %ld, returning %ld\n", w->refcount.c, rv);
     epoll_blocked_release(w);
     closure_finish();
-    return set_syscall_return(t, rv);
+    return syscall_return(t, rv);
 }
 
 /* Depending on the epoll flags given, we may:
@@ -630,10 +628,8 @@ closure_function(3, 1, sysreturn, select_bh,
     w->nfds = 0;
     w->rset = w->wset = w->eset = 0;
     epoll_blocked_release(w);
-    if (flags & BLOCKQ_ACTION_BLOCKED)
-        thread_wakeup(t);
     closure_finish();
-    return set_syscall_return(t, rv);
+    return syscall_return(t, rv);
 }
 
 static inline epoll select_get_epoll(void)
@@ -852,10 +848,8 @@ closure_function(3, 1, sysreturn, poll_bh,
     unwrap_buffer(w->e->h, w->poll_fds);
     w->poll_fds = 0;
     epoll_blocked_release(w);
-    if (flags & BLOCKQ_ACTION_BLOCKED)
-        thread_wakeup(t);
     closure_finish();
-    return set_syscall_return(t, rv);
+    return syscall_return(t, rv);
 }
 
 static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -573,10 +573,8 @@ closure_function(2, 1, sysreturn, rt_sigsuspend_bh,
               t->tid, bound(saved_mask), flags & BLOCKQ_ACTION_BLOCKED, flags & BLOCKQ_ACTION_NULLIFY);
 
     if ((flags & BLOCKQ_ACTION_NULLIFY) || get_effective_signals(t)) {
-        if (flags & BLOCKQ_ACTION_BLOCKED)
-            thread_wakeup(t);
         closure_finish();
-        return set_syscall_error(t, EINTR);
+        return syscall_return(t, -EINTR);
     }
 
     sig_debug("-> block\n");
@@ -759,12 +757,8 @@ closure_function(1, 1, sysreturn, pause_bh,
     sig_debug("tid %d, flags 0x%lx\n", t->tid, flags);
 
     if ((flags & BLOCKQ_ACTION_NULLIFY) || get_effective_signals(t)) {
-        if (flags & BLOCKQ_ACTION_BLOCKED) {
-            sig_debug("-> wakeup\n");
-            thread_wakeup(t);
-        }
         closure_finish();
-        return set_syscall_error(t, EINTR);
+        return syscall_return(t, -EINTR);
     }
 
     sig_debug("-> block\n");
@@ -790,9 +784,8 @@ closure_function(4, 1, sysreturn, rt_sigtimedwait_bh,
 
     if (flags & BLOCKQ_ACTION_TIMEDOUT) {
         assert(blocked);
-        thread_wakeup(t);
         closure_finish();
-        return set_syscall_error(t, EAGAIN);
+        return syscall_return(t, -EAGAIN);
     }
 
     sysreturn rv;
@@ -818,10 +811,8 @@ closure_function(4, 1, sysreturn, rt_sigtimedwait_bh,
         free_queued_signal(qs);
     }
 
-    if (blocked)
-        thread_wakeup(t);
     closure_finish();
-    return set_syscall_return(t, rv);
+    return syscall_return(t, rv);
 }
 
 sysreturn rt_sigtimedwait(const u64 * set, siginfo_t * info, const struct timespec * timeout, u64 sigsetsize)

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -464,10 +464,7 @@ closure_function(2, 1, sysreturn, connect_bh,
     s->connecting = false;  /* connection has been established */
     rv = 0;
 out:
-    set_syscall_return(t, rv);
-    if (bqflags & BLOCKQ_ACTION_BLOCKED) {
-        thread_wakeup(t);
-    }
+    syscall_return(t, rv);
     closure_finish();
     return rv;
 }
@@ -552,10 +549,7 @@ closure_function(5, 1, sysreturn, accept_bh,
     child->peer->peer = child;
     unixsock_notify_writer(child->peer);
 out:
-    set_syscall_return(t, rv);
-    if (bqflags & BLOCKQ_ACTION_BLOCKED) {
-        thread_wakeup(t);
-    }
+    syscall_return(t, rv);
     closure_finish();
     return rv;
 }

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -117,7 +117,7 @@ closure_function(6, 1, sysreturn, unixsock_read_bh,
     sysreturn rv;
 
     if ((flags & BLOCKQ_ACTION_NULLIFY) && s->peer) {
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
     shb = queue_peek(s->data);
@@ -241,7 +241,7 @@ closure_function(6, 1, sysreturn, unixsock_write_bh,
     sysreturn rv;
 
     if ((flags & BLOCKQ_ACTION_NULLIFY) && s->peer) {
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
     if (!s->peer) {
@@ -447,7 +447,7 @@ closure_function(2, 1, sysreturn, connect_bh,
     sysreturn rv;
 
     if ((bqflags & BLOCKQ_ACTION_NULLIFY) && s->connecting) {
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
     if (!s->connecting) {   /* the listening socket has been shut down */
@@ -520,7 +520,7 @@ closure_function(5, 1, sysreturn, accept_bh,
     sysreturn rv;
 
     if (bqflags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
     unixsock child = dequeue(s->conn_q);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -110,6 +110,8 @@ typedef struct iovec {
 #define EINPROGRESS     115
 #define ECANCELED       125             /* Used for timer cancel on RTC shift */
 
+#define ERESTARTSYS     512
+
 #define O_RDONLY	00000000
 #define O_WRONLY	00000001
 #define O_RDWR		00000002

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -311,7 +311,6 @@ thread create_thread(process p)
     // xxx another max 64
     t->affinity.mask[0] = MASK(total_processors);
     t->blocked_on = 0;
-    t->file_op_is_complete = false;
     init_sigstate(&t->signals);
     t->dispatch_sigstate = 0;
     t->active_signo = 0;

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -204,7 +204,7 @@ closure_function(5, 1, sysreturn, timerfd_read_bh,
 
     if (flags & BLOCKQ_ACTION_NULLIFY) {
         assert(blocked);
-        rv = -EINTR;
+        rv = -ERESTARTSYS;
         goto out;
     }
 

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -29,10 +29,8 @@ closure_function(5, 1, sysreturn, nanosleep_bh,
     if (!(flags & BLOCKQ_ACTION_TIMEDOUT) && elapsed < bound(interval))
         return BLOCKQ_BLOCK_REQUIRED;
   out:
-    if (flags & BLOCKQ_ACTION_BLOCKED)
-        thread_wakeup(t);
     closure_finish();
-    return set_syscall_return(t, rv);
+    return syscall_return(t, rv);
 }
 
 sysreturn nanosleep(const struct timespec *req, struct timespec *rem)

--- a/test/runtime/aio.c
+++ b/test/runtime/aio.c
@@ -141,6 +141,10 @@ static void aio_test_eventfd(void)
     test_assert(fd > 0);
     test_assert(syscall(SYS_io_setup, 1, &ioc) == 0);
 
+    /* Test zero-valued timeout (i.e. polling without blocking). */
+    ts.tv_sec = ts.tv_nsec = 0;
+    test_assert(syscall(SYS_io_getevents, ioc, 1, 1, &evt, &ts) == 0);
+
     iocb_setup_pwrite(&iocb, fd, "test", strlen("test"), 0);
     efd = eventfd(0, 0);
     test_assert(efd > 0);


### PR DESCRIPTION
When this flag is specified in a signal action, if the signal is raised while the recipient thread is blocked in a restartable syscall, the syscall is restarted internally by the kernel instead of returning -EINTR to userspace.
Restartable syscalls are those that don't have timeout values in their argument list.

Closes #930.