### PR TITLE
Convert IPv4-mapped IPv6 addresses to IPv4 for LwIP

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -275,6 +275,14 @@ static sysreturn sockaddr_to_addrport(int af, struct sockaddr *addr,
             return -EINVAL;
         struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)addr;
         sockaddr_to_ip6addr(sin6, ip_addr);
+        /* If this is an an IPv4 mapped address then this socket
+           is dual-stack, so convert the address to IPv4 to encourage
+           LwIP to use that transport
+        */
+        if (ip6_addr_isipv4mappedipv6(ip_2_ip6(ip_addr))) {
+            unmap_ipv4_mapped_ipv6(ip_2_ip4(ip_addr), ip_2_ip6(ip_addr));
+            IP_SET_TYPE_VAL(*ip_addr, IPADDR_TYPE_V4);
+        }
         *port = ntohs(sin6->port);
     }
     return 0;


### PR DESCRIPTION
A socket opened as AF_INET6 but with the any address accepts IPv4 and
IPv6 connections (dual-stack) but the address is always stored in IPv6
format. An IPv4-mapped address in a dual-stack configuration
implies using IPv4 for transport. LwIP doesn't convert for UDP, so this
patch will convert the IPv4-mapped address into an IPv4 address before
passing it along to LwIP so that it will use IPv4 for transport.