### PR TITLE
Klibs: add cloud_init klib

### DIFF
--- a/klib/Makefile
+++ b/klib/Makefile
@@ -2,9 +2,14 @@ LWIPDIR=		$(VENDORDIR)/lwip
 MBEDTLS_DIR=	$(VENDORDIR)/mbedtls
 
 PROGRAMS= \
+	cloud_init \
 	radar \
 	test \
 	tls \
+
+SRCS-cloud_init= \
+	$(CURDIR)/cloud_azure.c \
+	$(CURDIR)/cloud_init.c \
 
 SRCS-radar= \
 	$(CURDIR)/radar.c \

--- a/klib/cloud_azure.c
+++ b/klib/cloud_azure.c
@@ -1,0 +1,252 @@
+#include <kernel.h>
+#include <http.h>
+#include <lwip.h>
+
+#define AZURE_MS_VERSION    "2012-11-30"
+
+declare_closure_struct(1, 1, void, report_ready_func,
+    struct azure *, az,
+    u64, overruns);
+
+typedef struct azure {
+    heap h;
+    char container_id[64];
+    char instance_id[64];
+    timestamp report_backoff;
+    closure_struct(report_ready_func, report_ready);
+    tuple (*allocate_tuple)(void);
+    void (*table_set)(table z, void *c, void *v);
+    void *(*table_find)(table z, void *c);
+    void (*deallocate_table)(table t);
+    void (*destruct_tuple)(tuple t, boolean recursive);
+    void (*timm_dealloc)(tuple t);
+    symbol (*intern)(string name);
+    buffer (*allocate_buffer)(heap h, bytes s);
+    boolean (*buffer_read)(buffer b, void *dest, bytes length);
+    int (*buffer_strstr)(buffer b, const char *str);
+    void (*bprintf)(buffer b, const char *fmt, ...);
+    timer (*register_timer)(clock_id id, timestamp val, boolean absolute,
+            timestamp interval, timer_handler n);
+    status (*direct_connect)(heap h, ip_addr_t *addr, u16 port, connection_handler ch);
+    status (*http_request)(heap h, buffer_handler bh, http_method method,
+            tuple headers, buffer body);
+    buffer_handler (*allocate_http_parser)(heap h, value_handler each);
+} *azure;
+
+#undef sym
+#define sym(name)   sym_intern(name, az->intern)
+
+static void azure_report_ready(azure az);
+
+define_closure_function(1, 1, void, report_ready_func,
+                        azure, az,
+                        u64, overruns)
+{
+    azure_report_ready(bound(az));
+}
+
+static void azure_report_retry(azure az)
+{
+    az->register_timer(CLOCK_ID_MONOTONIC, az->report_backoff, false, 0,
+        init_closure(&az->report_ready, report_ready_func, az));
+    if (az->report_backoff < seconds(600))
+        az->report_backoff <<= 1;
+}
+
+closure_function(1, 1, void, wireserver_parse_resp,
+                 azure, az,
+                 value, v)
+{
+    azure az = bound(az);
+    buffer content = az->table_find(v, sym(content));
+    if (content) {
+        int index = az->buffer_strstr(content, "<ContainerId>");
+        if (index < 0)
+            goto exit;
+        buffer_consume(content, index);
+        buffer_consume(content, buffer_strchr(content, '>') + 1);
+        index = buffer_strchr(content, '<');
+        if (index < 0)
+            goto exit;
+        if (index >= sizeof(az->container_id))
+            goto exit;
+        az->buffer_read(content, az->container_id, index);
+        az->container_id[index] = '\0';
+        index = az->buffer_strstr(content, "<InstanceId>");
+        if (index < 0)
+            goto exit;
+        buffer_consume(content, index);
+        buffer_consume(content, buffer_strchr(content, '>') + 1);
+        index = buffer_strchr(content, '<');
+        if (index < 0)
+            goto exit;
+        if (index >= sizeof(az->instance_id))
+            goto exit;
+        az->buffer_read(content, az->instance_id, index);
+        az->instance_id[index] = '\0';
+        azure_report_ready(az);
+    }
+  exit:
+    az->destruct_tuple(v, true);
+    closure_finish();
+}
+
+closure_function(2, 1, status, wireserver_get_resp,
+                 azure, az, buffer_handler, out,
+                 buffer, data)
+{
+    if (data) {
+        azure az = bound(az);
+        heap h = az->h;
+        boolean success = false;
+        value_handler vh = closure(h, wireserver_parse_resp, az);
+        if (vh != INVALID_ADDRESS) {
+            buffer_handler parser = az->allocate_http_parser(h, vh);
+            if (parser != INVALID_ADDRESS) {
+                apply(parser, data);
+                success = true;
+            }
+        }
+        apply(bound(out), 0);
+        if (!success)
+            azure_report_retry(az);
+    } else {
+        closure_finish();
+    }
+    return STATUS_OK;
+}
+
+closure_function(1, 1, buffer_handler, wireserver_get_ch,
+                 azure, az,
+                 buffer_handler, out)
+{
+    azure az = bound(az);
+    buffer_handler in = INVALID_ADDRESS;
+    if (out) {    /* connection succeeded */
+        tuple req = az->allocate_tuple();
+        if (req == INVALID_ADDRESS)
+            goto exit;
+        az->table_set(req, sym(url), alloca_wrap_cstring("/machine?comp=goalstate"));
+        az->table_set(req, sym(Host), alloca_wrap_cstring("168.63.129.16"));
+        az->table_set(req, sym(x-ms-version), alloca_wrap_cstring(AZURE_MS_VERSION));
+        status s = az->http_request(az->h, out, HTTP_REQUEST_METHOD_GET, req, 0);
+        az->deallocate_table(req);
+        if (is_ok(s))
+            in = closure(az->h, wireserver_get_resp, az, out);
+        else
+            az->timm_dealloc(s);
+    }
+  exit:
+    closure_finish();
+    if (in == INVALID_ADDRESS)
+        azure_report_retry(az);
+    return in;
+}
+
+closure_function(1, 1, status, wireserver_post_resp,
+                 buffer_handler, out,
+                 buffer, data)
+{
+    if (data)
+        apply(bound(out), 0);
+    else
+        closure_finish();
+    return STATUS_OK;
+}
+
+closure_function(1, 1, buffer_handler, wireserver_post_ch,
+                 azure, az,
+                 buffer_handler, out)
+{
+    azure az = bound(az);
+    buffer_handler in = INVALID_ADDRESS;
+    if (out) {    /* connection succeeded */
+        tuple req = az->allocate_tuple();
+        if (req == INVALID_ADDRESS)
+            goto exit;
+        buffer b = az->allocate_buffer(az->h, 512);
+        if (b == INVALID_ADDRESS) {
+            az->deallocate_table(req);
+            goto exit;
+        }
+        az->table_set(req, sym(url), alloca_wrap_cstring("/machine?comp=health"));
+        az->table_set(req, sym(Host), alloca_wrap_cstring("168.63.129.16"));
+        az->table_set(req, sym(x-ms-version), alloca_wrap_cstring(AZURE_MS_VERSION));
+        az->table_set(req, sym(Content-Type), alloca_wrap_cstring("text/xml;charset=utf-8"));
+        az->bprintf(b, "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n\
+                <Health xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\
+                xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n\
+                  <GoalStateIncarnation>1</GoalStateIncarnation>\n\
+                  <Container>\n\
+                    <ContainerId>%s</ContainerId>\n\
+                    <RoleInstanceList>\n\
+                      <Role>\n\
+                        <InstanceId>%s</InstanceId>\n\
+                        <Health>\n\
+                          <State>Ready</State>\n\
+                        </Health>\n\
+                      </Role>\n\
+                    </RoleInstanceList>\n\
+                  </Container>\n\
+                </Health>\n", az->container_id, az->instance_id);
+        status s = az->http_request(az->h, out, HTTP_REQUEST_METHOD_POST, req, b);
+        az->deallocate_table(req);
+        if (is_ok(s))
+            in = closure(az->h, wireserver_post_resp, out);
+        else
+            az->timm_dealloc(s);
+    }
+  exit:
+    closure_finish();
+    if (in == INVALID_ADDRESS)
+        azure_report_retry(az);
+    return in;
+}
+
+
+static void azure_report_ready(azure az)
+{
+    connection_handler ch;
+    if (!az->instance_id[0])
+        ch = closure(az->h, wireserver_get_ch, az);
+    else
+        ch = closure(az->h, wireserver_post_ch, az);
+    if (ch == INVALID_ADDRESS)
+        return;
+    ip_addr_t wireserver_addr = IPADDR4_INIT_BYTES(168, 63, 129, 16);
+    status s = az->direct_connect(az->h, &wireserver_addr, 80, ch);
+    if (!is_ok(s)) {
+        az->timm_dealloc(s);
+        azure_report_retry(az);
+    }
+}
+
+boolean azure_cloud_init(heap h, klib_get_sym get_sym)
+{
+    azure az = allocate(h, sizeof(*az));
+    if (az == INVALID_ADDRESS)
+        return false;
+    if (!(az->allocate_tuple = get_sym("allocate_tuple")) ||
+            !(az->table_set = get_sym("table_set")) ||
+            !(az->table_find = get_sym("table_find")) ||
+            !(az->deallocate_table = get_sym("deallocate_table")) ||
+            !(az->destruct_tuple = get_sym("destruct_tuple")) ||
+            !(az->timm_dealloc = get_sym("timm_dealloc")) ||
+            !(az->intern = get_sym("intern")) ||
+            !(az->allocate_buffer = get_sym("allocate_buffer")) ||
+            !(az->buffer_read = get_sym("buffer_read")) ||
+            !(az->buffer_strstr = get_sym("buffer_strstr")) ||
+            !(az->bprintf = get_sym("bprintf")) ||
+            !(az->register_timer = get_sym("kern_register_timer")) ||
+            !(az->direct_connect = get_sym("direct_connect")) ||
+            !(az->http_request = get_sym("http_request")) ||
+            !(az->allocate_http_parser = get_sym("allocate_http_parser"))) {
+        deallocate(h, az, sizeof(*az));
+        return false;
+    }
+    az->h = h;
+    az->container_id[0] = az->instance_id[0] = '\0';
+    az->report_backoff = seconds(1);
+    azure_report_ready(az);
+    return true;
+}

