### PR TITLE
Add ability to print out klog contents from disk image

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -378,7 +378,7 @@ closure_function(1, 1, void, sync_complete,
 
 static void storage_shutdown(int status, status_handler completion)
 {
-    if ((status == 0) || !table_find(get_environment(), sym(RADAR_KEY))) {
+    if (status == 0) {
         storage_sync(completion);
     } else {
         merge m = allocate_merge(heap_locked(&heaps), completion);


### PR DESCRIPTION
This PR adds a new switch to the dump tool to print out the contents of the klog from a raw disk image. Since
the klog size can be configurable, it searches backwards from the end of the log to find the beginning. It will
not print out any strings in the general klog area without a valid klog header magic, however.
Fixes #1357 