### PR TITLE
Radar klib: add crash reporting functionality

### DIFF
--- a/klib/radar.c
+++ b/klib/radar.c
@@ -1,5 +1,6 @@
 #include <kernel.h>
 #include <http.h>
+#include <log.h>
 #include <lwip.h>
 
 #define RADAR_HOSTNAME  "radar.relayered.net"
@@ -34,16 +35,17 @@ GIo/ikGQI31bS/6kA1ibRrLDYGCD+H1QQc7CoZDDu+8CL9IVVO5EFdkKrqeKM+2x\
 LXY2JtwE65/3YR8V3Idv7kaWKK2hJn0KCacuBKONvPi8BDAB\
 -----END CERTIFICATE-----"
 
-declare_closure_struct(0, 1, void, boot_timer_func,
+declare_closure_struct(0, 1, void, retry_timer_func,
     u64, overruns);
 
 static struct telemetry {
     heap h;
     tuple env;
     buffer auth_header;
+    klog_dump dump;
     s64 boot_id;
-    timestamp boot_backoff;
-    closure_struct(boot_timer_func, boot_func);
+    timestamp retry_backoff;
+    closure_struct(retry_timer_func, retry_func);
     void (*rprintf)(const char *format, ...);
     tuple (*allocate_tuple)(void);
     void (*table_set)(table z, void *c, void *v);
@@ -52,6 +54,9 @@ static struct telemetry {
     void (*timm_dealloc)(tuple t);
     symbol (*intern)(string name);
     void *(*klib_sym)(klib kl, symbol s);
+    void (*klog_load)(klog_dump dest, status_handler sh);
+    void (*klog_dump_clear)(void);
+    void (*klog_set_boot_id)(s64 id);
     buffer (*allocate_buffer)(heap h, bytes s);
     void (*buffer_write)(buffer b, const void *source, bytes length);
     void (*bprintf)(buffer b, const char *fmt, ...);
@@ -72,6 +77,7 @@ static struct telemetry {
 /* To be used with literal strings only */
 #define buffer_write_cstring(b, s)  kfunc(buffer_write)(b, s, sizeof(s) - 1)
 
+static void telemetry_crash_report(void);
 static void telemetry_boot(void);
 
 static void telemetry_dns_cb(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
@@ -113,8 +119,17 @@ closure_function(1, 1, status, telemetry_recv,
 {
     if (data)
         apply(bound(out), 0);   /* close connection */
-    else   /* connection closed */
+    else {  /* connection closed */
         closure_finish();
+        if (telemetry.dump) {
+            /* We just sent a crash report: clear the log dump (so that it's not
+             * sent again at the next boot), then send a boot event. */
+            kfunc(klog_dump_clear)();
+            deallocate(telemetry.h, telemetry.dump, sizeof(*telemetry.dump));
+            telemetry.dump = 0;
+            telemetry_boot();
+        }
+    }
     return STATUS_OK;
 }
 
@@ -156,10 +171,76 @@ boolean telemetry_send(const char *url, buffer data)
     return false;
 }
 
-define_closure_function(0, 1, void, boot_timer_func,
+define_closure_function(0, 1, void, retry_timer_func,
                         u64, overruns)
 {
-    telemetry_boot();
+    if (telemetry.dump)
+        telemetry_crash_report();
+    else
+        telemetry_boot();
+}
+
+static void telemetry_retry(void)
+{
+    kfunc(register_timer)(CLOCK_ID_MONOTONIC, telemetry.retry_backoff, false, 0,
+            init_closure(&telemetry.retry_func, retry_timer_func));
+    if (telemetry.retry_backoff < seconds(600))
+        telemetry.retry_backoff <<= 1;
+}
+
+static void telemetry_crash_report(void)
+{
+    buffer b = kfunc(allocate_buffer)(telemetry.h, PAGESIZE);
+    if (b == INVALID_ADDRESS)
+        goto error;
+    kfunc(bprintf)(b, "{\"id\":%ld", telemetry.dump->boot_id);
+    buffer nanos_ver = kfunc(table_find)(telemetry.env, sym(NANOS_VERSION));
+    if (nanos_ver)
+        kfunc(bprintf)(b, ",\"nanosVersion\":\"%b\"", nanos_ver);
+    buffer ops_ver = kfunc(table_find)(telemetry.env, sym(OPS_VERSION));
+    if (ops_ver)
+        kfunc(bprintf)(b, ",\"opsVersion\":\"%b\"", ops_ver);
+    buffer_write_cstring(b, ",\"dump\":\"");
+    for (int i = 0; (i < sizeof(telemetry.dump->msgs)) && telemetry.dump->msgs[i]; i++) {
+        /* Escape JSON special characters. */
+        char c = telemetry.dump->msgs[i];
+        switch (c) {
+        case '\n':
+            buffer_write_cstring(b, "\\n");
+            break;
+        case '"':
+            buffer_write_cstring(b, "\\\"");
+            break;
+        case '/':
+            buffer_write_cstring(b, "\\/");
+            break;
+        case '\\':
+            buffer_write_cstring(b, "\\\\");
+            break;
+        case '\t':
+            buffer_write_cstring(b, "\\t");
+            break;
+        case '\r':
+            buffer_write_cstring(b, "\\r");
+            break;
+        case '\b':
+            buffer_write_cstring(b, "\\b");
+            break;
+        case '\f':
+            buffer_write_cstring(b, "\\f");
+            break;
+        default:
+            kfunc(buffer_write)(b, &c, 1);
+        }
+    }
+    buffer_write_cstring(b, "\"}\r\n");
+    if (!telemetry_send("/crashes", b)) {
+        deallocate_buffer(b);
+        goto error;
+    }
+    return;
+  error:
+    telemetry_retry();
 }
 
 static void telemetry_boot(void)
@@ -175,16 +256,30 @@ static void telemetry_boot(void)
     if (ops_ver)
         kfunc(bprintf)(b, ",\"opsVersion\":\"%b\"", ops_ver);
     buffer_write_cstring(b, "}\r\n");
-    if (!telemetry_send("/boots/create", b)) {
+    if (!telemetry_send("/boots", b)) {
         deallocate_buffer(b);
         goto error;
     }
     return;
   error:
-    kfunc(register_timer)(CLOCK_ID_MONOTONIC, telemetry.boot_backoff, false, 0,
-            init_closure(&telemetry.boot_func, boot_timer_func));
-    if (telemetry.boot_backoff < seconds(600))
-        telemetry.boot_backoff <<= 1;
+    telemetry_retry();
+}
+
+closure_function(0, 1, void, klog_dump_loaded,
+                 status, s)
+{
+    if (is_ok(s)) {
+        kfunc(klog_set_boot_id)(telemetry.boot_id);
+        if (telemetry.dump->exit_code != 0) {
+            telemetry_crash_report();
+        } else {
+            deallocate(telemetry.h, telemetry.dump, sizeof(*telemetry.dump));
+            telemetry.dump = 0;
+            telemetry_boot();
+        }
+    } else
+        kfunc(timm_dealloc)(s);
+    closure_finish();
 }
 
 closure_function(0, 2, void, tls_loaded,
@@ -195,7 +290,14 @@ closure_function(0, 2, void, tls_loaded,
         int (*tls_set_cacert)(void *, u64) = kfunc(klib_sym)(kl, sym(tls_set_cacert));
         if (tls_set_cacert(RADAR_CA_CERT, sizeof(RADAR_CA_CERT)) == 0) {
             telemetry.tls_connect = kfunc(klib_sym)(kl, sym(tls_connect));
-            telemetry_boot();
+            telemetry.dump = allocate(telemetry.h, sizeof(*telemetry.dump));
+            if (telemetry.dump != INVALID_ADDRESS) {
+                status_handler sh = closure(telemetry.h, klog_dump_loaded);
+                if (sh != INVALID_ADDRESS)
+                    kfunc(klog_load)(telemetry.dump, sh);
+                else
+                    deallocate(telemetry.h, telemetry.dump, sizeof(*telemetry.dump));
+            }
         }
     } else {
         kfunc(timm_dealloc)(s);
@@ -219,6 +321,9 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
             !(telemetry.timm_dealloc = get_sym("timm_dealloc")) ||
             !(telemetry.intern = get_sym("intern")) ||
             !(telemetry.klib_sym = get_sym("klib_sym")) ||
+            !(telemetry.klog_load = get_sym("klog_load")) ||
+            !(telemetry.klog_dump_clear = get_sym("klog_dump_clear")) ||
+            !(telemetry.klog_set_boot_id = get_sym("klog_set_boot_id")) ||
             !(telemetry.allocate_buffer = get_sym("allocate_buffer")) ||
             !(telemetry.buffer_write = get_sym("buffer_write")) ||
             !(telemetry.bprintf = get_sym("bprintf")) ||
@@ -241,7 +346,7 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
     kfunc(bprintf)(telemetry.auth_header, "Bearer %b",
             kfunc(table_find)(telemetry.env, sym(RADAR_KEY)));
     telemetry.boot_id = (s64)random_u64();
-    telemetry.boot_backoff = seconds(1);
+    telemetry.retry_backoff = seconds(1);
     load_klib("/klib/tls", tls_handler);
     return KLIB_INIT_OK;
 }

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -21,6 +21,7 @@ SRCS-kernel.img= \
 	$(SRCDIR)/kernel/kernel.c \
 	$(SRCDIR)/kernel/klib.c \
 	$(SRCDIR)/kernel/kvm_platform.c \
+	$(SRCDIR)/kernel/log.c \
 	$(SRCDIR)/kernel/pagecache.c \
 	$(SRCDIR)/kernel/pci.c \
 	$(SRCDIR)/kernel/pvclock.c \

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -103,6 +103,7 @@ SRCS-kernel.img= \
 	$(SRCS-lwip)
 SRCS-lwip= \
 	$(LWIPDIR)/src/core/def.c \
+	$(LWIPDIR)/src/core/dns.c \
 	$(LWIPDIR)/src/core/inet_chksum.c \
 	$(LWIPDIR)/src/core/init.c \
 	$(LWIPDIR)/src/core/ip.c \

--- a/platform/pc/boot/def32.h
+++ b/platform/pc/boot/def32.h
@@ -2,6 +2,7 @@ typedef unsigned char u8;
 typedef char s8;
 typedef unsigned short u16;
 typedef unsigned int u32;
+typedef int s32;
 typedef unsigned long long u64;
 typedef long long s64;
 typedef u32 bytes;

--- a/platform/pc/boot/stage2.c
+++ b/platform/pc/boot/stage2.c
@@ -75,6 +75,10 @@ void console_write(const char *s, bytes count)
     }
 }
 
+void klog_write(const char *s, bytes count)
+{
+}
+
 closure_function(1, 3, void, stage2_bios_read,
                  u64, offset,
                  void *, dest, range, blocks, status_handler, completion)
@@ -294,7 +298,8 @@ closure_function(3, 2, void, filesystem_initialized,
 void newstack()
 {
     stage2_debug("%s\n", __func__);
-    u32 fs_offset = SECTOR_SIZE + fsregion()->length; // MBR + stage2
+    struct partition_entry *bootfs_part = partition_get(MBR_ADDRESS, PARTITION_BOOTFS);
+    u32 fs_offset = bootfs_part->lba_start * SECTOR_SIZE;
     heap h = heap_general(&kh);
     buffer_handler bh = closure(h, kernel_read_complete);
 

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -17,6 +17,7 @@
 #include <drivers/storage.h>
 #include <drivers/console.h>
 #include <kvm_platform.h>
+#include <log.h>
 #include <xen_platform.h>
 #include <hyperv_platform.h>
 
@@ -71,7 +72,7 @@ static u64 bootstrap_alloc(heap h, bytes length)
 {
     u64 result = bootstrap_base;
     if ((result + length) >=  (u64_from_pointer(bootstrap_region) + sizeof(bootstrap_region))) {
-	console("*** bootstrap heap overflow! ***\n");
+        rputs("*** bootstrap heap overflow! ***\n");
         return INVALID_PHYSICAL;
     }
     bootstrap_base += length;
@@ -231,9 +232,14 @@ closure_function(5, 1, void, mbr_read,
             init_debug("unformatted storage device, ignoring");
         deallocate(h, mbr, SECTOR_SIZE);
     }
-    else
+    else {
+        /* The on-disk kernel log dump section is immediately before the boot FS partition. */
+        struct partition_entry *bootfs_part = partition_get(mbr, PARTITION_BOOTFS);
+        klog_disk_setup(bootfs_part->lba_start * SECTOR_SIZE - KLOG_DUMP_SIZE, bound(r), bound(w));
+
         rootfs_init(h, mbr, rootfs_part->lba_start * SECTOR_SIZE,
             bound(r), bound(w), bound(length));
+    }
   out:
     closure_finish();
 }
@@ -370,24 +376,38 @@ closure_function(1, 1, void, sync_complete,
     closure_finish();
 }
 
-closure_function(1, 0, void, do_storage_sync,
-                 status_handler, completion)
+static void storage_shutdown(int status, status_handler completion)
 {
-    storage_sync(bound(completion));
+    if ((status == 0) || !table_find(get_environment(), sym(RADAR_KEY))) {
+        storage_sync(completion);
+    } else {
+        merge m = allocate_merge(heap_locked(&heaps), completion);
+        status_handler sh = apply_merge(m);
+        klog_save(status, apply_merge(m));
+        storage_sync(apply_merge(m));
+        apply(sh, STATUS_OK);
+    }
+}
+
+closure_function(2, 0, void, do_storage_shutdown,
+                 int, status, status_handler, completion)
+{
+    storage_shutdown(bound(status), bound(completion));
     closure_finish();
 }
 
 extern boolean shutting_down;
-void kernel_shutdown_ex(status_handler completion)
+static void __attribute__((noreturn)) kernel_shutdown_internal(int status,
+    status_handler completion)
 {
     shutting_down = true;
     if (root_fs) {
         if (this_cpu_has_kernel_lock()) {
-            storage_sync(completion);
+            storage_shutdown(status, completion);
             kern_unlock();
         } else {
             enqueue_irqsafe(runqueue, closure(heap_locked(&heaps),
-                                              do_storage_sync, completion));
+                                              do_storage_shutdown, status, completion));
         }
         runloop();
     }
@@ -395,9 +415,14 @@ void kernel_shutdown_ex(status_handler completion)
     while(1);
 }
 
+void kernel_shutdown_ex(status_handler completion)
+{
+    kernel_shutdown_internal(0, completion);
+}
+
 void kernel_shutdown(int status)
 {
-    kernel_shutdown_ex(closure(heap_locked(&heaps), sync_complete, status));
+    kernel_shutdown_internal(status, closure(heap_locked(&heaps), sync_complete, status));
 }
 
 u64 total_processors = 1;
@@ -565,11 +590,11 @@ static id_heap init_physical_id_heap(heap h)
 		continue;
 	    u64 length = end - base;
 #ifdef STAGE3_INIT_DEBUG
-	    console("INIT:  [");
+	    rputs("INIT:  [");
 	    print_u64(base);
-	    console(", ");
+	    rputs(", ");
 	    print_u64(base + length);
-	    console(")\n");
+	    rputs(")\n");
 #endif
 	    if (!id_heap_add_range(physical, base, length))
 		halt("    - id_heap_add_range failed\n");

--- a/src/config.h
+++ b/src/config.h
@@ -50,3 +50,6 @@
 
 /* ftrace buffer size */
 #define DEFAULT_TRACE_ARRAY_SIZE        (512ULL << 20)
+
+/* on-disk log dump section */
+#define KLOG_DUMP_SIZE  (4 * KB)

--- a/src/kernel/kvm_platform.c
+++ b/src/kernel/kvm_platform.c
@@ -6,7 +6,7 @@
 
 //#define KVM_DEBUG
 #ifdef KVM_DEBUG
-#define kvm_debug(x) do {console(" KVM: " x "\n");} while(0)
+#define kvm_debug(x) do {rputs(" KVM: " x "\n");} while(0)
 #else
 #define kvm_debug(x)
 #endif

--- a/src/kernel/log.c
+++ b/src/kernel/log.c
@@ -1,0 +1,107 @@
+#include <kernel.h>
+#include <log.h>
+#include <storage.h>
+
+#define KLOG_BUF_SIZE       KLOG_DUMP_SIZE
+#define KLOG_BUF_SIZE_MASK  (KLOG_BUF_SIZE - 1)
+
+#define KLOG_DUMP_MAGIC "KLOG"
+
+declare_closure_struct(2, 1, void, klog_load_sh,
+    klog_dump, dest, status_handler, sh,
+    status, s);
+
+static struct {
+    char buf[KLOG_BUF_SIZE];
+    bytes count;
+    struct spinlock lock;
+    u64 disk_offset;
+    block_io disk_read, disk_write;
+    closure_struct(klog_load_sh, load_sh);
+    struct klog_dump dump;
+} klog;
+
+#define klog_lock()     u64 _irqflags = spin_lock_irq(&klog.lock)
+#define klog_unlock()   spin_unlock_irq(&klog.lock, _irqflags)
+
+void klog_write(const char *s, bytes count)
+{
+    if (count > KLOG_BUF_SIZE) {
+        /* Copy the last KLOG_BUF_SIZE bytes only. */
+        s += count - KLOG_BUF_SIZE;
+        count = KLOG_BUF_SIZE;
+    }
+    klog_lock();
+    bytes index = klog.count & KLOG_BUF_SIZE_MASK;
+    bytes limit = MIN(count, KLOG_BUF_SIZE - index);
+    runtime_memcpy(&klog.buf[index], s, limit);
+    if (limit < count)
+        runtime_memcpy(klog.buf, s + limit, count - limit);
+    klog.count += count;
+    klog_unlock();
+}
+
+void klog_disk_setup(u64 disk_offset, block_io disk_read, block_io disk_write)
+{
+    klog.disk_offset = disk_offset;
+    klog.disk_read = disk_read;
+    klog.disk_write = disk_write;
+}
+
+void klog_set_boot_id(s64 id)
+{
+    klog.dump.boot_id = id;
+}
+KLIB_EXPORT(klog_set_boot_id);
+
+define_closure_function(2, 1, void, klog_load_sh,
+                        klog_dump, dest, status_handler, sh,
+                        status, s)
+{
+    klog_dump dest = bound(dest);
+    if (is_ok(s) && runtime_memcmp(&dest->header, KLOG_DUMP_MAGIC, sizeof(KLOG_DUMP_MAGIC) - 1)) {
+        /* There is no log dump. */
+        dest->boot_id = dest->exit_code = 0;
+        dest->msgs[0] = '\0';
+    }
+    apply(bound(sh), s);
+}
+
+void klog_load(klog_dump dest, status_handler sh)
+{
+    apply(klog.disk_read, dest,
+        irangel(klog.disk_offset >> SECTOR_OFFSET, KLOG_DUMP_SIZE >> SECTOR_OFFSET),
+        init_closure(&klog.load_sh, klog_load_sh, dest, sh));
+}
+KLIB_EXPORT(klog_load);
+
+void klog_save(int exit_code, status_handler sh)
+{
+    bytes msg_len = 0;
+    if (klog.count > 0) {
+        klog_lock();
+        msg_len = MIN(klog.count, sizeof(klog.dump.msgs) - 1);
+        bytes index = (klog.count - msg_len) & KLOG_BUF_SIZE_MASK;
+        bytes limit = MIN(msg_len, KLOG_BUF_SIZE - index);
+        runtime_memcpy(klog.dump.msgs, &klog.buf[index], limit);
+        if (limit < msg_len)
+            runtime_memcpy(&klog.dump.msgs[limit], klog.buf, msg_len - limit);
+        klog_unlock();
+    }
+    runtime_memcpy(&klog.dump.header, KLOG_DUMP_MAGIC, sizeof(KLOG_DUMP_MAGIC) - 1);
+    klog.dump.msgs[msg_len] = '\0';
+    klog.dump.exit_code = exit_code;
+    apply(klog.disk_write, &klog.dump,
+        irangel(klog.disk_offset >> SECTOR_OFFSET, KLOG_DUMP_SIZE >> SECTOR_OFFSET), sh);
+}
+
+void klog_dump_clear(void)
+{
+    /* Make an invalid header. */
+    zero(&klog.dump.header, sizeof(klog.dump.header));
+
+    /* Only the first sector needs to be written. */
+    apply(klog.disk_write, &klog.dump,
+        irangel(klog.disk_offset >> SECTOR_OFFSET, 1), ignore_status);
+}
+KLIB_EXPORT(klog_dump_clear);

--- a/src/kernel/log.h
+++ b/src/kernel/log.h
@@ -1,0 +1,19 @@
+typedef struct klog_dump {
+    u8 header[4];
+    s64 boot_id;
+    s32 exit_code;
+    char msgs[KLOG_DUMP_SIZE - 16]; /* total size of the struct must match KLOG_DUMP_SIZE */
+} __attribute__((packed)) *klog_dump;
+
+void klog_write(const char *s, bytes count);
+
+static inline void klog_print(const char *s)
+{
+    klog_write(s, runtime_strlen(s));
+}
+
+void klog_disk_setup(u64 disk_offset, block_io disk_read, block_io disk_write);
+void klog_set_boot_id(s64 id);
+void klog_load(klog_dump dest, status_handler sh);
+void klog_save(int exit_code, status_handler sh);
+void klog_dump_clear(void);

--- a/src/kernel/region.h
+++ b/src/kernel/region.h
@@ -83,10 +83,10 @@ static inline void print_regions()
 {
     for_regions(e){    
          print_u64(e->type);
-         console(" ");
+         rputs(" ");
          print_u64(e->base);
-         console(" ");
+         rputs(" ");
          print_u64(e->length);
-         console("\n");
+         rputs("\n");
     }
 }

--- a/src/kernel/symtab.c
+++ b/src/kernel/symtab.c
@@ -76,7 +76,7 @@ void add_elf_syms(buffer b, u64 load_offset)
     if (elf_symtable)
 	elf_symbols(b, stack_closure(elf_symtable_add, load_offset));
     else
-	console("can't add ELF symbols; symtab not initialized\n");
+	rputs("can't add ELF symbols; symtab not initialized\n");
 }
 
 void init_symtab(kernel_heaps kh)

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -9,5 +9,6 @@
 #include <lwip/ip4_frag.h>
 #include <lwip/etharp.h>
 #include <lwip/dhcp.h>
+#include <lwip/dns.h>
 
 status direct_connect(heap h, ip_addr_t *addr, u16 port, connection_handler ch);

--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -71,6 +71,7 @@ typedef unsigned long size_t;
 #define LWIP_TIMERS 1
 #define LWIP_TIMERS_CUSTOM 1
 #define LWIP_DHCP_BOOTP_FILE 1
+#define LWIP_DNS 1
 
 #define LWIP_IPV6   1
 
@@ -119,6 +120,9 @@ extern void lwip_debug(char * format, ...);
 
 #define MEM_LIBC_MALLOC 1
 
+extern u32_t lwip_rand(void);
+#define LWIP_RAND   lwip_rand
+
 extern void net_debug(char *format, ...);
 extern void *lwip_allocate(unsigned long long size);
 extern void lwip_deallocate(void *z);
@@ -141,6 +145,7 @@ void lwip_memcpy(void *a, const void *b, unsigned long len);
 int lwip_strlen(char *a);
 void lwip_memset(void *x, unsigned char v, unsigned long len);
 int lwip_memcmp(const void *x, const void *y, unsigned long len);
+int lwip_strcmp(const char *x, const char *y);
 int lwip_strncmp(const char *x, const char *y, unsigned long len);
 
 #define memcpy(__a, __b, __c) lwip_memcpy(__a, __b, __c)
@@ -149,6 +154,7 @@ int lwip_strncmp(const char *x, const char *y, unsigned long len);
 #define memmove(__a, __b, __c) lwip_memcpy(__a, __b, __c)
 #define strlen(__a) lwip_strlen((void *)__a)
 #define strncmp(__a, __b, __c) lwip_strncmp(__a, __b, __c)
+#define strcmp(__a, __b) lwip_strcmp(__a, __b)
 #define atoi(__a) lwip_atoi(__a)
 
 static inline void *calloc(size_t n, size_t s)

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -74,6 +74,11 @@ void lwip_status_callback(struct netif *netif)
     rprintf("assigned: %d.%d.%d.%d\n", n[0], n[1], n[2], n[3]);
 }
 
+u32_t lwip_rand(void)
+{
+    return random_u64();
+}
+
 /* unsigned only ... don't imagine we'd have negative interface numbers! */
 int lwip_atoi(const char *p)
 {
@@ -103,6 +108,11 @@ int lwip_memcmp(const void *x, const void *y, unsigned long len)
     return runtime_memcmp(x, y, len);
 }
 
+int lwip_strcmp(const char *x, const char *y)
+{
+    return runtime_strcmp(x, y);
+}
+
 int lwip_strncmp(const char *x, const char *y, unsigned long len)
 {
     for (int i = 0; i < len; i++) {
@@ -111,6 +121,8 @@ int lwip_strncmp(const char *x, const char *y, unsigned long len)
     }
     return 0;
 }
+
+KLIB_EXPORT(dns_gethostbyname);
 
 #define MAX_ADDR_LEN 20
 static boolean get_config_addr(tuple root, symbol s, ip4_addr_t *addr)

--- a/src/runtime/buffer.c
+++ b/src/runtime/buffer.c
@@ -1,4 +1,5 @@
 #include <runtime.h>
+#include <log.h>
 
 buffer allocate_buffer(heap h, bytes s)
 {
@@ -48,3 +49,9 @@ int buffer_strstr(buffer b, const char *str) {
     return -1;
 }
 KLIB_EXPORT(buffer_strstr);
+
+void buffer_print(buffer b)
+{
+    console_write(buffer_ref(b, 0), buffer_length(b));
+    klog_write(buffer_ref(b, 0), buffer_length(b));
+}

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -425,8 +425,4 @@ static inline key fnv64(void *z)
     return hash;
 }
 
-static inline void buffer_print(buffer b)
-{
-    // should probably use foreach_character() once it supports UTF-8 properly
-    console_write(buffer_ref(b, 0), buffer_length(b));
-}
+void buffer_print(buffer b);

--- a/src/runtime/heap/freelist.c
+++ b/src/runtime/heap/freelist.c
@@ -34,24 +34,22 @@ static u64 freelist_allocate(heap h, bytes size)
 {
     freelist f = (freelist)h;
     if (size != f->size) {
-        console("bad unsized allocator ");
+        rputs("bad unsized allocator ");
         print_u64(size);
-        console(" ");
+        rputs(" ");
         print_u64(f->size);
-        console(" ");
+        rputs(" ");
         print_u64(u64_from_pointer(__builtin_return_address(0)));        
-        console("\n");
+        rputs("\n");
 	return INVALID_PHYSICAL;
     }
 
     size = MAX(size, sizeof(void *));
     f->count += size;
     if (!f->free) {
-        //        console("freelist spill\n");
         f->total += size;
         return allocate_u64(f->parent, size);
     }
-    //    console("freelist cached\n");
     void *result = f->free;
     f->free = *(void **)f->free;
     return u64_from_pointer(result);

--- a/src/runtime/heap/mcache.c
+++ b/src/runtime/heap/mcache.c
@@ -24,23 +24,23 @@ u64 mcache_alloc(heap h, bytes b)
     mcache m = (mcache)h;
     heap o;
 #ifdef MCACHE_DEBUG
-    console("mcache_alloc:   heap ");
+    rputs("mcache_alloc:   heap ");
     print_u64(u64_from_pointer(h));
-    console(", size ");
+    rputs(", size ");
     print_u64(b);
-    console(": ");
+    rputs(": ");
 #endif
     /* Could become a binary search if search set is large... */
     vector_foreach(m->caches, o) {
 	if (o && b <= o->pagesize) {
 #ifdef MCACHE_DEBUG
-	    console("match cache ");
+	    rputs("match cache ");
 	    print_u64(u64_from_pointer(o));
-	    console(" obj size ");
+	    rputs(" obj size ");
 	    print_u64(o->pagesize);
-	    console(", pre validate...");
+	    rputs(", pre validate...");
 	    if (objcache_validate((heap)o))
-		console("pass, alloc ");
+		rputs("pass, alloc ");
 	    else
 		halt("failed!\n");
 #endif
@@ -49,9 +49,9 @@ u64 mcache_alloc(heap h, bytes b)
 		m->allocated += o->pagesize;
 #ifdef MCACHE_DEBUG
 	    print_u64(a);
-	    console(", post validate...");
+	    rputs(", post validate...");
 	    if (objcache_validate((heap)o))
-		console("pass\n");
+		rputs("pass\n");
 	    else
 		halt("failed!\n");
 #endif
@@ -59,7 +59,7 @@ u64 mcache_alloc(heap h, bytes b)
 	}
     }
 #ifdef MCACHE_DEBUG
-    console("no matching cache; fail\n");
+    rputs("no matching cache; fail\n");
 #endif
     return INVALID_PHYSICAL;
 }
@@ -67,44 +67,44 @@ u64 mcache_alloc(heap h, bytes b)
 void mcache_dealloc(heap h, u64 a, bytes b)
 {
 #ifdef MCACHE_DEBUG
-    console("mcache_dealloc: heap ");
+    rputs("mcache_dealloc: heap ");
     print_u64(u64_from_pointer(h));
-    console(", addr ");
+    rputs(", addr ");
     print_u64(a);
-    console(", size ");
+    rputs(", size ");
     print_u64(b);
 #endif
 
     mcache m = (mcache)h;
     heap o = objcache_from_object(a, m->pagesize);
     if (o == INVALID_ADDRESS) {
-	console("mcache ");
+	rputs("mcache ");
 	print_u64(u64_from_pointer(m));
-	console(": can't find cache for object ");
+	rputs(": can't find cache for object ");
 	print_u64(u64_from_pointer(a));
-	console(", size ");
+	rputs(", size ");
 	print_u64(b);
-	console("; leaking\n");
+	rputs("; leaking\n");
 	return;
     }
 
     /* We don't really need the size, but if we're given a valid one,
        make some attempt to verify it. */
     if (b != -1ull && b > o->pagesize) {
-	console("mcache ");
+	rputs("mcache ");
 	print_u64(u64_from_pointer(m));
-	console(": dealloc size (");
+	rputs(": dealloc size (");
 	print_u64(b);
-	console(") exceeds found cache size (");
+	rputs(") exceeds found cache size (");
 	print_u64(o->pagesize);
-	console("); leaking\n");
+	rputs("); leaking\n");
 	return;
     }
 
 #ifdef MCACHE_DEBUG
-    console(", pre validate...");
+    rputs(", pre validate...");
     if (objcache_validate((heap)o))
-	console("pass");
+	rputs("pass");
     else
 	halt("fail!\n");
 #endif
@@ -113,9 +113,9 @@ void mcache_dealloc(heap h, u64 a, bytes b)
     m->allocated -= o->pagesize;
     deallocate(o, a, o->pagesize);
 #ifdef MCACHE_DEBUG
-    console(", post validate...");
+    rputs(", post validate...");
     if (objcache_validate((heap)o))
-	console("pass\n");
+	rputs("pass\n");
     else
 	halt("fail!\n");
 #endif
@@ -124,9 +124,9 @@ void mcache_dealloc(heap h, u64 a, bytes b)
 void destroy_mcache(heap h)
 {
 #ifdef MCACHE_DEBUG
-    console("destroy_mcache: heap at ");
+    rputs("destroy_mcache: heap at ");
     print_u64(u64_from_pointer(h));
-    console("\n");
+    rputs("\n");
 #endif
     mcache m = (mcache)h;
     heap o;
@@ -166,9 +166,9 @@ heap allocate_mcache(heap meta, heap parent, int min_order, int max_order, bytes
 	return INVALID_ADDRESS;
 
 #ifdef MCACHE_DEBUG
-    console("allocate_mcache: heap at ");
+    rputs("allocate_mcache: heap at ");
     print_u64(u64_from_pointer(m));
-    console("\n");
+    rputs("\n");
 #endif
 
     m->h.alloc = mcache_alloc;
@@ -187,16 +187,16 @@ heap allocate_mcache(heap meta, heap parent, int min_order, int max_order, bytes
 	u64 obj_size = U64_FROM_BIT(order);
 	heap h = allocate_objcache(meta, parent, obj_size, pagesize);
 #ifdef MCACHE_DEBUG
-	console(" - cache size ");
+	rputs(" - cache size ");
 	print_u64(obj_size);
-	console(": ");
+	rputs(": ");
 	print_u64(u64_from_pointer(h));
-	console("\n");
+	rputs("\n");
 #endif
 	if (h == INVALID_ADDRESS) {
-	    console("allocate_mcache: failed to allocate objcache of size ");
+	    rputs("allocate_mcache: failed to allocate objcache of size ");
 	    print_u64(obj_size);
-	    console("\n");
+	    rputs("\n");
 	    destroy_mcache((heap)m);
 	    return INVALID_ADDRESS;
 	}

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -64,6 +64,8 @@ static inline int runtime_strlen(const char *a)
     return i;
 }
 
+void rputs(const char *s);
+
 static inline void console(const char *s)
 {
     console_write(s, runtime_strlen(s));

--- a/src/runtime/runtime_init.c
+++ b/src/runtime/runtime_init.c
@@ -1,4 +1,5 @@
 #include <runtime.h>
+#include <log.h>
 
 void initialize_buffer();
 
@@ -102,6 +103,13 @@ void init_runtime(heap general, heap safe)
     ignore_status = (void*)ignore;
     errheap = safe;
     null_value = wrap_buffer(general, "", 1);
+}
+
+void rputs(const char *s)
+{
+    int len = runtime_strlen(s);
+    console_write(s, len);
+    klog_write(s, len);
 }
 
 #define STACK_CHK_GUARD 0x595e9fbd94fda766

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -25,7 +25,7 @@ enum partition {
     u16 *mbr_sig = (u16 *)((u64)(mbr) + SECTOR_SIZE - sizeof(*mbr_sig));  \
     struct partition_entry *e;  \
     if (*mbr_sig == 0xaa55) \
-        e = (struct partition_entry *)((u64_from_pointer(mbr_sig)) -    \
+        e = (struct partition_entry *)(((void *)mbr_sig) -  \
                 (4 - (index)) * sizeof(struct partition_entry));    \
     else    \
         e = 0;  \

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -137,7 +137,7 @@ void start_process(thread t, void *start)
 closure_function(0, 1, void, load_interp_fail,
                  status, s)
 {
-    console("interp fail\n");
+    rputs("interp fail\n");
     closure_finish();
     halt("read interp failed %v\n", s);
 }

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -1,6 +1,7 @@
 #include <unix_internal.h>
 #include <ftrace.h>
 #include <gdb.h>
+#include <log.h>
 
 //#define PF_DEBUG
 #ifdef PF_DEBUG
@@ -215,7 +216,7 @@ define_closure_function(1, 1, context, default_fault_handler,
     frame[FRAME_FULL] = 0;
 
     if (p && table_find(p->process_root, sym(fault))) {
-        console("starting gdb\n");
+        rputs("starting gdb\n");
         init_tcp_gdb(heap_general(get_kernel_heaps()), p, 9090);
         thread_sleep_uninterruptible();
     } else {
@@ -250,6 +251,7 @@ closure_function(0, 6, sysreturn, stdout,
                  void*, d, u64, length, u64, offset, thread, t, boolean, bh, io_completion, completion)
 {
     console_write(d, length);
+    klog_write(d, length);
     if (completion)
         apply(completion, t, length);
     return length;

--- a/src/unix_process/unix_process_runtime.c
+++ b/src/unix_process/unix_process_runtime.c
@@ -179,6 +179,10 @@ void console_write(const char *s, bytes count)
     igr(write(1, s, count));
 }
 
+void klog_write(const char *s, bytes count)
+{
+}
+
 u64 physical_from_virtual(void *__x)
 {
     return u64_from_pointer(__x);

--- a/src/x86_64/hpet.c
+++ b/src/x86_64/hpet.c
@@ -153,7 +153,7 @@ static void timer_config(int timer, timestamp rate, thunk t, boolean periodic)
 
     if (periodic) {
         if ((hpet->timers[timer].config & TCONF(PER_INT_CAP)) == 0) {
-	    console("HPET timer not capable of periodic interrupts.\n");
+	    rputs("HPET timer not capable of periodic interrupts.\n");
 	    return;
 	}
         tim->config |= TCONF(VAL_SET_CNF) | TCONF(TYPE_CNF);

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -119,13 +119,13 @@ void print_u64_with_sym(u64 a)
 
     name = find_elf_sym(a, &offset, &len);
     if (name) {
-	console("\t(");
-	console(name);
-	console(" + ");
-	print_u64(offset);
-        console("/");
+        rputs("\t(");
+        rputs(name);
+        rputs(" + ");
+        print_u64(offset);
+        rputs("/");
         print_u64(len);
-	console(")");
+        rputs(")");
     }
 }
 
@@ -146,7 +146,7 @@ void __print_stack_with_rbp(u64 *rbp)
             break;
         rbp = (u64 *) rbp[0];
         print_u64_with_sym(rip);
-        console("\n");
+        rputs("\n");
     }
 }
 
@@ -160,51 +160,51 @@ void print_stack_from_here(void)
 #define STACK_TRACE_DEPTH       24
 void print_stack(context c)
 {
-    console("\nframe trace:\n");
+    rputs("\nframe trace:\n");
     __print_stack_with_rbp(pointer_from_u64(c[FRAME_RBP]));
 
-    console("\nstack trace:\n");
+    rputs("\nstack trace:\n");
     u64 *x = pointer_from_u64(c[FRAME_RSP]);
     for (u64 i = 0; i < STACK_TRACE_DEPTH; i++) {
         print_u64_with_sym(*(x+i));
-        console("\n");
+        rputs("\n");
     }
-    console("\n");
+    rputs("\n");
 }
 
 void print_frame(context f)
 {
     u64 v = f[FRAME_VECTOR];
-    console(" interrupt: ");
+    rputs(" interrupt: ");
     print_u64(v);
     if (v < INTERRUPT_VECTOR_START) {
-        console(" (");
-        console((char *)interrupt_names[v]);
-        console(")");
+        rputs(" (");
+        rputs((char *)interrupt_names[v]);
+        rputs(")");
     }
-    console("\n     frame: ");
+    rputs("\n     frame: ");
     print_u64_with_sym(u64_from_pointer(f));
-    console("\n");    
+    rputs("\n");
 
     if (v == 13 || v == 14) {
-	console("error code: ");
+	rputs("error code: ");
 	print_u64(f[FRAME_ERROR_CODE]);
-	console("\n");
+	rputs("\n");
     }
 
     // page fault
     if (v == 14)  {
-        console("   address: ");
+        rputs("   address: ");
         print_u64_with_sym(f[FRAME_CR2]);
-        console("\n");
+        rputs("\n");
     }
     
-    console("\n");
+    rputs("\n");
     for (int j = 0; j < 24; j++) {
-        console(register_name(j));
-        console(": ");
+        rputs(register_name(j));
+        rputs(": ");
         print_u64_with_sym(f[j]);
-        console("\n");        
+        rputs("\n");
     }
 }
 

--- a/src/x86_64/mp.c
+++ b/src/x86_64/mp.c
@@ -17,7 +17,7 @@ u64 ap_lock;
 static void (*start_callback)();
 
 #ifdef MP_DEBUG
-#define mp_debug(x) console(x)
+#define mp_debug(x) rputs(x)
 #define mp_debug_u64(x) print_u64(x)
 #else
 #define mp_debug(x)

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -174,32 +174,32 @@ static void write_pte(u64 target, physical to, u64 flags, boolean * invalidate)
     u64 new = to | flags;
     u64 *pteptr = pointer_from_pteaddr(target);
 #ifdef PTE_DEBUG
-    console(", write_pte: ");
+    rputs(", write_pte: ");
     print_u64(u64_from_pointer(target));
-    console(" = ");
+    rputs(" = ");
     print_u64(new);
 #endif
     assert((new & PAGE_NO_FAT) == 0);
     if (*pteptr == new) {
 #ifdef PTE_DEBUG
-	console(", pte same; no op");
+	rputs(", pte same; no op");
 #endif
 	return;
     }
     /* invalidate when changing any pte that was marked as present */
     if (*pteptr & PAGE_PRESENT) {
 #ifdef PTE_DEBUG
-        console("   invalidate, old ");
+        rputs("   invalidate, old ");
         print_u64(*pteptr);
-        console(", new ");
+        rputs(", new ");
         print_u64(new);
-        console("\n");
+        rputs("\n");
 #endif
 	*invalidate = true;
     }
     *pteptr = new;
 #ifdef PTE_DEBUG
-    console("\n");
+    rputs("\n");
 #endif
 }
 
@@ -224,9 +224,9 @@ static boolean force_entry(u64 b, u64 v, physical p, int level,
 
     if (level == (fat ? 3 : 4)) {
 #ifdef PTE_DEBUG
-	console("! ");
+	rputs("! ");
 	print_level(level);
-	console(", phys ");
+	rputs(", phys ");
 	print_u64(pte_phys);
 #endif
 	if (fat)
@@ -236,7 +236,7 @@ static boolean force_entry(u64 b, u64 v, physical p, int level,
     } else {
 	if (*pointer_from_pteaddr(pte_phys) & PAGE_PRESENT) {
             if (pt_entry_is_fat(level, *pointer_from_pteaddr(pte_phys))) {
-                console("\nforce_entry fail: attempting to map a 4K page over an "
+                rputs("\nforce_entry fail: attempting to map a 4K page over an "
                         "existing 2M mapping\n");
                 return false;
             }
@@ -261,9 +261,9 @@ static boolean force_entry(u64 b, u64 v, physical p, int level,
                 return false;
 #ifdef PTE_DEBUG
             // XXX update debugs
-	    console("- ");
+	    rputs("- ");
 	    print_level(level);
-	    console(", phys ");
+	    rputs(", phys ");
 	    print_u64(pte_phys);
 #endif
             /* user and writable are AND of flags from all levels */
@@ -507,26 +507,26 @@ static void map_range(u64 virtual, physical p, u64 length, u64 flags)
 
     if ((virtual & PAGEMASK) || (p & PAGEMASK) || (length & PAGEMASK)) {
 	if (flags == 0)
-	    console("un");
-	console("map() called with unaligned paramters!\n v: ");
+	    rputs("un");
+	rputs("map() called with unaligned paramters!\n v: ");
 	print_u64(virtual);
-	console(", p: ");
+	rputs(", p: ");
 	print_u64(p);
-	console(", length: ");
+	rputs(", length: ");
 	print_u64(length);
 	halt("\n");
     }
 
 #ifdef PAGE_DEBUG
-    console("map_range v: ");
+    rputs("map_range v: ");
     print_u64(virtual);
-    console(", p: ");
+    rputs(", p: ");
     print_u64(p);
-    console(", length: ");
+    rputs(", length: ");
     print_u64(length);
-    console(", flags: ");
+    rputs(", flags: ");
     print_u64(flags);
-    console("\n");
+    rputs("\n");
 #endif
 
     boolean invalidate = false;
@@ -545,7 +545,7 @@ static void map_range(u64 virtual, physical p, u64 length, u64 flags)
     }
 #ifdef PAGE_DEBUG
     if (invalidate && p)        /* don't care about invalidate on unmap */
-        console("   - part of map caused invalidate\n");
+        rputs("   - part of map caused invalidate\n");
 #endif
 
     memory_barrier();
@@ -560,11 +560,11 @@ void map(u64 virtual, physical p, u64 length, u64 flags)
 void unmap(u64 virtual, u64 length)
 {
 #ifdef PAGE_DEBUG
-    console("unmap v: ");
+    rputs("unmap v: ");
     print_u64(virtual);
-    console(", length: ");
+    rputs(", length: ");
     print_u64(length);
-    console("\n");
+    rputs("\n");
 #endif
     unmap_pages(virtual, length);
 }

--- a/src/x86_64/xapic.c
+++ b/src/x86_64/xapic.c
@@ -66,7 +66,7 @@ static void xapic_ipi(apic_iface i, u32 target, u64 flags, u8 vector)
             return;
         kern_pause();
     }
-    console("ipi timed out\n");
+    rputs("ipi timed out\n");
 }
 
 static boolean detect(apic_iface i, kernel_heaps kh)

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -275,7 +275,7 @@ static void write_mbr(descriptor f)
     region r = (region) ((char *) e - sizeof(*r));
     if (r->type != REGION_FILESYSTEM)
         halt("invalid boot record (missing filesystem region) \n");
-    u64 fs_offset = SECTOR_SIZE + r->length;
+    u64 fs_offset = SECTOR_SIZE + r->length + KLOG_DUMP_SIZE;
     assert(fs_offset % SECTOR_SIZE == 0);
     u64 fs_size = BOOTFS_SIZE;
     partition_write(&e[PARTITION_BOOTFS], true, 0x83, fs_offset, fs_size);
@@ -476,6 +476,9 @@ int main(int argc, char **argv)
             }
         }
         if (boot) {
+            /* The boot FS partition is immediately after the on-disk kernel log dump section. */
+            offset += KLOG_DUMP_SIZE;
+
             create_filesystem(h, SECTOR_SIZE, BOOTFS_SIZE, 0,
                               closure(h, bwrite, out, offset),
                               "", closure(h, fsc, h, out, boot, target_root));


### PR DESCRIPTION
Crash reporting to the radar server is enabled when the manifest file contains the RADAR_KEY environment variable.
A "crash" is defined as either a user application fatal error (e.g. anything that causes the application to terminate with a non-zero
exit code), or a kernel fatal error. When any of these happens, before shutting down the VM the kernel dumps on disk a trace of log messages (printed by both the user application and the kernel); at the next boot, the radar klib detects the log dump and sends it to the radar server as a crash report; the value of the "id" field of a crash report is the same as the "boot id" (sent right after each boot), so that a crash can be unequivocally associated to a boot.

The log dump is saved in a section of the disk that is being carved between stage2 and the boot filesystem.

Throughout the kernel, most calls to console() have been replaced by calls to a new function, rputs(), which prints the supplied string to both the console and the kernel log (so that in case of a crash the console messages will be sent in the crash report).
Analogously, the buffer_print() and stdout() functions have been changed so that their output goes to both the console and the
kernel log.