--- a/klib/cloud_init.c
+++ b/klib/cloud_init.c
@@ -1,0 +1,48 @@
+#include <kernel.h>
+#include <cloud_init.h>
+#include <drivers/dmi.h>
+
+#define AZURE_CHASSIS   "7783-7084-3265-9085-8269-3286-77"
+
+enum cloud {
+    CLOUD_ERROR,
+    CLOUD_AZURE,
+    CLOUD_UNKNOWN
+};
+
+static enum cloud cloud_detect(klib_get_sym get_sym)
+{
+    const char *(*dmi_get_string)(enum dmi_field) = get_sym("dmi_get_string");
+    int (*runtime_strcmp)(const char *, const char *) = get_sym("runtime_strcmp");
+    if (!dmi_get_string || !runtime_strcmp)
+        return CLOUD_ERROR;
+    const char *chassis_asset_tag = dmi_get_string(DMI_CHASSIS_ASSET_TAG);
+    if (!chassis_asset_tag)
+        return CLOUD_UNKNOWN;
+    if (!runtime_strcmp(chassis_asset_tag, AZURE_CHASSIS))
+        return CLOUD_AZURE;
+    return CLOUD_UNKNOWN;
+}
+
+int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
+{
+    void *(*get_kernel_heaps)(void) = get_sym("get_kernel_heaps");
+    boolean (*first_boot)(void) = get_sym("first_boot");
+    if (!get_kernel_heaps || !first_boot)
+        return KLIB_INIT_FAILED;
+    heap h = heap_general(get_kernel_heaps());
+    if (first_boot()) {
+        enum cloud c = cloud_detect(get_sym);
+        switch (c) {
+        case CLOUD_ERROR:
+            return KLIB_INIT_FAILED;
+        case CLOUD_AZURE:
+            if (!azure_cloud_init(h, get_sym))
+                return KLIB_INIT_FAILED;
+            break;
+        default:
+            break;
+        }
+    }
+    return KLIB_INIT_OK;
+}

