### PR TITLE
Add telemetry functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CLEANFILES+=	$(IMAGE)
 CLEANDIRS+=	$(OUTDIR)/image $(OUTDIR)/platform/$(PLATFORM) $(OUTDIR)/platform
 
 LWIPDIR=	$(VENDORDIR)/lwip
-GITFLAGS+=	--depth 1  https://github.com/nanovms/lwip.git -b STABLE-2_1_2_RELEASE
+MBEDTLS_DIR=	$(VENDORDIR)/mbedtls
 
 # VMware
 QEMU_IMG=	qemu-img
@@ -38,11 +38,16 @@ all: image
 
 include rules.mk
 
-image: $(LWIPDIR)/.vendored tools
+THIRD_PARTY= $(LWIPDIR)/.vendored $(MBEDTLS_DIR)/.vendored
+
+$(LWIPDIR)/.vendored: GITFLAGS= --depth 1  https://github.com/nanovms/lwip.git -b STABLE-2_1_2_RELEASE
+$(MBEDTLS_DIR)/.vendored: GITFLAGS= --depth 1 https://github.com/nanovms/mbedtls.git
+
+image: $(THIRD_PARTY) tools
 	$(Q) $(MAKE) -C klib
 	$(Q) $(MAKE) -C $(PLATFORMDIR) image TARGET=$(TARGET)
 
-release: $(LWIPDIR)/.vendored mkfs
+release: $(THIRD_PARTY) mkfs
 	$(Q) $(MAKE) -C $(PLATFORMDIR) boot
 	$(Q) $(MAKE) -C $(PLATFORMDIR) kernel
 	$(Q) $(RM) -r release

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -1,7 +1,101 @@
-PROGRAMS=	test
+LWIPDIR=		$(VENDORDIR)/lwip
+MBEDTLS_DIR=	$(VENDORDIR)/mbedtls
+
+PROGRAMS= \
+	radar \
+	test \
+	tls \
+
+SRCS-radar= \
+	$(CURDIR)/radar.c \
 
 SRCS-test= \
 	$(CURDIR)/test.c
+
+SRCS-tls= \
+	$(CURDIR)/mbedtls.c \
+	$(SRCS-mbedtls)
+
+SRCS-mbedtls= $(SRCS-mbedtls-crypto) $(SRCS-mbedtls-x509) $(SRCS-mbedtls-tls)
+
+SRCS-mbedtls-crypto= \
+	$(MBEDTLS_DIR)/library/aes.c \
+	$(MBEDTLS_DIR)/library/arc4.c \
+	$(MBEDTLS_DIR)/library/aria.c \
+	$(MBEDTLS_DIR)/library/asn1parse.c \
+	$(MBEDTLS_DIR)/library/asn1write.c \
+	$(MBEDTLS_DIR)/library/base64.c \
+	$(MBEDTLS_DIR)/library/bignum.c \
+	$(MBEDTLS_DIR)/library/blowfish.c \
+	$(MBEDTLS_DIR)/library/camellia.c \
+	$(MBEDTLS_DIR)/library/ccm.c \
+	$(MBEDTLS_DIR)/library/chacha20.c \
+	$(MBEDTLS_DIR)/library/chachapoly.c \
+	$(MBEDTLS_DIR)/library/cipher.c \
+	$(MBEDTLS_DIR)/library/cipher_wrap.c \
+	$(MBEDTLS_DIR)/library/cmac.c \
+	$(MBEDTLS_DIR)/library/ctr_drbg.c \
+	$(MBEDTLS_DIR)/library/des.c \
+	$(MBEDTLS_DIR)/library/dhm.c \
+	$(MBEDTLS_DIR)/library/ecdh.c \
+	$(MBEDTLS_DIR)/library/ecdsa.c \
+	$(MBEDTLS_DIR)/library/ecjpake.c \
+	$(MBEDTLS_DIR)/library/ecp.c \
+	$(MBEDTLS_DIR)/library/ecp_curves.c \
+	$(MBEDTLS_DIR)/library/entropy.c \
+	$(MBEDTLS_DIR)/library/entropy_poll.c \
+	$(MBEDTLS_DIR)/library/gcm.c \
+	$(MBEDTLS_DIR)/library/havege.c \
+	$(MBEDTLS_DIR)/library/hkdf.c \
+	$(MBEDTLS_DIR)/library/hmac_drbg.c \
+	$(MBEDTLS_DIR)/library/md.c \
+	$(MBEDTLS_DIR)/library/md2.c \
+	$(MBEDTLS_DIR)/library/md4.c \
+	$(MBEDTLS_DIR)/library/md5.c \
+	$(MBEDTLS_DIR)/library/memory_buffer_alloc.c \
+	$(MBEDTLS_DIR)/library/nist_kw.c \
+	$(MBEDTLS_DIR)/library/oid.c \
+	$(MBEDTLS_DIR)/library/padlock.c \
+	$(MBEDTLS_DIR)/library/pem.c \
+	$(MBEDTLS_DIR)/library/pk.c \
+	$(MBEDTLS_DIR)/library/pk_wrap.c \
+	$(MBEDTLS_DIR)/library/pkcs12.c \
+	$(MBEDTLS_DIR)/library/pkcs5.c \
+	$(MBEDTLS_DIR)/library/pkparse.c \
+	$(MBEDTLS_DIR)/library/pkwrite.c \
+	$(MBEDTLS_DIR)/library/platform.c \
+	$(MBEDTLS_DIR)/library/platform_util.c \
+	$(MBEDTLS_DIR)/library/poly1305.c \
+	$(MBEDTLS_DIR)/library/psa_crypto.c \
+	$(MBEDTLS_DIR)/library/psa_crypto_se.c \
+	$(MBEDTLS_DIR)/library/psa_crypto_slot_management.c \
+	$(MBEDTLS_DIR)/library/psa_its_file.c \
+	$(MBEDTLS_DIR)/library/ripemd160.c \
+	$(MBEDTLS_DIR)/library/rsa.c \
+	$(MBEDTLS_DIR)/library/rsa_internal.c \
+	$(MBEDTLS_DIR)/library/sha1.c \
+	$(MBEDTLS_DIR)/library/sha256.c \
+	$(MBEDTLS_DIR)/library/sha512.c \
+	$(MBEDTLS_DIR)/library/threading.c \
+	$(MBEDTLS_DIR)/library/version.c \
+	$(MBEDTLS_DIR)/library/version_features.c \
+	$(MBEDTLS_DIR)/library/xtea.c \
+
+SRCS-mbedtls-x509= \
+	$(MBEDTLS_DIR)/library/certs.c \
+	$(MBEDTLS_DIR)/library/pkcs11.c \
+	$(MBEDTLS_DIR)/library/x509.c \
+	$(MBEDTLS_DIR)/library/x509_crt.c \
+
+SRCS-mbedtls-tls= \
+	$(MBEDTLS_DIR)/library/ssl_cache.c \
+	$(MBEDTLS_DIR)/library/ssl_ciphersuites.c \
+	$(MBEDTLS_DIR)/library/ssl_cli.c \
+	$(MBEDTLS_DIR)/library/ssl_cookie.c \
+	$(MBEDTLS_DIR)/library/ssl_msg.c \
+	$(MBEDTLS_DIR)/library/ssl_srv.c \
+	$(MBEDTLS_DIR)/library/ssl_ticket.c \
+	$(MBEDTLS_DIR)/library/ssl_tls.c \
 
 all: $(PROGRAMS)
 
