### PR TITLE
build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,16 @@ MKFS=		$(TOOLDIR)/mkfs
 BOOTIMG=	$(PLATFORMOBJDIR)/boot/boot.img
 KERNEL=		$(PLATFORMOBJDIR)/bin/kernel.img
 
-all: image tools
+all: image
 
 .PHONY: image release target tools distclean
 
 include rules.mk
 
-image: $(LWIPDIR)/.vendored mkfs
+image: $(LWIPDIR)/.vendored tools
 	$(Q) $(MAKE) -C $(PLATFORMDIR) image TARGET=$(TARGET)
 
-release: mkfs
+release: $(LWIPDIR)/.vendored mkfs
 	$(Q) $(MAKE) -C $(PLATFORMDIR) boot
 	$(Q) $(MAKE) -C $(PLATFORMDIR) kernel
 	$(Q) $(RM) -r release
@@ -71,7 +71,7 @@ contgen mkfs:
 test-all: contgen
 	$(Q) $(MAKE) -C test
 
-test test-noaccel: mkfs image
+test test-noaccel: image
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
@@ -79,7 +79,7 @@ RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst getdents 
 
 .PHONY: runtime-tests runtime-tests-noaccel
 
-runtime-tests runtime-tests-noaccel: mkfs image
+runtime-tests runtime-tests-noaccel: image
 	$(foreach t,$(RUNTIME_TESTS),$(call execute_command,$(Q) $(MAKE) run$(subst runtime-tests,,$@) TARGET=$t))
 
 run: contgen image

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -29,30 +29,7 @@ SRCS-kernel.img= \
 	$(SRCDIR)/net/direct.c \
 	$(SRCDIR)/net/net.c \
 	$(SRCDIR)/net/netsyscall.c \
-	$(SRCDIR)/runtime/bitmap.c \
-	$(SRCDIR)/runtime/buffer.c \
-	$(SRCDIR)/runtime/extra_prints.c \
-	$(SRCDIR)/runtime/format.c \
-	$(SRCDIR)/runtime/heap/freelist.c \
-	$(SRCDIR)/runtime/heap/id.c \
-	$(SRCDIR)/runtime/heap/mcache.c \
-	$(SRCDIR)/runtime/heap/objcache.c \
-	$(SRCDIR)/runtime/memops.c \
-	$(SRCDIR)/runtime/merge.c \
-	$(SRCDIR)/runtime/pqueue.c \
-	$(SRCDIR)/runtime/queue.c \
-	$(SRCDIR)/runtime/random.c \
-	$(SRCDIR)/runtime/range.c \
-	$(SRCDIR)/runtime/rbtree.c \
-	$(SRCDIR)/runtime/runtime_init.c \
-	$(SRCDIR)/runtime/sg.c \
-	$(SRCDIR)/runtime/sha256.c \
-	$(SRCDIR)/runtime/symbol.c \
-	$(SRCDIR)/runtime/table.c \
-	$(SRCDIR)/runtime/timer.c \
-	$(SRCDIR)/runtime/tuple.c \
-	$(SRCDIR)/runtime/string.c \
-	$(SRCDIR)/runtime/crypto/chacha.c \
+	$(RUNTIME) \
 	$(SRCDIR)/tfs/tfs.c \
 	$(SRCDIR)/tfs/tlog.c \
 	$(SRCDIR)/unix/aio.c \

--- a/rules.mk
+++ b/rules.mk
@@ -15,6 +15,8 @@ PLATFORMDIR=	$(ROOTDIR)/platform/$(PLATFORM)
 PLATFORMOBJDIR=	$(subst $(ROOTDIR),$(OUTDIR),$(PLATFORMDIR))
 IMAGE=		$(OUTDIR)/image/disk.raw
 
+include $(SRCDIR)/runtime/files.mk
+
 # To reveal verbose build messages, override Q= in command line.
 Q=		@
 

--- a/src/runtime/files.mk
+++ b/src/runtime/files.mk
@@ -1,0 +1,25 @@
+RUNTIME=$(SRCDIR)/runtime/bitmap.c \
+	$(SRCDIR)/runtime/buffer.c \
+	$(SRCDIR)/runtime/extra_prints.c \
+	$(SRCDIR)/runtime/format.c \
+	$(SRCDIR)/runtime/heap/freelist.c \
+	$(SRCDIR)/runtime/heap/id.c \
+	$(SRCDIR)/runtime/heap/mcache.c \
+	$(SRCDIR)/runtime/heap/objcache.c \
+	$(SRCDIR)/runtime/memops.c \
+	$(SRCDIR)/runtime/merge.c \
+	$(SRCDIR)/runtime/pqueue.c \
+	$(SRCDIR)/runtime/queue.c \
+	$(SRCDIR)/runtime/random.c \
+	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/rbtree.c \
+	$(SRCDIR)/runtime/runtime_init.c \
+	$(SRCDIR)/runtime/sg.c \
+	$(SRCDIR)/runtime/sha256.c \
+	$(SRCDIR)/runtime/symbol.c \
+	$(SRCDIR)/runtime/table.c \
+	$(SRCDIR)/runtime/timer.c \
+	$(SRCDIR)/runtime/tuple.c \
+	$(SRCDIR)/runtime/tuple_parser.c \
+	$(SRCDIR)/runtime/string.c \
+	$(SRCDIR)/runtime/crypto/chacha.c

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -109,30 +109,7 @@ LDFLAGS-io_uring=	-static
 SRCS-mmap= \
 	$(CURDIR)/mmap.c \
 	$(SRCDIR)/unix_process/unix_process_runtime.c \
