### PR TITLE
in-kernel loadable module support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SUBDIR=		$(PLATFORMDIR) test tools
+SUBDIR=		$(PLATFORMDIR) klib test tools
 
 # runtime tests / ready-to-use targets
 TARGET=		webg
@@ -34,11 +34,12 @@ KERNEL=		$(PLATFORMOBJDIR)/bin/kernel.img
 
 all: image
 
-.PHONY: image release target tools distclean
+.PHONY: distclean image release target tools
 
 include rules.mk
 
 image: $(LWIPDIR)/.vendored tools
+	$(Q) $(MAKE) -C klib
 	$(Q) $(MAKE) -C $(PLATFORMDIR) image TARGET=$(TARGET)
 
 release: $(LWIPDIR)/.vendored mkfs
@@ -54,7 +55,7 @@ release: $(LWIPDIR)/.vendored mkfs
 target: contgen
 	$(Q) $(MAKE) -C test/runtime $(TARGET)
 
-tools:
+tools: contgen
 	$(Q) $(MAKE) -C $@
 
 distclean: clean
@@ -75,7 +76,7 @@ test test-noaccel: image
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst getdents getrandom hw hws io_uring mkdir mmap netsock pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst getdents getrandom hw hws io_uring klibs mkdir mmap netsock pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -3,13 +3,18 @@ PROGRAMS=	test
 SRCS-test= \
 	$(CURDIR)/test.c
 
-CFLAGS+=	$(KERNCFLAGS) -I$(CURDIR) -fPIC
-LDFLAGS+=	-pie -nostdlib -DKLIB -T$(ARCHDIR)/klib.lds
-
-ifeq ($(ARCH),x86_64)
-CFLAGS+=	-mcmodel=kernel
-endif
-
 all: $(PROGRAMS)
 
 include ../rules.mk
+
+ifeq ($(UNAME_s),Darwin)
+ELF_TARGET=     -target x86_64-elf
+CFLAGS+=        $(ELF_TARGET)
+LD=             x86_64-elf-ld
+OBJDUMP=        x86_64-elf-objdump
+else
+LD=             $(CROSS_COMPILE)ld
+endif
+
+CFLAGS+=	$(KERNCFLAGS) -I$(CURDIR) -fPIC -DKLIB
+LDFLAGS+=	-pie -nostdlib -T$(ARCHDIR)/klib.lds

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -4,10 +4,11 @@ SRCS-test= \
 	$(CURDIR)/test.c
 
 CFLAGS+=	$(KERNCFLAGS) -I$(CURDIR) -fPIC
+LDFLAGS+=	-pie -nostdlib -DKLIB -T$(ARCHDIR)/klib.lds
 
-# should prob grab from platform dir
-# verify flags, borrowed from vdso build
-LDFLAGS+=	-n -pie -nostdlib -shared -DKLIB -T$(ARCHDIR)/klib.lds
+ifeq ($(ARCH),x86_64)
+CFLAGS+=	-mcmodel=kernel
+endif
 
 all: $(PROGRAMS)
 

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -17,4 +17,7 @@ LD=             $(CROSS_COMPILE)ld
 endif
 
 CFLAGS+=	$(KERNCFLAGS) -I$(CURDIR) -fPIC -DKLIB
+
+# TODO should add stack protection to klibs...
+CFLAGS+=	-fno-stack-protector
 LDFLAGS+=	-pie -nostdlib -T$(ARCHDIR)/klib.lds

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -1,0 +1,14 @@
+PROGRAMS=	test
+
+SRCS-test= \
+	$(CURDIR)/test.c
+
+CFLAGS+=	$(KERNCFLAGS) -I$(CURDIR) -fPIC
+
+# should prob grab from platform dir
+# verify flags, borrowed from vdso build
+LDFLAGS+=	-n -pie -nostdlib -shared -DKLIB -T$(ARCHDIR)/klib.lds
+
+all: $(PROGRAMS)
+
+include ../rules.mk

--- a/klib/klib.h
+++ b/klib/klib.h
@@ -3,4 +3,6 @@ enum {
     KLIB_INIT_FAILED
 };
 
+typedef void *(*klib_get_sym)(const char *name);
+
 typedef void (*klib_add_sym)(void *e, const char *a, void *v);

--- a/klib/klib.h
+++ b/klib/klib.h
@@ -1,0 +1,6 @@
+enum {
+    KLIB_INIT_OK = 0,
+    KLIB_INIT_FAILED
+};
+
+typedef void (*klib_add_sym)(void *e, const char *a, void *v);