@@ -16,7 +110,22 @@ else
 LD=             $(CROSS_COMPILE)ld
 endif
 
-CFLAGS+=	$(KERNCFLAGS) -I$(CURDIR) -fPIC -DKLIB
+INCLUDES= \
+	-I$(CURDIR) \
+	-I$(ARCHDIR) \
+	-I$(LWIPDIR)/src/include \
+	-I$(MBEDTLS_DIR)/include \
+	-I$(SRCDIR) \
+	-I$(SRCDIR)/http \
+	-I$(SRCDIR)/kernel \
+	-I$(SRCDIR)/net \
+	-I$(SRCDIR)/runtime \
+
+DEFINES= \
+	-DKLIB \
+	-DMBEDTLS_USER_CONFIG_FILE=\"mbedtls_conf.h\" \
+
+CFLAGS+=	$(KERNCFLAGS) $(INCLUDES) -fPIC $(DEFINES)
 
 # TODO should add stack protection to klibs...
 CFLAGS+=	-fno-stack-protector

--- a/klib/mbedtls.c
+++ b/klib/mbedtls.c
@@ -1,0 +1,323 @@
+#include <kernel.h>
+#include <lwip.h>
+
+#define _RUNTIME_H_ /* guard against double inclusion of runtime.h */
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ssl.h>
+
+declare_closure_struct(1, 1, buffer_handler, tls_conn_handler,
+                       struct tls_conn *, conn,
+                       buffer_handler, out);
+declare_closure_struct(1, 1, status, tls_in_handler,
+                       struct tls_conn *, conn,
+                       buffer, b);
+declare_closure_struct(1, 1, status, tls_out_handler,
+                       struct tls_conn *, conn,
+                       buffer, b);
+
+typedef struct tls_conn {
+    mbedtls_ssl_context ssl;
+    closure_struct(tls_conn_handler, ch);
+    closure_struct(tls_in_handler, in);
+    buffer_handler out;
+    connection_handler app_ch;
+    buffer_handler app_in;
+    closure_struct(tls_out_handler, app_out);
+    buffer incoming, outgoing;
+    enum {
+        tls_handshake,
+        tls_open,
+        tls_closing,
+    } state;
+} *tls_conn;
+
+struct kern_funcs kern_funcs;
+
+static struct {
+    mbedtls_ssl_config conf;
+    mbedtls_ctr_drbg_context ctr_drbg;
+    mbedtls_entropy_context entropy;
+    mbedtls_x509_crt cacert;
+    void (*rprintf)(const char *format, ...);
+    status (*direct_connect)(heap h, ip_addr_t *addr, u16 port, connection_handler ch);
+    tuple (*timm_alloc)(char *name, ...);
+    void (*timm_dealloc)(tuple t);
+    u64 (*random_buffer)(buffer b);
+    struct tm *(*gmtime_r)(const long *timep, struct tm *result);
+    heap h;
+} tls;
+
+static void tls_close(tls_conn conn)
+{
+    if (conn->app_in) {
+        apply(conn->app_in, 0); /* notify connection shutdown to application layer */
+        conn->app_in = 0;
+    } else if (conn->app_ch) {
+        apply(conn->app_ch, 0); /* notify connection failure to application layer */
+        conn->app_ch = 0;
+    }
+    if (conn->out) {
+        buffer_handler out = conn->out;
+        conn->out = 0;
+        apply(out, 0);  /* close underlying TCP connection */
+    } else {
+        mbedtls_ssl_free(&conn->ssl);
+        deallocate(tls.h, conn, sizeof(*conn));
+    }
+}
+
+static int tls_send(void *ctx, const unsigned char *buf, size_t len)
+{
+    tls_conn conn = ctx;
+    if (!conn->out)
+        return MBEDTLS_ERR_SSL_CONN_EOF;
+    buffer b = wrap_buffer(tls.h, (void *)buf, len);
+    if (b == INVALID_ADDRESS)
+        return MBEDTLS_ERR_SSL_ALLOC_FAILED;
+    status s = apply(conn->out, b);
+    if (!is_ok(s)) {
+        tls.timm_dealloc(s);
+        deallocate_buffer(b);
+        return MBEDTLS_ERR_SSL_ALLOC_FAILED;
+    }
+    return len;
+}
+
+static int tls_recv(void *ctx, unsigned char *buf, size_t len)
+{
+    tls_conn conn = ctx;
+    if (!conn->incoming || (buffer_length(conn->incoming) == 0))
+        return MBEDTLS_ERR_SSL_WANT_READ;
+    len = MIN(buffer_length(conn->incoming), len);
+    kern_funcs.memcopy(buf, buffer_ref(conn->incoming, 0), len);
+    buffer_consume(conn->incoming, len);
+    return len;
+}
+
+static int tls_out_internal(tls_conn conn, buffer b)
+{
+    if (!b)
+        b = conn->outgoing;
+    int ret = mbedtls_ssl_write(&conn->ssl, buffer_ref(b, 0), buffer_length(b));
+    if (ret > 0) {
+        buffer_consume(b, ret);
+    } else if ((ret != MBEDTLS_ERR_SSL_WANT_READ) && (ret != MBEDTLS_ERR_SSL_WANT_WRITE)) {
+        tls_close(conn);
+        deallocate_buffer(b);
+        return -1;
+    }
+    if (buffer_length(b) == 0) {
+        deallocate_buffer(b);
+        if (b == conn->outgoing)
+            conn->outgoing = 0;
+    } else {
+        conn->outgoing = b;
+    }
+    return ret;
+}
+
+define_closure_function(1, 1, status, tls_out_handler,
+                        struct tls_conn *, conn,
+                        buffer, b)
+{
+    tls_conn conn = bound(conn);
+    if (b) {
+        tls_out_internal(conn, b);
+    } else {    /* application requested connection shutdown */
+        int ret = mbedtls_ssl_close_notify(&conn->ssl);
+        if ((ret == MBEDTLS_ERR_SSL_WANT_READ) || (ret == MBEDTLS_ERR_SSL_WANT_WRITE))
+            conn->state = tls_closing;
+        else
+            tls_close(conn);
+    }
+    return STATUS_OK;
+}
+
+define_closure_function(1, 1, status, tls_in_handler,
+                        struct tls_conn *, conn,
+                        buffer, b)
+{
+    tls_conn conn = bound(conn);
+    if (!b) {   /* underlying TCP connection closed */
+        conn->out = 0;
+        goto conn_close;
+    }
+    conn->incoming = b;
+    int ret;
+    switch (conn->state) {
+    case tls_handshake:
+        ret = mbedtls_ssl_handshake(&conn->ssl);
+        if (ret == 0) {
+            conn->state = tls_open;
+            conn->app_in = apply(conn->app_ch, init_closure(&conn->app_out, tls_out_handler, conn));
+            conn->app_ch = 0;   /* so that it is not invoked when the connection is closed */
+            if (!conn->app_in)  /* application-level error */
+                goto conn_close;
+        } else if ((ret != MBEDTLS_ERR_SSL_WANT_READ) && (ret != MBEDTLS_ERR_SSL_WANT_WRITE)) {
+            goto conn_close;
+        }
+        break;
+    case tls_open:
+        b = little_stack_buffer(512);
+        ret = mbedtls_ssl_read(&conn->ssl, buffer_ref(b, 0), b->length);
+        if (ret > 0) {
+            buffer_produce(b, ret);
+            if (conn->app_in) {
+                status s = apply(conn->app_in, b);
+                if (!is_ok(s))
+                    return s;
+            }
+        } else if ((ret != MBEDTLS_ERR_SSL_WANT_READ) && (ret != MBEDTLS_ERR_SSL_WANT_WRITE)) {
+            goto conn_close;
+        }
+        if (conn->outgoing && (tls_out_internal(conn, 0) < 0))
+            /* An error happened and the connection has been closed. */
+            return tls.timm_alloc("result", "failed to send outgoing data");
+        break;
+    case tls_closing:
+        ret = mbedtls_ssl_close_notify(&conn->ssl);
+        if ((ret != MBEDTLS_ERR_SSL_WANT_READ) && (ret != MBEDTLS_ERR_SSL_WANT_WRITE))
+            goto conn_close;
+        break;
+    }
+    conn->incoming = 0;
+    return STATUS_OK;
+  conn_close:
+    tls_close(conn);
+    return tls.timm_alloc("result", "connection closed");
+}
+
+define_closure_function(1, 1, buffer_handler, tls_conn_handler,
+                        struct tls_conn *, conn,
+                        buffer_handler, out)
+{
+    tls_conn conn = bound(conn);
+    conn->out = out;
+    if (!out)   /* TCP connection failed */
+        goto conn_close;
+    buffer_handler in = init_closure(&conn->in, tls_in_handler, conn);
+    mbedtls_ssl_set_bio(&conn->ssl, conn, tls_send, tls_recv, NULL);
+    conn->state = tls_handshake;
+    int ret = mbedtls_ssl_handshake(&conn->ssl);
+    if ((ret != 0) && (ret != MBEDTLS_ERR_SSL_WANT_READ) && (ret != MBEDTLS_ERR_SSL_WANT_WRITE))
+        goto conn_close;
+    return in;
+  conn_close:
+    tls_close(conn);
+    return 0;
+}
+
+static int tls_set_cacert(void *cert, u64 len)
+{
+    mbedtls_x509_crt_init(&tls.cacert);
+    int ret = mbedtls_x509_crt_parse(&tls.cacert, cert, len);
+    if (ret < 0) {
+        tls.rprintf("%s: cannot parse certificate (%d)\n", __func__, ret);
+        return ret;
+    }
+    mbedtls_ssl_conf_ca_chain(&tls.conf, &tls.cacert, NULL);
+    mbedtls_ssl_conf_authmode(&tls.conf, MBEDTLS_SSL_VERIFY_REQUIRED);
+    return ret;
+}
+
+static int tls_connect(ip_addr_t *addr, u16 port, connection_handler ch)
+{
+    tls_conn conn = allocate(tls.h, sizeof(*conn));
+    if (conn == INVALID_ADDRESS)
+        return -1;
+    mbedtls_ssl_init(&conn->ssl);
+    int ret = mbedtls_ssl_setup(&conn->ssl, &tls.conf);
+    if (ret) {
+        tls.rprintf("%s: cannot set up SSL context\n", __func__);
+        goto err_ssl_setup;
+    }
+    conn->app_ch = ch;
+    conn->app_in = 0;
+    conn->incoming = conn->outgoing = 0;
+    status s = tls.direct_connect(tls.h, addr, port,
+        init_closure(&conn->ch, tls_conn_handler, conn));
+    if (!is_ok(s)) {
+        tls.timm_dealloc(s);
+        ret = -1;
+        goto err_connect;
+    }
+    return 0;
+  err_connect:
+    mbedtls_ssl_free(&conn->ssl);
+  err_ssl_setup:
+    deallocate(tls.h, conn, sizeof(*conn));
+    return ret;
+}
+
+int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
+{
+    tls.rprintf = get_sym("rprintf");
+    if (!tls.rprintf)
+        return KLIB_INIT_FAILED;
+    void *(*get_kernel_heaps)(void) = get_sym("get_kernel_heaps");
+    if (!get_kernel_heaps || !(kern_funcs.memset = get_sym("runtime_memset")) ||
+            !(kern_funcs.memcopy = get_sym("runtime_memcpy")) ||
+            !(kern_funcs.memcmp = get_sym("runtime_memcmp")) ||
+            !(kern_funcs.strcmp_f = get_sym("runtime_strcmp")) ||
+            !(kern_funcs.strstr_f = get_sym("runtime_strstr")) ||
+            !(kern_funcs.time_f = get_sym("rtime")) ||
+            !(kern_funcs.rsnprintf = get_sym("rsnprintf")) ||
+            !(tls.direct_connect = get_sym("direct_connect")) ||
+            !(tls.timm_alloc = get_sym("timm")) ||
+            !(tls.timm_dealloc = get_sym("timm_dealloc")) ||
+            !(tls.random_buffer = get_sym("random_buffer")) ||
+            !(tls.gmtime_r = get_sym("gmtime_r"))) {
+        tls.rprintf("TLS init: kernel symbols not found\n");
+        return KLIB_INIT_FAILED;
+    }
+    tls.h = heap_general(get_kernel_heaps());
+    mbedtls_ssl_config_init(&tls.conf);
+    mbedtls_ctr_drbg_init(&tls.ctr_drbg);
+    mbedtls_entropy_init(&tls.entropy);
+    if (mbedtls_ctr_drbg_seed(&tls.ctr_drbg, mbedtls_entropy_func, &tls.entropy, 0, 0)) {
+        tls.rprintf("TLS init: cannot seed entropy source\n");
+        return KLIB_INIT_FAILED;
+    }
+    mbedtls_ssl_config_defaults(&tls.conf, MBEDTLS_SSL_IS_CLIENT,
+        MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT);
+    mbedtls_ssl_conf_authmode(&tls.conf, MBEDTLS_SSL_VERIFY_NONE);
+    mbedtls_ssl_conf_rng(&tls.conf, mbedtls_ctr_drbg_random, &tls.ctr_drbg);
+    add_sym(md, "tls_set_cacert", tls_set_cacert);
+    add_sym(md, "tls_connect", tls_connect);
+    return KLIB_INIT_OK;
+}
+
+void mbedtls_platform_zeroize( void *buf, size_t len )
+{
+#undef memset   // due to lwip_memset()
+    kern_funcs.memset(buf, 0, len);
+}
+
+void *mbedtls_calloc(size_t n, size_t s)
+{
+    void *p = allocate(tls.h, n * s);
+    if (p != INVALID_ADDRESS) {
+        kern_funcs.memset(p, 0, n * s);
+        return p;
+    } else {
+        return 0;
+    }
+}
+
+void mbedtls_free(void *x)
+{
+    if (x)
+        deallocate(tls.h, x, -1ull);
+}
+
+int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen)
+{
+    *olen = tls.random_buffer(alloca_wrap_buffer(output, len));
+    return 0;
+}
+
+struct tm *mbedtls_platform_gmtime_r(const mbedtls_time_t *tt, struct tm *tm_buf)
+{
+    return tls.gmtime_r(tt, tm_buf);
+}

