### PR TITLE
Klib symbol table: align linker section start address to 16 bytes

### DIFF
--- a/platform/pc/linker_script
+++ b/platform/pc/linker_script
@@ -52,9 +52,8 @@ SECTIONS
         *(.rodata.*)
     }
 
-    .klib_symtab ALIGN(8): AT(ADDR(.klib_symtab) - LOAD_OFFSET)
+    .klib_symtab ALIGN(16): AT(ADDR(.klib_symtab) - LOAD_OFFSET)
     {
-        . = ALIGN(8);
         klib_syms_start = .;
         KEEP(*(.klib_symtab.syms))
         klib_syms_end = .;


### PR DESCRIPTION
The GNU ld linker aligns to 16 bytes the address of global struct variables large 16 bytes or more, even if none of the struct members requires this alignment. For this reason, the start address of the klib_symtab linker section must be aligned to 16 bytes, otherwise the address of klib_syms_start may not match the address of the first (16-byte-sized) struct export_sym.