--- a/klib/cloud_init.h
+++ b/klib/cloud_init.h
@@ -1,0 +1,1 @@
+boolean azure_cloud_init(heap h, klib_get_sym get_sym);

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -8,6 +8,7 @@ SRCS-kernel.img= \
 	$(SRCDIR)/drivers/ata.c \
 	$(SRCDIR)/drivers/ata-pci.c \
 	$(SRCDIR)/drivers/console.c \
+	$(SRCDIR)/drivers/dmi.c \
 	$(SRCDIR)/drivers/storage.c \
 	$(SRCDIR)/drivers/vga.c \
 	$(SRCDIR)/gdb/gdbstub.c \

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -153,6 +153,9 @@ closure_function(4, 2, void, fsstarted,
     root_fs = fs;
     enqueue(runqueue, create_init(&heaps, root, fs));
     closure_finish();
+    symbol booted = sym(booted);
+    if (!table_find(root, booted))
+        filesystem_write_eav(fs, root, booted, null_value);
 }
 
 /* This is very simplistic and uses a fixed drain threshold. This
@@ -188,6 +191,12 @@ tuple get_environment(void)
     return table_find(filesystem_getroot(root_fs), sym(environment));
 }
 KLIB_EXPORT(get_environment);
+
+boolean first_boot(void)
+{
+    return !table_find(filesystem_getroot(root_fs), sym(booted));
+}
+KLIB_EXPORT(first_boot);
 
 static void rootfs_init(heap h, u8 *mbr, u64 offset,
                         block_io r, block_io w, u64 length)

--- a/src/drivers/dmi.c
+++ b/src/drivers/dmi.c
@@ -1,0 +1,106 @@
+#include <kernel.h>
+#include <page.h>
+#include "dmi.h"
+
+#define SMBIOS_SCAN_START   0xF0000
+#define SMBIOS_SCAN_SIZE    0x10000
+
+#define DMI_TYPE_BIOS_INFO      0
+#define DMI_TYPE_SYSTEM_INFO    1
+#define DMI_TYPE_BASEBOARD_INFO 2
+#define DMI_TYPE_CHASSIS_INFO   3
+
+//#define DMI_DEBUG
+#ifdef DMI_DEBUG
+#define dmi_debug(x, ...) do {rprintf("DMI: " x "\n", ##__VA_ARGS__);} while(0)
+#else
+#define dmi_debug(x, ...)
+#endif
+
+struct dmi_header {
+    u8 type;
+    u8 length;
+    u16 handle;
+} __attribute__((packed));
+
+static u32 dmi_len;
+static u16 dmi_num;
+static void *dmi_base;
+
+static void dmi_map(void)
+{
+    heap h = (heap)heap_virtual_page(get_kernel_heaps());
+    u8 *smbios = allocate(h, SMBIOS_SCAN_SIZE);
+    if (smbios == INVALID_ADDRESS)
+        return;
+    map(u64_from_pointer(smbios), SMBIOS_SCAN_START, SMBIOS_SCAN_SIZE, PAGE_DEV_FLAGS);
+    for (u8 *p = smbios; p < smbios + SMBIOS_SCAN_SIZE; p += 16) {
+        if (!runtime_memcmp(p, "_DMI_", 5)) {
+            u8 buf[16];
+            runtime_memcpy(buf, p, sizeof(buf));    /* so that unaligned access is possible */
+            dmi_len = le16toh(*(u16 *)(buf + 6));
+            u64 phys_base = le32toh(*(u32 *)(buf + 8));
+            dmi_num = le16toh(*(u16 *)(buf + 12));
+            dmi_debug("mapping base %p, len %d, num %d", phys_base, dmi_len, dmi_num);
+            unmap(u64_from_pointer(smbios), SMBIOS_SCAN_SIZE);
+            deallocate(h, smbios, SMBIOS_SCAN_SIZE);
+            dmi_base = allocate(h, dmi_len);
+            if (dmi_base == INVALID_ADDRESS) {
+                dmi_base = 0;
+                return;
+            }
+            u64 map_end = pad(phys_base + dmi_len, PAGESIZE);
+            map(u64_from_pointer(dmi_base), phys_base & ~PAGEMASK,
+                map_end - (phys_base & ~PAGEMASK), PAGE_DEV_FLAGS);
+            dmi_base += phys_base & PAGEMASK;
+            return;
+        }
+    }
+}
+
+static const char *dmi_string(const struct dmi_header *dm, u8 s)
+{
+    const char *str = ((char *)dm) + dm->length;
+    if (!s)
+        return "";
+    while (--s && *str)
+        str += runtime_strlen(str) + 1;
+    dmi_debug("returning string '%s'", str);
+    return str;
+}
+
+const char *dmi_get_string(enum dmi_field field)
+{
+    dmi_debug("get string %d", field);
+    int type, offset;
+    switch (field) {
+    case DMI_CHASSIS_ASSET_TAG:
+        type = DMI_TYPE_CHASSIS_INFO;
+        offset = 8;
+        break;
+    default:
+        return 0;
+    }
+    if (!dmi_base)
+        dmi_map();
+    if (!dmi_base)
+        return 0;
+    int i = 0;
+    for (u8 *data = dmi_base;
+            (i < dmi_num) && (data + sizeof(struct dmi_header) <= (u8 *)dmi_base + dmi_len); i++) {
+        const struct dmi_header *dm = (const struct dmi_header *)data;
+        dmi_debug("table type %d, length %d, handle %d", dm->type, dm->length, dm->handle);
+        data += dm->length;
+
+        /* Find the end of the strings section. */
+        while ((data < (u8 *)dmi_base + dmi_len - 1) && (data[0] || data[1]))
+            data++;
+        data += 2;
+
+        if ((dm->type == type) && (dm->length > offset) && (data <= (u8 *)dmi_base + dmi_len)) {
+            return dmi_string(dm, *(((u8 *)dm) + offset));
+        }
+    }
+    return 0;
+}
+KLIB_EXPORT(dmi_get_string);