--- a/klib/mbedtls_conf.h
+++ b/klib/mbedtls_conf.h
@@ -1,0 +1,73 @@
+#ifndef _RUNTIME_H_
+#include <runtime.h>
+#endif
+
+#define NULL    ((void *)0)
+
+#define CHAR_BIT    8
+
+#define INT_MAX     0x7fffffff
+#define UINT_MAX    0xffffffff
+#define SIZE_MAX    0x7fffffffffffffffll
+
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef short int16_t;
+typedef unsigned short uint16_t;
+typedef int int32_t;
+typedef unsigned int uint32_t;
+typedef long int64_t;
+typedef unsigned long uint64_t;
+
+typedef unsigned long size_t;
+typedef unsigned long uintptr_t;
+
+struct tm {
+    int tm_year;
+    uint8_t tm_mon;
+    uint8_t tm_mday;
+    uint8_t tm_hour;
+    uint8_t tm_min;
+    uint8_t tm_sec;
+};
+
+extern struct kern_funcs {
+    void (*memset)(void *a, unsigned char b, unsigned long len);
+    void (*memcopy)(void *a, const void *b, unsigned long len);
+    int (*memcmp)(const void *a, const void *b, unsigned long len);
+    int (*strcmp_f)(const char *string1, const char *string2);
+    char *(*strstr_f)(const char *haystack, const char *needle);
+    long (*time_f)(long *result);
+    int (*rsnprintf)(char *str, u64 size, const char *fmt, ...);
+} kern_funcs;
+
+#define MBEDTLS_PLATFORM_CALLOC_MACRO       mbedtls_calloc
+#define MBEDTLS_PLATFORM_FREE_MACRO         mbedtls_free
+#define MBEDTLS_PLATFORM_TIME_MACRO         kern_funcs.time_f
+#define MBEDTLS_PLATFORM_TIME_TYPE_MACRO    long
+#define MBEDTLS_PLATFORM_SNPRINTF_MACRO     kern_funcs.rsnprintf
+
+void *mbedtls_calloc(size_t n, size_t s);
+void mbedtls_free(void *ptr);
+
+#ifndef memset
+#define memset  kern_funcs.memset
+#endif
+#ifndef memcpy
+#define memcpy  kern_funcs.memcopy
+#endif
+#ifndef memmove
+#define memmove kern_funcs.memcopy
+#endif
+#ifndef memcmp
+#define memcmp  kern_funcs.memcmp
+#endif
+#ifndef strlen
+#define strlen  runtime_strlen
+#endif
+#ifndef strcmp
+#define strcmp  kern_funcs.strcmp_f
+#endif
+#ifndef strstr
+#define strstr  kern_funcs.strstr_f
+#endif

