### PR TITLE
Fix syscall setup and implement getcpu syscall

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -509,7 +509,7 @@ static void __attribute__((noinline)) init_service_new_stack()
     init_debug("install GDT64 and TSS");
     install_gdt64_and_tss(0);
     unmap(PAGESIZE, INITIAL_MAP_SIZE - PAGESIZE);
-
+    set_syscall_handler(syscall_enter);
 #ifdef SMP_ENABLE
     init_debug("starting APs");
     start_cpu(misc, heap_backed(kh), TARGET_EXCLUSIVE_BROADCAST, new_cpu);

--- a/src/kernel/vdso.c
+++ b/src/kernel/vdso.c
@@ -49,8 +49,9 @@ do_vdso_gettimeofday(struct timeval * tv, void * tz)
 static sysreturn
 do_vdso_getcpu(unsigned * cpu, unsigned * node, void * tcache)
 {
+    cpuinfo ci = current_cpu();
     if (cpu)
-        *cpu = 0;
+        *cpu = ci->id;
     if (node)
         *node = 0;
     return 0;

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -177,7 +177,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, open_by_handle_at, 0);
     register_syscall(map, clock_adjtime, 0);
     register_syscall(map, setns, 0);
-    register_syscall(map, getcpu, 0);
     register_syscall(map, process_vm_readv, 0);
     register_syscall(map, process_vm_writev, 0);
     register_syscall(map, kcmp, 0);
@@ -2333,6 +2332,17 @@ sysreturn umask(int mask)
     return mask;
 }
 
+sysreturn getcpu(unsigned int *cpu, unsigned int *node, void *tcache)
+{
+    cpuinfo ci = current_cpu();
+    if (cpu)
+        *cpu = ci->id;
+    /* XXX to do */
+    if (node)
+        *node = 0;
+    return 0;
+}
+
 void register_file_syscalls(struct syscall *map)
 {
     register_syscall(map, read, read);
@@ -2422,6 +2432,7 @@ void register_file_syscalls(struct syscall *map)
     register_syscall(map, io_uring_setup, io_uring_setup);
     register_syscall(map, io_uring_enter, io_uring_enter);
     register_syscall(map, io_uring_register, io_uring_register);
+    register_syscall(map, getcpu, getcpu);
 }
 
 #define SYSCALL_F_NOTRACE 0x1

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2335,8 +2335,8 @@ sysreturn umask(int mask)
 sysreturn getcpu(unsigned int *cpu, unsigned int *node, void *tcache)
 {
     cpuinfo ci = current_cpu();
-    if (!validate_user_memory(cpu, sizeof *cpu, true) ||
-            !validate_user_memory(node, sizeof *node, true))
+    if ((cpu != 0 && !validate_user_memory(cpu, sizeof *cpu, true)) ||
+            (node != 0 && !validate_user_memory(node, sizeof *node, true)))
         return -EFAULT;
     if (cpu)
         *cpu = ci->id;

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2335,6 +2335,9 @@ sysreturn umask(int mask)
 sysreturn getcpu(unsigned int *cpu, unsigned int *node, void *tcache)
 {
     cpuinfo ci = current_cpu();
+    if (!validate_user_memory(cpu, sizeof *cpu, true) ||
+            !validate_user_memory(node, sizeof *node, true))
+        return -EFAULT;
     if (cpu)
         *cpu = ci->id;
     /* XXX to do */

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -468,7 +468,6 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
         goto alloc_fail;
 #endif
 
-    set_syscall_handler(syscall_enter);
     process kernel_process = create_process(uh, root, fs);
     dummy_thread = create_thread(kernel_process);
     runtime_memcpy(dummy_thread->name, "dummy_thread",


### PR DESCRIPTION
This PR fixes syscall setup for SMP by guaranteeing set_syscall_handler is run on the first processor. It also implements the getcpu syscall for userspace programs that want to know which cpu they're running on.