### PR TITLE
CPU time: fix thread and process time accounting, and fix runtime test

### DIFF
--- a/src/aarch64/machine.h
+++ b/src/aarch64/machine.h
@@ -160,11 +160,6 @@ static inline word fetch_and_add(word *target, word num)
     return __sync_fetch_and_add(target, num);
 }
 
-static inline u64 fetch_and_add_64(u64 *target, u64 num)
-{
-    return __sync_fetch_and_add(target, num);
-}
-
 static inline void kern_pause(void)
 {
   // XXX

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -151,9 +151,8 @@ static inline void run_thread_frame(thread t)
     check_stop_conditions(t);
     kern_lock(); // xx - make thread entry a separate exclusion region for performance
     thread old = current;
-    set_current_thread((nanos_thread)t);
-    ftrace_thread_switch(old, current);    /* ftrace needs to know about the switch event */
     thread_enter_user(t);
+    ftrace_thread_switch(old, t);    /* ftrace needs to know about the switch event */
 
     /* cover wake-before-sleep situations (e.g. sched yield, fs ops that don't go to disk, etc.) */
     t->blocked_on = 0;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -413,7 +413,6 @@ typedef struct process {
     rangemap          vmaps;    /* process mappings */
     vmap              stack_map;
     vmap              heap_map;
-    timestamp         utime, stime;
     struct sigstate   signals;
     struct sigaction  sigactions[NSIG];
     id_heap           posix_timer_ids;

--- a/src/x86_64/machine.h
+++ b/src/x86_64/machine.h
@@ -50,8 +50,7 @@ static inline void memory_barrier(void)
 
 static inline word fetch_and_add(word *variable, word value)
 {
-    asm volatile("lock; xadd %0, %1" : "+r" (value), "+m" (*variable) :: "memory", "cc");
-    return value;
+    return __sync_fetch_and_add(variable, value);
 }
 
 static inline void atomic_set_bit(u64 *target, u64 bit)
@@ -62,11 +61,6 @@ static inline void atomic_set_bit(u64 *target, u64 bit)
 static inline void atomic_clear_bit(u64 *target, u64 bit)
 {
     asm volatile("lock btrq %1, %0": "+m"(*target):"r"(bit) : "memory");
-}
-
-static inline u64 fetch_and_add_64(u64 *target, u64 num)
-{
-    return __sync_fetch_and_add(target, num);
 }
 
 static inline void kern_pause(void)

--- a/test/runtime/time.c
+++ b/test/runtime/time.c
@@ -210,14 +210,15 @@ static void test_cputime(void)
         thread_delta = delta_nsec(&thread_ts, &tmp_ts);
         if (thread_delta < 0)
             fail_error("%s: thread_delta %lld\n", __func__, thread_delta);
+        thread_ts = tmp_ts;
         if (clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tmp_ts) < 0)
             fail_perror("clock_gettime(CLOCK_PROCESS_CPUTIME_ID)");
         proc_delta = delta_nsec(&proc_ts, &tmp_ts);
         if (proc_delta < 0)
             fail_error("%s: proc_delta %lld\n", __func__, proc_delta);
-        if (proc_delta < thread_delta)
-            fail_error("%s: proc_delta %lld: thread_delta %lld\n", __func__,
-                       proc_delta, thread_delta);
+        proc_ts = tmp_ts;
+        if (delta_nsec(&thread_ts, &proc_ts) < 0)
+            fail_error("%s: process CPU time < thread CPU time\n", __func__);
     } while ((thread_delta == 0) || (proc_delta == 0));
 }
 


### PR DESCRIPTION
Commit 29c970f introduced a regression which caused CPU time for the threads of a process to be accounted twice in the CPU time of the process. This commit removes the utime and stime members from struct process, which are not necessary because the times of the individual threads need to be summed anyway when the process CPU time is requested from userspace.
In addition, calling set_current_thread() directly from run_thread_frame() messes up time accounting, because when thread_enter_user() is called it sees that the provided thread is already the current thread. This is now fixed.

fetch_and_add_64() is now unused and is being removed; the existing fetch_and_add() for x86 is being changed to use the same implementation as fetch_and_add_64(), because, as noted in https://github.com/nanovms/nanos/pull/1171#discussion_r423757729, the compiler-generated code is a little better.

The CPU time test now compares the absolute timestamps of the current thread and process, and not the deltas.

Closes #1305.