-	$(SRCDIR)/runtime/bitmap.c \
-	$(SRCDIR)/runtime/buffer.c \
-	$(SRCDIR)/runtime/extra_prints.c \
-	$(SRCDIR)/runtime/format.c \
-	$(SRCDIR)/runtime/memops.c \
-	$(SRCDIR)/runtime/pqueue.c \
-	$(SRCDIR)/runtime/random.c \
-	$(SRCDIR)/runtime/range.c \
-	$(SRCDIR)/runtime/rbtree.c \
-	$(SRCDIR)/runtime/runtime_init.c \
-	$(SRCDIR)/runtime/sg.c \
-	$(SRCDIR)/runtime/sha256.c \
-	$(SRCDIR)/runtime/string.c \
-	$(SRCDIR)/runtime/symbol.c \
-	$(SRCDIR)/runtime/table.c \
-	$(SRCDIR)/runtime/tuple_parser.c \
-	$(SRCDIR)/runtime/tuple.c \
-	$(SRCDIR)/runtime/timer.c \
-	$(SRCDIR)/runtime/crypto/chacha.c \
-	$(SRCDIR)/runtime/heap/id.c \
-	$(SRCDIR)/runtime/heap/freelist.c \
-	$(SRCDIR)/runtime/heap/debug_heap.c \
-	$(SRCDIR)/runtime/heap/objcache.c \
-	$(SRCDIR)/runtime/heap/mcache.c
+	$(RUNTIME)
 LDFLAGS-mmap=		-static
 
 SRCS-mkdir= \
@@ -157,29 +134,8 @@ LDFLAGS-paging=		-static
 SRCS-pipe= \
 	$(CURDIR)/pipe.c \
 	$(SRCDIR)/unix_process/unix_process_runtime.c \
-	$(SRCDIR)/runtime/bitmap.c \
-	$(SRCDIR)/runtime/buffer.c \
-	$(SRCDIR)/runtime/extra_prints.c \
-	$(SRCDIR)/runtime/format.c \
-	$(SRCDIR)/runtime/memops.c \
-	$(SRCDIR)/runtime/pqueue.c \
-	$(SRCDIR)/runtime/random.c \
-	$(SRCDIR)/runtime/range.c \
-	$(SRCDIR)/runtime/rbtree.c \
-	$(SRCDIR)/runtime/runtime_init.c \
-	$(SRCDIR)/runtime/sg.c \
-	$(SRCDIR)/runtime/string.c \
-	$(SRCDIR)/runtime/symbol.c \
-	$(SRCDIR)/runtime/table.c \
-	$(SRCDIR)/runtime/tuple_parser.c \
-	$(SRCDIR)/runtime/tuple.c \
-	$(SRCDIR)/runtime/timer.c \
-	$(SRCDIR)/runtime/crypto/chacha.c \
-	$(SRCDIR)/runtime/heap/id.c \
-	$(SRCDIR)/runtime/heap/freelist.c \
-	$(SRCDIR)/runtime/heap/debug_heap.c \
-	$(SRCDIR)/runtime/heap/objcache.c \
-	$(SRCDIR)/runtime/heap/mcache.c
+	$(RUNTIME)
+
 LDFLAGS-pipe=		-static
 LIBS-pipe=		-lm -lpthread
 
@@ -194,29 +150,7 @@ LDFLAGS-sendfile=	-static
 SRCS-signal= \
 	$(CURDIR)/signal.c \
 	$(SRCDIR)/unix_process/unix_process_runtime.c \
