### PR TITLE
Added klib vendor directories to CLEANDIRS

### DIFF
--- a/klib/Makefile
+++ b/klib/Makefile
@@ -130,3 +130,5 @@ CFLAGS+=	$(KERNCFLAGS) $(INCLUDES) -fPIC $(DEFINES)
 # TODO should add stack protection to klibs...
 CFLAGS+=	-fno-stack-protector
 LDFLAGS+=	-pie -nostdlib -T$(ARCHDIR)/klib.lds
+
+CLEANDIRS+=	$(OUTDIR)/klib/vendor $(OUTDIR)/klib/vendor/mbedtls


### PR DESCRIPTION
Just a little fix to get 'make clean' working with the new klib stuff.