### PR TITLE
runloop: service the bhqueue before taking kernel lock

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -178,6 +178,7 @@ SRCS-kernel.img+= \
 	$(ARCHDIR)/ftrace.s
 endif
 
+CFLAGS+=	-DSPIN_LOCK_DEBUG_NOSMP
 #CFLAGS+=	-DLWIPDIR_DEBUG -DEPOLL_DEBUG -DNETSYSCALL_DEBUG -DKERNEL_DEBUG
 AFLAGS+=	-felf64 -I$(OBJDIR)/
 LDFLAGS+=	$(KERNLDFLAGS) --undefined=_start -T linker_script

--- a/src/hyperv/include/vmbus.h
+++ b/src/hyperv/include/vmbus.h
@@ -141,11 +141,11 @@ typedef void	(*vmbus_chan_callback_t)(struct vmbus_channel *, void *);
  *			memory passed through 'br'.
  */
 void		vmbus_chan_open(struct vmbus_channel *chan,
-		    int txbr_size, int rxbr_size, const void *udata, int udlen,
-		    vmbus_chan_callback_t cb, void *cbarg);
+                                int txbr_size, int rxbr_size, const void *udata, int udlen,
+                                vmbus_chan_callback_t cb, void *cbarg, queue sched_queue);
 int		vmbus_chan_open_br(struct vmbus_channel *chan,
-		    const struct vmbus_chan_br *cbr, const void *udata,
-		    int udlen, vmbus_chan_callback_t cb, void *cbarg);
+                                   const struct vmbus_chan_br *cbr, const void *udata,
+                                   int udlen, vmbus_chan_callback_t cb, void *cbarg, queue sched_queue);
 void		vmbus_chan_gpadl_connect(struct vmbus_channel *chan,
 		    bus_addr_t paddr, int size, uint32_t *gpadl);
 void		vmbus_chan_gpadl_disconnect(struct vmbus_channel *chan,

--- a/src/hyperv/netvsc/hv_net_vsc.c
+++ b/src/hyperv/netvsc/hv_net_vsc.c
@@ -635,7 +635,7 @@ hv_nv_on_device_add(struct hv_device *device, void *additional_info)
      */
     vmbus_chan_open(device->channel,
         NETVSC_DEVICE_RING_BUFFER_SIZE, NETVSC_DEVICE_RING_BUFFER_SIZE,
-        NULL, 0, hv_nv_on_channel_callback, device);
+        NULL, 0, hv_nv_on_channel_callback, device, runqueue);
     /*
      * Connect with the NetVsp
      */

--- a/src/hyperv/storvsc/storvsc.c
+++ b/src/hyperv/storvsc/storvsc.c
@@ -471,7 +471,7 @@ static void hv_storvsc_connect_vsp(struct storvsc_softc *sc)
         sc->hs_drv_props->drv_ringbuffer_size,
         (void *)&props,
         sizeof(struct vmstor_chan_props),
-        hv_storvsc_on_channel_callback, sc);
+        hv_storvsc_on_channel_callback, sc, bhqueue);
 
     hv_storvsc_channel_init(sc);
 }

--- a/src/hyperv/utilities/vmbus_ic.c
+++ b/src/hyperv/utilities/vmbus_ic.c
@@ -189,7 +189,7 @@ vmbus_ic_attach(struct vmbus_ic_softc *sc, vmbus_chan_callback_t cb)
      */
     vmbus_chan_set_readbatch(chan, false);
 
-    vmbus_chan_open(chan, VMBUS_IC_BRSIZE, VMBUS_IC_BRSIZE, 0, 0, cb, sc);
+    vmbus_chan_open(chan, VMBUS_IC_BRSIZE, VMBUS_IC_BRSIZE, 0, 0, cb, sc, runqueue);
 }
 
 int

--- a/src/hyperv/vmbus/vmbus.c
+++ b/src/hyperv/vmbus/vmbus.c
@@ -96,7 +96,7 @@ vmbus_handle_intr1(vmbus_dev sc, int cpu)
     msg = msg_base + VMBUS_SINT_MESSAGE;
     if (msg->msg_type != HYPERV_MSGTYPE_NONE) {
         vmbus_debug("SINT Message!");
-        enqueue(bhqueue, VMBUS_PCPU_GET(sc, message_task, cpu));
+        enqueue(runqueue, VMBUS_PCPU_GET(sc, message_task, cpu));
     }
 }
 

