### PR TITLE
spool net direct output using a periodic timer

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -44,3 +44,6 @@
 /* mm stuff */
 #define PAGECACHE_DRAIN_CUTOFF (64 * MB)
 #define PAGECACHE_SCAN_PERIOD_SECONDS 5
+
+/* direct net for service */
+#define DIRECT_CONN_SEND_INTERVAL milliseconds(200)


### PR DESCRIPTION
This fixes a regression in trace downloading via HTTP by using a periodic runloop timer to send spooled data over a direct TCP connection.
