### PR TITLE
Volume mounting: add support for volumes identified by a label

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -194,7 +194,7 @@ closure_function(5, 1, void, mbr_read,
         u8 uuid[UUID_LEN];
         char label[VOLUME_LABEL_MAX_LEN];
         if (filesystem_probe(mbr, uuid, label))
-            volume_add(uuid, bound(r), bound(w), bound(length));
+            volume_add(uuid, label, bound(r), bound(w), bound(length));
         else
             init_debug("unformatted storage device, ignoring");
         deallocate(h, mbr, SECTOR_SIZE);

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -192,7 +192,8 @@ closure_function(5, 1, void, mbr_read,
     struct partition_entry *rootfs_part = partition_get(mbr, PARTITION_ROOTFS);
     if (!rootfs_part) {
         u8 uuid[UUID_LEN];
-        if (filesystem_probe(mbr, uuid))
+        char label[VOLUME_LABEL_MAX_LEN];
+        if (filesystem_probe(mbr, uuid, label))
             volume_add(uuid, bound(r), bound(w), bound(length));
         else
             init_debug("unformatted storage device, ignoring");

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -287,7 +287,7 @@ static inline boolean buffer_compare_with_cstring(buffer b, const char *x)
 {
     int len = buffer_length(b);
     for (int i = 0; i < len; i++) {
-        if (byte(b, i) != x[i])
+        if (byte(b, i) != (u8)x[i])
             return false;
         if (x[i] == '\0')       /* must terminate */
             return i == len - 1;

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -64,7 +64,7 @@ struct filesystem;
 void init_volumes(heap h);
 void storage_set_root_fs(struct filesystem *root_fs);
 void storage_set_mountpoints(tuple mounts);
-boolean volume_add(u8 *uuid, block_io r, block_io w, u64 size);
+boolean volume_add(u8 *uuid, char *label, block_io r, block_io w, u64 size);
 void storage_when_ready(thunk complete);
 void storage_sync(status_handler sh);
 

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -19,6 +19,8 @@ enum partition {
 #define HEADS 255
 #define MAX_CYL 1023
 
+#define VOLUME_LABEL_MAX_LEN    32  /* null-terminated string */
+
 #define partition_get(mbr, index)    ({ \
     u16 *mbr_sig = (u16 *)((u64)(mbr) + SECTOR_SIZE - sizeof(*mbr_sig));  \
     struct partition_entry *e;  \

--- a/src/runtime/text.h
+++ b/src/runtime/text.h
@@ -136,6 +136,21 @@ static inline character pop_character(buffer b)
     return c;
 }
 
+static inline boolean read_cstring(buffer b, char *dest, bytes maxlen)
+{
+    bytes count = 0;
+    u8 c;
+    do {
+        if (buffer_length(b) == 0)
+            return false;
+        c = *(u8 *)buffer_ref(b, 0);
+        bytes len = utf8_length(c);
+        if ((len > maxlen - count) || !buffer_read(b, dest + count, len))
+            return false;
+        count += len;
+    } while (c);
+    return true;
+}
 
 // status
 static inline boolean parse_int(buffer b, u32 base, u64 *result)

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -18,7 +18,8 @@ extern io_status_handler ignore_io_status;
 #define MIN_EXTENT_SIZE PAGESIZE
 #define MAX_EXTENT_SIZE (1 * MB)
 
-boolean filesystem_probe(u8 *first_sector, u8 *uuid);
+boolean filesystem_probe(u8 *first_sector, u8 *uuid, char *label);
+const char *filesystem_get_label(filesystem fs);
 void filesystem_get_uuid(filesystem fs, u8 *uuid);
 
 void create_filesystem(heap h,
@@ -26,7 +27,7 @@ void create_filesystem(heap h,
                        u64 size,
                        block_io read,
                        block_io write,
-                       boolean initialize,
+                       const char *label,
                        filesystem_complete complete);
 void destroy_filesystem(filesystem fs);
 

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -4,9 +4,10 @@
 #include <runtime.h>
 #endif
 #include <pagecache.h>
+#include <storage.h>
 #include <tfs.h>
 
-#define TFS_VERSION 0x00000003
+#define TFS_VERSION 0x00000004
 
 typedef struct log *log;
 
@@ -18,6 +19,7 @@ typedef struct filesystem {
     int alignment_order;        /* in blocks */
     int page_order;
     u8 uuid[UUID_LEN];
+    char label[VOLUME_LABEL_MAX_LEN];
     table files; // maps tuple to fsfile
     closure_type(log, void, tuple);
     heap dma;

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -121,6 +121,7 @@ closure_function(3, 2, void, fsc,
     filesystem_get_uuid(fs, uuid);
     tuple root = filesystem_getroot(fs);
     buffer rb = allocate_buffer(h, PAGESIZE);
+    bprintf(rb, "Label: %s\n", filesystem_get_label(fs));
     bprintf(rb, "UUID: ");
     print_uuid(rb, uuid);
     bprintf(rb, "\nmetadata ");


### PR DESCRIPTION
In volume mount directives included in a manifest file, it is now possible to specify a volume by its filesystem label (alternatively
to using the filesystem UUID). This allows to easily change volumes to be mounted by a VM instance without re-creating the image for the instance.
Example of a mount directive using a label: `mounts:(my_label:/mnt)`.
The mkfs tool has an additional command line option (-l) that allows to specify a label (if not specified, the default label is an emtpy
string), and the dump tool displays the label retrieved from an existing filesystem.
Example to create an empty filesystem with label "my_label": `mkfs -l my_label -e volume.raw`.