--- a/src/hyperv/vmbus/vmbus_chanvar.h
+++ b/src/hyperv/vmbus/vmbus_chanvar.h
@@ -53,6 +53,7 @@ struct vmbus_channel {
 
 	vmbus_chan_callback_t		ch_cb;
 	void				*ch_cbarg;
+	queue				sched_queue;
 
 	/*
 	 * TX bufring; at the beginning of ch_bufring.

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1,5 +1,5 @@
 /* TODO:
-   - reinstate free list, keep refault counts
+   - keep refault stats
    - interface to physical free page list / shootdown epochs
 
    - would be nice to propagate a priority alone with requests to
@@ -1133,9 +1133,14 @@ closure_function(3, 3, boolean, pagecache_unmap_page_nodelocked,
             assert(pp->refcount.c >= 1);
             refcount_release(&pp->refcount);
         } else {
-            /* private copy */
-            pagecache pc = bound(pn)->pv->pc;
-            deallocate_u64(pc->physical, phys, cache_pagesize(pc));
+            /* private copy: free physical page
+
+               It's gross to go around the wrapped physical heap
+               specified to pagecache init, but this is really a
+               short-term fix; the physical heap parameter needs to be
+               replaced with the free page / tlb shootdown interface.
+            */
+            deallocate_phys_page_from_traversal(phys, cache_pagesize(bound(pn)->pv->pc));
         }
     }
     return true;

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -115,8 +115,6 @@ NOTRACE void __attribute__((noreturn)) kernel_sleep(void)
     sched_debug("sleep\n");
     ci->state = cpu_idle;
     atomic_set_bit(&idle_cpu_mask, ci->id);
-    if (ci->have_kernel_lock)
-        kern_unlock();
 
     /* loop to absorb spurious wakeups from hlt - happens on some platforms (e.g. xen) */
     while (1)
@@ -141,6 +139,9 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
                 queue_length(bhqueue), queue_length(runqueue), queue_length(thread_queue),
                 idle_cpu_mask, ci->have_kernel_lock);
     ci->state = cpu_kernel;
+
+    /* bhqueue is for operations outside the realm of the kernel lock,
+       e.g. storage I/O completions */
     while ((t = dequeue(bhqueue)) != INVALID_ADDRESS)
         run_thunk(t, cpu_kernel);
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -369,7 +369,7 @@ define_closure_function(2, 2, void, iov_op_each_complete,
     } else {
         if (p->file_offset != infinity)
             p->file_offset += rv;
-        enqueue(bhqueue, &p->bh);
+        enqueue(runqueue, &p->bh);
     }
     return;
   out_complete:

--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -45,14 +45,14 @@ void vtdev_set_status(vtdev dev, u8 status)
     }
 }
 
-status virtio_alloc_virtqueue(vtdev dev, const char *name, int idx,
-                             struct virtqueue **result)
+status virtio_alloc_virtqueue(vtdev dev, const char *name, int idx, queue sched_queue,
+                              struct virtqueue **result)
 {
     switch (dev->transport) {
     case VTIO_TRANSPORT_MMIO:
-        return vtmmio_alloc_virtqueue((vtmmio)dev, name, idx, result);
+        return vtmmio_alloc_virtqueue((vtmmio)dev, name, idx, sched_queue, result);
     case VTIO_TRANSPORT_PCI:
-        return vtpci_alloc_virtqueue((vtpci)dev, name, idx, result);
+        return vtpci_alloc_virtqueue((vtpci)dev, name, idx, sched_queue, result);
     default:
         return timm("status", "unknown transport %d", dev->transport);
     }

--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -84,17 +84,18 @@ static inline void virtio_attach(heap h, heap page_allocator,
     d->transport = transport;
 }
 
-status virtio_alloc_virtqueue(vtdev dev, const char *name, int idx,
+status virtio_alloc_virtqueue(vtdev dev, const char *name, int idx, queue sched_queue,
                               struct virtqueue **result);
 
 status virtqueue_alloc(vtdev dev,
                        const char *name,
-                       u16 queue,
+                       u16 queue_index,
                        u16 size,
                        bytes notify_offset,
                        int align,
                        struct virtqueue **vqp,
-                       thunk *t);
+                       thunk *t,
+                       queue sched_queue);
 
 void virtqueue_set_max_queued(virtqueue, int);
 

--- a/src/virtio/virtio_mmio.c
+++ b/src/virtio/virtio_mmio.c
@@ -160,7 +160,7 @@ define_closure_function(1, 0, void, vtmmio_irq,
     }
 }
 
