### PR TITLE
vm_exit(): add support for platform-specific VM halt function

### DIFF
--- a/src/hyperv/utilities/vmbus_shutdown.c
+++ b/src/hyperv/utilities/vmbus_shutdown.c
@@ -46,7 +46,8 @@ static const struct hyperv_guid vmbus_shutdown_device_type = {
        0x81, 0x8b, 0x38, 0xd9, 0x0c, 0xed, 0x39, 0xdb }
 };
 
-closure_function(0, 1, void, hv_sync_complete, status, s) {
+closure_function(0, 1, void, hv_sync_complete,
+                 int, status) {
     HV_SHUTDOWN();
 }
 
@@ -115,7 +116,7 @@ static void vmbus_shutdown_cb(struct vmbus_channel *chan, void *xsc)
    vmbus_ic_sendresp(sc, chan, data, dlen, xactid);
 
    if (do_shutdown)
-       kernel_shutdown_ex(closure(sc->general, hv_sync_complete));
+       kernel_shutdown(0);
 }
 
 
@@ -130,6 +131,7 @@ static status vmbus_shutdown_attach(kernel_heaps kh, hv_device* device)
     sc->hs_dev = device;
 
     vmbus_ic_attach(sc, vmbus_shutdown_cb);
+    vm_halt = closure(sc->general, hv_sync_complete);
 
     return STATUS_OK;
 }

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -325,3 +325,6 @@ static inline u64 total_frame_size(void)
 extern void xsave(context f);
 
 extern int shutdown_vector;
+
+typedef closure_type(halt_handler, void, int);
+extern halt_handler vm_halt;

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -182,8 +182,6 @@ typedef closure_type(thunk, void);
 #include <clock.h>
 #include <timer.h>
 
-void kernel_shutdown_ex(status_handler completion) __attribute__((noreturn));
-
 typedef closure_type(buffer_handler, status, buffer);
 typedef closure_type(connection_handler, buffer_handler, buffer_handler);
 typedef closure_type(io_status_handler, void, status, bytes);


### PR DESCRIPTION
If the platform on which the kernel is running has a defined procedure to stop an instance, this procedure should be used not only when the instance is stopped from the cloud platform but also when the program finishes executing (unless the reboot_on_exit
manifest flag is set).
This PR adds a vm_halt global closure that can be set by platform-specific code and is called by vm_exit().