### PR TITLE
Go and e2e tests: use strings for port configuration

### DIFF
--- a/test/e2e/go/config.json
+++ b/test/e2e/go/config.json
@@ -1,7 +1,7 @@
 {
     "Args": ["main"],
     "RunConfig": {
-        "Ports": [8080]
+        "Ports": ["8080"]
     },
     "Boot": "../../../output/test/e2e/boot.img",
     "Kernel": "../../../output/test/e2e/kernel.img",

--- a/test/e2e/nginx_1.15.6/config.json
+++ b/test/e2e/nginx_1.15.6/config.json
@@ -2,7 +2,7 @@
   "Files": ["index.html"],
   "Dirs": ["usr"],
   "RunConfig": {
-    "Ports": [8084]
+    "Ports": ["8084"]
   },
   "Boot": "../../../output/test/e2e/boot.img",
   "Kernel": "../../../output/test/e2e/kernel.img",

--- a/test/e2e/node_v11.5.0/config.json
+++ b/test/e2e/node_v11.5.0/config.json
@@ -1,7 +1,7 @@
 {
     "Args": ["hi.js"],
     "RunConfig": {
-        "Ports": [8083]
+        "Ports": ["8083"]
     },
     "Boot": "../../../output/test/e2e/boot.img",
     "Kernel": "../../../output/test/e2e/kernel.img",

--- a/test/e2e/php_7.3.5/config.json
+++ b/test/e2e/php_7.3.5/config.json
@@ -1,7 +1,7 @@
 {
     "Args": ["b.php"],
     "RunConfig": {
-        "Ports": [9501]
+        "Ports": ["9501"]
     },
     "Boot": "../../../output/test/e2e/boot.img",
     "Kernel": "../../../output/test/e2e/kernel.img",

--- a/test/e2e/python_3.6.7/config.json
+++ b/test/e2e/python_3.6.7/config.json
@@ -1,7 +1,7 @@
 {
   "Args":["-m", "http.server"],
   "RunConfig": {
-        "Ports": [8000]
+        "Ports": ["8000"]
   },
   "Boot": "../../../output/test/e2e/boot.img",
   "Kernel": "../../../output/test/e2e/kernel.img",

--- a/test/e2e/ruby_2.5.1/config.json
+++ b/test/e2e/ruby_2.5.1/config.json
@@ -5,7 +5,7 @@
         "GEM_HOME": ".ruby"
     },
     "RunConfig": {
-        "Ports": [4567]
+        "Ports": ["4567"]
     },
     "Boot": "../../../output/test/e2e/boot.img",
     "Kernel": "../../../output/test/e2e/kernel.img",

--- a/test/e2e/rust/config.json
+++ b/test/e2e/rust/config.json
@@ -1,7 +1,7 @@
 {
     "Args": ["main"],
     "RunConfig": {
-        "Ports": [8080]
+        "Ports": ["8080"]
     },
     "Boot": "../../../output/test/e2e/boot.img",
     "Kernel": "../../../output/test/e2e/kernel.img",

--- a/test/go/go_test.go
+++ b/test/go/go_test.go
@@ -45,7 +45,7 @@ func prepareTestImage(finalImage string) {
 func TestArgsAndEnv(t *testing.T) {
 	const finalImage = "image"
 	prepareTestImage(finalImage)
-	rconfig := lepton.RuntimeConfig(finalImage, []int{8080}, true)
+	rconfig := lepton.RuntimeConfig(finalImage, []string{"8080"}, true)
 	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
 	defer hypervisor.Stop()
 
@@ -80,7 +80,7 @@ func TestArgsAndEnv(t *testing.T) {
 func TestFileSystem(t *testing.T) {
 	const finalImage = "image"
 	prepareTestImage(finalImage)
-	rconfig := lepton.RuntimeConfig(finalImage, []int{8080}, true)
+	rconfig := lepton.RuntimeConfig(finalImage, []string{"8080"}, true)
 	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
 	defer hypervisor.Stop()
 
@@ -99,7 +99,7 @@ func TestFileSystem(t *testing.T) {
 }
 
 func validateResponse(t *testing.T, finalImage string, expected string) {
-	rconfig := lepton.RuntimeConfig(finalImage, []int{8080}, true)
+	rconfig := lepton.RuntimeConfig(finalImage, []string{"8080"}, true)
 	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
 	defer hypervisor.Stop()
 
@@ -128,7 +128,7 @@ func TestInstancePersistence(t *testing.T) {
 func TestHTTP(t *testing.T) {
 	const finalImage = "image"
 	prepareTestImage(finalImage)
-	rconfig := lepton.RuntimeConfig(finalImage, []int{8080}, true)
+	rconfig := lepton.RuntimeConfig(finalImage, []string{"8080"}, true)
 	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
 	defer hypervisor.Stop()
 


### PR DESCRIPTION
This is needed to comply with a change in the Ops repository to support configuration of port ranges.
https://github.com/nanovms/ops/commit/d8f0a5c043d1d964071ba11acca09808bc47eeb8