--- a/klib/radar.c
+++ b/klib/radar.c
@@ -1,0 +1,220 @@
+#include <kernel.h>
+#include <http.h>
+#include <lwip.h>
+
+#define RADAR_HOSTNAME  "radar.relayered.net"
+
+#define RADAR_IP_1  34
+#define RADAR_IP_2  94
+#define RADAR_IP_3  88
+#define RADAR_IP_4  162
+
+#define RADAR_PORT      443
+
+#define RADAR_CA_CERT   "-----BEGIN CERTIFICATE-----\n\
+MIIE0DCCA7igAwIBAgIBBzANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx\
+EDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT\
+EUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp\
+ZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTExMDUwMzA3MDAwMFoXDTMxMDUwMzA3\
+MDAwMFowgbQxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH\
+EwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjEtMCsGA1UE\
+CxMkaHR0cDovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkvMTMwMQYDVQQD\
+EypHbyBEYWRkeSBTZWN1cmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIwggEi\
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC54MsQ1K92vdSTYuswZLiBCGzD\
+BNliF44v/z5lz4/OYuY8UhzaFkVLVat4a2ODYpDOD2lsmcgaFItMzEUz6ojcnqOv\
+K/6AYZ15V8TPLvQ/MDxdR/yaFrzDN5ZBUY4RS1T4KL7QjL7wMDge87Am+GZHY23e\
+cSZHjzhHU9FGHbTj3ADqRay9vHHZqm8A29vNMDp5T19MR/gd71vCxJ1gO7GyQ5HY\
+pDNO6rPWJ0+tJYqlxvTV0KaudAVkV4i1RFXULSo6Pvi4vekyCgKUZMQWOlDxSq7n\
+eTOvDCAHf+jfBDnCaQJsY1L6d8EbyHSHyLmTGFBUNUtpTrw700kuH9zB0lL7AgMB\
+AAGjggEaMIIBFjAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNV\
+HQ4EFgQUQMK9J47MNIMwojPX+2yz8LQsgM4wHwYDVR0jBBgwFoAUOpqFBxBnKLbv\
+9r0FQW4gwZTaD94wNAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8v\
+b2NzcC5nb2RhZGR5LmNvbS8wNQYDVR0fBC4wLDAqoCigJoYkaHR0cDovL2NybC5n\
+b2RhZGR5LmNvbS9nZHJvb3QtZzIuY3JsMEYGA1UdIAQ/MD0wOwYEVR0gADAzMDEG\
+CCsGAQUFBwIBFiVodHRwczovL2NlcnRzLmdvZGFkZHkuY29tL3JlcG9zaXRvcnkv\
+MA0GCSqGSIb3DQEBCwUAA4IBAQAIfmyTEMg4uJapkEv/oV9PBO9sPpyIBslQj6Zz\
+91cxG7685C/b+LrTW+C05+Z5Yg4MotdqY3MxtfWoSKQ7CC2iXZDXtHwlTxFWMMS2\
+RJ17LJ3lXubvDGGqv+QqG+6EnriDfcFDzkSnE3ANkR/0yBOtg2DZ2HKocyQetawi\
+DsoXiWJYRBuriSUBAA/NxBti21G00w9RKpv0vHP8ds42pM3Z2Czqrpv1KrKQ0U11\
+GIo/ikGQI31bS/6kA1ibRrLDYGCD+H1QQc7CoZDDu+8CL9IVVO5EFdkKrqeKM+2x\
+LXY2JtwE65/3YR8V3Idv7kaWKK2hJn0KCacuBKONvPi8BDAB\
+-----END CERTIFICATE-----"
+
+declare_closure_struct(0, 1, void, boot_timer_func,
+    u64, overruns);
+
+static struct telemetry {
+    heap h;
+    tuple env;
+    buffer auth_header;
+    s64 boot_id;
+    timestamp boot_backoff;
+    closure_struct(boot_timer_func, boot_func);
+    tuple (*allocate_tuple)(void);
+    void (*table_set)(table z, void *c, void *v);
+    void *(*table_find)(table z, void *c);
+    void (*deallocate_table)(table t);
+    void (*timm_dealloc)(tuple t);
+    symbol (*intern)(string name);
+    void *(*klib_sym)(klib kl, symbol s);
+    buffer (*allocate_buffer)(heap h, bytes s);
+    void (*buffer_write)(buffer b, const void *source, bytes length);
+    void (*bprintf)(buffer b, const char *fmt, ...);
+    timer (*register_timer)(clock_id id, timestamp val, boolean absolute,
+            timestamp interval, timer_handler n);
+    status (*http_request)(heap h, buffer_handler bh, http_method method,
+            tuple headers, buffer body);
+    int (*tls_connect)(ip_addr_t *addr, u16 port, connection_handler ch);
+} telemetry;
+
+#undef sym
+#define sym(name)   sym_intern(name, telemetry.intern)
+
+#define kfunc(name) telemetry.name
+
+/* To be used with literal strings only */
+#define buffer_write_cstring(b, s)  kfunc(buffer_write)(b, s, sizeof(s) - 1)
+
+static void telemetry_boot(void);
+
+static boolean telemetry_req(const char *url, buffer data, buffer_handler bh)
+{
+    tuple req = kfunc(allocate_tuple)();
+    if (req == INVALID_ADDRESS)
+        return false;
+    kfunc(table_set)(req, sym(url), alloca_wrap_cstring(url));
+    kfunc(table_set)(req, sym(Host), alloca_wrap_cstring(RADAR_HOSTNAME));
+    kfunc(table_set)(req, sym(Authorization), telemetry.auth_header);
+    kfunc(table_set)(req, sym(Content-Type), alloca_wrap_cstring("application/json"));
+    status s = kfunc(http_request)(telemetry.h, bh, HTTP_REQUEST_METHOD_POST, req, data);
+    kfunc(deallocate_table)(req);
+    if (is_ok(s)) {
+        return true;
+    } else {
+        kfunc(timm_dealloc)(s);
+        return false;
+    }
+}
+
+closure_function(1, 1, status, telemetry_recv,
+                 buffer_handler, out,
+                 buffer, data)
+{
+    if (data)
+        apply(bound(out), 0);   /* close connection */
+    else   /* connection closed */
+        closure_finish();
+    return STATUS_OK;
+}
+
+closure_function(2, 1, buffer_handler, telemetry_ch,
+                 const char *, url, buffer, data,
+                 buffer_handler, out)
+{
+    buffer data = bound(data);
+    buffer_handler in = 0;
+    if (out) {
+        boolean success = telemetry_req(bound(url), data, out);
+        if (success)
+            in = closure(telemetry.h, telemetry_recv, out);
+        else
+            deallocate_buffer(data);
+    } else {    /* connection failed */
+        deallocate_buffer(data);
+    }
+    closure_finish();
+    return in;
+}
+
+boolean telemetry_send(const char *url, buffer data)
+{
+    connection_handler ch = closure(telemetry.h, telemetry_ch, url, data);
+    if (ch == INVALID_ADDRESS)
+        return false;
+    ip_addr_t radar_addr = IPADDR4_INIT_BYTES(RADAR_IP_1, RADAR_IP_2, RADAR_IP_3, RADAR_IP_4);
+    return (telemetry.tls_connect(&radar_addr, RADAR_PORT, ch) == 0);
+}
+
+define_closure_function(0, 1, void, boot_timer_func,
+                        u64, overruns)
+{
+    telemetry_boot();
+}
+
+static void telemetry_boot(void)
+{
+    buffer b = kfunc(allocate_buffer)(telemetry.h, 64);
+    if (b == INVALID_ADDRESS)
+        goto error;
+    kfunc(bprintf)(b, "{\"id\":%ld", telemetry.boot_id);
+    buffer nanos_ver = kfunc(table_find)(telemetry.env, sym(NANOS_VERSION));
+    if (nanos_ver)
+        kfunc(bprintf)(b, ",\"nanosVersion\":\"%b\"", nanos_ver);
+    buffer ops_ver = kfunc(table_find)(telemetry.env, sym(OPS_VERSION));
+    if (ops_ver)
+        kfunc(bprintf)(b, ",\"opsVersion\":\"%b\"", ops_ver);
+    buffer_write_cstring(b, "}\r\n");
+    if (!telemetry_send("/boots/create", b)) {
+        deallocate_buffer(b);
+        goto error;
+    }
+    return;
+  error:
+    kfunc(register_timer)(CLOCK_ID_MONOTONIC, telemetry.boot_backoff, false, 0,
+            init_closure(&telemetry.boot_func, boot_timer_func));
+    if (telemetry.boot_backoff < seconds(600))
+        telemetry.boot_backoff <<= 1;
+}
+
+closure_function(0, 2, void, tls_loaded,
+                 klib, kl, status, s)
+{
+    closure_finish();
+    if (is_ok(s)) {
+        int (*tls_set_cacert)(void *, u64) = kfunc(klib_sym)(kl, sym(tls_set_cacert));
+        if (tls_set_cacert(RADAR_CA_CERT, sizeof(RADAR_CA_CERT)) == 0) {
+            telemetry.tls_connect = kfunc(klib_sym)(kl, sym(tls_connect));
+            telemetry_boot();
+        }
+    } else {
+        kfunc(timm_dealloc)(s);
+    }
+}
+
+int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
+{
+    void *(*get_kernel_heaps)(void) = get_sym("get_kernel_heaps");
+    void *(*get_environment)(void) = get_sym("get_environment");
+    u64 (*random_u64)(void) = get_sym("random_u64");
+    void (*load_klib)(const char *, klib_handler) = get_sym("load_klib");
+    if (!get_kernel_heaps || !get_environment || !random_u64 || !load_klib ||
+            !(telemetry.allocate_tuple = get_sym("allocate_tuple")) ||
+            !(telemetry.table_set = get_sym("table_set")) ||
+            !(telemetry.table_find = get_sym("table_find")) ||
+            !(telemetry.deallocate_table = get_sym("deallocate_table")) ||
+            !(telemetry.timm_dealloc = get_sym("timm_dealloc")) ||
+            !(telemetry.intern = get_sym("intern")) ||
+            !(telemetry.klib_sym = get_sym("klib_sym")) ||
+            !(telemetry.allocate_buffer = get_sym("allocate_buffer")) ||
+            !(telemetry.buffer_write = get_sym("buffer_write")) ||
+            !(telemetry.bprintf = get_sym("bprintf")) ||
+            !(telemetry.register_timer = get_sym("kern_register_timer")) ||
+            !(telemetry.http_request = get_sym("http_request")))
+        return KLIB_INIT_FAILED;
+    telemetry.h = heap_general(get_kernel_heaps());
+    telemetry.auth_header = kfunc(allocate_buffer)(telemetry.h, 256);
+    if (telemetry.auth_header == INVALID_ADDRESS)
+        return KLIB_INIT_FAILED;
+    klib_handler tls_handler = closure(telemetry.h, tls_loaded);
+    if (tls_handler == INVALID_ADDRESS) {
+        deallocate_buffer(telemetry.auth_header);
+        return KLIB_INIT_FAILED;
+    }
+    telemetry.env = get_environment();
+    kfunc(bprintf)(telemetry.auth_header, "Bearer %b",
+            kfunc(table_find)(telemetry.env, sym(RADAR_KEY)));
+    telemetry.boot_id = (s64)random_u64();
+    telemetry.boot_backoff = seconds(1);
+    load_klib("/klib/tls", tls_handler);
+    return KLIB_INIT_OK;
+}

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -177,6 +177,18 @@ void mm_service(void)
     }
 }
 
