### PR TITLE
Go runtime tests: do not fail if unknown env vars are found

### DIFF
--- a/test/go/go_test.go
+++ b/test/go/go_test.go
@@ -71,9 +71,9 @@ func TestArgsAndEnv(t *testing.T) {
 		t.Fatal("ReadAll failed")
 	}
 
-	if sortString(string(body)) !=
-		sortString("USER=bobbyPWD=password") {
-		t.Error("unexpected response" + string(body))
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "USER=bobby") || !strings.Contains(bodyStr, "PWD=password") {
+		t.Error("unexpected response " + bodyStr)
 	}
 }
 


### PR DESCRIPTION
https://github.com/nanovms/ops/pull/637 modified Ops so that it automatically adds NANOS_VERSION and OPS_VERSION environment variables to an image being created. The Go runtime test for environment variables was not prepared to find variables other than those specified when building the image.
This commit changes the runtime test so that it only checks for the existence and correctness of the specified variables, and doesn't fail if other variables are found.

Closes #1295.