### PR TITLE
TLB shootdowns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ test test-noaccel: image
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst getdents getrandom hw hws io_uring klibs mkdir mmap netsock pipe readv rename sendfile signal socketpair time unlink thread_test vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst getdents getrandom hw hws io_uring klibs mkdir mmap netsock pipe readv rename sendfile signal socketpair time unlink thread_test tlbshootdown vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -556,6 +556,7 @@ static void __attribute__((noinline)) init_service_new_stack()
     start_cpu(misc, heap_backed(kh), TARGET_EXCLUSIVE_BROADCAST, new_cpu);
     kernel_delay(milliseconds(200));   /* temp, til we check tables to know what we have */
     init_debug("total CPUs %d\n", total_processors);
+    init_flush(heap_general(kh));
 #endif
     init_debug("starting runloop");
     runloop();

--- a/src/config.h
+++ b/src/config.h
@@ -13,6 +13,8 @@
 #define BH_STACK_SIZE      (32 * KB)
 #define SYSCALL_STACK_SIZE (32 * KB)
 
+#define PAGE_INVAL_QUEUE_LENGTH  4096
+
 /* maximum buckets that can fit within a PAGESIZE_2M mcache */
 #define TABLE_MAX_BUCKETS 131072
 

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -104,7 +104,6 @@ static void init_cpuinfos(heap backed)
         ci->kernel_context = allocate_kernel_context(backed);
         ci->exception_stack = allocate_stack(backed, EXCEPT_STACK_SIZE);
         ci->int_stack = allocate_stack(backed, INT_STACK_SIZE);
-        ci->inval_queue = allocate_queue(backed, PAGE_INVAL_QUEUE_LENGTH);
 #ifdef SMP_DEBUG
         rprintf("cpu %2d: kernel_frame %p, kernel_stack %p", i, ci->kernel_frame, ci->kernel_stack);
         rprintf("        fault_stack  %p, int_stack    %p", ci->fault_stack, ci->int_stack);

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -104,6 +104,7 @@ static void init_cpuinfos(heap backed)
         ci->kernel_context = allocate_kernel_context(backed);
         ci->exception_stack = allocate_stack(backed, EXCEPT_STACK_SIZE);
         ci->int_stack = allocate_stack(backed, INT_STACK_SIZE);
+        ci->inval_queue = allocate_queue(backed, PAGE_INVAL_QUEUE_LENGTH);
 #ifdef SMP_DEBUG
         rprintf("cpu %2d: kernel_frame %p, kernel_stack %p", i, ci->kernel_frame, ci->kernel_stack);
         rprintf("        fault_stack  %p, int_stack    %p", ci->fault_stack, ci->int_stack);

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -61,8 +61,8 @@ typedef struct cpuinfo {
     /* Stack for interrupts */
     void *int_stack;
 
-    /* queue of pages to invalidate */
-    queue inval_queue;
+    /* Generation number for invalidates */
+    word inval_gen;
 
 #ifdef CONFIG_FTRACE
     int graph_idx;

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -61,6 +61,9 @@ typedef struct cpuinfo {
     /* Stack for interrupts */
     void *int_stack;
 
+    /* queue of pages to invalidate */
+    queue inval_queue;
+
 #ifdef CONFIG_FTRACE
     int graph_idx;
     struct ftrace_graph_entry * graph_stack;

--- a/src/kernel/pagecache.h
+++ b/src/kernel/pagecache.h
@@ -37,7 +37,7 @@ void pagecache_node_fetch_pages(pagecache_node pn, range r /* bytes */);
 
 void pagecache_node_scan_and_commit_shared_pages(pagecache_node pn, range q /* bytes */);
 
-void pagecache_node_close_shared_pages(pagecache_node pn, range q /* bytes */);
+void pagecache_node_close_shared_pages(pagecache_node pn, range q /* bytes */, flush_entry fe);
 
 void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node_offset);
 

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -122,6 +122,8 @@ typedef struct buffer *buffer;
 
 void print_number(buffer s, u64 x, int base, int pad);
 
+typedef struct flush_entry *flush_entry;
+
 #include <text.h>
 #include <vector.h>
 #include <format.h>

--- a/src/x86_64/flush.c
+++ b/src/x86_64/flush.c
@@ -217,11 +217,10 @@ void init_flush(heap h)
     flush_service = closure(flush_heap, do_flush_service);
     free_flush_entries = allocate_queue(flush_heap, MAX_FLUSH_ENTRIES + 1);
     flush_completion_queue = allocate_queue(flush_heap, COMP_QUEUE_SIZE);
-    for (int i = 0; i < MAX_FLUSH_ENTRIES; i++) {
-        flush_entry f = allocate(flush_heap, sizeof(struct flush_entry));
-        assert(f);
+    flush_entry fa = allocate(flush_heap, sizeof(struct flush_entry) * MAX_FLUSH_ENTRIES);
+    assert(fa);
+    for (flush_entry f = fa; f < fa + MAX_FLUSH_ENTRIES; f++)
         assert(enqueue(free_flush_entries, f));
-    }
     initialized = true;
 }
 