+kernel_heaps get_kernel_heaps(void)
+{
+    return &heaps;
+}
+KLIB_EXPORT(get_kernel_heaps);
+
+tuple get_environment(void)
+{
+    return table_find(filesystem_getroot(root_fs), sym(environment));
+}
+KLIB_EXPORT(get_environment);
+
 static void rootfs_init(heap h, u8 *mbr, u64 offset,
                         block_io r, block_io w, u64 length)
 {

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -40,18 +40,25 @@ static void http_header(buffer dest, tuple t)
     bprintf(dest, "\r\n");    
 }
 
-status http_request(heap h, buffer_handler bh, tuple headers)
+status http_request(heap h, buffer_handler bh, http_method method, tuple headers, buffer body)
 {
     buffer b = allocate_buffer(h, 100);
     buffer url = table_find(headers, sym(url));
-    bprintf(b, "GET %b HTTP/1.1\r\n", url);
+    bprintf(b, "%s %b HTTP/1.1\r\n", http_request_methods[method], url);
+    if (body) {
+        buffer content_len = little_stack_buffer(16);
+        bprintf(content_len, "%ld", buffer_length(body));
+        table_set(headers, sym(Content-Length), content_len);
+    }
     http_header(b, headers);
     status s = apply(bh, b);
     if (!is_ok(s)) {
         deallocate_buffer(b);
         return timm_up(s, "result", "%s failed to send", __func__);
     }
-    return STATUS_OK;
+    if (body)
+        s = apply(bh, body);
+    return s;
 }
 
 static status send_http_headers(buffer_handler out, tuple t)

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -60,6 +60,7 @@ status http_request(heap h, buffer_handler bh, http_method method, tuple headers
         s = apply(bh, body);
     return s;
 }
