### PR TITLE
Add syscall count summary

### DIFF
--- a/platform/pc/boot/stage2.c
+++ b/platform/pc/boot/stage2.c
@@ -240,7 +240,7 @@ closure_function(0, 1, status, kernel_read_complete,
 
     /* reset initial pages length */
     initial_pages_region->length = INITIAL_PAGES_SIZE;
-    stage2_debug("%s: run64, start address 0xffffffff%8lx\n", __func__, u64_from_pointer(k));
+    stage2_debug("%s: run64, start address 0xffffffff%08lx\n", __func__, u64_from_pointer(k));
     run64(u64_from_pointer(k));
     halt("failed to start long mode\n");
 }

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -105,7 +105,7 @@ static void init_cpuinfos(heap backed)
         ci->exception_stack = allocate_stack(backed, EXCEPT_STACK_SIZE);
         ci->int_stack = allocate_stack(backed, INT_STACK_SIZE);
 #ifdef SMP_DEBUG
-        rprintf("cpu %2d: kernel_frame %p, kernel_stack %p", i, ci->kernel_frame, ci->kernel_stack);
+        rprintf("cpu %02d: kernel_frame %p, kernel_stack %p", i, ci->kernel_frame, ci->kernel_stack);
         rprintf("        fault_stack  %p, int_stack    %p", ci->fault_stack, ci->int_stack);
 #endif
     }

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -327,6 +327,10 @@ static inline u64 total_frame_size(void)
 
 extern void xsave(context f);
 
+#define SHUTDOWN_COMPLETIONS_SIZE    8
+extern vector shutdown_completions;
+typedef closure_type(shutdown_handler, void, merge);
+
 extern int shutdown_vector;
 
 typedef closure_type(halt_handler, void, int);

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -329,7 +329,7 @@ extern void xsave(context f);
 
 #define SHUTDOWN_COMPLETIONS_SIZE    8
 extern vector shutdown_completions;
-typedef closure_type(shutdown_handler, void, merge);
+typedef closure_type(shutdown_handler, void, int, merge);
 
 extern int shutdown_vector;
 

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -7,7 +7,7 @@
    don't create too much of a mess. */
 //#define SCHED_DEBUG
 #ifdef SCHED_DEBUG
-#define sched_debug(x, ...) do {log_printf("SCHED", "[%2d] " x, current_cpu()->id, ##__VA_ARGS__);} while(0)
+#define sched_debug(x, ...) do {log_printf("SCHED", "[%02d] " x, current_cpu()->id, ##__VA_ARGS__);} while(0)
 #else
 #define sched_debug(x, ...)
 #endif

