### PR TITLE
PCI: add support for a driver to operate more than one device

### DIFF
--- a/src/kernel/pci.c
+++ b/src/kernel/pci.c
@@ -41,13 +41,9 @@
 #define PCICAP_NEXTPTR  0x1
 
 // use the global nodespace
+static vector devices;
 static vector drivers;
 static heap virtual_page;
-
-struct pci_driver {
-    pci_probe probe;
-    boolean attached;
-};
 
 /* enable configuration space accesses and return data port address */
 static int pci_cfgenable(pci_dev dev, int reg, int bytes)
@@ -277,8 +273,17 @@ void register_pci_driver(pci_probe probe)
 {
     struct pci_driver *d = allocate(drivers->h, sizeof(struct pci_driver));
     d->probe = probe;
-    d->attached = false;
     vector_push(drivers, d);
+}
+
+static int pci_dev_find(pci_dev dev)
+{
+    for (int i = 0; i < vector_length(devices); i++) {
+        pci_dev d = vector_get(devices, i);
+        if ((d->bus == dev->bus) && (d->slot == dev->slot) && (d->function == dev->function))
+            return i;
+    }
+    return -1;
 }
 
 static void pci_probe_bus(int bus);
@@ -290,6 +295,23 @@ static void pci_probe_device(pci_dev dev)
         return;
     pci_debug("%s: %02x:%02x:%x: %04x:%04x\n",
         __func__, dev->bus, dev->slot, dev->function, vendor, pci_get_device(dev));
+    pci_dev pcid;
+    int dev_index = pci_dev_find(dev);
+    if (dev_index < 0) {
+        pci_dev new_dev = allocate(devices->h, sizeof(*new_dev));
+        if (new_dev == INVALID_ADDRESS) {
+            msg_err("cannot allocate memory for PCI device\n");
+            return;
+        }
+        *new_dev = *dev;
+        new_dev->driver = 0;
+        vector_push(devices, new_dev);
+        pcid = new_dev;
+    } else {
+        pcid = vector_get(devices, dev_index);
+        if (pcid->driver)
+            return;
+    }
 
     // PCI-PCI bridge
     u8 class = pci_get_class(dev);
@@ -306,8 +328,9 @@ static void pci_probe_device(pci_dev dev)
     // probe drivers
     struct pci_driver *d;
     vector_foreach(drivers, d) {
-        if (!d->attached && apply(d->probe, dev)) {
-            d->attached = true;
+        if (apply(d->probe, pcid)) {
+            pcid->driver = d;
+            break;
         }
     }
 }
@@ -360,5 +383,6 @@ void init_pci(kernel_heaps kh)
 {
     // should use the global node space
     virtual_page = (heap)heap_virtual_page(kh);
+    devices = allocate_vector(heap_general(kh), 8);
     drivers = allocate_vector(heap_general(kh), 8);
 }

--- a/src/virtio/virtio_pci.c
+++ b/src/virtio/virtio_pci.c
@@ -292,8 +292,7 @@ vtpci attach_vtpci(heap h, heap page_allocator, pci_dev d, u64 feature_mask)
     if (is_modern)
         feature_mask |= VIRTIO_F_VERSION_1;
 
-    dev->_dev = *d;
-    dev->dev = &dev->_dev;
+    dev->dev = d;
     if (feature_mask & VIRTIO_F_VERSION_1) {
         vtpci_modern_alloc_resources(dev);
     } else {

--- a/src/virtio/virtio_pci.h
+++ b/src/virtio/virtio_pci.h
@@ -53,7 +53,6 @@ declare_closure_struct(1, 2, void, vtpci_notify,
 
 struct vtpci {
     struct vtdev virtio_dev; /* must be first */
-    struct pci_dev _dev;
     pci_dev dev;
     int regs[VTPCI_REG_MAX];
     bytes notify_offset_multiplier;

--- a/src/vmware/pvscsi.c
+++ b/src/vmware/pvscsi.c
@@ -37,7 +37,6 @@ struct pvscsi_hcb {
 };
 
 typedef struct pvscsi {
-    struct pci_dev _dev;
     pci_dev dev;
 
     struct pci_bar bar;
@@ -454,8 +453,7 @@ closure_function(1, 0, void, pvscsi_rx_service_bh, pvscsi, dev)
 static void pvscsi_attach(heap general, storage_attach a, heap page_allocator, pci_dev d)
 {
     struct pvscsi *dev = allocate(general, sizeof(struct pvscsi));
-    dev->_dev = *d;
-    dev->dev = &dev->_dev;
+    dev->dev = d;
 
     dev->general = general;
     dev->contiguous = page_allocator;

--- a/src/vmware/vmxnet3_net.c
+++ b/src/vmware/vmxnet3_net.c
@@ -348,8 +348,7 @@ static void vmxnet3_net_attach(heap general, heap page_allocator, pci_dev d)
     struct vmxnet3_pci *dev = allocate(general, sizeof(struct vmxnet3_pci));
     assert(dev != INVALID_ADDRESS);
 
-    dev->_dev = *d;
-    dev->dev = &dev->_dev;
+    dev->dev = d;
 
     pci_bar_init(dev->dev, &dev->bar0, 0, 0, -1);
     pci_bar_init(dev->dev, &dev->bar1, 1, 0, -1);

--- a/src/vmware/vmxnet3_net.h
+++ b/src/vmware/vmxnet3_net.h
@@ -69,7 +69,6 @@ typedef struct vmxnet3_pci *vmxnet3_pci;
 #define VMXNET3_CMD_GET_INTRCFG	0xF00D0008	/* Get interrupt config */
 
 typedef struct vmxnet3_pci {
-    struct pci_dev _dev;
     pci_dev dev;
 
     struct pci_bar bar0;

--- a/src/x86_64/pci.h
+++ b/src/x86_64/pci.h
@@ -33,10 +33,17 @@
 
 typedef struct pci_dev *pci_dev;
 
+typedef closure_type(pci_probe, boolean, pci_dev); // bus slot func
+
+typedef struct pci_driver {
+    pci_probe probe;
+} *pci_driver;
+
 struct pci_dev {
     int bus;
     int slot;
     int function;
+    pci_driver driver;
     u32 *msix_table;
 };
 
@@ -128,7 +135,5 @@ void pci_setup_msix(pci_dev dev, int msi_slot, thunk h, const char *name);
 #define PCIM_CMD_BUSMASTEREN    0x0004
 
 void init_pci(kernel_heaps kh);
-
-typedef closure_type(pci_probe, boolean, pci_dev); // bus slot func
 
 void register_pci_driver(pci_probe p);


### PR DESCRIPTION
With this change, the core PCI code allocates a struct pci_dev for each discovered device, and keeps track of whether a driver has
been attached to it; in this way, the probe function is not called more than once for the same device, while allowing a given driver
to control more than one device. This is needed to support multiple storage devices instantiated as separate PCI devices.
Since now each PCI device has an allocated structure in the core code, there is no need for drivers to keep a local struct pci_dev.