+KLIB_EXPORT(http_request);
 
 static status send_http_headers(buffer_handler out, tuple t)
 {

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -20,8 +20,17 @@ typedef struct http_parser {
 
 static void each_header(buffer dest, symbol n, value v)
 {
-    if (n != sym(url))
-        bprintf(dest, "%v: %v\r\n", n, v);
+    if (n != sym(url)) {
+        switch(tagof(v)) {
+        case tag_tuple:
+        case tag_symbol:
+            bprintf(dest, "%v: %v\r\n", n, v);
+            break;
+        default:
+            bprintf(dest, "%v: %b\r\n", n, (buffer)v);
+            break;
+        }
+    }
 }
 
 static void http_header(buffer dest, tuple t)

--- a/src/http/http.h
+++ b/src/http/http.h
@@ -16,7 +16,8 @@ typedef closure_type(value_handler, void, value);
 
 buffer_handler allocate_http_parser(heap h, value_handler each);
 // just format the buffer?
-status http_request(heap h, buffer_handler bh, tuple headers);
+status http_request(heap h, buffer_handler bh, http_method method,
+                    tuple headers, buffer body);
 status send_http_response(buffer_handler out,
                           tuple t,
                           buffer c);

--- a/src/kernel/elf64.h
+++ b/src/kernel/elf64.h
@@ -189,6 +189,7 @@ typedef struct {
 typedef closure_type(elf_map_handler, void, u64 /* vaddr */, u64 /* paddr, -1ull if bss */, u64 /* size */, u64 /* flags */);
 typedef closure_type(elf_sym_handler, void, char *, u64, u64, u8);
 void elf_symbols(buffer elf, elf_sym_handler each);
+void walk_elf(buffer elf, range_handler rh);
 void *load_elf(buffer elf, u64 load_offset, elf_map_handler mapper);
 
 /* Architecture-specific */

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -227,6 +227,10 @@ void kern_unlock(void);
 void init_scheduler(heap);
 void mm_service(void);
 
+kernel_heaps get_kernel_heaps(void);
+
+tuple get_environment(void);
+
 extern void interrupt_exit(void);
 extern char **state_strings;
 

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -148,6 +148,19 @@ void load_klib(const char *name, klib_handler complete)
                                closure(h, load_klib_failed, complete));
     }
 }
+KLIB_EXPORT(load_klib);
+
+void *klib_sym(klib kl, symbol s)
+{
+    void *p = table_find(kl->syms, s);
+    if (p == 0)
+        return INVALID_ADDRESS;
+    else if (p == INVALID_ADDRESS)
+        return 0;
+    else
+        return p;
+}
+KLIB_EXPORT(klib_sym);
 
 closure_function(1, 1, void, destruct_mapping,
                  klib, kl,

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -32,6 +32,22 @@ static void *get_sym(const char *name)
     return table_find(export_syms, sym_this(name));
 }
 
+closure_function(1, 1, void, klib_elf_walk,
+                 klib, kl,
+                 range, r)
+{
+    klib kl = bound(kl);
+    if (range_empty(kl->load_range)) {
+        kl->load_range = r;
+    } else {
+        if (r.start < kl->load_range.start)
+            kl->load_range.start = r.start;
+        else if (r.end > kl->load_range.end)
+            kl->load_range.end = r.end;
+    }
+    klib_debug("%s: kl %s, r %R, load_range %R\n", __func__, kl->name, r, kl->load_range);
+}
+
 closure_function(1, 4, void, klib_elf_map,
                  klib, kl,
                  u64, vaddr, u64, paddr, u64, size, u64, flags)