--- a/klib/test.c
+++ b/klib/test.c
@@ -11,7 +11,9 @@ static int foo(int x)
     return z[0] + y; /* test data */
 }
 
-int init(void *md, klib_add_sym add_sym)
+void (*memset)(void *a, unsigned char b, unsigned long len);
+
+int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
 {
     /* test that bss is clear */
     for (int i = 0; i < Z_LEN; i++)
@@ -20,5 +22,12 @@ int init(void *md, klib_add_sym add_sym)
 
     add_sym(md, "foo", foo);
     add_sym(md, "bar", (void*)0);
-    return KLIB_INIT_OK;
+
+    memset = get_sym("runtime_memset");
+    if (!memset)
+        return KLIB_INIT_FAILED;
+
+    unsigned long a = -1ull;
+    memset(&a, 0, sizeof(unsigned long));
+    return a == 0 ? KLIB_INIT_OK : KLIB_INIT_FAILED;
 }

--- a/klib/test.c
+++ b/klib/test.c
@@ -1,0 +1,14 @@
+#include <klib.h>
+
+#define INVALID_ADDRESS ((void*)-1ull)
+static int foo(int x)
+{
+    return x + 123;
+}
+
+int init(void *md, klib_add_sym add_sym)
+{
+    add_sym(md, "foo", foo);
+    add_sym(md, "bar", (void*)0);
+    return KLIB_INIT_OK;
+}

--- a/klib/test.c
+++ b/klib/test.c
@@ -1,7 +1,5 @@
 #include <klib.h>
 
-#define INVALID_ADDRESS ((void*)-1ull)
-
 #define Z_LEN 1024
 
 int y = 123;

--- a/klib/test.c
+++ b/klib/test.c
@@ -1,13 +1,25 @@
 #include <klib.h>
 
 #define INVALID_ADDRESS ((void*)-1ull)
+
+#define Z_LEN 1024
+
+int y = 123;
+unsigned long z[Z_LEN];
+
 static int foo(int x)
 {
-    return x + 123;
+    z[0] = x; /* bss write */
+    return z[0] + y; /* test data */
 }
 
 int init(void *md, klib_add_sym add_sym)
 {
+    /* test that bss is clear */
+    for (int i = 0; i < Z_LEN; i++)
+        if (z[i] != 0)
+            return KLIB_INIT_FAILED;
+
     add_sym(md, "foo", foo);
     add_sym(md, "bar", (void*)0);
     return KLIB_INIT_OK;

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -144,7 +144,7 @@ INCLUDES=\
 
 AFLAGS+=-I$(ARCHDIR)/
 
-CFLAGS+=$(KERNCFLAGS) -DSTAGE3 -DKERNEL -mcmodel=kernel
+CFLAGS+=$(KERNCFLAGS) -DSTAGE3 -DKERNEL -fno-pic -mcmodel=kernel
 CFLAGS+=-Wno-address # lwIP build sadness
 CFLAGS+=$(INCLUDES)
 

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -17,6 +17,7 @@ SRCS-kernel.img= \
 	$(SRCDIR)/kernel/backed_heap.c \
 	$(SRCDIR)/kernel/elf.c \
 	$(SRCDIR)/kernel/kernel.c \
+	$(SRCDIR)/kernel/klib.c \
 	$(SRCDIR)/kernel/kvm_platform.c \
 	$(SRCDIR)/kernel/pagecache.c \
 	$(SRCDIR)/kernel/pci.c \

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -85,6 +85,7 @@ SRCS-kernel.img= \
 	$(SRCDIR)/x86_64/breakpoint.c \
 	$(SRCDIR)/x86_64/clock.c \
 	$(SRCDIR)/x86_64/crt0.s \
+	$(SRCDIR)/x86_64/elf64.c \
 	$(SRCDIR)/x86_64/flush.c \
 	$(SRCDIR)/x86_64/hpet.c \
 	$(SRCDIR)/x86_64/interrupt.c \

--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -27,7 +27,7 @@ SRCS-stage2.elf= \
 	$(SRCDIR)/tfs/tfs.c \
 	$(SRCDIR)/tfs/tlog.c
 
-CFLAGS+=	$(KERNCFLAGS) -DBOOT -DPAGE_USE_FLUSH
+CFLAGS+=	$(KERNCFLAGS) -DBOOT -DPAGE_USE_FLUSH -fno-pic
 CFLAGS+= \
 	-I$(CURDIR) \
 	-I$(SRCDIR) \

--- a/platform/pc/linker_script
+++ b/platform/pc/linker_script
@@ -52,6 +52,15 @@ SECTIONS
         *(.rodata.*)
     }
 
