### PR TITLE
Use Xen event upcall mask vs individual hypercalls

### DIFF
--- a/src/xen/xen.c
+++ b/src/xen/xen.c
@@ -115,7 +115,7 @@ closure_function(0, 0, void, xen_interrupt)
                 } else {
                     /* XXX we have an issue with seemingly spurious interrupts at evtchn >= 2048... */
                     xenint_debug("  evtchn %d: spurious interrupt", i2);
-                    si->evtchn_mask[bit1] |= 1ULL<<bit2;
+                    si->evtchn_mask[bit1] |= U64_FROM_BIT(bit2);
                 }
             }
         }

--- a/src/xen/xenblk.c
+++ b/src/xen/xenblk.c
@@ -241,7 +241,6 @@ define_closure_function(1, 0, void, xenblk_event_handler,
     if (done_empty && !list_empty(&xbd->done))
         enqueue(bhqueue, &xbd->bh_service);
     spin_unlock(&xbd->lock);
-    assert(xen_unmask_evtchn(xbd->evtchn) == 0);
 }
 
 define_closure_function(1, 0, void, xenblk_bh_service,

--- a/src/xen/xennet.c
+++ b/src/xen/xennet.c
@@ -655,9 +655,6 @@ closure_function(1, 0, void, xennet_event_handler,
     xennet_populate_tx_ring(xd);
     xennet_service_rx_ring(xd);
     xennet_populate_rx_ring(xd);
-    int rv = xen_unmask_evtchn(xd->evtchn);
-    if (rv != 0)
-        halt("%s: failed to unmask evtchn %d, rv %d\n", xd->evtchn, rv);
 }
 
 static status xennet_enable(xennet_dev xd)


### PR DESCRIPTION
By using the xen event upcall mask we can eliminate the unmask hypercalls
in each interrupt handler, improving performance and latency. This changeset
continues to set the second level mask for spurious interrupts so those will
only interrupt once. My tests with webg and ab show around a 7.5% improvement
in requests per second and request latency for Xen.