### PR TITLE
use irq-safe enqueue when scheduling to bhqueue and runqueue

### DIFF
--- a/src/hyperv/vmbus/vmbus_chan.c
+++ b/src/hyperv/vmbus/vmbus_chan.c
@@ -715,7 +715,7 @@ vmbus_event_flags_proc(vmbus_dev sc, volatile u64 *event_flags,
             if (chan->ch_flags & VMBUS_CHAN_FLAG_BATCHREAD)
                 vmbus_rxbr_intr_mask(&chan->ch_rxbr);
             if (!sc->poll_mode) {
-                enqueue(chan->sched_queue, chan->ch_tq);
+                enqueue_irqsafe(chan->sched_queue, chan->ch_tq);
             } else {
                 apply(chan->ch_tq);
             }

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -182,19 +182,43 @@ static inline void set_page_write_protect(boolean enable)
     mov_to_cr("cr0", cr0);
 }
 
-typedef struct queue *queue;
+#ifdef KERNEL
+#define _IRQSAFE_1(rtype, name, t0)              \
+    static inline rtype name ## _irqsafe (t0 a0) \
+    {                                            \
+        u64 flags = irq_disable_save();          \
+        rtype r = name(a0);                      \
+        irq_restore(flags);                      \
+        return r;                                \
+    }
+
+#define _IRQSAFE_2(rtype, name, t0, t1)                 \
+    static inline rtype name ## _irqsafe (t0 a0, t1 a1) \
+    {                                                   \
+        u64 flags = irq_disable_save();                 \
+        rtype r = name(a0, a1);                         \
+        irq_restore(flags);                             \
+        return r;                                       \
+    }
+
+_IRQSAFE_2(boolean, enqueue, queue, void *);
+_IRQSAFE_2(boolean, enqueue_single, queue, void *);
+
+_IRQSAFE_1(void *, dequeue, queue);
+_IRQSAFE_1(void *, dequeue_single, queue);
+
+/* may not need irqsafe variants of these ... but it doesn't hurt to add */
+_IRQSAFE_1(u64, queue_length, queue);
+_IRQSAFE_1(boolean, queue_empty, queue);
+_IRQSAFE_1(boolean, queue_full, queue);
+_IRQSAFE_1(void *, queue_peek, queue);
+#undef _IRQSAFE_1
+#undef _IRQSAFE_2
+#endif
+
 extern queue bhqueue;
 extern queue runqueue;
 extern timerheap runloop_timers;
-
-static inline void bhqueue_enqueue_irqsafe(thunk t)
-{
-    /* an interrupted enqueue and competing enqueue from int handler could cause a
-       deadlock; disable ints for safe enqueue from any context */
-    u64 flags = irq_disable_save();
-    enqueue(bhqueue, t);
-    irq_restore(flags);
-}
 
 heap physically_backed(heap meta, heap virtual, heap physical, u64 pagesize);
 void physically_backed_dealloc_virtual(heap h, u64 x, bytes length);

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -212,7 +212,7 @@ static inline void queue_completions_locked_internal(pagecache pc, list head,
     assert(enqueue(cq->q, qhead));
     if (!cq->scheduled) {
         cq->scheduled = true;
-        assert(enqueue(sched_queue, &cq->service));
+        assert(enqueue_irqsafe(sched_queue, &cq->service));
     }
 }
 

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -169,7 +169,7 @@ static void netsock_check_loop(void)
      * enqueued more than once. */
     if (!net_loop_poll_queued) {
         net_loop_poll_queued = true;
-        enqueue(runqueue, net_loop_poll);
+        enqueue_irqsafe(runqueue, net_loop_poll);
     }
 }
 

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -32,7 +32,7 @@ closure_function(0, 1, void, kernel_demand_pf_complete,
     if (faulting_kernel_context) {
         init_closure(&do_kernel_frame_return, kernel_frame_return, faulting_kernel_context);
         faulting_kernel_context = 0;
-        bhqueue_enqueue_irqsafe((thunk)&do_kernel_frame_return);
+        enqueue_irqsafe(bhqueue, (thunk)&do_kernel_frame_return);
     }
     kernel_demand_page_completed = true;
 }

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -449,7 +449,7 @@ static void check_syscall_restart(thread t, sigaction sa)
     if (rv == -ERESTARTSYS) {
         if (sa->sa_flags & SA_RESTART) {
             sig_debug("restarting syscall\n");
-            enqueue(runqueue, &t->deferred_syscall);
+            enqueue_irqsafe(runqueue, &t->deferred_syscall);
             kern_unlock();
             runloop();
         } else {

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -372,7 +372,7 @@ define_closure_function(2, 2, void, iov_op_each_complete,
     } else {
         if (p->file_offset != infinity)
             p->file_offset += rv;
-        enqueue(runqueue, &p->bh);
+        enqueue_irqsafe(runqueue, &p->bh);
     }
     return;
   out_complete:
@@ -2512,7 +2512,7 @@ static void syscall_schedule(context f, u64 call)
     if (!syscall_defer)
         kern_lock();
     else if (!kern_try_lock()) {
-        enqueue(runqueue, &current->deferred_syscall);
+        enqueue_irqsafe(runqueue, &current->deferred_syscall);
         thread_pause(current);
         runloop();
     }

--- a/src/virtio/virtio_scsi.c
+++ b/src/virtio/virtio_scsi.c
@@ -301,7 +301,7 @@ closure_function(3, 2, void, virtio_scsi_read_capacity_done,
     virtio_scsi_debug("%s: target %d, lun %d, block size 0x%lx, capacity 0x%lx\n",
         __func__, target, lun, d->block_size, d->capacity);
 
-    enqueue(runqueue, closure(s->v->virtio_dev.general, virtio_scsi_init_done,
+    enqueue_irqsafe(runqueue, closure(s->v->virtio_dev.general, virtio_scsi_init_done,
         d, bound(a)));
   out:
     closure_finish();

--- a/src/vmware/pvscsi.c
+++ b/src/vmware/pvscsi.c
@@ -657,10 +657,10 @@ static void pvscsi_process_cmp_ring(pvscsi dev)
 
     list l = list_get_next(&q);
     if (l) {
-        /* trick: remove (local) head and queue first element */
-        list_delete(&q);
-        assert(enqueue(dev->rx_servicequeue, l));
-        enqueue(bhqueue, dev->rx_service);
+        /* only called from int handler, but use irqsafe in case this changes */
+        list_delete(&q); /* trick: remove (local) head and queue first element */
+        assert(enqueue_irqsafe(dev->rx_servicequeue, l));
+        enqueue_irqsafe(bhqueue, dev->rx_service);
     }
 }
 


### PR DESCRIPTION
The queue type that we use to implement scheduling queues allows for lock-free access between concurrent enqueues and dequeues. However, an enqueue that occurs in interrupt level could potentially hang if an enqueue to the same scheduling queue was interrupted. Thus any non-interrupt-level enqueues that could compete with an interrupt-level enqueue must be placed within a critical section / irq disable.

This isn't likely to be a source of failures at the moment given that most of our kernel processing occurs with interrupts disabled. But, in keeping with the precedent of not assuming that this will always be the case, irq-safe wrappers to the queue methods have been added here, and enqueues to the bhqueue or runqueue that aren't exclusively from within an interrupt handler have been changed to use enqueue_irqsafe. (Presently, only bhqueue and runqueue may have enqueues that occur directly from interrupt handlers.)
