### PR TITLE
Misc fixes in preparation for enabling SMP support

### DIFF
--- a/src/x86_64/crt0.s
+++ b/src/x86_64/crt0.s
@@ -348,22 +348,7 @@ install_gdt64_and_tss:
         ret
 .end:
 
-%define SEG_DESC_G          (1 << 23) ; Granularity
-%define SEG_DESC_DB         (1 << 22) ; Code: default size, Data: big
-%define SEG_DESC_L          (1 << 21) ; Code: Long (64-bit)
-%define SEG_DESC_AVL        (1 << 20) ; Available
-%define SEG_DESC_P          (1 << 15) ; Present
-%define SEG_DESC_DPL_SHIFT  13
-%define SEG_DESC_S          (1 << 12) ; Code/data (vs sys)
-%define SEG_DESC_CODE       (1 << 11) ; Code descriptor type (vs data)
-%define SEG_DESC_C          (1 << 10) ; Conforming
-%define SEG_DESC_RW         (1 << 9)  ; Code: readable, Data: writeable
-%define SEG_DESC_A          (1 << 8)  ; Accessed
-
-%define KERN_CODE_SEG_DESC  (SEG_DESC_L | SEG_DESC_P | SEG_DESC_S | SEG_DESC_CODE | SEG_DESC_RW)
-%define KERN_DATA_SEG_DESC  (SEG_DESC_P | SEG_DESC_S | SEG_DESC_RW)
-%define USER_CODE_SEG_DESC  (SEG_DESC_L | SEG_DESC_P | (3 << SEG_DESC_DPL_SHIFT) | SEG_DESC_S | SEG_DESC_CODE | SEG_DESC_RW)
-%define USER_DATA_SEG_DESC  (SEG_DESC_S | (3 << SEG_DESC_DPL_SHIFT) | SEG_DESC_P | SEG_DESC_RW)
+%include "segment.inc"
 
         ;; Global Descriptor Table (64-bit).
 align 16

--- a/src/x86_64/lock.h
+++ b/src/x86_64/lock.h
@@ -2,7 +2,7 @@ typedef struct spinlock {
     word w;
 } *spinlock;
 
-#ifdef SMP_ENABLE
+#if defined(KERNEL) && defined(SMP_ENABLE)
 static inline boolean spin_try(spinlock l) {
     u64 tmp = 1;
     /* Is it worth the compare and branch to skip a pause? */

--- a/src/x86_64/mp.c
+++ b/src/x86_64/mp.c
@@ -6,7 +6,7 @@
 
 static void *apboot = INVALID_ADDRESS;
 extern u8 apinit, apinit_end;
-extern void *ap_pagetable, *ap_gdt_pointer, *ap_idt_pointer, *ap_stack;
+extern void *ap_pagetable, *ap_idt_pointer, *ap_stack;
 void *ap_stack;
 u64 ap_lock;
 
@@ -58,7 +58,6 @@ void start_cpu(heap h, heap stackheap, int index, void (*ap_entry)()) {
         apboot = pointer_from_u64(AP_BOOT_START);
         map((u64)apboot, (u64)apboot, PAGESIZE, PAGE_WRITABLE);
 
-        asm("sgdt %0": "=m"(ap_gdt_pointer));
         asm("sidt %0": "=m"(ap_idt_pointer));
         mov_from_cr("cr3", ap_pagetable);
         // just one function call

--- a/src/x86_64/segment.inc
+++ b/src/x86_64/segment.inc
@@ -1,0 +1,16 @@
+%define SEG_DESC_G          (1 << 23) ; Granularity
+%define SEG_DESC_DB         (1 << 22) ; Code: default size, Data: big
+%define SEG_DESC_L          (1 << 21) ; Code: Long (64-bit)
+%define SEG_DESC_AVL        (1 << 20) ; Available
+%define SEG_DESC_P          (1 << 15) ; Present
+%define SEG_DESC_DPL_SHIFT  13
+%define SEG_DESC_S          (1 << 12) ; Code/data (vs sys)
+%define SEG_DESC_CODE       (1 << 11) ; Code descriptor type (vs data)
+%define SEG_DESC_C          (1 << 10) ; Conforming
+%define SEG_DESC_RW         (1 << 9)  ; Code: readable, Data: writeable
+%define SEG_DESC_A          (1 << 8)  ; Accessed
+
+%define KERN_CODE_SEG_DESC  (SEG_DESC_L | SEG_DESC_P | SEG_DESC_S | SEG_DESC_CODE | SEG_DESC_RW)
+%define KERN_DATA_SEG_DESC  (SEG_DESC_P | SEG_DESC_S | SEG_DESC_RW)
+%define USER_CODE_SEG_DESC  (SEG_DESC_L | SEG_DESC_P | (3 << SEG_DESC_DPL_SHIFT) | SEG_DESC_S | SEG_DESC_CODE | SEG_DESC_RW)
+%define USER_DATA_SEG_DESC  (SEG_DESC_S | (3 << SEG_DESC_DPL_SHIFT) | SEG_DESC_P | SEG_DESC_RW)


### PR DESCRIPTION
Since the kernel lives at the top of the 64-bit address space, the GDT address used at runtime does not fit in 32 bits, so a "temporary" GDT is needed in the AP boot page for secondary CPUs to use when switching to 64-bit mode.
Handling of the /sys/devices/system/cpu/online special file has been updated to report the correct number of available CPUs (its
events callback has been changed so that the EPOLLIN flag is always returned, which is the correct behavior for files that do not block when read).