### PR TITLE
Fixed two ftrace problems

### DIFF
--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -107,7 +107,7 @@ static inline void *stack_from_kernel_context(kernel_context c)
 
 void runloop_internal() __attribute__((noreturn));
 
-static inline __attribute__((noreturn)) void runloop(void)
+NOTRACE static inline __attribute__((noreturn)) void runloop(void)
 {
     set_running_frame(current_cpu()->kernel_context->frame);
     switch_stack(stack_from_kernel_context(current_cpu()->kernel_context),

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -177,7 +177,6 @@ define_closure_function(1, 0, void, run_thread,
                         thread, t)
 {
     thread t = bound(t);
-    current_cpu()->current_thread = (nanos_thread)t;
     dispatch_signals(t);
     run_thread_frame(t);
 }


### PR DESCRIPTION
Ftrace enabled builds on mac would overflow the ftrace call record
with runloop on Xen. This does not happen on Linux builds, but adding
NOTRACE to runloop fixes the problem.
The other change reverts a change from the current_thread cleanup
that was required for dispatch_signals to work when current was
invalidated. Since we aren't doing the invalidation now, the line is
unnecessary, and was breaking ftrace thread switch analysis.