@@ -78,10 +94,13 @@ closure_function(2, 1, status, load_klib_complete,
     kl->elf = b;
 
     klib_debug("%s: klib %p, read length %ld\n", __func__, kl, buffer_length(b));
-    u64 where = allocate_u64((heap)klib_heap, PAGESIZE);
+    kl->load_range = irange(0, 0);
+    walk_elf(b, stack_closure(klib_elf_walk, kl));
+    u64 where = allocate_u64((heap)klib_heap, range_span(kl->load_range));
     assert(where != INVALID_PHYSICAL);
+    kl->load_range = range_add(kl->load_range, where);
 
-    klib_debug("   loading klib @ 0x%lx, resolving relocations\n", where);
+    klib_debug("   loading klib @ %R, resolving relocations\n", kl->load_range);
     elf_apply_relocs(b, where);
 
     klib_debug("   loading elf file\n");
@@ -145,6 +164,7 @@ void unload_klib(klib kl)
     klib_debug("%s: kl %s\n", __func__, kl->name);
     heap h = heap_general(klib_kh);
     deallocate_rangemap(kl->mappings, stack_closure(destruct_mapping, kl));
+    deallocate_u64((heap)klib_heap, kl->load_range.start, range_span(kl->load_range));
     deallocate_buffer(kl->elf);
     deallocate_table(kl->syms);
     deallocate(h, kl, sizeof(struct klib));

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -212,6 +212,14 @@ closure_function(0, 2, void, klib_test_loaded,
     return;
 }
 
+closure_function(0, 2, void, radar_loaded,
+                 klib, kl, status, s)
+{
+    if (!is_ok(s))
+        halt("Radar klib load failed: %v\n", s);
+    closure_finish();
+}
+
 void init_klib(kernel_heaps kh, void *fs, tuple config_root, tuple klib_md)
 {
     klib_debug("%s: fs %p, config_root %p, klib_md %p\n",
@@ -243,4 +251,6 @@ void init_klib(kernel_heaps kh, void *fs, tuple config_root, tuple klib_md)
         klib_debug("   loading klib test\n");
         load_klib("/klib/test", closure(h, klib_test_loaded));
     }
+    if (table_find(get_environment(), sym(RADAR_KEY)))
+        load_klib("/klib/radar", closure(h, radar_loaded));
 }

--- a/src/kernel/klib.h
+++ b/src/kernel/klib.h
@@ -19,16 +19,7 @@ typedef struct klib {
 typedef closure_type(klib_handler, void, klib, status);
 typedef int (*klib_init)(void *md, klib_get_sym get_sym, klib_add_sym add_sym);
 
-static inline void *klib_sym(klib kl, symbol s)
-{
-    void *p = table_find(kl->syms, s);
-    if (p == 0)
-        return INVALID_ADDRESS;
-    else if (p == INVALID_ADDRESS)
-        return 0;
-    else
-        return p;
-}
+void *klib_sym(klib kl, symbol s);
 
 void load_klib(const char *name, klib_handler complete);
 

--- a/src/kernel/klib.h
+++ b/src/kernel/klib.h
@@ -11,6 +11,7 @@ typedef struct klib_mapping {
 typedef struct klib {
     char name[KLIB_MAX_NAME];
     table syms;
+    range load_range;
     rangemap mappings;
     buffer elf;
 } *klib;

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -62,6 +62,13 @@ void kern_unlock()
     spin_unlock(&kernel_lock);
 }
 
+timer kern_register_timer(clock_id id, timestamp val, boolean absolute,
+            timestamp interval, timer_handler n)
+{
+    return register_timer(runloop_timers, id, val, absolute, interval, n);
+}
+KLIB_EXPORT(kern_register_timer);
+
 static void run_thunk(thunk t, int cpustate)
 {
     cpuinfo ci = current_cpu();

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -9,3 +9,5 @@
 #include <lwip/ip4_frag.h>
 #include <lwip/etharp.h>
 #include <lwip/dhcp.h>
+
+status direct_connect(heap h, ip_addr_t *addr, u16 port, connection_handler ch);

--- a/src/runtime/buffer.c
+++ b/src/runtime/buffer.c
@@ -17,6 +17,19 @@ buffer allocate_buffer(heap h, bytes s)
     }
     return b;
 }
+KLIB_EXPORT(allocate_buffer);
+
+void kern_buffer_write(buffer b, const void *source, bytes length)
+{
+    return buffer_write(b, source, length);
+}
+KLIB_EXPORT_RENAME(kern_buffer_write, buffer_write);
+
+boolean kern_buffer_read(buffer b, void *dest, bytes length)
+{
+    return buffer_read(b, dest, length);
+}
+KLIB_EXPORT_RENAME(kern_buffer_read, buffer_read);
 
 void buffer_append(buffer b,
                      const void *body,

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -111,7 +111,8 @@ static inline buffer wrap_buffer(heap h,
                                  bytes length)
 {
     buffer new = allocate(h, sizeof(struct buffer));
-    assert(new != INVALID_ADDRESS);
+    if (new == INVALID_ADDRESS)
+        return new;
     new->contents = body;
     new->start = 0;
     new->h = h;

--- a/src/runtime/format.h
+++ b/src/runtime/format.h
@@ -18,4 +18,5 @@ void register_format(character c, formatter f, int accepts_long);
 buffer aprintf(heap h, const char *fmt, ...);
 void bbprintf(buffer b, buffer fmt, ...);
 void bprintf(buffer b, const char *fmt, ...);
+int rsnprintf(char *str, u64 size, const char *fmt, ...);
 void rprintf(const char *format, ...);

--- a/src/runtime/random.c
+++ b/src/runtime/random.c
@@ -114,9 +114,11 @@ u64 random_u64()
     arc4rand(&retval, sizeof(retval));
     return retval;
 }
+KLIB_EXPORT(random_u64);
 
 u64 random_buffer(buffer b)
 {
     arc4rand(buffer_ref(b, 0), buffer_length(b));
     return buffer_length(b);
 }
+KLIB_EXPORT(random_buffer);

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -2,7 +2,7 @@
 #include <config.h>
 #include <machine.h>
 #include <attributes.h>
-#if !defined(BOOT) && !defined(STAGE3)
+#if !defined(BOOT) && !defined(STAGE3) && !defined(KLIB)
 #include <unix_process_runtime.h>
 #endif
 
@@ -234,11 +234,13 @@ typedef struct export_sym {
     void *v;
 } *export_sym;
 
-#define KLIB_EXPORT(sym)                                                \
-    static const char * __attribute__((section(".klib_symtab.strs")))   \
-        __attribute__((used)) _klib_sym_str_ ##sym = #sym;              \
+#define KLIB_EXPORT_RENAME(sym, name)                                      \
+    static const char * __attribute__((section(".klib_symtab.strs")))      \
+        __attribute__((used)) _klib_sym_str_ ##sym = #name;                \
     static struct export_sym __attribute__((section(".klib_symtab.syms"))) \
-        __attribute__((used)) _klib_export_sym_ ##sym = (struct export_sym){#sym, (sym)};
+        __attribute__((used)) _klib_export_sym_ ##sym = (struct export_sym){#name, (sym)};
+#define KLIB_EXPORT(sym)    KLIB_EXPORT_RENAME(sym, sym)
 #else
 #define KLIB_EXPORT(x)
+#define KLIB_EXPORT_RENAME(x, y)
 #endif

--- a/src/runtime/status.h
+++ b/src/runtime/status.h
@@ -34,11 +34,7 @@ static inline tuple timm_internal(tuple t, char *first, ...)
     return t;
 }
 
-static inline void timm_dealloc(tuple t)
-{
-    if (t != STATUS_OK)
-        destruct_tuple(t, true);
-}
+void timm_dealloc(tuple t);
 
 // fix for zero argument case
 #define timm(first, ...)  timm_internal(STATUS_OK, first, __VA_ARGS__, INVALID_ADDRESS)

--- a/src/runtime/string.c
+++ b/src/runtime/string.c
@@ -15,6 +15,27 @@ runtime_strchr (const char *string, int _c)
 }
     
 char *
+runtime_strstr(const char *haystack, const char *needle)
+{
+    const char *haystack_p = haystack;
+    const char *needle_p = needle;
+    while (*haystack_p && *needle_p) {
+        if (*needle_p == *haystack_p) {
+            needle_p++;
+            haystack_p++;
+        } else {
+            needle_p = needle;
+            haystack_p = ++haystack;
+        }
+    }
+    if (!*needle_p)
+        return (char *)haystack;
+    else
+        return 0;
+}
+KLIB_EXPORT(runtime_strstr);
+
+char *
 runtime_strtok_r (char *s, const char *delimiters, char **save_ptr)
 {
     char *token;
@@ -54,3 +75,4 @@ runtime_strcmp (const char *string1, const char *string2)
 
     return *(const unsigned char *)string1 - *(const unsigned char *)string2;
 }
+KLIB_EXPORT(runtime_strcmp);

--- a/src/runtime/stringtok.h
+++ b/src/runtime/stringtok.h
@@ -1,3 +1,4 @@
 extern char *runtime_strchr(const char *, int);
+extern char *runtime_strstr(const char *haystack, const char *needle);
 extern char *runtime_strtok_r (char *, const char *, char **);
 extern int runtime_strcmp (const char *, const char *);

--- a/src/runtime/symbol.c
+++ b/src/runtime/symbol.c
@@ -37,6 +37,7 @@ symbol intern(string name)
   alloc_fail:
     halt("intern: alloc fail\n");
 }
