### PR TITLE
Klibs_radar: add memory usage metric

### DIFF
--- a/klib/radar.c
+++ b/klib/radar.c
@@ -43,7 +43,7 @@ static struct telemetry {
     tuple env;
     buffer auth_header;
     klog_dump dump;
-    s64 boot_id;
+    u64 boot_id;
     timestamp retry_backoff;
     closure_struct(retry_timer_func, retry_func);
     void (*rprintf)(const char *format, ...);
@@ -51,19 +51,22 @@ static struct telemetry {
     void (*table_set)(table z, void *c, void *v);
     void *(*table_find)(table z, void *c);
     void (*deallocate_table)(table t);
+    void (*destruct_tuple)(tuple t, boolean recursive);
     void (*timm_dealloc)(tuple t);
     symbol (*intern)(string name);
     void *(*klib_sym)(klib kl, symbol s);
     void (*klog_load)(klog_dump dest, status_handler sh);
     void (*klog_dump_clear)(void);
-    void (*klog_set_boot_id)(s64 id);
+    void (*klog_set_boot_id)(u64 id);
     buffer (*allocate_buffer)(heap h, bytes s);
     void (*buffer_write)(buffer b, const void *source, bytes length);
+    int (*buffer_strstr)(buffer b, const char *str);
     void (*bprintf)(buffer b, const char *fmt, ...);
     timer (*register_timer)(clock_id id, timestamp val, boolean absolute,
             timestamp interval, timer_handler n);
     err_t (*dns_gethostbyname)(const char *hostname, ip_addr_t *addr,
             dns_found_callback found, void *callback_arg);
+    buffer_handler (*allocate_http_parser)(heap h, value_handler each);
     status (*http_request)(heap h, buffer_handler bh, http_method method,
             tuple headers, buffer body);
     int (*tls_connect)(ip_addr_t *addr, u16 port, connection_handler ch);
@@ -113,13 +116,23 @@ static boolean telemetry_req(const char *url, buffer data, buffer_handler bh)
     }
 }
 