-status vtmmio_alloc_virtqueue(vtmmio dev, const char *name, int idx,
+status vtmmio_alloc_virtqueue(vtmmio dev, const char *name, int idx, queue sched_queue,
                               struct virtqueue **result)
 {
     virtio_mmio_debug("allocating virtqueue %d (%s)", idx, name);
@@ -173,7 +173,7 @@ status vtmmio_alloc_virtqueue(vtmmio dev, const char *name, int idx,
         size = U16_MAX;
     thunk handler;
     status s = virtqueue_alloc(&dev->virtio_dev, name, idx, size,
-        VTMMIO_OFFSET_QUEUENOTIFY, PAGESIZE, &vq, &handler);
+                               VTMMIO_OFFSET_QUEUENOTIFY, PAGESIZE, &vq, &handler, sched_queue);
     if (!is_ok(s))
         return s;
     if (!dev->irq_vector) {

--- a/src/virtio/virtio_mmio.h
+++ b/src/virtio/virtio_mmio.h
@@ -60,5 +60,5 @@ typedef closure_type(vtmmio_probe, void, vtmmio);
 void vtmmio_probe_devs(vtmmio_probe probe);
 void vtmmio_set_status(vtmmio dev, u8 status);
 boolean attach_vtmmio(heap h, heap page_allocator, vtmmio d, u64 feature_mask);
-status vtmmio_alloc_virtqueue(vtmmio dev, const char *name, int idx,
+status vtmmio_alloc_virtqueue(vtmmio dev, const char *name, int idx, queue sched_queue,
                               struct virtqueue **result);

--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -289,8 +289,8 @@ static void virtio_net_attach(vtdev dev)
     /* rx = 0, tx = 1, ctl = 2 by 
        page 53 of http://docs.oasis-open.org/virtio/virtio/v1.0/cs01/virtio-v1.0-cs01.pdf */
     vn->dev = dev;
-    virtio_alloc_virtqueue(dev, "virtio net tx", 1, &vn->txq);
-    virtio_alloc_virtqueue(dev, "virtio net rx", 0, &vn->rxq);
+    virtio_alloc_virtqueue(dev, "virtio net tx", 1, runqueue, &vn->txq);
+    virtio_alloc_virtqueue(dev, "virtio net rx", 0, runqueue, &vn->rxq);
     // just need vn->net_header_len contig bytes really
     vn->empty = allocate(contiguous, contiguous->pagesize);
     for (int i = 0; i < vn->net_header_len; i++)  ((u8 *)vn->empty)[i] = 0;

--- a/src/virtio/virtio_pci.c
+++ b/src/virtio/virtio_pci.c
@@ -186,6 +186,7 @@ static void vtpci_modern_write_8(struct pci_bar *b, bytes offset, u64 val)
 status vtpci_alloc_virtqueue(vtpci dev,
                              const char *name,
                              int idx,
+                             queue sched_queue,
                              struct virtqueue **result)
 {
     // allocate virtqueue
@@ -197,7 +198,7 @@ status vtpci_alloc_virtqueue(vtpci dev,
         pci_bar_read_2(&dev->common_config, VTPCI_R_QUEUE_NOTIFY_OFF) * dev->notify_offset_multiplier :
         VIRTIO_PCI_QUEUE_NOTIFY;
     status s = virtqueue_alloc(&dev->virtio_dev, name, idx, size, notify_offset,
-        VIRTIO_PCI_VRING_ALIGN, &vq, &handler);
+                               VIRTIO_PCI_VRING_ALIGN, &vq, &handler, sched_queue);
     if (!is_ok(s))
         return s;
 

--- a/src/virtio/virtio_pci.h
+++ b/src/virtio/virtio_pci.h
@@ -90,7 +90,7 @@ struct vtpci {
 
 boolean vtpci_probe(pci_dev d, int virtio_dev_id);
 vtpci attach_vtpci(heap h, heap page_allocator, pci_dev d, u64 feature_mask);
-status vtpci_alloc_virtqueue(vtpci dev, const char *name, int idx, struct virtqueue **result);
+status vtpci_alloc_virtqueue(vtpci dev, const char *name, int idx, queue sched_queue, struct virtqueue **result);
 void vtpci_set_status(vtpci dev, u8 status);
 boolean vtpci_is_modern(vtpci dev);
 

--- a/src/virtio/virtio_scsi.c
+++ b/src/virtio/virtio_scsi.c
@@ -460,11 +460,11 @@ static void virtio_scsi_attach(heap general, storage_attach a, heap page_allocat
     s->max_lun = pci_bar_read_4(&s->v->device_config, VIRTIO_SCSI_R_MAX_LUN);
     virtio_scsi_debug("max lun %d\n", s->max_lun);
 
-    status st = vtpci_alloc_virtqueue(s->v, "virtio scsi command", 0, &s->command);
+    status st = vtpci_alloc_virtqueue(s->v, "virtio scsi command", 0, bhqueue, &s->command);
     assert(st == STATUS_OK);
-    st = vtpci_alloc_virtqueue(s->v, "virtio scsi event", 1, &s->eventq);
+    st = vtpci_alloc_virtqueue(s->v, "virtio scsi event", 1, bhqueue, &s->eventq);
     assert(st == STATUS_OK);
-    st = vtpci_alloc_virtqueue(s->v, "virtio scsi request", 2, &s->requestq);
+    st = vtpci_alloc_virtqueue(s->v, "virtio scsi request", 2, bhqueue, &s->requestq);
     assert(st == STATUS_OK);
 
     // On reset, the device MUST set sense_size to 96 and cdb_size to 32

--- a/src/virtio/virtio_storage.c
+++ b/src/virtio/virtio_storage.c
@@ -179,7 +179,7 @@ static void virtio_blk_attach(heap general, storage_attach a, vtdev v)
     s->capacity = (vtdev_cfg_read_4(v, VIRTIO_BLK_R_CAPACITY_LOW) |
 		   ((u64) vtdev_cfg_read_4(v, VIRTIO_BLK_R_CAPACITY_HIGH) << 32)) * s->block_size;
     virtio_blk_debug("%s: capacity 0x%lx, block size 0x%x\n", __func__, s->capacity, s->block_size);
-    virtio_alloc_virtqueue(v, "virtio blk", 0, &s->command);
+    virtio_alloc_virtqueue(v, "virtio blk", 0, bhqueue, &s->command);
     // initialization complete
     vtdev_set_status(v, VIRTIO_CONFIG_STATUS_DRIVER_OK);
 

--- a/src/virtio/virtqueue.c
+++ b/src/virtio/virtqueue.c
@@ -78,7 +78,7 @@ struct vring_used {
 } __attribute__((packed));
 
 typedef struct vqmsg {
-    struct list l;              /* vq->msgqueue when queued, or chained for bh process */
+    struct list l;              /* vq->msg_queue when queued, or chained for bh process */
     union {
         u64 count;              /* descriptor count when queued */
         u64 len;                /* length on return */
@@ -103,9 +103,10 @@ typedef struct virtqueue {
     u16 desc_idx;               /* head of descriptor free list */
     u16 last_used_idx;          /* irq only */
     int max_queued;
-    struct list msgqueue;
-    queue servicequeue;
+    struct list msg_queue;
+    queue service_queue;
     thunk service;
+    queue sched_queue;
     struct spinlock fill_lock;  /* XXX - tmp hack for smp */
     vqmsg msgs[0];
 } *virtqueue;
@@ -150,7 +151,7 @@ void vqmsg_commit(virtqueue vq, vqmsg m, vqfinish completion)
 {
     m->completion = completion;
     /* XXX noirq */
-    list_push_back(&vq->msgqueue, &m->l);
+    list_push_back(&vq->msg_queue, &m->l);
     virtqueue_fill(vq);
 }
 
@@ -200,7 +201,7 @@ closure_function(1, 0, void, vq_interrupt,
         list l = list_get_next(&q);
         assert(l);
         list_delete(&q);
-        assert(enqueue(vq->servicequeue, l));
+        assert(enqueue(vq->service_queue, l));
         enqueue(bhqueue, vq->service);
     }
 
@@ -215,7 +216,7 @@ closure_function(1, 0, void, virtqueue_service_vqmsgs,
     virtqueue vq = bound(vq);
     virtqueue_debug("%s enter, vq %s\n", __func__, vq->name);
     list l;
-    while ((l = (list)dequeue(vq->servicequeue)) != INVALID_ADDRESS) {
+    while ((l = (list)dequeue(vq->service_queue)) != INVALID_ADDRESS) {
         struct list q;
         list_insert_before(l, &q);
         list_foreach(&q, p) {
@@ -231,12 +232,13 @@ closure_function(1, 0, void, virtqueue_service_vqmsgs,
 
 status virtqueue_alloc(vtdev dev,
                        const char *name,
-                       u16 queue,
+                       u16 queue_index,
                        u16 size,
                        bytes notify_offset,
                        int align,
                        virtqueue *vqp,
-                       thunk *t)
+                       thunk *t,
+                       queue sched_queue)
 {
     u64 vq_alloc_size = sizeof(struct virtqueue) + size * sizeof(vqmsg);
     virtqueue vq = allocate(dev->general, vq_alloc_size);
@@ -250,16 +252,17 @@ status virtqueue_alloc(vtdev dev,
     vq->dev = dev;
     vq->name = name;
     virtqueue_debug("%s: vq %s: idx %d, size %d, alloc %d\n",
-                    __func__, vq->name, queue, size, alloc);
-    vq->queue_index = queue;
+                    __func__, vq->name, queue_index, size, alloc);
+    vq->queue_index = queue_index;
     vq->notify_offset = notify_offset;
     vq->entries = size;
     vq->free_cnt = size;
     vq->max_queued = 0;
-    list_init(&vq->msgqueue);
-    vq->servicequeue = allocate_queue(dev->general, 512);
-    assert(vq->servicequeue != INVALID_ADDRESS);
+    list_init(&vq->msg_queue);
+    vq->service_queue = allocate_queue(dev->general, 512);
+    assert(vq->service_queue != INVALID_ADDRESS);
     vq->service = closure(dev->general, virtqueue_service_vqmsgs, vq);
+    vq->sched_queue = sched_queue;
     spin_lock_init(&vq->fill_lock);
 
     if ((vq->ring_mem = allocate_zero(dev->contiguous, alloc)) == INVALID_ADDRESS) {
@@ -328,9 +331,9 @@ static void virtqueue_fill(virtqueue vq)
 
     /* irqs already disabled */
     spin_lock(&vq->fill_lock);
-    list n = list_get_next(&vq->msgqueue);
+    list n = list_get_next(&vq->msg_queue);
     u16 added = 0;
-    while (n && n != &vq->msgqueue) {
+    while (n && n != &vq->msg_queue) {
         vqmsg m = struct_from_list(n, vqmsg, l);
         if (vq->free_cnt < m->count) {
             virtqueue_debug_verbose("%s: vq %s: queue full (vq->free_cnt %ld)\n",

--- a/src/vmware/vmxnet3_net.c
+++ b/src/vmware/vmxnet3_net.c
@@ -607,6 +607,6 @@ static void process_interrupt(vmxnet3 vn)
         /* trick: remove (local) head and queue first element */
         list_delete(&q);
         assert(enqueue(vn->rx_servicequeue, l));
-        enqueue(bhqueue, vn->rx_service);
+        enqueue(runqueue, vn->rx_service);
     }
 }

--- a/src/x86_64/lock.h
+++ b/src/x86_64/lock.h
@@ -20,9 +20,31 @@ static inline void spin_unlock(spinlock l) {
     *(volatile u64 *)&l->w = 0;
 }
 #else
+#ifdef SPIN_LOCK_DEBUG_NOSMP
+static inline boolean spin_try(spinlock l)
+{
+    if (l->w)
+        return false;
+    l->w = 1;
+    return true;
+}
+
+static inline void spin_lock(spinlock l)
+{
+    assert(l->w == 0);
+    l->w = 1;
+}
+
+static inline void spin_unlock(spinlock l)
+{
+    assert(l->w == 1);
+    l->w = 0;
+}
+#else
 #define spin_try(x) (true)
 #define spin_lock(x) ((void)x)
 #define spin_unlock(x) ((void)x)
+#endif
 #endif
 
 static inline u64 spin_lock_irq(spinlock l)
@@ -41,5 +63,5 @@ static inline void spin_unlock_irq(spinlock l, u64 flags)
 
 static inline void spin_lock_init(spinlock l)
 {
-    *&l->w = 0;
+    l->w = 0;
 }

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -598,6 +598,12 @@ void unmap_and_free_phys(u64 virtual, u64 length)
     unmap_pages_with_handler(virtual, length, stack_closure(dealloc_phys_page));
 }
 
+/* backdoor dealloc to call from pt traversals (which hold the lock) */
+void deallocate_phys_page_from_traversal(u64 phys, u64 size)
+{
+    deallocate_u64((heap)phys_internal, phys, size);
+}
+
 /* these methods would hook into free page list / epoch stuff... */
 static u64 wrap_alloc(heap h, bytes b)
 {

--- a/src/x86_64/page.h
+++ b/src/x86_64/page.h
@@ -51,6 +51,7 @@ void map(u64 virtual, physical p, u64 length, u64 flags);
 void unmap(u64 virtual, u64 length);
 void unmap_pages_with_handler(u64 virtual, u64 length, range_handler rh);
 void unmap_and_free_phys(u64 virtual, u64 length);
+void deallocate_phys_page_from_traversal(u64 phys, u64 size);
 
 static inline void unmap_pages(u64 virtual, u64 length)
 {

--- a/src/xen/xennet.c
+++ b/src/xen/xennet.c
@@ -91,7 +91,7 @@ struct xennet_dev {
     vector rxbufs;
     struct list rx_free;
 
-    thunk rx_service;           /* for bhqueue processing */
+    thunk rx_service;           /* for runqueue processing */
     queue rx_servicequeue;
 
     struct spinlock tx_fill_lock;
@@ -99,7 +99,7 @@ struct xennet_dev {
     struct list tx_pending;     /* awaiting ring queueing (head may be partial) */
     struct list tx_free;
 
-    thunk tx_service;           /* for bhqueue processing */
+    thunk tx_service;           /* for runqueue processing */
     queue tx_servicequeue;
 };
 
@@ -290,7 +290,7 @@ static void xennet_service_tx_ring(xennet_dev xd)
             /* trick: remove (local) head and queue first element */
             list_delete(&q);
             assert(enqueue(xd->tx_servicequeue, l));
-            enqueue(bhqueue, xd->tx_service);
+            enqueue(runqueue, xd->tx_service);
         }
         RING_FINAL_CHECK_FOR_RESPONSES(&xd->tx_ring, more);
     } while (more);
@@ -616,7 +616,7 @@ static void xennet_service_rx_ring(xennet_dev xd)
             list_delete(&q);
             assert(l->prev);
             assert(enqueue(xd->rx_servicequeue, l));
-            enqueue(bhqueue, xd->rx_service);
+            enqueue(runqueue, xd->rx_service);
         }
         RING_FINAL_CHECK_FOR_RESPONSES(&xd->rx_ring, more);
     } while (more);


### PR DESCRIPTION
These changes move bhqueue service outside of the locked region in runloop_internal, necessary for storage completions to execute while a syscall continuation, holding the kernel lock, awaits a file-backed page to be faulted in. This divides the various I/O completions around the system between those that queue to bhqueue (storage completions) - which run without the kernel lock held - and ones that queue to runqueue (e.g. net / lwIP processing) and execute with the kernel lock held.

Also:
- spin locks on a non-SMP build are changed from nops to sanity checks
- address a deadlock issue when attempting to deallocate a physical page in pagecache_unmap_page_nodelocked