--- a/src/x86_64/flush.c
+++ b/src/x86_64/flush.c
@@ -2,23 +2,88 @@
 #include <page.h>
 #include <apic.h>
 
+#define FLUSH_THRESHOLD 32
+#define MAX_FLUSH_ENTRIES 1024
+#define COMP_QUEUE_SIZE (MAX_FLUSH_ENTRIES*2)
+#define ENTRIES_SERVICE_THRESHOLD (MAX_FLUSH_ENTRIES/2)
+
 static boolean initialized = false;
 static int flush_ipi;
 static heap flush_heap;
+static volatile word inval_gen;
+static queue free_flush_entries;
+static struct list entries;
+static int entries_count;
+static volatile boolean service_scheduled;
+static thunk flush_service;
+static queue flush_completion_queue;
+static struct spinlock flush_lock;
 
+static void queue_flush_service();
+
+declare_closure_struct(1, 0, void, flush_complete,
+    flush_entry, f);
+
+struct flush_entry {
+    struct list l;
+    u64 gen;
+    u64 cpu_mask;
+    struct refcount ref;
+    boolean flush;
+    u64 pages[FLUSH_THRESHOLD];
+    int npages;
+    thunk completion;
+    closure_struct(flush_complete, finish);
+};
 
 static void invalidate (u64 page)
 {
     asm volatile("invlpg (%0)" :: "r" (page) : "memory");
 }
 
+define_closure_function(1, 0, void, flush_complete, flush_entry, f)
+{
+    flush_entry f = bound(f);
+    assert(f->cpu_mask == 0);
+    queue_flush_service();
+}
+
+/* must be called with interrupts off */
 static void _flush_handler(void)
 {
     cpuinfo ci = current_cpu();
-    void *p;
-    while ((p = dequeue(ci->inval_queue)) != INVALID_ADDRESS) {
-        invalidate((u64)p);
+    /* Each generation has at least one page, so if the gen difference is
+     * greater than FLUSH_THRESHOLD, just do a full tlb flush */
+    boolean full_flush = inval_gen - ci->inval_gen > FLUSH_THRESHOLD;
+
+    spin_rlock(&flush_lock);
+    while (ci->inval_gen != inval_gen) {
+        word oldgen = ci->inval_gen;
+        ci->inval_gen = inval_gen;
+        list_foreach(&entries, l) {
+            flush_entry f = struct_from_list(l, flush_entry, l);
+            if (f->gen <= oldgen)
+                continue;
+            if (f->gen > ci->inval_gen)
+                break;
+            if ((f->cpu_mask & U64_FROM_BIT(ci->id)) == 0)
+                continue;
+            if (!full_flush) {
+                if (f->flush)
+                    full_flush = true;
+                else {
+                    for (int i = 0; i < f->npages; i++)
+                        invalidate(f->pages[i]);
+                }
+            }
+            atomic_clear_bit(&f->cpu_mask, ci->id);
+            refcount_release(&f->ref);
+        }
     }
+    spin_runlock(&flush_lock);
+
+    if (full_flush)
+        flush_tlb();
 }
 
 closure_function(0, 0, void, flush_handler)
@@ -26,41 +91,137 @@ closure_function(0, 0, void, flush_handler)
     _flush_handler();
 }
 
+void page_invalidate_flush()
+{
+    _flush_handler();
+}
 
