### PR TITLE
TFS log fixes

### DIFF
--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -550,6 +550,11 @@ static void log_set_dirty(log tl)
 /* mkfs: flush on close */
 static void log_set_dirty(log tl)
 {
+    if (buffer_length(tl->tuple_staging) >=
+            bytes_from_sectors(tl->fs, range_span(tl->current->sectors))) {
+        log_flush(tl, 0);
+        return;
+    }
     tl->dirty = true;
 }
 #endif

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -500,7 +500,7 @@ int main(int argc, char **argv)
     }
     if (!img_size)
         img_size = current_size;
-    img_size = pad(img_size, TFS_LOG_DEFAULT_EXTENSION_SIZE);
+    img_size = pad(img_size - offset, TFS_LOG_DEFAULT_EXTENSION_SIZE) + offset;
     if (current_size < img_size) {
         if (ftruncate(out, img_size)) {
             halt("could not set image size: %s\n", strerror(errno));


### PR DESCRIPTION
This PR fixes a couple of issues that are preventing creation of images with a large number of files, where the TFS log exceeds the size of one extension.