### PR TITLE
Add support for robust futex syscalls and handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ test test-noaccel: image
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst getdents getrandom hw hws io_uring klibs mkdir mmap netsock pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst futexrobust getdents getrandom hw hws io_uring klibs mkdir mmap netsock pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -186,6 +186,22 @@ void vmap_iterator(process p, vmap_handler vmh)
     vmap_unlock(p);
 }
 
+closure_function(0, 1, void, vmap_validate_range_gap,
+                 range, q)
+{
+
+}
+
+boolean vmap_validate_range(process p, range q)
+{
+    boolean valid;
+    vmap_lock(p);
+    valid = !rangemap_range_find_gaps(p->vmaps, q,
+                             stack_closure(vmap_validate_range_gap));
+    vmap_unlock(p);
+    return valid;
+}
+
 closure_function(0, 1, void, vmap_dump_node,
                  rmnode, n)
 {

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -158,8 +158,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, fchmodat, syscall_ignore);
     register_syscall(map, faccessat, 0);
     register_syscall(map, unshare, 0);
-    register_syscall(map, set_robust_list, 0);
-    register_syscall(map, get_robust_list, 0);
     register_syscall(map, splice, 0);
     register_syscall(map, tee, 0);
     register_syscall(map, sync_file_range, 0);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -93,6 +93,8 @@ sysreturn clone(unsigned long flags, void *child_stack, int *ptid, int *ctid, un
 void register_thread_syscalls(struct syscall *map)
 {
     register_syscall(map, futex, futex);
+    register_syscall(map, set_robust_list, set_robust_list);
+    register_syscall(map, get_robust_list, get_robust_list);
     register_syscall(map, clone, clone);
     register_syscall(map, arch_prctl, arch_prctl);
     register_syscall(map, set_tid_address, set_tid_address);
@@ -361,7 +363,8 @@ void exit_thread(thread t)
     if (t->select_epoll)
         epoll_finish(t->select_epoll);
 
-    /* XXX futex robust list needs implementing - wake up robust futexes here */
+    wake_robust_list(t->p, t->robust_list);
+    t->robust_list = 0;
 
     blockq_flush(t->thread_bq);
     deallocate_blockq(t->thread_bq);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -703,6 +703,7 @@ extern sysreturn syscall_ignore();
 boolean do_demand_page(u64 vaddr, vmap vm, context frame);
 vmap vmap_from_vaddr(process p, u64 vaddr);
 void vmap_iterator(process p, vmap_handler vmh);
+boolean vmap_validate_range(process p, range q);
 void truncate_file_maps(process p, fsfile f, u64 new_length);
 const char *string_from_mmap_type(int type);
 
@@ -714,6 +715,14 @@ void thread_sleep_uninterruptible(void) __attribute__((noreturn));
 void thread_yield(void) __attribute__((noreturn));
 void thread_wakeup(thread);
 boolean thread_attempt_interrupt(thread t);
+
+/* XXX This should eventually be rolled into validate_user_memory */
+static inline boolean validate_process_memory(process p, const void *a, bytes length, boolean write)
+{
+    u64 v = u64_from_pointer(a);
+
+    return vmap_validate_range(p, irange(v, v + length));
+}
 
 static inline boolean thread_in_interruptible_sleep(thread t)
 {

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -247,6 +247,9 @@ typedef struct thread {
     int *clear_tid;
     int tid;
 
+    /* set by set_robust_list syscall */
+    void *robust_list;
+
     /* blockq thread is waiting on, INVALID_ADDRESS for uninterruptible */
     blockq blocked_on;
 
@@ -790,6 +793,9 @@ void init_threads(process p);
 void init_futices(process p);
 
 sysreturn futex(int *uaddr, int futex_op, int val, u64 val2, int *uaddr2, int val3);
+sysreturn get_robust_list(int pid, void *head, u64 *len);
+sysreturn set_robust_list(void *head, u64 len);
+void wake_robust_list(process p, void *head);
 boolean futex_wake_many_by_uaddr(process p, int *uaddr, int val);
 
 static inline boolean futex_wake_one_by_uaddr(process p, int *uaddr)

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -10,6 +10,7 @@ PROGRAMS= \
 	fcntl \
 	fst \
 	ftrace \
+	futexrobust \
 	getdents \
 	getrandom \
 	hw \
@@ -89,6 +90,12 @@ SRCS-ftrace= \
 	$(SRCDIR)/unix_process/ssp.c
 
 LDFLAGS-ftrace=	-static
+
+SRCS-futexrobust= \
+	$(CURDIR)/futexrobust.c \
+	$(SRCDIR)/unix_process/ssp.c
+LDFLAGS-futexrobust=		-static
+LIBS-futexrobust=			-lpthread
 
 SRCS-getdents=		$(CURDIR)/getdents.c
 LDFLAGS-getdents=	-static

--- a/test/runtime/futexrobust.c
+++ b/test/runtime/futexrobust.c
@@ -1,0 +1,117 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <errno.h>
+
+pthread_mutex_t mut;
+uint32_t val;
+
+#define INCS 1000
+#define BADLUCK 765
+#define MAX_THREADS 4
+
+void *
+worker(void *v)
+{
+    int myincs = 0;
+    int done = 0;
+    int err;
+    unsigned int seed = time(NULL);
+    void *self = (void *)pthread_self();
+    for (;;) {
+        usleep(rand_r(&seed) % 1000);
+        err = pthread_mutex_lock(&mut);
+        switch (err) {
+        case 0:
+            break;
+        case EOWNERDEAD:
+            pthread_mutex_consistent(&mut);
+            break;
+        default:
+            printf("got unexpected value from mutex: %d\n", err);
+            exit(EXIT_FAILURE);
+        }
+        usleep(rand_r(&seed) % 1000);
+        if (val == BADLUCK) {
+            val++;
+            printf("worker %p aborting after %d increments\n", self, myincs);
+            return NULL;
+        }
+        if (val > INCS)
+            done = 1;
+        else {
+            val++;
+            myincs++;
+        }
+        pthread_mutex_unlock(&mut);
+        if (done)
+            break;
+    }
+    printf("worker %p completed %d increments\n", self, myincs);
+    return NULL;
+}
+
+void *
+worker2(void *v)
+{
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+    int sleepus = *(int *)v;
+    printf("worker2 (%d) start\n", sleepus);
+    int err = pthread_mutex_lock(&mut);
+    switch (err) {
+    case 0:
+        break;
+    case EOWNERDEAD:
+        pthread_mutex_consistent(&mut);
+        break;
+    default:
+        printf("got unexpected value from mutex: %d\n", err);
+        exit(EXIT_FAILURE);
+    }
+    printf("worker2 (%d) acquired lock\n", sleepus);
+    usleep(sleepus);
+    printf("worker2 (%d) complete\n", sleepus);
+    pthread_mutex_unlock(&mut);
+    return NULL;
+}
+
+int
+main(int argc, char **argv)
+{
+    pthread_t threads[MAX_THREADS];
+
+    setbuf(stdout, NULL);
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr); /* initialize the attributes object */
+    pthread_mutexattr_setrobust(&attr, PTHREAD_MUTEX_ROBUST); /* set robustness */
+    pthread_mutex_init(&mut, &attr);
+
+    /* alarm to fail test if things get stuck */
+    alarm(10);
+
+    printf("*** test clean exit with mutex held ***\n");
+    for (int i = 0; i < MAX_THREADS; i++) {
+        pthread_create(&threads[i], NULL, worker, NULL);
+    }
+    for (int i = 0; i < MAX_THREADS; i++) {
+        pthread_join(threads[i], NULL);
+    }
+
+    for (int i = 0; i < 2; i++) {
+        printf("\n*** test %d aborted exit with mutex held ***\n", i);
+        int sleepus = 1000000;
+        pthread_create(&threads[0], NULL, worker2, &sleepus);
+        usleep(10000);
+        sleepus = 10000;
+        pthread_create(&threads[1], NULL, worker2, &sleepus);
+        usleep(10000);
+        printf("canceling thread...\n");
+        pthread_cancel(threads[0]);
+        pthread_join(threads[0], NULL);
+        pthread_join(threads[1], NULL);
+    }
+    exit(EXIT_SUCCESS);
+}

--- a/test/runtime/futexrobust.manifest
+++ b/test/runtime/futexrobust.manifest
@@ -1,0 +1,14 @@
+(
+    children:(
+              #user program
+	      futexrobust:(contents:(host:output/test/runtime/bin/futexrobust))
+	      )
+    # filesystem path to elf for kernel to run
+    program:/futexrobust
+#    trace:t
+#    debugsyscalls:t
+#    futex_trace:t
+    fault:t
+    arguments:[futexrobust]
+    environment:()
+)


### PR DESCRIPTION
This change implements the get_robust_list and set_robust_list syscalls
as well as adds support for handling locked mutices during thread exit
by marking the mutex and waking any waiters. The test program included
verifies basic robust mutex functionality. See #457 for more information.