-void page_invalidate(u64 p)
+void page_invalidate(flush_entry f, u64 p)
 {
     if (initialized) {
-        for (int i = 0; i < total_processors; i++) {
-            while (!enqueue(cpuinfos[i].inval_queue, (void *)p))
-                page_invalidate_sync(ignore);
-        }
+        if (f->flush)
+            return;
+        f->pages[f->npages++] = p;
+        if (f->npages >= FLUSH_THRESHOLD)
+            f->flush = true;
     } else {
         invalidate(p);
     }
 }
 
-void page_invalidate_sync(thunk completion)
+static void service_list(boolean trydefer)
+{
+    list_foreach(&entries, l) {
+        flush_entry f = struct_from_list(l, flush_entry, l);
+        if (f->ref.c > 0)
+            continue;
+        list_delete(&f->l);
+        entries_count--;
+        if (trydefer) {
+            if (!enqueue(flush_completion_queue, f->completion))
+                apply(f->completion);
+        } else
+            apply(f->completion);
+        assert(enqueue(free_flush_entries, f));
+    }
+}
+
+closure_function(0, 0, void, do_flush_service)
+{
+    thunk c;
+
+    while (service_scheduled) {
+        service_scheduled = false;
+        u64 flags = spin_wlock_irq(&flush_lock);
+        service_list(false);
+        spin_wunlock_irq(&flush_lock, flags);
+        while ((c = dequeue(flush_completion_queue)) != INVALID_ADDRESS) {
+            apply(c);
+        }
+    }
+}
+
+static void queue_flush_service()
+{
+    if (!service_scheduled) {
+        service_scheduled = true;
+        assert(enqueue(runqueue, flush_service));
+    }
+}
+
+void page_invalidate_sync(flush_entry f, thunk completion)
 {
     if (initialized) {
-        u64 flags = irq_disable_save();
-        int id = current_cpu()->id;
-        for (int i = 0; i < total_processors; i++) {
-            if (i != id)
-                apic_ipi(i, 0, flush_ipi);
+        if (f->npages == 0) {
+            assert(enqueue(free_flush_entries, f));
+            if (completion && completion != ignore) {
+                assert(enqueue(flush_completion_queue, completion));
+                queue_flush_service();
+            }
+            return;
         }
+        f->cpu_mask = MASK(total_processors);
+        init_refcount(&f->ref, total_processors, init_closure(&f->finish, flush_complete, f));
+        f->completion = completion;
+
+        u64 flags = irq_disable_save();
+        spin_wlock(&flush_lock);
+
+        /* The service thunk doesn't always get a chance to run before
+         * running out of flush resources, so proactively service the list */
+        if (entries_count > ENTRIES_SERVICE_THRESHOLD)
+            service_list(true);
+        list_push_back(&entries, &f->l);
+        entries_count++;
+        f->gen = fetch_and_add((word *)&inval_gen, 1) + 1;
+        spin_wunlock(&flush_lock);
+
+        apic_ipi(TARGET_EXCLUSIVE_BROADCAST, 0, flush_ipi);
         _flush_handler();
         irq_restore(flags);
+    } else {
+        if (completion)
+            apply(completion);
     }
+}
 
-    if (completion)
-        apply(completion);
+flush_entry get_page_flush_entry()
+{
+    if (initialized) {
+        flush_entry fe;
+
+        u64 flags = irq_disable_save();
+        /* Do the flush work here if this cpu gets too far behind which
+         * can happen with large mapping operations */
+        if (inval_gen - current_cpu()->inval_gen > FLUSH_THRESHOLD)
+            _flush_handler();
+        irq_restore(flags);
+
+        /* This spins because it must succeed */
+        while ((fe = dequeue(free_flush_entries)) == INVALID_ADDRESS)
+            kern_pause();
+
+        assert(fe != INVALID_ADDRESS);
+        runtime_memset((void *)fe, 0, sizeof(*fe));
+        return fe;
     }
+    return 0;
+}
 
 void init_flush(heap h)
 {
     flush_ipi = allocate_interrupt();
     register_interrupt(flush_ipi, closure(h, flush_handler), "flush ipi");
-    flush_heap = h; // xxx - not really
+    flush_heap = h;
+    list_init(&entries);
+    flush_service = closure(flush_heap, do_flush_service);
+    free_flush_entries = allocate_queue(flush_heap, MAX_FLUSH_ENTRIES + 1);
+    flush_completion_queue = allocate_queue(flush_heap, COMP_QUEUE_SIZE);
+    for (int i = 0; i < MAX_FLUSH_ENTRIES; i++) {
+        flush_entry f = allocate(flush_heap, sizeof(struct flush_entry));
+        assert(f);
+        assert(enqueue(free_flush_entries, f));
+    }
     initialized = true;
 }
 

--- a/src/x86_64/flush.c
+++ b/src/x86_64/flush.c
@@ -17,7 +17,7 @@ static int entries_count;
 static volatile boolean service_scheduled;
 static thunk flush_service;
 static queue flush_completion_queue;
-static struct spinlock flush_lock;
+static struct rw_spinlock flush_lock;
 
 static void queue_flush_service();
 

--- a/src/x86_64/lock.h
+++ b/src/x86_64/lock.h
@@ -21,7 +21,7 @@ static inline void spin_unlock(spinlock l) {
 static inline void spin_rlock(rw_spinlock l) {
     while (1) {
         fetch_and_add(&l->readers, 1);
-        if (!l->w)
+        if (!l->l.w)
             return;
         fetch_and_add(&l->readers, -1);
         kern_pause();

--- a/src/x86_64/machine.h
+++ b/src/x86_64/machine.h
@@ -29,8 +29,12 @@ static inline __attribute__((always_inline)) u16 tagof(void* v) {
 
 typedef struct spinlock {
     word w;
-    u64 readers;
 } *spinlock;
+
+typedef struct rw_spinlock {
+    struct spinlock l;
+    u64 readers;
+} *rw_spinlock;
 #endif
 
 static inline __attribute__((always_inline)) void compiler_barrier(void)

--- a/src/x86_64/machine.h
+++ b/src/x86_64/machine.h
@@ -29,6 +29,7 @@ static inline __attribute__((always_inline)) u16 tagof(void* v) {
 
 typedef struct spinlock {
     word w;
+    u64 readers;
 } *spinlock;
 #endif
 

--- a/src/x86_64/page.h
+++ b/src/x86_64/page.h
@@ -46,6 +46,7 @@ static inline u64 page_from_pte(u64 pte)
 #ifndef physical_from_virtual
 physical physical_from_virtual(void *x);
 #endif
+typedef struct flush_entry *flush_entry;
 
 void map(u64 virtual, physical p, u64 length, u64 flags);
 void unmap(u64 virtual, u64 length);
@@ -67,8 +68,10 @@ void dump_ptes(void *x);
 typedef closure_type(entry_handler, boolean /* success */, int /* level */,
         u64 /* vaddr */, u64 * /* entry */);
 boolean traverse_ptes(u64 vaddr, u64 length, entry_handler eh);
-void page_invalidate(u64 p);
-void page_invalidate_sync(thunk completion);
+void page_invalidate(flush_entry f, u64 p);
+void page_invalidate_sync(flush_entry f, thunk completion);
+flush_entry get_page_flush_entry();
+void page_invalidate_flush();
 void flush_tlb();
 void init_flush(heap);
 void *bootstrap_page_tables(heap initial);

--- a/src/x86_64/page.h
+++ b/src/x86_64/page.h
@@ -67,9 +67,10 @@ void dump_ptes(void *x);
 typedef closure_type(entry_handler, boolean /* success */, int /* level */,
         u64 /* vaddr */, u64 * /* entry */);
 boolean traverse_ptes(u64 vaddr, u64 length, entry_handler eh);
-void page_invalidate(u64 p, thunk completion);
+void page_invalidate(u64 p);
+void page_invalidate_sync(thunk completion);
 void flush_tlb();
-void init_flush();
+void init_flush(heap);
 void *bootstrap_page_tables(heap initial);
 #ifdef STAGE3
 void map_setup_2mbpages(u64 v, physical p, int pages, u64 flags,

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -30,6 +30,7 @@ PROGRAMS= \
 	symlink \
 	thread_test \
 	time \
+	tlbshootdown \
 	udploop \
 	unixsocket \
 	unlink \
@@ -180,6 +181,13 @@ SRCS-time= \
 	$(SRCDIR)/unix_process/ssp.c
 LDFLAGS-time=		-static
 LIBS-time=		-lrt -lpthread
+
+SRCS-tlbshootdown= \
+	$(CURDIR)/tlbshootdown.c \
+	$(SRCDIR)/unix_process/unix_process_runtime.c \
+	$(RUNTIME)
+LDFLAGS-tlbshootdown=		-static
+LIBS-tlbshootdown=	-lpthread
 
 SRCS-udploop= \
 	$(CURDIR)/udploop.c \

--- a/test/runtime/tlbshootdown.c
+++ b/test/runtime/tlbshootdown.c
@@ -40,7 +40,7 @@ void *cpu_thread(void *v)
 {
     int i, id;
 
-    id = (int)v;
+    id = (int)((uintptr_t)v);
     wait_for_sync();
 
     if (sigsetjmp(jbs[id], 1)) {

--- a/test/runtime/tlbshootdown.c
+++ b/test/runtime/tlbshootdown.c
@@ -40,7 +40,7 @@ void *cpu_thread(void *v)
 {
     int i, id;
 
-    id = (pthread_t *)v - threads;
+    id = (int)v;
     wait_for_sync();
 
     if (sigsetjmp(jbs[id], 1)) {
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     np = get_nprocs();
     printf("There are %d processors available\n", np);
 
-    for (loops = 0; loops < 100; loops++) {
+    for (loops = 0; loops < 1000; loops++) {
         stage = 0;
         m = mmap(NULL, PAGESIZE * np, PROT_READ|PROT_WRITE, MAP_ANONYMOUS|MAP_PRIVATE, 0, 0);
         if (m == (void *)-1) {
@@ -128,8 +128,8 @@ int main(int argc, char **argv)
             exit(EXIT_FAILURE);
         }
         memset((void *)m, 0, PAGESIZE * np);
-        for (int i = 0; i < np; i++) {
-            pthread_create(&threads[i], NULL, cpu_thread, &threads[i]);
+        for (long i = 0; i < np; i++) {
+            pthread_create(&threads[i], NULL, cpu_thread, (void *)i);
         }
         wait_for_children();
         wake_children();    /* trigger children to check for good memory access */

--- a/test/runtime/tlbshootdown.c
+++ b/test/runtime/tlbshootdown.c
@@ -1,0 +1,147 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/sysinfo.h>
+#include <sched.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <signal.h>
+#include <setjmp.h>
+
+#define MAX_CPUS 16
+#define PAGESIZE 4096
+#define NBYTES 256
+
+pthread_t threads[MAX_CPUS];
+sigjmp_buf jbs[MAX_CPUS];
+volatile uint8_t *m;
+volatile int stage;
+int np;
+
+int kidcnt;
+pthread_cond_t kid_cv;
+pthread_cond_t sync_cv;
+pthread_mutex_t sync_mut;
+
+void
+wait_for_sync(void)
+{
+    pthread_mutex_lock(&sync_mut);
+    kidcnt++;
+    pthread_cond_signal(&kid_cv);
+    pthread_cond_wait(&sync_cv, &sync_mut);
+    pthread_mutex_unlock(&sync_mut);
+}
+
+void *cpu_thread(void *v)
+{
+    int i, id;
+
+    id = (pthread_t *)v - threads;
+    wait_for_sync();
+
+    if (sigsetjmp(jbs[id], 1)) {
+        if (stage == 0) {
+            printf("thread %d failed expected memory access\n", id);
+            exit(EXIT_FAILURE);
+        }
+        return NULL;
+    }
+    /* this one is expected to succeed */
+    for (i = PAGESIZE * id; i < PAGESIZE * id + NBYTES; i++)
+        m[i] += id;
+    wait_for_sync();
+    /* this one is expected to fail and generated SIGSEGV */
+    for (i = PAGESIZE * id; i < PAGESIZE * id + NBYTES; i++)
+        m[i] += id;
+    printf("thread %d on cpu %d accessed unmapped memory without segfault\n", id, sched_getcpu());
+
+    exit(EXIT_FAILURE);
+    return NULL;
+}
+
+void handle_sigbuf(int sig, siginfo_t *si, void *uctxt)
+{
+    // printf("** received %s: sig %d, si_errno %d, si_code %d, addr 0x%lx\n",
+    //     strsignal(sig), sig, si->si_errno, si->si_code, (unsigned long)si->si_addr);
+    pthread_t self = pthread_self();
+    int id = -1;
+    for (int i = 0; i < MAX_CPUS; i++) {
+        if (self == threads[i]) {
+            id = i;
+            break;
+        }
+    }
+    if (id < 0) {
+        printf("unable to get thread id in sighandler\n");
+        exit(EXIT_FAILURE);
+    }
+    siglongjmp(jbs[id], si->si_code);
+}
+
+void
+wait_for_children(void)
+{
+    pthread_mutex_lock(&sync_mut);
+    while (kidcnt != np) {
+        pthread_cond_wait(&kid_cv, &sync_mut);
+    }
+    kidcnt = 0;
+    pthread_mutex_unlock(&sync_mut);
+}
+
+void
+wake_children(void)
+{
+    pthread_cond_broadcast(&sync_cv);
+}
+
+int main(int argc, char **argv)
+{
+    int loops;
+    struct sigaction sa;
+
+    setbuf(stdout, NULL);
+    pthread_cond_init(&kid_cv, NULL);
+    pthread_cond_init(&sync_cv, NULL);
+    pthread_mutex_init(&sync_mut, NULL);
+
+    memset(&sa, 0, sizeof sa);
+    sa.sa_sigaction = handle_sigbuf;
+    sa.sa_flags |= SA_SIGINFO;
+    if (sigaction(SIGSEGV, &sa, 0) < 0) {
+        printf("failed to set signal handler\n");
+        exit(EXIT_FAILURE);
+    }
+
+    np = get_nprocs();
+    printf("There are %d processors available\n", np);
+
+    for (loops = 0; loops < 100; loops++) {
+        stage = 0;
+        m = mmap(NULL, PAGESIZE * np, PROT_READ|PROT_WRITE, MAP_ANONYMOUS|MAP_PRIVATE, 0, 0);
+        if (m == (void *)-1) {
+            printf("mmap failure\n");
+            exit(EXIT_FAILURE);
+        }
+        memset((void *)m, 0, PAGESIZE * np);
+        for (int i = 0; i < np; i++) {
+            pthread_create(&threads[i], NULL, cpu_thread, &threads[i]);
+        }
+        wait_for_children();
+        wake_children();    /* trigger children to check for good memory access */
+
+        wait_for_children();
+        stage = 1;
+        munmap((void *)m, PAGESIZE * np);
+        wake_children();    /* trigger children to check for page fault */
+
+        for (int i = 0; i < np; i++)
+            pthread_join(threads[i], NULL);
+    }
+    printf("%s passed\n", argv[0]);
+    exit(EXIT_SUCCESS);
+}

--- a/test/runtime/tlbshootdown.manifest
+++ b/test/runtime/tlbshootdown.manifest
@@ -1,0 +1,15 @@
+(
+    children:(
+        tlbshootdown:(contents:(host:output/test/runtime/bin/tlbshootdown))
+    )
+    # filesystem path to elf for kernel to run
+    program:/tlbshootdown
+#    trace:t
+#    debugsyscalls:t
+#    futex_trace:t
+    fault:t
+    arguments:[tlbshootdown]
+    environment:(USER:bobby PWD:/)
+    exec_protection:t
+    imagesize:30M
+)


### PR DESCRIPTION
This PR implements TLB shootdowns. The page invalidate interface has been modified
so that page invalidates are batched up using a new tracking structure called a
flush_entry. A finite number of flush_entry structs are created at startup so they can be
allocated without going through any heap allocators. The existing calls to page_invalidate
now take a pointer to a flush_entry, which is passed in to the page walkers. When all the
addresses have been added, a call to page_invalidate_sync is made which assigns a
generation number to the flush_entry and adds it to a central linked list. It then fires off
the flush ipi and processes the flush_entry list on the calling cpu. If there are more than
a certain number of addresses to invalidate then a full tlb flush (cr3 reload) is performed.
A refcount on the flush_entry tracks cpu progress, and when the last cpu processes the
flush_entry then a service thunk is queued to runqueue. This service routine processes
the flush_entry list, removing completed entries and running their completion thunks. It
also processes any completion thunks stored on a separate queue from flush_entries
that had no pages to invalidate.

There is also a new simple read-write spinlock implementation to protect the flush_entry
list and allow cpus to process the list concurrently inside of the flush interrupt. It builds
on the existing spinlock data and functions.