-closure_function(1, 1, status, telemetry_recv,
-                 buffer_handler, out,
+closure_function(2, 1, status, telemetry_recv,
+                 value_handler, vh, buffer_handler, out,
                  buffer, data)
 {
-    if (data)
+    if (data) {
+        value_handler vh = bound(vh);
+        if (vh) {
+            buffer_handler parser = kfunc(allocate_http_parser)(telemetry.h, vh);
+            if (parser != INVALID_ADDRESS) {
+                apply(parser, data);
+            } else {
+                kfunc(rprintf)("Radar: failed to allocate HTTP parser\n");
+                apply(vh, 0);
+            }
+        }
         apply(bound(out), 0);   /* close connection */
-    else {  /* connection closed */
+    } else {  /* connection closed */
         closure_finish();
         if (telemetry.dump) {
             /* We just sent a crash report: clear the log dump (so that it's not
@@ -133,8 +146,8 @@ closure_function(1, 1, status, telemetry_recv,
     return STATUS_OK;
 }
 
-closure_function(2, 1, buffer_handler, telemetry_ch,
-                 const char *, url, buffer, data,
+closure_function(3, 1, buffer_handler, telemetry_ch,
+                 const char *, url, buffer, data, value_handler, vh,
                  buffer_handler, out)
 {
     buffer data = bound(data);
@@ -142,7 +155,7 @@ closure_function(2, 1, buffer_handler, telemetry_ch,
     if (out) {
         boolean success = telemetry_req(bound(url), data, out);
         if (success)
-            in = closure(telemetry.h, telemetry_recv, out);
+            in = closure(telemetry.h, telemetry_recv, bound(vh), out);
         else
             deallocate_buffer(data);
     } else {    /* connection failed */
@@ -152,9 +165,9 @@ closure_function(2, 1, buffer_handler, telemetry_ch,
     return in;
 }
 
-boolean telemetry_send(const char *url, buffer data)
+boolean telemetry_send(const char *url, buffer data, value_handler vh)
 {
-    connection_handler ch = closure(telemetry.h, telemetry_ch, url, data);
+    connection_handler ch = closure(telemetry.h, telemetry_ch, url, data, vh);
     if (ch == INVALID_ADDRESS)
         return false;
     ip_addr_t radar_addr;
@@ -193,7 +206,7 @@ static void telemetry_crash_report(void)
     buffer b = kfunc(allocate_buffer)(telemetry.h, PAGESIZE);
     if (b == INVALID_ADDRESS)
         goto error;
-    kfunc(bprintf)(b, "{\"id\":%ld", telemetry.dump->boot_id);
+    kfunc(bprintf)(b, "{\"bootID\":%ld", telemetry.dump->boot_id);
     buffer nanos_ver = kfunc(table_find)(telemetry.env, sym(NANOS_VERSION));
     if (nanos_ver)
         kfunc(bprintf)(b, ",\"nanosVersion\":\"%b\"", nanos_ver);
@@ -234,7 +247,7 @@ static void telemetry_crash_report(void)
         }
     }
     buffer_write_cstring(b, "\"}\r\n");
-    if (!telemetry_send("/crashes", b)) {
+    if (!telemetry_send("/crashes", b, 0)) {
         deallocate_buffer(b);
         goto error;
     }
@@ -243,24 +256,57 @@ static void telemetry_crash_report(void)
     telemetry_retry();
 }
 
+closure_function(0, 1, void, telemetry_boot_recv,
+                 value, v)
+{
+    telemetry.boot_id = 0;
+    if (!v) /* couldn't allocate HTTP parser */
+        return;
+    buffer content = kfunc(table_find)(v, sym(content));
+    if (content) {
+        int index = kfunc(buffer_strstr)(content, "\"id\"");
+        if (index < 0)
+            goto exit;
+        buffer_consume(content, index);
+        buffer_consume(content, buffer_strchr(content, ':') + 1);
+        index = buffer_strchr(content, ',');
+        if (index < 0) {
+            index = buffer_strchr(content, '}');
+            if (index < 0)
+                goto exit;
+        }
+        parse_int(alloca_wrap_buffer(buffer_ref(content, 0), index), 10, &telemetry.boot_id);
+        kfunc(klog_set_boot_id)(telemetry.boot_id);
+    }
+  exit:
+    kfunc(destruct_tuple)(v, true);
+    closure_finish();
+}
+
 static void telemetry_boot(void)
 {
     buffer b = kfunc(allocate_buffer)(telemetry.h, 64);
     if (b == INVALID_ADDRESS)
         goto error;
-    kfunc(bprintf)(b, "{\"id\":%ld", telemetry.boot_id);
+    value_handler vh = closure(telemetry.h, telemetry_boot_recv);
+    if (vh == INVALID_ADDRESS) {
+        goto err_free_buf;
+    }
+    buffer_write_cstring(b, "{");
     buffer nanos_ver = kfunc(table_find)(telemetry.env, sym(NANOS_VERSION));
     if (nanos_ver)
-        kfunc(bprintf)(b, ",\"nanosVersion\":\"%b\"", nanos_ver);
+        kfunc(bprintf)(b, "\"nanosVersion\":\"%b\"", nanos_ver);
     buffer ops_ver = kfunc(table_find)(telemetry.env, sym(OPS_VERSION));
     if (ops_ver)
         kfunc(bprintf)(b, ",\"opsVersion\":\"%b\"", ops_ver);
     buffer_write_cstring(b, "}\r\n");
-    if (!telemetry_send("/boots", b)) {
-        deallocate_buffer(b);
-        goto error;
+    if (!telemetry_send("/boots", b, vh)) {
+        deallocate_closure(vh);
+        goto err_free_buf;
     }
     return;
+  err_free_buf:
+    deallocate_buffer(b);
   error:
     telemetry_retry();
 }
@@ -269,7 +315,6 @@ closure_function(0, 1, void, klog_dump_loaded,
                  status, s)
 {
     if (is_ok(s)) {
-        kfunc(klog_set_boot_id)(telemetry.boot_id);
         if (telemetry.dump->exit_code != 0) {
             telemetry_crash_report();
         } else {
@@ -318,6 +363,7 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
             !(telemetry.table_set = get_sym("table_set")) ||
             !(telemetry.table_find = get_sym("table_find")) ||
             !(telemetry.deallocate_table = get_sym("deallocate_table")) ||
+            !(telemetry.destruct_tuple = get_sym("destruct_tuple")) ||
             !(telemetry.timm_dealloc = get_sym("timm_dealloc")) ||
             !(telemetry.intern = get_sym("intern")) ||
             !(telemetry.klib_sym = get_sym("klib_sym")) ||
@@ -326,9 +372,11 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
             !(telemetry.klog_set_boot_id = get_sym("klog_set_boot_id")) ||
             !(telemetry.allocate_buffer = get_sym("allocate_buffer")) ||
             !(telemetry.buffer_write = get_sym("buffer_write")) ||
+            !(telemetry.buffer_strstr = get_sym("buffer_strstr")) ||
             !(telemetry.bprintf = get_sym("bprintf")) ||
             !(telemetry.register_timer = get_sym("kern_register_timer")) ||
             !(telemetry.dns_gethostbyname = get_sym("dns_gethostbyname")) ||
+            !(telemetry.allocate_http_parser = get_sym("allocate_http_parser")) ||
             !(telemetry.http_request = get_sym("http_request"))) {
         kfunc(rprintf)("Radar: kernel symbols not found\n");
         return KLIB_INIT_FAILED;
@@ -340,7 +388,6 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
     }
     telemetry.env = get_environment();
     telemetry.auth_header = kfunc(table_find)(telemetry.env, sym(RADAR_KEY));
-    telemetry.boot_id = (s64)random_u64();
     telemetry.retry_backoff = seconds(1);
     load_klib("/klib/tls", tls_handler);
     return KLIB_INIT_OK;

--- a/src/kernel/log.c
+++ b/src/kernel/log.c
@@ -48,7 +48,7 @@ void klog_disk_setup(u64 disk_offset, block_io disk_read, block_io disk_write)
     klog.disk_write = disk_write;
 }
 
-void klog_set_boot_id(s64 id)
+void klog_set_boot_id(u64 id)
 {
     klog.dump.boot_id = id;
 }

--- a/src/kernel/log.h
+++ b/src/kernel/log.h
@@ -1,6 +1,6 @@
 typedef struct klog_dump {
     u8 header[4];
-    s64 boot_id;
+    u64 boot_id;
     s32 exit_code;
     char msgs[KLOG_DUMP_SIZE - 16]; /* total size of the struct must match KLOG_DUMP_SIZE */
 } __attribute__((packed)) *klog_dump;
@@ -13,7 +13,7 @@ static inline void klog_print(const char *s)
 }
 
 void klog_disk_setup(u64 disk_offset, block_io disk_read, block_io disk_write);
-void klog_set_boot_id(s64 id);
+void klog_set_boot_id(u64 id);
 void klog_load(klog_dump dest, status_handler sh);
 void klog_save(int exit_code, status_handler sh);
 void klog_dump_clear(void);


### PR DESCRIPTION
This adds functionality to the radar klib so that it retrieves from the kernel total memory usage every minute, and sends retrieved data to the server every 5 minutes.
Format of POST request data to /machine-stats server endpoint:
`{"bootID":<boot_id>,"memUsed":[<num_bytes1>,<num_bytes2>,<num_bytes3>,<num_bytes4>,<num_bytes5>]}`