-	$(SRCDIR)/runtime/bitmap.c \
-	$(SRCDIR)/runtime/buffer.c \
-	$(SRCDIR)/runtime/extra_prints.c \
-	$(SRCDIR)/runtime/format.c \
-	$(SRCDIR)/runtime/memops.c \
-	$(SRCDIR)/runtime/pqueue.c \
-	$(SRCDIR)/runtime/random.c \
-	$(SRCDIR)/runtime/range.c \
-	$(SRCDIR)/runtime/rbtree.c \
-	$(SRCDIR)/runtime/runtime_init.c \
-	$(SRCDIR)/runtime/sg.c \
-	$(SRCDIR)/runtime/string.c \
-	$(SRCDIR)/runtime/symbol.c \
-	$(SRCDIR)/runtime/table.c \
-	$(SRCDIR)/runtime/tuple_parser.c \
-	$(SRCDIR)/runtime/tuple.c \
-	$(SRCDIR)/runtime/timer.c \
-	$(SRCDIR)/runtime/crypto/chacha.c \
-	$(SRCDIR)/runtime/heap/id.c \
-	$(SRCDIR)/runtime/heap/freelist.c \
-	$(SRCDIR)/runtime/heap/debug_heap.c \
-	$(SRCDIR)/runtime/heap/objcache.c \
-	$(SRCDIR)/runtime/heap/mcache.c
+	$(RUNTIME)
 LDFLAGS-signal=		-static
 LIBS-signal=		-lm -lpthread
 
@@ -250,32 +184,7 @@ SRCS-udploop= \
 	$(SRCDIR)/unix_process/mmap_heap.c \
 	$(SRCDIR)/unix_process/socket_user.c \
 	$(SRCDIR)/unix_process/tiny_heap.c \
-	$(SRCDIR)/runtime/bitmap.c \
-	$(SRCDIR)/runtime/buffer.c \
-	$(SRCDIR)/runtime/extra_prints.c \
-	$(SRCDIR)/runtime/format.c \
-	$(SRCDIR)/runtime/heap/id.c \
-	$(SRCDIR)/runtime/heap/freelist.c \
-	$(SRCDIR)/runtime/heap/debug_heap.c \
-	$(SRCDIR)/runtime/heap/objcache.c \
-	$(SRCDIR)/runtime/heap/mcache.c \
-	$(SRCDIR)/runtime/memops.c \
-	$(SRCDIR)/runtime/merge.c \
-	$(SRCDIR)/runtime/pqueue.c \
-	$(SRCDIR)/runtime/random.c \
-	$(SRCDIR)/runtime/range.c \
-	$(SRCDIR)/runtime/rbtree.c \
-	$(SRCDIR)/runtime/runtime_init.c \
-	$(SRCDIR)/runtime/sg.c \
-	$(SRCDIR)/runtime/sha256.c \
-	$(SRCDIR)/runtime/signature.c \
-	$(SRCDIR)/runtime/string.c \
-	$(SRCDIR)/runtime/symbol.c \
-	$(SRCDIR)/runtime/table.c \
-	$(SRCDIR)/runtime/timer.c \
-	$(SRCDIR)/runtime/tuple_parser.c \
-	$(SRCDIR)/runtime/tuple.c \
-	$(SRCDIR)/runtime/crypto/chacha.c
+	$(RUNTIME)
 LDFLAGS-udploop=	 -static
 
 SRCS-unixsocket= \
@@ -301,32 +210,7 @@ SRCS-web= \
 	$(SRCDIR)/unix_process/mmap_heap.c \
 	$(SRCDIR)/unix_process/socket_user.c \
 	$(SRCDIR)/unix_process/tiny_heap.c \
-	$(SRCDIR)/runtime/bitmap.c \
-	$(SRCDIR)/runtime/buffer.c \
-	$(SRCDIR)/runtime/extra_prints.c \
-	$(SRCDIR)/runtime/format.c \
-	$(SRCDIR)/runtime/heap/id.c \
-	$(SRCDIR)/runtime/heap/freelist.c \
-	$(SRCDIR)/runtime/heap/debug_heap.c \
-	$(SRCDIR)/runtime/heap/objcache.c \
-	$(SRCDIR)/runtime/heap/mcache.c \
-	$(SRCDIR)/runtime/memops.c \
-	$(SRCDIR)/runtime/merge.c \
-	$(SRCDIR)/runtime/pqueue.c \
-	$(SRCDIR)/runtime/random.c \
-	$(SRCDIR)/runtime/range.c \
-	$(SRCDIR)/runtime/rbtree.c \
-	$(SRCDIR)/runtime/runtime_init.c \
-	$(SRCDIR)/runtime/sg.c \
-	$(SRCDIR)/runtime/sha256.c \
-	$(SRCDIR)/runtime/signature.c \
-	$(SRCDIR)/runtime/string.c \
-	$(SRCDIR)/runtime/symbol.c \
-	$(SRCDIR)/runtime/table.c \
-	$(SRCDIR)/runtime/timer.c \
-	$(SRCDIR)/runtime/tuple_parser.c \
-	$(SRCDIR)/runtime/tuple.c \
-	$(SRCDIR)/runtime/crypto/chacha.c
+	$(RUNTIME)
 
 SRCS-webs=		$(SRCS-web)
 LDFLAGS-webs=		-static

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -17,27 +17,6 @@ PROGRAMS= \
 	vector_test
 SKIP_TEST=	network_test udp_test
 
