### PR TITLE
Really fix print_syscall_stats multiple definition linker error

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -26,6 +26,7 @@ sysreturn close(int fd);
 
 io_completion syscall_io_complete;
 io_completion io_completion_ignore;
+shutdown_handler print_syscall_stats;
 
 void register_other_syscalls(struct syscall *map)
 {

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -707,7 +707,7 @@ static inline void count_syscall_noreturn(thread t)
     t->syscall_time = 0;
     t->last_syscall = -1;
 }
-shutdown_handler print_syscall_stats;
+extern shutdown_handler print_syscall_stats;
 extern boolean do_syscall_stats;
 
 void register_file_syscalls(struct syscall *);


### PR DESCRIPTION
The symbol was defined in a header without extern which caused an error on certain linkers.