### PR TITLE
Fix thread hang

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -23,6 +23,9 @@
 /* XXX just for initial mp bringup... */
 #define MAX_CPUS 16
 
+/* length of thread scheduling queue */
+#define MAX_THREADS 8192
+
 /* could probably find progammatically via cpuid... */
 #define DEFAULT_CACHELINE_SIZE 64
 

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -228,7 +228,7 @@ extern void interrupt_exit(void);
 extern char **state_strings;
 
 // static inline void schedule_frame(context f) stupid header deps
-#define schedule_frame(__f)  do { assert((__f)[FRAME_QUEUE] != INVALID_PHYSICAL); enqueue((queue)pointer_from_u64((__f)[FRAME_QUEUE]), pointer_from_u64((__f)[FRAME_RUN])); } while(0)
+#define schedule_frame(__f)  do { assert((__f)[FRAME_QUEUE] != INVALID_PHYSICAL); assert(enqueue((queue)pointer_from_u64((__f)[FRAME_QUEUE]), pointer_from_u64((__f)[FRAME_RUN]))); } while(0)
 
 void kernel_unlock();
 

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -184,7 +184,7 @@ void init_scheduler(heap h)
     /* scheduling queues init */
     runqueue = allocate_queue(h, 64);
     bhqueue = allocate_queue(h, 2048);
-    thread_queue = allocate_queue(h, 1024);
+    thread_queue = allocate_queue(h, MAX_THREADS);
     runloop_timers = allocate_timerheap(h, "runloop");
     assert(runloop_timers != INVALID_ADDRESS);
     shutting_down = false;

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -184,7 +184,7 @@ void init_scheduler(heap h)
     /* scheduling queues init */
     runqueue = allocate_queue(h, 64);
     bhqueue = allocate_queue(h, 2048);
-    thread_queue = allocate_queue(h, 64);
+    thread_queue = allocate_queue(h, 1024);
     runloop_timers = allocate_timerheap(h, "runloop");
     assert(runloop_timers != INVALID_ADDRESS);
     shutting_down = false;


### PR DESCRIPTION
This change fixes #1314 by increasing the thread_queue length. When enough threads are 
scheduled (as can be in thread_test), the enqueue in schedule_frame was silently failing
causing the thread never to be run again. I have also added an assert for that enqueue
so that it will panic if too many threads are scheduled.

I also cleaned up thread_test so that it can take an argument of the number of threads to test and now
calculates the expected sum instead of using the hard coded values.