### PR TITLE
atomic test alternate asm implementations

### DIFF
--- a/src/x86_64/machine.h
+++ b/src/x86_64/machine.h
@@ -66,14 +66,22 @@ static inline void atomic_clear_bit(u64 *target, u64 bit)
 static inline int atomic_test_and_set_bit(u64 *target, u64 bit)
 {
     int oldbit;
+    #ifdef __GCC_ASM_FLAG_OUTPUTS__
     asm volatile("lock btsq %2, %0" : "+m"(*target), "=@ccc"(oldbit) : "r"(bit) : "memory");
+    #else
+    asm volatile("lock btsq %2, %0\nsetc %1" : "+m"(*target), "=m"(oldbit) : "r"(bit) : "memory");
+    #endif
     return oldbit;
 }
 
 static inline int atomic_test_and_clear_bit(u64 *target, u64 bit)
 {
     int oldbit;
+    #ifdef __GCC_ASM_FLAG_OUTPUTS__
     asm volatile("lock btrq %2, %0" : "+m"(*target), "=@ccc"(oldbit) : "r"(bit) : "memory");
+    #else
+    asm volatile("lock btrq %2, %0\nsetc %1" : "+m"(*target), "=m"(oldbit) : "r"(bit) : "memory");
+    #endif
     return oldbit;
 }
 


### PR DESCRIPTION
Provide an alternate conditional implementation
of atomic_test_and_*_bit functions for compilers
that don't support asm flag outputs