--- a/src/drivers/dmi.h
+++ b/src/drivers/dmi.h
@@ -1,0 +1,5 @@
+enum dmi_field {
+    DMI_CHASSIS_ASSET_TAG,
+};
+
+const char *dmi_get_string(enum dmi_field field);

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -266,6 +266,7 @@ buffer_handler allocate_http_parser(heap h, value_handler each)
     reset_parser(p);
     return closure(h, http_recv, p);
 }
+KLIB_EXPORT(allocate_http_parser);
 
 const char *http_request_methods[] = {
     [HTTP_REQUEST_METHOD_GET] = "GET",

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -266,6 +266,8 @@ kernel_heaps get_kernel_heaps(void);
 
 tuple get_environment(void);
 
+boolean first_boot(void);
+
 extern void interrupt_exit(void);
 extern char **state_strings;
 

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -220,6 +220,16 @@ closure_function(0, 2, void, radar_loaded,
     closure_finish();
 }
 
+closure_function(0, 2, void, klib_optional_loaded,
+                 klib, kl, status, s)
+{
+    if (is_ok(s))
+        klib_debug("%s loaded\n", kl->name);
+    else
+        timm_dealloc(s);
+    closure_finish();
+}
+
 void init_klib(kernel_heaps kh, void *fs, tuple config_root, tuple klib_md)
 {
     klib_debug("%s: fs %p, config_root %p, klib_md %p\n",
@@ -253,4 +263,5 @@ void init_klib(kernel_heaps kh, void *fs, tuple config_root, tuple klib_md)
     }
     if (table_find(get_environment(), sym(RADAR_KEY)))
         load_klib("/klib/radar", closure(h, radar_loaded));
+    load_klib("/klib/cloud_init", closure(h, klib_optional_loaded));
 }

--- a/src/runtime/buffer.c
+++ b/src/runtime/buffer.c
@@ -38,3 +38,13 @@ void buffer_append(buffer b,
     buffer_extend(b, length);
     buffer_write(b, body, length);
 }
+
+int buffer_strstr(buffer b, const char *str) {
+    int len = runtime_strlen(str);
+    for (int i = 0; b->start + i + len <= b->end; i++) {
+        if (!runtime_memcmp(buffer_ref(b, i), str, len))
+            return i;
+    }
+    return -1;
+}
+KLIB_EXPORT(buffer_strstr);

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -326,6 +326,8 @@ static inline int buffer_strchr(buffer b, int c)
     return -1;
 }
 