+    .klib_symtab ALIGN(8): AT(ADDR(.klib_symtab) - LOAD_OFFSET)
+    {
+        . = ALIGN(8);
+        klib_syms_start = .;
+        KEEP(*(.klib_symtab.syms))
+        klib_syms_end = .;
+        KEEP(*(.klib_symtab.strs))
+    }
+
     .data ALIGN(4096): AT(ADDR(.data) - LOAD_OFFSET)
     {
         *(.data)

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -250,7 +250,7 @@ static void read_kernel_syms()
 	    rprintf("kernel ELF image at 0x%lx, length %ld, mapped at 0x%lx\n",
 		    kern_base, kern_length, v);
 #endif
-	    add_elf_syms(alloca_wrap_buffer(v, kern_length));
+	    add_elf_syms(alloca_wrap_buffer(v, kern_length), 0);
             unmap(v, kern_length);
 	    break;
 	}

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -148,7 +148,7 @@ closure_function(4, 2, void, fsstarted,
     }
 
     if (klibs && !klibs_in_bootfs)
-        init_klib(&heaps, fs, root);
+        init_klib(&heaps, fs, root, root);
 
     root_fs = fs;
     enqueue(runqueue, create_init(&heaps, root, fs));

--- a/rules.mk
+++ b/rules.mk
@@ -240,8 +240,7 @@ ifeq ($(WITHOUT_SSP),)
 CFLAGS+=	-fstack-protector-strong
 ifneq ($(CC),clang)
 ifneq ($(UNAME_s),Darwin)
-KERNCFLAGS+=	-mstack-protector-guard=global \
-		-fno-pic
+KERNCFLAGS+=	-mstack-protector-guard=global
 endif
 endif
 endif

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -7,6 +7,8 @@
 // currently maps to the linux gdb frame layout for convenience
 #include "frame.h"
 