--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -57,7 +57,7 @@ static buffer bulk_test_buffer(heap h)
 {
     buffer b = allocate_buffer(h, BULK_TEST_BUFSIZ);
     for (int i = 0; i < (BULK_TEST_BUFSIZ / 10); i += 8) {
-        bprintf(b, "%8d %8d %8d %8d %8d %8d %8d %8d\r\n",
+        bprintf(b, "%08d %08d %80d %08d %08d %08d %08d %08d\r\n",
                 i, i + 1, i + 2, i + 3, i + 4, i + 5, i + 6, i + 7);
     }
     return b;

--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -57,7 +57,7 @@ static buffer bulk_test_buffer(heap h)
 {
     buffer b = allocate_buffer(h, BULK_TEST_BUFSIZ);
     for (int i = 0; i < (BULK_TEST_BUFSIZ / 10); i += 8) {
-        bprintf(b, "%08d %08d %80d %08d %08d %08d %08d %08d\r\n",
+        bprintf(b, "%08d %08d %08d %08d %08d %08d %08d %08d\r\n",
                 i, i + 1, i + 2, i + 3, i + 4, i + 5, i + 6, i + 7);
     }
     return b;

--- a/src/runtime/format.h
+++ b/src/runtime/format.h
@@ -8,6 +8,8 @@ struct formatter_state {
     int format;    // format character ('s', 'd', ...)
     int modifier;  // format modifier ('l')
     int width;     // format width
+    int align;     // format align ('-')
+    int fill;      // format fill
 };
 
 // make sure its safe to read more than one format char ala %02x

--- a/src/runtime/format.h
+++ b/src/runtime/format.h
@@ -10,6 +10,7 @@ struct formatter_state {
     int width;     // format width
     int align;     // format align ('-')
     int fill;      // format fill
+    int precision; // format precision
 };
 
 // make sure its safe to read more than one format char ala %02x

--- a/src/runtime/runtime_init.c
+++ b/src/runtime/runtime_init.c
@@ -62,13 +62,12 @@ static void format_number(buffer dest, struct formatter_state *s, vlist *a)
     int len = buffer_length(tmp) + sign;
     if (s->precision == 0 && x == 0)
         len = 0;
-    if (len < s->width && s->align == 0) {
-        if (sign && s->fill == '0')
-            push_u8(dest, '-');
+    if (sign && s->fill == '0')
+        push_u8(dest, '-');
+    if (len < s->width && s->align == 0)
         for (int i = 0; i < s->width - len; i++) push_u8(dest, s->fill);
-        if (sign && s->fill != '0')
-            push_u8(dest, '-');
-    }
+    if (sign && s->fill != '0')
+        push_u8(dest, '-');
     if (!(s->precision == 0 && x == 0))
         push_buffer(dest, tmp);
     if (len < s->width && s->align == '-')

--- a/src/runtime/runtime_init.c
+++ b/src/runtime/runtime_init.c
@@ -35,6 +35,11 @@ static void format_pointer(buffer dest, struct formatter_state *s, vlist *a)
     print_number(dest, x, 16, pad);
 }
 
+static inline void fill(buffer b, int len, u8 c)
+{
+    for (int i = 0; i < len; i++) push_u8(b, c);
+}
+
 static void format_number(buffer dest, struct formatter_state *s, vlist *a)
 {
     int base = s->format == 'x' ? 16 : 10;
@@ -65,13 +70,13 @@ static void format_number(buffer dest, struct formatter_state *s, vlist *a)
     if (sign && s->fill == '0')
         push_u8(dest, '-');
     if (len < s->width && s->align == 0)
-        for (int i = 0; i < s->width - len; i++) push_u8(dest, s->fill);
+        fill(dest, s->width - len, s->fill);
     if (sign && s->fill != '0')
         push_u8(dest, '-');
     if (!(s->precision == 0 && x == 0))
         push_buffer(dest, tmp);
     if (len < s->width && s->align == '-')
-        for (int i = 0; i < s->width - len; i++) push_u8(dest, ' ');
+        fill(dest, s->width - len, ' ');
 }
 
 static void format_buffer(buffer dest, struct formatter_state *s, vlist *ap)
@@ -93,16 +98,16 @@ static void format_cstring(buffer dest, struct formatter_state *s, vlist *a)
     if (s->precision > 0)
         len = s->precision;
     if (len < s->width && s->align == 0)
-        for (int i = 0; i < s->width - len; i++) push_u8(dest, ' ');
+        fill(dest, s->width - len, ' ');
     assert(buffer_write(dest, c, len));
     if (len < s->width && s->align == '-')
-        for (int i = 0; i < s->width - len; i++) push_u8(dest, ' ');
+        fill(dest, s->width - len, ' ');
 }
 
 static void format_spaces(buffer dest, struct formatter_state *s, vlist *a)
 {
     int n = varg(*a, int);
-    for (int i = 0; i < n; i++) push_u8(dest, ' ');
+    fill(dest, n, ' ');
 }
 
 // maybe the same?

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -17,7 +17,7 @@ static inline void report_sha256(buffer b)
 {
     buffer sha = little_stack_buffer(32);
     sha256(sha, b);
-    rprintf("   SHA256: %16lx%16lx%16lx%16lx\n",
+    rprintf("   SHA256: %016lx%016lx%016lx%016lx\n",
             be64toh(*(u64*)buffer_ref(sha, 0)),
             be64toh(*(u64*)buffer_ref(sha, 8)),
             be64toh(*(u64*)buffer_ref(sha, 16)),

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -2,7 +2,7 @@
 
 //#define PF_DEBUG
 #ifdef PF_DEBUG
-#define pf_debug(x, ...) do {log_printf("FAULT", "[%2d] " x, current_cpu()->id, ##__VA_ARGS__);} while(0)
+#define pf_debug(x, ...) do {log_printf("FAULT", "[%02d] " x, current_cpu()->id, ##__VA_ARGS__);} while(0)
 #else
 #define pf_debug(x, ...)
 #endif

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -77,7 +77,7 @@ boolean do_demand_page(u64 vaddr, vmap vm, context frame)
         return false;
     }
 
-    pf_debug("%s: %s, %s, vaddr 0x%16lx, vm flags 0x%2lx,\n", __func__,
+    pf_debug("%s: %s, %s, vaddr %p, vm flags 0x%02lx,\n", __func__,
              in_kernel ? "kern" : "user", string_from_mmap_type(vm->flags & VMAP_MMAP_TYPE_MASK),
              vaddr, vm->flags);
     pf_debug("   vmap %p, frame %p\n", vm, frame);

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -484,7 +484,7 @@ sysreturn rt_sigreturn(void)
 
     /* ftrace needs to know that this call stack does not return */
     ftrace_thread_noreturn(t);
-
+    count_syscall_noreturn(t);
     /* see if we have more handlers to invoke */
     if (!dispatch_signals(t))
         set_thread_frame(t, t->default_frame);

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -46,7 +46,7 @@ closure_function(1, 1, void, maps_handler,
 
     /* All mappings are assumed to be readable and private; offset, device and
      * inode are unknown. */
-    bprintf(b, "%16lx-%16lx r%c%cp 00000000 00:00 0", map->node.r.start,
+    bprintf(b, "%016lx-%016lx r%c%cp 00000000 00:00 0", map->node.r.start,
             map->node.r.end, (map->flags & VMAP_FLAG_WRITABLE) ? 'w' : '-',
             (map->flags & VMAP_FLAG_EXEC) ? 'x' : '-');
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2549,10 +2549,10 @@ static boolean stat_compare(void *za, void *zb)
     return sb->usecs > sa->usecs;
 }
 
-static inline char *print_ts(buffer b, u64 x)
+static inline char *print_usecs(buffer b, u64 x)
 {
     buffer_clear(b);
-    print_timestamp(b, microseconds(x));
+    bprintf(b, "%d.%06d", x / MILLION, x % MILLION);
     buffer_write_byte(b, 0);
     return buffer_ref(b, 0);
 }
@@ -2571,7 +2571,8 @@ static inline char *print_pct(buffer b, u64 x, u64 y)
 #define LINE3 LINE LINE LINE
 #define SEPARATOR LINE " " LINE2 " " LINE2 " " LINE2 " " LINE2 " " LINE3 "\n"
 #define HDR_FMT "%6s %12s %12s %12s %12s %-18s\n"
-#define DATA_FMT "%6s %12s %12.0d %12d %12.0d %-18s\n"
+#define DATA_FMT "%6s %12s %12d %12d %12.0d %-18s\n"
+#define SUM_FMT "%6s %12s %12.0d %12d %12.0d %-18s\n"
 
 #define ROUNDED_IDIV(x, y) (((x)* 10 / (y) + 5) / 10)
 
@@ -2597,10 +2598,10 @@ closure_function(0, 1, void, print_syscall_stats_cfn,
     while ((ss = pqueue_pop(pq)) != INVALID_ADDRESS) {
         tot_calls += ss->calls;
         tot_errs += ss->errors;
-        rprintf(DATA_FMT, print_pct(pbuf, ss->usecs, tot_usecs), print_ts(tbuf, ss->usecs),
+        rprintf(DATA_FMT, print_pct(pbuf, ss->usecs, tot_usecs), print_usecs(tbuf, ss->usecs),
             ROUNDED_IDIV(ss->usecs, ss->calls), ss->calls, ss->errors, _linux_syscalls[ss - stats].name);
     }
-    rprintf(SEPARATOR DATA_FMT, "100.00", print_ts(tbuf, tot_usecs), 0, tot_calls, tot_errs, "total");
+    rprintf(SEPARATOR SUM_FMT, "100.00", print_usecs(tbuf, tot_usecs), 0, tot_calls, tot_errs, "total");
     deallocate_pqueue(pq);
 }
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2466,7 +2466,12 @@ void count_syscall(thread t, sysreturn rv)
     fetch_and_add(&ss->calls, 1);
     if (rv < 0 && rv >= -255)
         fetch_and_add(&ss->errors, 1);
-    fetch_and_add(&ss->usecs, usec_from_timestamp(now(CLOCK_ID_MONOTONIC) - t->syscall_enter_ts) + t->syscall_time);
+    u64 us;
+    if (t->syscall_enter_ts)
+        us = usec_from_timestamp(now(CLOCK_ID_MONOTONIC) - t->syscall_enter_ts) + t->syscall_time;
+    else
+        us = t->syscall_time;
+    fetch_and_add(&ss->usecs, us);
     t->syscall_time = 0;
 }
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2581,8 +2581,8 @@ static inline char *print_pct(buffer b, u64 x, u64 y)
 
 #define ROUNDED_IDIV(x, y) (((x)* 10 / (y) + 5) / 10)
 
-closure_function(0, 1, void, print_syscall_stats_cfn,
-                 merge, m)
+closure_function(0, 2, void, print_syscall_stats_cfn,
+                 int, status, merge, m)
 {
     u64 tot_usecs = 0;
     u64 tot_calls = 0;
@@ -2592,6 +2592,8 @@ closure_function(0, 1, void, print_syscall_stats_cfn,
     pqueue pq = allocate_pqueue(heap_general(get_kernel_heaps()), stat_compare);
     syscall_stat ss;
 
+    if (status != 0)
+        return;
     rprintf("\n" HDR_FMT SEPARATOR, "% time", "seconds", "usecs/call", "calls", "errors", "syscall");
     for (int i = 0; i < SYS_MAX; i++) {
         ss = &stats[i];

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -159,6 +159,8 @@ static inline void run_thread_frame(thread t)
     t->blocked_on = 0;
     t->syscall = -1;
 
+    if (do_syscall_stats && t->last_syscall == SYS_sched_yield)
+        count_syscall(t, 0);
     context f = thread_frame(t);
     f[FRAME_FLAGS] |= U64_FROM_BIT(FLAG_INTERRUPT);
     cpuinfo ci = current_cpu();

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -208,6 +208,7 @@ void thread_sleep_interruptible(void)
     assert(current->blocked_on);
     thread_log(current, "sleep interruptible (on \"%s\")", blockq_name(current->blocked_on));
     ftrace_thread_switch(current, 0);
+    count_syscall_save(current);
     kern_unlock();
     runloop();
 }
@@ -219,6 +220,7 @@ void thread_sleep_uninterruptible(void)
     current->blocked_on = INVALID_ADDRESS;
     thread_log(current, "sleep uninterruptible");
     ftrace_thread_switch(current, 0);
+    count_syscall_save(current);
     kern_unlock();
     runloop();
 }
@@ -321,6 +323,7 @@ thread create_thread(process p)
     t->sysctx = false;
     t->utime = t->stime = 0;
     t->start_time = now(CLOCK_ID_MONOTONIC);
+    t->last_syscall = -1;
 
     // XXX sigframe
     assert(vector_set(p->threads, t->tid, t)); 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -514,6 +514,9 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     register_timer_syscalls(linux_syscalls);
     register_other_syscalls(linux_syscalls);
     configure_syscalls(kernel_process);
+    do_syscall_stats = table_find(kernel_process->process_root, sym(syscall_summary)) != 0;
+    if (do_syscall_stats)
+        vector_push(shutdown_completions, print_syscall_stats);
     return kernel_process;
   alloc_fail:
     msg_err("failed to allocate kernel objects\n");

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -5,7 +5,7 @@
 
 //#define PF_DEBUG
 #ifdef PF_DEBUG
-#define pf_debug(x, ...) do {log_printf("FAULT", "[%2d] tid %2d " x "\n", current_cpu()->id, \
+#define pf_debug(x, ...) do {log_printf("FAULT", "[%02d] tid %02d " x "\n", current_cpu()->id, \
                                         current->tid, ##__VA_ARGS__);} while(0)
 #else
 #define pf_debug(x, ...) thread_log(current, x, ##__VA_ARGS__);

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -395,6 +395,7 @@ void thread_pause(thread t)
 
 void thread_resume(thread t)
 {
+    count_syscall_resume(t);
     if (get_current_thread() == &t->thrd)
         return;
     t->start_time = now(CLOCK_ID_MONOTONIC);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -264,6 +264,7 @@ typedef struct thread {
     timestamp start_time;
     int last_syscall;
     timestamp syscall_enter_ts;
+    u64 syscall_time;
 
     /* signals pending and saved state */
     struct sigstate signals;
@@ -682,7 +683,30 @@ void _register_syscall(struct syscall *m, int n, sysreturn (*f)(), const char *n
 void configure_syscalls(process p);
 boolean syscall_notrace(process p, int syscall);
 
-void count_syscall(thread t, int rv);
+void count_syscall(thread t, sysreturn rv);
+
+extern boolean do_syscall_stats;
+static inline void count_syscall_save(thread t)
+{
+    if (do_syscall_stats && !t->syscall_complete) {
+        t->syscall_time += usec_from_timestamp(now(CLOCK_ID_MONOTONIC) - t->syscall_enter_ts);
+        t->syscall_enter_ts = 0;
+    }
+}
+
+static inline void count_syscall_resume(thread t)
+{
+    if (do_syscall_stats && !t->syscall_complete && t->syscall_enter_ts == 0)
+        t->syscall_enter_ts = now(CLOCK_ID_MONOTONIC);
+}
+
+static inline void count_syscall_noreturn(thread t)
+{
+    if (!do_syscall_stats)
+        return;
+    t->syscall_time = 0;
+    t->last_syscall = -1;
+}
 shutdown_handler print_syscall_stats;
 extern boolean do_syscall_stats;
 
@@ -783,11 +807,10 @@ static inline sysreturn syscall_return(thread t, sysreturn val)
     set_syscall_return(t, val);
     u64 flags = irq_disable_save(); /* XXX mutex / spinlock */
     t->syscall_complete = true;
-    if (t->blocked_on) {
-        if (do_syscall_stats)
-            count_syscall(t, val);
+    if (do_syscall_stats)
+        count_syscall(t, val);
+    if (t->blocked_on)
         thread_wakeup(t);
-    }
     irq_restore(flags);
     return val;
 }

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -237,7 +237,7 @@ void common_handler()
     // if we were idle, we are no longer
     atomic_clear_bit(&idle_cpu_mask, ci->id);
 
-    int_debug("[%2d] # %d (%s), state %s, frame %p, rip 0x%lx, cr2 0x%lx\n",
+    int_debug("[%02d] # %d (%s), state %s, frame %p, rip 0x%lx, cr2 0x%lx\n",
               ci->id, i, interrupt_names[i], state_strings[ci->state],
               f, f[FRAME_RIP], f[FRAME_CR2]);
 

--- a/src/xen/xennet.c
+++ b/src/xen/xennet.c
@@ -782,7 +782,7 @@ static status xennet_attach(kernel_heaps kh, int id, buffer frontend, tuple meta
             pop_u8((buffer)v);
     }
 
-    xennet_debug("MAC address %2x:%2x:%2x:%2x:%2x:%2x",
+    xennet_debug("MAC address %02x:%02x:%02x:%02x:%02x:%02x",
                  xd->mac[0], xd->mac[1], xd->mac[2],
                  xd->mac[3], xd->mac[4], xd->mac[5]);
 


### PR DESCRIPTION
This changeset adds support for outputting an 'strace -c' like list of syscall counts and times on
vm exit. The syscall tracking and summary output are controlled through a new manifest symbol
called 'syscall_summary'. New print formatting support for alignment, padding, and precision has
been added in order to make printing the report output simpler. The change also adds a list to 
track shutdown completions that are then run in kernel_shutdown. The existing fs sync is now added
to that list at shutdown time so it always runs last, and a merge is used to run the halt completion 
after the shutdown completions have finished.