### PR TITLE
Separate APIC id from cpu id and make sigstate SMP safe

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -377,7 +377,6 @@ u64 total_processors = 1;
 #ifdef SMP_ENABLE
 static void new_cpu()
 {
-    fetch_and_add(&total_processors, 1);
     if (platform_timer_percpu_init)
         apply(platform_timer_percpu_init);
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -182,6 +182,7 @@ typedef struct sigstate {
     u64         saved;          /* original mask saved on rt_sigsuspend or handler dispatch */
     u64         ignored;        /* mask of signals set to SIG_IGN */
     u64         interest;       /* signals of interest, regardless of mask or ignored */
+    struct spinlock   ss_lock;
     struct list heads[NSIG];
 } *sigstate;
 

--- a/src/x86_64/apic.c
+++ b/src/x86_64/apic.c
@@ -28,6 +28,7 @@
 
 static heap apic_heap;
 apic_iface apic_if;
+int apic_id_map[MAX_CPUS];
 
 static inline void apic_write(int reg, u32 val)
 {
@@ -41,6 +42,8 @@ static inline u32 apic_read(int reg)
 
 void apic_ipi(u32 target, u64 flags, u8 vector)
 {
+    if (target != TARGET_EXCLUSIVE_BROADCAST)
+        target = apic_id_map[target];
     apic_if->ipi(apic_if, target, flags, vector);
 }
 


### PR DESCRIPTION
This PR contains fixes for two issues I found while making ftrace SMP safe. The first issue was that there was concurrent access to the sigstate lists and pending field that would cause a crash. That just needed a spinlock to protect those fields. I did not protect the mask field because I'm not convinced it's needed, but could use a second opinion. 

The second issue is that on ESXi the APIC ID for additional cpus is incremented by two and not by one, so the cpuinfo array would have holes in it since the APIC ID is used as cpu id. ESXi uses an x2APIC unlike QEMU, which may be the explanation. In any case, I made the two IDs independent: cpu id is now generated in ap_start with the new stack, and a separate array is used to map cpu id to APIC ID. IPIs are called with cpu id which get converted to the proper APIC ID in apic.c.