+#include "klib.h"
+
 #define HUGE_PAGESIZE 0x100000000ull
 
 typedef u64 *context;

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -1,0 +1,136 @@
+#include <kernel.h>
+#include <elf64.h>
+#include <pagecache.h>
+#include <tfs.h>
+#include <page.h>
+
+//#define KLIB_DEBUG
+#ifdef KLIB_DEBUG
+#define klib_debug(x, ...) do {log_printf("KLIB", x, ##__VA_ARGS__);} while(0)
+#else
+#define klib_debug(x, ...)
+#endif
+
+static kernel_heaps klib_kh;
+static filesystem klib_fs;
+static tuple klib_root;
+
+closure_function(1, 4, void, klib_elf_map,
+                 klib, kl,
+                 u64, vaddr, u64, paddr, u64, size, u64, flags)
+{
+    klib kl = bound(kl);
+    boolean is_bss = paddr == INVALID_PHYSICAL;
+    if (is_bss) {
+        paddr = allocate_u64((heap)heap_physical(klib_kh), size);
+        assert(paddr != INVALID_PHYSICAL);
+    }
+
+    klib_mapping km = allocate(heap_general(klib_kh), sizeof(struct klib_mapping));
+    assert(km != INVALID_ADDRESS);
+    km->n.r = irangel(vaddr, size);
+    km->phys = paddr;
+    km->flags = flags;
+
+    klib_debug("%s: kl %s, vaddr 0x%lx, paddr 0x%lx%s, size 0x%lx, flags 0x%lx\n",
+               __func__, kl->name, vaddr, paddr, is_bss ? " (bss)" : "", size, flags);
+
+    assert(rangemap_insert(kl->mappings, &km->n));
+    map(vaddr, paddr, size, flags);
+    if (is_bss)
+        zero(pointer_from_u64(vaddr), size);
+}
+
+static void add_sym(void *syms, const char *s, void *p)
+{
+    table_set((tuple)syms, sym_this(s), p ? p : INVALID_ADDRESS); /* allow zero value */
+}
+
+closure_function(2, 1, status, load_klib_complete,
+                 const char *, name, klib_handler, complete,
+                 buffer, b)
+{
+    heap h = heap_general(klib_kh);
+    klib_handler complete = bound(complete);
+    klib kl = allocate(h, sizeof(struct klib));
+    assert(kl != INVALID_ADDRESS);
+
+    /* rangemap is kind of overkill...this would be a good use for variable stride vec */
+    kl->mappings = allocate_rangemap(h);
+    if (kl->mappings == INVALID_ADDRESS) {
+        deallocate(h, kl, sizeof(struct klib));
+        return INVALID_ADDRESS;
+    }
+
+    runtime_memcpy(kl->name, bound(name), MIN(runtime_strlen(bound(name)), KLIB_MAX_NAME - 1));
+    kl->name[KLIB_MAX_NAME - 1] = '\0';
+    kl->syms = allocate_tuple();
+    kl->elf = b;
+
+    klib_debug("%s: klib %p, read length %ld\n", __func__, kl, buffer_length(b));
+    u64 where = allocate_u64((heap)heap_virtual_huge(klib_kh), HUGE_PAGESIZE);
+    assert(where != INVALID_PHYSICAL);
+
+    klib_debug("   loading elf file at 0x%lx\n", where);
+    void *entry = load_elf(b, where, stack_closure(klib_elf_map, kl));
+
+    klib_debug("   entry @ %p, first word 0x%lx\n", entry, *(u64*)entry);
+    klib_init ki = (klib_init)entry;
+    int rv = ki(kl->syms, add_sym);
+    status s = rv == KLIB_INIT_OK ? STATUS_OK :
+        timm("result", "module initialization failed with %d", rv);
+    closure_finish();
+    apply(complete, kl, s);
+    return STATUS_OK;
+}
+
+closure_function(1, 1, void, load_klib_failed,
+                 klib_handler, complete,
+                 status, s)
+{
+    klib_handler complete = bound(complete);
+    klib_debug("%s: complete %p (%F), status %v\n", __func__, complete, complete, s);
+    apply(complete, INVALID_ADDRESS, s);
+    closure_finish();
+}
+
+void load_klib(const char *name, klib_handler complete)
+{
+    // wouldn't it make more sense to just pass a buffer and status handler?
+    klib_debug("%s: \"%s\", complete %p (%F)\n", __func__, name, complete, complete);
+    if (!klib_root || !klib_fs) {
+        apply(complete, INVALID_ADDRESS, timm("result", "klib not initialized"));
+        return;
+    }
+    heap h = heap_general(klib_kh);
+    tuple md = resolve_path(klib_root, split(h, alloca_wrap_buffer(name, runtime_strlen(name)), '/'));
+    if (!md) {
+        apply(complete, INVALID_ADDRESS, timm("result", "unable to resolve module name \"%s\"", name));
+    } else {
+        filesystem_read_entire(klib_fs, md, heap_backed(klib_kh),
+                               closure(h, load_klib_complete, name, complete),
+                               closure(h, load_klib_failed, complete));
+    }
+}
+
+void unload_klib(klib kl)
+{
+    klib_debug("%s: kl %s\n", __func__, kl->name);
+    heap h = heap_general(klib_kh);
+    rangemap_foreach(kl->mappings, n) {
+        klib_mapping km = (klib_mapping)n;
+        klib_debug("   v %R, p 0x%lx, flags 0x%lx\n", km->n.r, km->phys, km->flags);
+        unmap(km->n.r.start, range_span(km->n.r));
+        deallocate(h, km, sizeof(struct klib_mapping));
+    }
+    deallocate_buffer(kl->elf);
+    deallocate_tuple(kl->syms);
+    deallocate(h, kl, sizeof(struct klib));
+}
+
+void init_klib(kernel_heaps kh, void *fs, tuple root)
+{
+    klib_kh = kh;
+    klib_fs = (filesystem)fs;
+    klib_root = root;
+}