+KLIB_EXPORT(intern);
 
 string symbol_string(symbol s)
 {

--- a/src/runtime/symbol.h
+++ b/src/runtime/symbol.h
@@ -5,10 +5,12 @@ symbol intern_u64(u64);
 
 string symbol_string(symbol s);
 
-#define sym(name)\
+#define sym_intern(name, intern)\
     ({static symbol __s = 0;\
       if (!__s){char x[] = #name; __s = intern(alloca_wrap_buffer(x, sizeof(x)-1));} \
      __s;})              
+
+#define sym(name)   sym_intern(name, intern)
 
 #define sym_this(name)\
     (intern(alloca_wrap_buffer(name, runtime_strlen(name))))

--- a/src/runtime/table.c
+++ b/src/runtime/table.c
@@ -62,6 +62,7 @@ void deallocate_table(table t)
     deallocate(t->h, t->entries, t->buckets * sizeof(void *));
     deallocate(t->h, t, sizeof(struct table));
 }
+KLIB_EXPORT(deallocate_table);
 
 static inline key position(int buckets, key x)
 {
@@ -101,6 +102,7 @@ void *table_find(table z, void *c)
     }
     return EMPTY;
 }
+KLIB_EXPORT(table_find);
 
 void table_set(table z, void *c, void *v)
 {
@@ -143,6 +145,7 @@ void table_set(table z, void *c, void *v)
         }
     }
 }
+KLIB_EXPORT(table_set);
 
 int table_elements(table z)
 {

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -100,3 +100,12 @@ timerheap allocate_timerheap(heap h, const char *name)
     th->name = name;
     return th;
 }
+
+s64 rtime(s64 *result)
+{
+    s64 t = (s64)(sec_from_timestamp(now(CLOCK_ID_REALTIME)));
+    if (result)
+        *result = t;
+    return t;
+}
+KLIB_EXPORT(rtime);

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -161,3 +161,5 @@ static inline u64 usec_from_timestamp(timestamp t)
     return (sec * MILLION) +
         ((truncate_seconds(t) * MILLION) / TIMESTAMP_SECOND);
 }
+
+s64 rtime(s64 *result);

--- a/src/runtime/tuple.c
+++ b/src/runtime/tuple.c
@@ -36,6 +36,7 @@ tuple allocate_tuple()
 {
     return tag(allocate_table(theap, key_from_symbol, pointer_equal), tag_tuple);
 }
+KLIB_EXPORT(allocate_tuple);
 
 void destruct_tuple(tuple t, boolean recursive)
 {
@@ -51,6 +52,26 @@ void destruct_tuple(tuple t, boolean recursive)
     }
     deallocate_tuple(t);
 }
+
+/* Compared to timm(), kern_timm() supports one key-value pair only. */
+tuple kern_timm(char *name, ...)
+{
+    tuple s = allocate_tuple();
+    assert(s != INVALID_ADDRESS);
+    vlist ap;
+    vstart(ap, name);
+    timm_term(s, name, &ap);
+    vend(ap);
+    return s;
+}
+KLIB_EXPORT_RENAME(kern_timm, timm);
+
+void timm_dealloc(tuple t)
+{
+    if (t != STATUS_OK)
+        destruct_tuple(t, true);
+}
+KLIB_EXPORT(timm_dealloc);
 
 // header: immediate(1)
 //         type(1)

--- a/src/unix/mktime.c
+++ b/src/unix/mktime.c
@@ -42,3 +42,36 @@ int mktime(struct tm *tm) {
 
     return ((days * 24 + tm->tm_hour) * 60 + tm->tm_min) * 60 + tm->tm_sec;
 }
+
+struct tm *gmtime_r(u64 *timep, struct tm *result) {
+    u64 seconds = *timep;
+    int days = seconds / (24 * 60 * 60);
+    seconds -= days * (24 * 60 * 60);
+    result->tm_year = 70;   /* 1970 (Epoch) */
+    while (true) {
+        int days_in_year = (is_leap_year(1900 + result->tm_year)) ? 366 : 365;
+        if (days >= days_in_year) {
+            result->tm_year++;
+            days -= days_in_year;
+        } else {
+            break;
+        }
+    }
+    result->tm_mon = 0;
+    while (true) {
+        int d = days_in_month(result->tm_mon + 1);
+        if (days >= d) {
+            result->tm_mon++;
+            days -= d;
+        } else {
+            break;
+        }
+    }
+    result->tm_mday = 1 + days;
+    result->tm_hour = seconds / (60 * 60);
+    seconds -= result->tm_hour * (60 * 60);
+    result->tm_min = seconds / 60;
+    result->tm_sec = seconds - result->tm_min * 60;
+    return result;
+}
+KLIB_EXPORT(gmtime_r);

--- a/src/unix/mktime.h
+++ b/src/unix/mktime.h
@@ -8,3 +8,4 @@ struct tm {
 };
 
 extern int mktime(struct tm *tm);
+extern struct tm *gmtime_r(u64 *timep, struct tm *result);

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -85,11 +85,7 @@ sysreturn sys_time(time_t *tloc)
 {
     if (tloc && !validate_user_memory(tloc, sizeof(time_t), true))
         return -EFAULT;
-    time_t t = time_t_from_time(now(CLOCK_ID_REALTIME));
-
-    if (tloc)
-        *tloc = t;
-    return t;
+    return rtime(tloc);
 }
 
 sysreturn times(struct tms *buf)

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -518,11 +518,6 @@ static inline void thread_release(thread t)
 
 unix_heaps get_unix_heaps();
 
-static inline kernel_heaps get_kernel_heaps()
-{
-    return (kernel_heaps)get_unix_heaps();
-}
-
 #define unix_cache_alloc(uh, c) ({ heap __c = uh->c ## _cache; allocate(__c, __c->pagesize); })
 #define unix_cache_free(uh, c, p) ({ heap __c = uh->c ## _cache; deallocate(__c, p, __c->pagesize); })
 

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -1,4 +1,4 @@
-#if !(defined(KERNEL) || defined(BOOT))
+#if !(defined(KERNEL) || defined(BOOT) || defined(KLIB))
 #error must be in kernel or bootloader build
 #endif
 

--- a/test/unit/network_test.c
+++ b/test/unit/network_test.c
@@ -14,7 +14,7 @@ typedef struct stats {
 static void send_request(heap h, stats s, buffer_handler out, tuple t)
 {
     s->requests++;
-    http_request(h, out, t);
+    http_request(h, out, HTTP_REQUEST_METHOD_POST, t, 0);
 }
 
 u64 requests_per_connection;


### PR DESCRIPTION
This PR implements sending at each boot an HTTPS POST request to the radar server. This functionality is enabled when the environment contains a RADAR_KEY entry, for example:
environment:(NANOS_VERSION:0.1.28 OPS_VERSION:0.1.13 RADAR_KEY:eyJhbGciOiJIUzI1NiIsIGrAJrvhT7bwnPEqYp3kofAMCVoK2CTJ6eQ).
The telemetry functionality is implemented in the radar klib, which depends on the TLS klib, which is being added as part of this commit.
The telemetry client verifies the server certificate when establishing a TLS session, using a PEM certificate hardcoded in the radar klib.

A unique boot identifier is generated at each boot and sent in the HTTPS request, along with the Nanos and Ops version numbers if found in the environment.

The TLS klib uses the Mbed TLS library, which is imported from a separate git repository.