### PR TITLE
Nightly builds: add kernel libraries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run: sudo gcloud config set project ${GOOGLE_PROJECT_ID}
       - run: gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
 
-      - run: mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/tools/bin/mkfs temp/
+      - run: mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/tools/bin/mkfs temp/ && mkdir temp/klibs && cp output/klib/bin/* temp/klibs
       - run: cd temp && tar cvzf nanos-nightly-linux.tar.gz * && gsutil cp nanos-nightly-linux.tar.gz gs://nanos/release/nightly
       - run: gsutil acl ch -u AllUsers:R gs://nanos/release/nightly/nanos-nightly-linux.tar.gz
       - run: rm -r temp
@@ -92,7 +92,7 @@ jobs:
       - run: sudo gcloud config set project ${GOOGLE_PROJECT_ID}
       - run: gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
 
-      - run: mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/tools/bin/mkfs temp/
+      - run: mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/tools/bin/mkfs temp/ && mkdir temp/klibs && cp output/klib/bin/* temp/klibs
       - run: cd temp && tar cvzf nanos-nightly-darwin.tar.gz * && gsutil cp nanos-nightly-darwin.tar.gz gs://nanos/release/nightly
       - run: gsutil acl ch -u AllUsers:R gs://nanos/release/nightly/nanos-nightly-darwin.tar.gz
       - run: rm -r temp


### PR DESCRIPTION
This change adds the klibs to the nightly tarballs.

Closes #1339.