### PR TITLE
Scheduler: SMP performance improvements

### DIFF
--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -97,6 +97,7 @@ static void init_cpuinfos(heap backed)
         ci->id = i;
         ci->state = cpu_not_present;
         ci->have_kernel_lock = false;
+        ci->thread_queue = allocate_queue(backed, MAX_THREADS);
         ci->frcount = 0;
         /* frame and stacks */
         ci->kernel_context = allocate_kernel_context(backed);

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -98,6 +98,7 @@ static void init_cpuinfos(heap backed)
         ci->state = cpu_not_present;
         ci->have_kernel_lock = false;
         ci->thread_queue = allocate_queue(backed, MAX_THREADS);
+        ci->last_timer_update = 0;
         ci->frcount = 0;
         /* frame and stacks */
         ci->kernel_context = allocate_kernel_context(backed);

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -44,6 +44,7 @@ typedef struct cpuinfo {
     int state;
     boolean have_kernel_lock;
     queue thread_queue;
+    timestamp last_timer_update;
     u64 frcount;
 
     /* The following fields are used rarely or only on initialization. */

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -43,6 +43,7 @@ typedef struct cpuinfo {
     u32 id;
     int state;
     boolean have_kernel_lock;
+    queue thread_queue;
     u64 frcount;
 
     /* The following fields are used rarely or only on initialization. */
@@ -172,7 +173,6 @@ static inline void set_page_write_protect(boolean enable)
 typedef struct queue *queue;
 extern queue bhqueue;
 extern queue runqueue;
-extern queue thread_queue;
 extern timerheap runloop_timers;
 
 static inline void bhqueue_enqueue_irqsafe(thunk t)

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -98,10 +98,10 @@ static inline void update_timer(void)
     timestamp next = timer_check(runloop_timers);
     if (last_timer_update && next == last_timer_update)
         return;
-    last_timer_update = next;
     s64 delta = next - now(CLOCK_ID_MONOTONIC);
-    timestamp timeout = delta > (s64)runloop_timer_min ? MAX(delta, runloop_timer_max) : runloop_timer_min;
+    timestamp timeout = delta > (s64)runloop_timer_min ? MIN(delta, runloop_timer_max) : runloop_timer_min;
     sched_debug("set platform timer: delta %lx, timeout %lx\n", delta, timeout);
+    last_timer_update = next + timeout - delta;
     runloop_timer(timeout);
 }
 

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -116,7 +116,7 @@ NOTRACE void __attribute__((noreturn)) kernel_sleep(void)
 {
     // we're going to cover up this race by checking the state in the interrupt
     // handler...we shouldn't return here if we do get interrupted
-    cpuinfo ci = get_cpuinfo();
+    cpuinfo ci = current_cpu();
     sched_debug("sleep\n");
     ci->state = cpu_idle;
     atomic_set_bit(&idle_cpu_mask, ci->id);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2435,8 +2435,6 @@ struct syscall {
 static struct syscall _linux_syscalls[SYS_MAX];
 struct syscall *linux_syscalls = _linux_syscalls;
 
-extern u64 kernel_lock;
-
 void syscall_debug(context f)
 {
     u64 call = f[FRAME_VECTOR];
@@ -2505,18 +2503,21 @@ closure_function(0, 2, void, io_complete_ignore,
 {
 }
 
+static boolean syscall_defer;
+
 // some validation can be moved up here
 static void syscall_schedule(context f, u64 call)
 {
     /* kernel context set on syscall entry */
-    if (kern_try_lock()) {
-        current_cpu()->state = cpu_kernel;
-        syscall_debug(f);
-    } else {
+    if (!syscall_defer)
+        kern_lock();
+    else if (!kern_try_lock()) {
         enqueue(runqueue, &current->deferred_syscall);
         thread_pause(current);
         runloop();
     }
+    current_cpu()->state = cpu_kernel;
+    syscall_debug(f);
 }
 
 void init_syscalls()
@@ -2538,6 +2539,7 @@ void _register_syscall(struct syscall *m, int n, sysreturn (*f)(), const char *n
 
 void configure_syscalls(process p)
 {
+    syscall_defer = !!table_find(p->process_root, sym(syscall_defer));
     void *notrace = table_find(p->process_root, sym(notrace));
     if (notrace) {
         table_foreach(notrace, k, v) {

--- a/src/x86_64/apic.h
+++ b/src/x86_64/apic.h
@@ -76,15 +76,3 @@ static inline u8 apic_id(void)
     assert(apic_if);
     return apic_if->legacy_id(apic_if);
 }
-
-static inline int this_cpu(void)
-{
-    // for now, assume legacy apic id == cpu num
-    return apic_id();
-}
-
-static inline cpuinfo get_cpuinfo(void)
-{
-    int cpu = this_cpu();
-    return &cpuinfos[cpu];
-}

--- a/src/x86_64/machine.h
+++ b/src/x86_64/machine.h
@@ -63,6 +63,20 @@ static inline void atomic_clear_bit(u64 *target, u64 bit)
     asm volatile("lock btrq %1, %0": "+m"(*target):"r"(bit) : "memory");
 }
 
+static inline int atomic_test_and_set_bit(u64 *target, u64 bit)
+{
+    int oldbit;
+    asm volatile("lock btsq %2, %0" : "+m"(*target), "=@ccc"(oldbit) : "r"(bit) : "memory");
+    return oldbit;
+}
+
+static inline int atomic_test_and_clear_bit(u64 *target, u64 bit)
+{
+    int oldbit;
+    asm volatile("lock btrq %2, %0" : "+m"(*target), "=@ccc"(oldbit) : "r"(bit) : "memory");
+    return oldbit;
+}
+
 static inline void kern_pause(void)
 {
     asm volatile("pause");

--- a/src/x86_64/mp.c
+++ b/src/x86_64/mp.c
@@ -49,7 +49,7 @@ static void __attribute__((noinline)) ap_new_stack()
 void ap_start()
 {
     apic_per_cpu_init();
-    switch_stack(stack_from_kernel_context(get_cpuinfo()->kernel_context), ap_new_stack);
+    switch_stack(stack_from_kernel_context(cpuinfo_from_id(apic_id())->kernel_context), ap_new_stack);
 }
 
 void start_cpu(heap h, heap stackheap, int index, void (*ap_entry)()) {


### PR DESCRIPTION
This PR makes some changes to the scheduler in order to improve performance on SMP systems.
The major changes are:
- the introduction of per-CPU thread queues (as opposed to a single global thread queue)
- changes in the scheduler policy for waking up idle CPUs, in order to minimize IPIs
- on a syscall entry, the CPU handling the syscall now waits unconditionally to acquire the kernel lock (instead of calling `kern_try_lock()`), in order to minimize the chance that the CPU goes to sleep and then needs to be woken up again