+int buffer_strstr(buffer b, const char *str);
+
 // the ascii subset..utf8 me
 #define foreach_character(__i, __c, __s)                                \
     for (u32 __i = 0, __c, __limit = buffer_length(__s);                \

--- a/src/runtime/runtime_init.c
+++ b/src/runtime/runtime_init.c
@@ -101,7 +101,7 @@ void init_runtime(heap general, heap safe)
     ignore = closure(general, ignore_body);
     ignore_status = (void*)ignore;
     errheap = safe;
-    null_value = wrap_buffer_cstring(general, "");
+    null_value = wrap_buffer(general, "", 1);
 }
 
 #define STACK_CHK_GUARD 0x595e9fbd94fda766

--- a/src/runtime/tuple.c
+++ b/src/runtime/tuple.c
@@ -52,6 +52,7 @@ void destruct_tuple(tuple t, boolean recursive)
     }
     deallocate_tuple(t);
 }
+KLIB_EXPORT(destruct_tuple);
 
 /* Compared to timm(), kern_timm() supports one key-value pair only. */
 tuple kern_timm(char *name, ...)

--- a/test/unit/buffer_test.c
+++ b/test/unit/buffer_test.c
@@ -49,6 +49,7 @@ boolean basic_tests(heap h)
     test_assert(buffer_length(b) == 0);
     test_assert(buffer_memcmp(b, test_str, 0) == 0);
     test_assert(buffer_strchr(b, '0') < 0);
+    test_assert(buffer_strstr(b, test_str) == -1);
 
     /* Buffer capacity */
     buffer_write_cstring(b, test_str);
@@ -61,6 +62,12 @@ boolean basic_tests(heap h)
     test_assert(buffer_memcmp(b, test_str, sizeof(test_str)) < 0);
     test_assert(buffer_strchr(b, 't') == 10);
     test_assert(buffer_strchr(b, 'u') < 0);
+    test_assert(buffer_strstr(b, "") == 0);
+    test_assert(buffer_strstr(b, test_str) == 0);
+    test_assert(buffer_strstr(b, "This") == 0);
+    test_assert(buffer_strstr(b, "is") == 2);
+    test_assert(buffer_strstr(b, "g") == 20);
+    test_assert(buffer_strstr(b, "TT") == -1);
 
     /* Create and then deallocate a wrapped buffer. */
     deallocate_buffer(wrap_buffer_cstring(h, test_str));


### PR DESCRIPTION
At the first boot of the kernel for a given image, this library detects (by reading the DMI tables) the cloud platform on which the kernel is running, and executes a cloud-specific initialization. The only cloud platform currently supported is Azure.

Closes #1319.