-RUNTIME = \
-	$(SRCDIR)/runtime/bitmap.c \
-	$(SRCDIR)/runtime/buffer.c \
-	$(SRCDIR)/runtime/extra_prints.c \
-	$(SRCDIR)/runtime/format.c \
-	$(SRCDIR)/runtime/heap/id.c \
-	$(SRCDIR)/runtime/memops.c \
-	$(SRCDIR)/runtime/merge.c \
-	$(SRCDIR)/runtime/pqueue.c \
-	$(SRCDIR)/runtime/random.c \
-	$(SRCDIR)/runtime/range.c \
-	$(SRCDIR)/runtime/rbtree.c \
-	$(SRCDIR)/runtime/runtime_init.c \
-	$(SRCDIR)/runtime/sg.c \
-	$(SRCDIR)/runtime/symbol.c \
-	$(SRCDIR)/runtime/table.c \
-	$(SRCDIR)/runtime/timer.c \
-	$(SRCDIR)/runtime/tuple.c \
-	$(SRCDIR)/runtime/string.c \
-	$(SRCDIR)/runtime/crypto/chacha.c 
-
 SRCS-buffer_test= \
 	$(CURDIR)/buffer_test.c \
 	$(RUNTIME)\

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -6,26 +6,7 @@ PROGRAMS=dump mkfs vdsogen
 SRCS-dump= \
 	$(CURDIR)/dump.c \
 	$(SRCDIR)/kernel/pagecache.c \
-	$(SRCDIR)/runtime/bitmap.c \
-	$(SRCDIR)/runtime/buffer.c \
-	$(SRCDIR)/runtime/extra_prints.c \
-	$(SRCDIR)/runtime/format.c \
-	$(SRCDIR)/runtime/heap/id.c \
-	$(SRCDIR)/runtime/memops.c \
-	$(SRCDIR)/runtime/merge.c \
-	$(SRCDIR)/runtime/pqueue.c \
-	$(SRCDIR)/runtime/random.c \
-	$(SRCDIR)/runtime/range.c \
-	$(SRCDIR)/runtime/rbtree.c \
-	$(SRCDIR)/runtime/runtime_init.c \
-	$(SRCDIR)/runtime/symbol.c \
-	$(SRCDIR)/runtime/table.c \
-	$(SRCDIR)/runtime/timer.c \
-	$(SRCDIR)/runtime/tuple.c \
-	$(SRCDIR)/runtime/sg.c \
-	$(SRCDIR)/runtime/string.c \
-	$(SRCDIR)/runtime/sha256.c \
-	$(SRCDIR)/runtime/crypto/chacha.c \
+	$(RUNTIME) \
 	$(SRCDIR)/tfs/tfs.c \
 	$(SRCDIR)/tfs/tlog.c \
 	$(SRCDIR)/unix_process/unix_process_runtime.c
@@ -33,27 +14,7 @@ SRCS-dump= \
 SRCS-mkfs= \
 	$(SRCDIR)/kernel/pagecache.c \
 	$(CURDIR)/mkfs.c \
-	$(SRCDIR)/runtime/bitmap.c \
-	$(SRCDIR)/runtime/buffer.c \
-	$(SRCDIR)/runtime/extra_prints.c \
-	$(SRCDIR)/runtime/format.c \
-	$(SRCDIR)/runtime/heap/id.c \
-	$(SRCDIR)/runtime/memops.c \
-	$(SRCDIR)/runtime/merge.c \
-	$(SRCDIR)/runtime/pqueue.c \
-	$(SRCDIR)/runtime/random.c \
-	$(SRCDIR)/runtime/range.c \
-	$(SRCDIR)/runtime/rbtree.c \
-	$(SRCDIR)/runtime/runtime_init.c \
-	$(SRCDIR)/runtime/symbol.c \
-	$(SRCDIR)/runtime/table.c \
-	$(SRCDIR)/runtime/timer.c \
-	$(SRCDIR)/runtime/tuple_parser.c \
-	$(SRCDIR)/runtime/tuple.c \
-	$(SRCDIR)/runtime/sg.c \
-	$(SRCDIR)/runtime/string.c \
-	$(SRCDIR)/runtime/sha256.c \
-	$(SRCDIR)/runtime/crypto/chacha.c \
+	$(RUNTIME) \
 	$(SRCDIR)/tfs/tfs.c \
 	$(SRCDIR)/tfs/tlog.c \
 	$(SRCDIR)/unix_process/unix_process_runtime.c


### PR DESCRIPTION
- fix parallel build breakage on fresh tree caused by redundant tools build
- maintain runtime source files in a single list (from https://github.com/convolvatron/nanos)