--- a/src/kernel/klib.h
+++ b/src/kernel/klib.h
@@ -10,7 +10,7 @@ typedef struct klib_mapping {
 
 typedef struct klib {
     char name[KLIB_MAX_NAME];
-    tuple syms;
+    table syms;
     rangemap mappings;
     buffer elf;
 } *klib;

--- a/src/kernel/klib.h
+++ b/src/kernel/klib.h
@@ -1,0 +1,37 @@
+/* in-kernel loadable library interface */
+#include "../klib/klib.h"
+#define KLIB_MAX_NAME 16
+
+typedef struct klib_mapping {
+    struct rmnode n; /* virtual */
+    u64 phys;
+    u64 flags;
+} *klib_mapping;
+
+typedef struct klib {
+    char name[KLIB_MAX_NAME];
+    tuple syms;
+    rangemap mappings;
+    buffer elf;
+} *klib;
+
+typedef closure_type(klib_handler, void, klib, status);
+typedef int (*klib_init)(void *md, klib_add_sym add_sym);
+
+static inline void *klib_sym(klib kl, symbol s)
+{
+    void *p = table_find(kl->syms, s);
+    if (p == 0)
+        return INVALID_ADDRESS;
+    else if (p == INVALID_ADDRESS)
+        return 0;
+    else
+        return p;
+}
+
+void load_klib(const char *name, klib_handler complete);
+
+/* The caller must assure no references to klib remain before unloading. */
+void unload_klib(klib kl);
+
+void init_klib(kernel_heaps kh, void *fs, tuple root);

--- a/src/kernel/klib.h
+++ b/src/kernel/klib.h
@@ -16,7 +16,7 @@ typedef struct klib {
 } *klib;
 
 typedef closure_type(klib_handler, void, klib, status);
-typedef int (*klib_init)(void *md, klib_add_sym add_sym);
+typedef int (*klib_init)(void *md, klib_get_sym get_sym, klib_add_sym add_sym);
 
 static inline void *klib_sym(klib kl, symbol s)
 {
@@ -34,4 +34,4 @@ void load_klib(const char *name, klib_handler complete);
 /* The caller must assure no references to klib remain before unloading. */
 void unload_klib(klib kl);
 
-void init_klib(kernel_heaps kh, void *fs, tuple root);
+void init_klib(kernel_heaps kh, void *fs, tuple root, tuple klib_md);

--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -166,7 +166,7 @@ closure_function(0, 2, void, klib_test_loaded,
         halt("%s: sym \"bar\" should have 0 value\n", __func__);
 
     unload_klib(kl);
-    rprintf("klib test passed\n");
+    rprintf("   klib test passed\n");
     closure_finish();
     return;
 }
@@ -203,7 +203,6 @@ closure_function(3, 0, void, startup,
         rprintf("Debug http server started on port 9090\n");
     }
 #endif
-
     value p = table_find(root, sym(program));
     assert(p);
     tuple pro = resolve_path(root, split(general, p, '/'));
@@ -223,7 +222,7 @@ closure_function(2, 1, status, kernel_read_complete,
                  filesystem, fs, boolean, destroy_fs,
                  buffer, b)
 {
-    add_elf_syms(b);
+    add_elf_syms(b, 0);
     deallocate_buffer(b);
     if (bound(destroy_fs))
         destroy_filesystem(bound(fs));

--- a/src/kernel/symtab.c
+++ b/src/kernel/symtab.c
@@ -22,7 +22,8 @@ static inline elfsym allocate_elfsym(range r, char * name)
     return es;
 }
 
-closure_function(0, 4, void, elf_symtable_add,
+closure_function(1, 4, void, elf_symtable_add,
+                 u64, load_offset,
                  char *, name, u64, a, u64, len, u8, info)
 {
     int type = ELF64_ST_TYPE(info);
@@ -34,7 +35,7 @@ closure_function(0, 4, void, elf_symtable_add,
 
     assert(elf_symtable);
 
-    range r = irange(a, a + len);
+    range r = irangel(a + bound(load_offset), len);
     boolean match = rangemap_range_intersects(elf_symtable, r);
     if (match) {
 #ifdef ELF_SYMTAB_DEBUG
@@ -70,10 +71,10 @@ char * find_elf_sym(u64 a, u64 *offset, u64 *len)
     return es->name;
 }
 
-void add_elf_syms(buffer b)
+void add_elf_syms(buffer b, u64 load_offset)
 {
     if (elf_symtable)
-	elf_symbols(b, stack_closure(elf_symtable_add));
+	elf_symbols(b, stack_closure(elf_symtable_add, load_offset));
     else
 	console("can't add ELF symbols; symtab not initialized\n");
 }

--- a/src/kernel/symtab.h
+++ b/src/kernel/symtab.h
@@ -1,4 +1,4 @@
 void init_symtab(kernel_heaps kh);
-void add_elf_syms(buffer b);
+void add_elf_syms(buffer b, u64 load_offset);
 char * find_elf_sym(u64 a, u64 *offset, u64 *len);
 

--- a/src/runtime/memops.c
+++ b/src/runtime/memops.c
@@ -123,6 +123,7 @@ void runtime_memcpy(void *a, const void *b, bytes len)
         memcpyb_8(a, b, end_len);
     }
 }
+KLIB_EXPORT(runtime_memcpy);
 
 void runtime_memset(u8 *a, u8 b, bytes len)
 {
@@ -150,6 +151,8 @@ void runtime_memset(u8 *a, u8 b, bytes len)
     }
     memset_8(dest, b, end_len);
 }
+KLIB_EXPORT(runtime_memset);
+
 
 int runtime_memcmp(const void *a, const void *b, bytes len)
 {
@@ -203,3 +206,4 @@ int runtime_memcmp(const void *a, const void *b, bytes len)
     }
     return memcmp_8(a + len - end_len, p_long_b, end_len);
 }
+KLIB_EXPORT(runtime_memcmp);

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -227,3 +227,18 @@ status_handler apply_merge(merge m);
 void __stack_chk_guard_init();
 
 #define _countof(a) (sizeof(a) / sizeof(*(a)))
+
+#ifdef KERNEL
+typedef struct export_sym {
+    const char *name;
+    void *v;
+} *export_sym;
+
+#define KLIB_EXPORT(sym)                                                \
+    static const char * __attribute__((section(".klib_symtab.strs")))   \
+        __attribute__((used)) _klib_sym_str_ ##sym = #sym;              \
+    static struct export_sym __attribute__((section(".klib_symtab.syms"))) \
+        __attribute__((used)) _klib_export_sym_ ##sym = (struct export_sym){#sym, (sym)};
+#else
+#define KLIB_EXPORT(x)
+#endif

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -14,7 +14,7 @@ enum partition {
 
 #define SECTOR_OFFSET 9ULL
 #define SECTOR_SIZE (1ULL << SECTOR_OFFSET)
-#define BOOTFS_SIZE (8 * MB)
+#define BOOTFS_SIZE (12 * MB)
 #define SEC_PER_TRACK 63
 #define HEADS 255
 #define MAX_CYL 1023

--- a/src/runtime/table.c
+++ b/src/runtime/table.c
@@ -39,21 +39,20 @@ table allocate_table(heap h, u64 (*key_function)(void *x), boolean (*equals_func
 {
     table new = allocate(h, sizeof(struct table));
     if (new == INVALID_ADDRESS)
-        goto alloc_fail;
+        return new;
 
     table t = tablev(new);
     t->h = h;
     t->count = 0;
     t->buckets = 4;
     t->entries = allocate_zero(h, t->buckets * sizeof(void *));
-    if (t->entries == INVALID_ADDRESS)
-        goto alloc_fail;
+    if (t->entries == INVALID_ADDRESS) {
+        deallocate(h, new, sizeof(struct table));
+        return INVALID_ADDRESS;
+    }
     t->key_function = key_function;
     t->equals_function = equals_function;
     return new;
-
-  alloc_fail:
-    halt("allocation failure in allocate_table\n");
 }
 
 void deallocate_table(table t)

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -261,7 +261,7 @@ process exec_elf(buffer ex, process kp)
 
     if (table_find(proc->process_root, sym(ingest_program_symbols))) {
         exec_debug("ingesting symbols...\n");
-        add_elf_syms(ex);
+        add_elf_syms(ex, load_offset);
         exec_debug("...done\n");
     }
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -126,18 +126,30 @@ define_closure_function(1, 1, context, default_fault_handler,
                         thread, t,
                         context, frame)
 {
+    process p = 0;
+    u64 vaddr = fault_address(frame);
+    if (vaddr >= USER_LIMIT) {
+        rprintf("\nPage fault on non-user memory (vaddr 0x%lx)\n", vaddr);
+        goto bug;
+    }
+
+    thread current_thread = current;
+    if (!current_thread) {
+        rprintf("\nPage fault outside of thread context\n");
+        goto bug;
+    }
+
     boolean user = is_usermode_fault(frame);
 
     /* Really this should be the enclosed thread, but that won't fly
        for kernel page faults on user pages. If we were ever to
        support multiple processes, we may need to install current when
        resuming deferred processing. */
-    process p = current->p;
+    p = current_thread->p;
 
-    u64 vaddr = fault_address(frame);
     if (frame[FRAME_VECTOR] == 0) {
         if (current_cpu()->state == cpu_user) {
-            deliver_fault_signal(SIGFPE, current, vaddr, FPE_INTDIV);
+            deliver_fault_signal(SIGFPE, current_thread, vaddr, FPE_INTDIV);
             schedule_frame(frame);
             return 0;
         } else {
@@ -149,7 +161,7 @@ define_closure_function(1, 1, context, default_fault_handler,
         if (vm == INVALID_ADDRESS) {
             if (user) {
                 pf_debug("no vmap found for addr 0x%lx, rip 0x%lx", vaddr, frame[FRAME_RIP]);
-                deliver_fault_signal(SIGSEGV, current, vaddr, SEGV_MAPERR);
+                deliver_fault_signal(SIGSEGV, current_thread, vaddr, SEGV_MAPERR);
 
                 /* schedule this thread to either run signal handler or terminate */
                 schedule_frame(frame);
@@ -189,7 +201,7 @@ define_closure_function(1, 1, context, default_fault_handler,
     } else if (frame[FRAME_VECTOR] == 13) {
         if (current_cpu()->state == cpu_user) {
             pf_debug("general protection fault in user mode, rip 0x%lx", frame[FRAME_RIP]);
-            deliver_fault_signal(SIGSEGV, current, 0, SI_KERNEL);
+            deliver_fault_signal(SIGSEGV, current_thread, 0, SI_KERNEL);
             schedule_frame(frame);
             return 0;
         }
@@ -200,8 +212,9 @@ define_closure_function(1, 1, context, default_fault_handler,
     rprintf("cpu: %d\n", current_cpu()->id);
     print_frame(frame);
     print_stack(frame);
+    frame[FRAME_FULL] = 0;
 
-    if (table_find(p->process_root, sym(fault))) {
+    if (p && table_find(p->process_root, sym(fault))) {
         console("starting gdb\n");
         init_tcp_gdb(heap_general(get_kernel_heaps()), p, 9090);
         thread_sleep_uninterruptible();

--- a/src/x86_64/elf64.c
+++ b/src/x86_64/elf64.c
@@ -1,0 +1,25 @@
+#include <kernel.h>
+#include <elf64.h>
+
+#define R_X86_64_NONE       0
+#define R_X86_64_64         1
+#define R_X86_64_PC32       2
+#define R_X86_64_GOT32      3
+#define R_X86_64_PLT32      4
+#define R_X86_64_COPY       5
+#define R_X86_64_GLOB_DAT   6
+#define R_X86_64_JUMP_SLOT  7
+#define R_X86_64_RELATIVE   8
+
+void elf_apply_relocate_add(buffer elf, Elf64_Shdr *s, u64 offset)
+{
+    Elf64_Rela *rel = buffer_ref(elf, s->sh_addr);
+    for (int i = 0; i < s->sh_size / sizeof(*rel); i++) {
+        void *loc = buffer_ref(elf, rel[i].r_offset);
+        switch (ELF64_R_TYPE(rel[i].r_info)) {
+        case R_X86_64_RELATIVE:
+            *(u64 *)loc += offset;
+            break;
+        }
+    }
+}

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -4,9 +4,10 @@
 
 #define MBR_ADDRESS 0x7c00
 
-#define KERNEL_BASE 0xffffffff80000000ull
-#define KMEM_LIMIT  0xffffffff00000000ull
-#define PAGES_BASE  0xffffffffc0000000ull
+#define KERNEL_BASE  0xffffffff80000000ull
+#define KERNEL_LIMIT 0xfffffffffffff000ull
+#define KMEM_LIMIT   0xffffffff00000000ull
+#define PAGES_BASE   0xffffffffc0000000ull
 
 #define KERNEL_BASE_PHYS 0x00200000ul
 #define STACK_ALIGNMENT     16

--- a/src/x86_64/klib.lds
+++ b/src/x86_64/klib.lds
@@ -8,6 +8,8 @@ SECTIONS
         .text : { *(.text)}
         .rodata : { *(.rodata)}
 
-        .data ALIGN(4096) : { *(.data) }
-        .bss ALIGN(32): { *(.bss) }
+        .data ALIGN(4096) : { *(.data) *(.data.*) }
+        .bss ALIGN(32): { *(.bss) *(.bss.*) }
+
+        /DISCARD/ : { *(.interp) }
 }

--- a/src/x86_64/klib.lds
+++ b/src/x86_64/klib.lds
@@ -1,0 +1,13 @@
+OUTPUT_FORMAT("elf64-x86-64")
+
+ENTRY(init)
+
+SECTIONS
+{
+        . = SIZEOF_HEADERS;
+        .text : { *(.text)}
+        .rodata : { *(.rodata)}
+
+        .data ALIGN(4096) : { *(.data) }
+        .bss ALIGN(32): { *(.bss) }
+}

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -14,6 +14,7 @@ PROGRAMS= \
 	getrandom \
 	hw \
 	hws \
+	klibs \
 	io_uring \
 	mkdir \
 	mmap \
@@ -105,6 +106,9 @@ SRCS-io_uring= \
 	$(CURDIR)/io_uring.c \
 	$(SRCDIR)/unix_process/ssp.c
 LDFLAGS-io_uring=	-static
+
+SRCS-klibs=		$(CURDIR)/klibs.c
+LDFLAGS-klibs=		-static
 
 SRCS-mmap= \
 	$(CURDIR)/mmap.c \

--- a/test/runtime/klibs.c
+++ b/test/runtime/klibs.c
@@ -1,0 +1,10 @@
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+    /* simply wait a second for async bootfs open / klib read and test */
+    sleep(1);
+    return EXIT_SUCCESS;
+}
+

--- a/test/runtime/klibs.manifest
+++ b/test/runtime/klibs.manifest
@@ -1,0 +1,25 @@
+(
+    boot:(
+          children:(
+                    kernel:(contents:(host:output/platform/pc/bin/kernel.img))
+                    klib:(children:(test:(contents:(host:output/klib/bin/test))))
+                    )
+          )
+    children:(
+              #user program
+	      klibs:(contents:(host:output/test/runtime/bin/klibs))
+	      etc:(children:(ld.so.cache:(contents:(host:/etc/ld.so.cache))))
+	      lib:(children:(x86_64-linux-gnu:(children:(libc.so.6:(contents:(host:/lib/x86_64-linux-gnu/libc.so.6))))))
+	      lib64:(children:(ld-linux-x86-64.so.2:(contents:(host:/lib64/ld-linux-x86-64.so.2))))
+	      )
+    # filesystem path to elf for kernel to run
+    program:/klibs
+#    trace:t
+#    debugsyscalls:t
+#    futex_trace:t    
+    fault:t
+    klibs:bootfs
+    klib_test:t
+    arguments:[klibs poppy]
+    environment:(USER:bobby PWD:/)
+)

--- a/test/runtime/klibs.manifest
+++ b/test/runtime/klibs.manifest
@@ -1,7 +1,6 @@
 (
     boot:(
           children:(
-                    kernel:(contents:(host:output/platform/pc/bin/kernel.img))
                     klib:(children:(test:(contents:(host:output/klib/bin/test))))
                     )
           )

--- a/test/runtime/write.manifest
+++ b/test/runtime/write.manifest
@@ -11,5 +11,5 @@
 #    arguments:[write -p]
     environment:(USER:bobby PWD:/)
     exec_protection:t
-    imagesize:30M
+    imagesize:64M
 )


### PR DESCRIPTION
These changes introduce dynamically-loadable library modules ("klibs") into the kernel. Klibs are statically-built, PIE ELF binaries located in either the root or boot filesystems (specified in manifest) and may be loaded (and unloaded) on demand.

The loading process does not perform explicit dynamic linking into the kernel, instead favoring a dlopen-style interface for resolving symbols by name. Symbols exported from the kernel (using the KLIB_EXPORT macro) are resolved in the klib by name using a "get_sym" method passed as an argument to the module init function. An "add_sym" method is used to export symbols from the klib. These are resolved within the kernel using klib_sym().

This interface is designed to allow the loading of optional components, e.g. crypto libraries, without needing to link them directly into the kernel.

Other notes / fixes:

- Note that module loading is an asynchronous operation (which may also follow asynchronous mounting of the boot filesystem if klibs are placed there). This may occur after other kernel initialization and program start have occurred. This is the reason for the "sleep(1)" call in the klibs runtime test; without it, the VM exits before the boot filesystem finishes mounting. It may be necessary to hold up program start until this process has finished if, for some reason, a klib needs to be initialized before the program executes.
- A load_offset argument was added to add_elf_syms() to accommodate PIE executables and ASLR. (Note that the klib code reads in the elf symbols for extra context on a crash, not for resolving calls into the kmod by symbol name.)
- The unix default_fault_handler was not acting appropriately for faults on kernel addresses or when a thread context was not available. This was fixed to allow a more graceful crash dump and shutdown on an unrecoverable fault in the kernel.
- BOOTFS_SIZE needed to be expanded to accommodate the test klib. It will likely need to grow more as larger klibs are included. Perhaps we could look at a way to set this size dynamically according to staged content.
