### PR TITLE
miscellaneous fixes

### DIFF
--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -643,7 +643,9 @@ closure_function(1, 3, void, pagecache_write_sg,
             pp = allocate_page_nodelocked(pn, pi);
             if (pp == INVALID_ADDRESS) {
                 pagecache_unlock_node(pn);
-                apply(completion, timm("result", "failed to allocate pagecache_page"));
+                const char *err = "failed to allocate pagecache_page";
+                apply(sh, timm("result", err)); /* close out merge, record write error */
+                apply(completion, timm("result", err));
                 return;
             }
 
@@ -666,7 +668,7 @@ closure_function(1, 3, void, pagecache_write_sg,
             realloc_pagelocked(pc, pp);
         refcount_reserve(&pp->refcount);
         if (page_state(pp) == PAGECACHE_PAGESTATE_READING)
-            enqueue_page_completion_statelocked(pc, pp, apply_merge(m), true /* complete on bhqueue */);
+            enqueue_page_completion_statelocked(pc, pp, apply_merge(m), false);
         pagecache_unlock_state(pc);
     }
     pagecache_unlock_node(pn);


### PR DESCRIPTION
some minor fixes:

- kernel_shutdown* funcs assumed the kernel lock was held. Change to checking if it is held on the local cpu before calling storage_sync and releasing the lock. If it isn't, schedule a thunk on the runqueue to run storage_sync.
- A pagecache write should only add to runqueue completions for pages in reading state, not bhqueue. Also close out merge on alloc failure.
- Improve reporting of unhandled signals with a terminal disposition and add thread logs for signal dispatch.
