### PR TITLE
VDSO: getcpu(): avoid calling current_cpu()

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -485,6 +485,7 @@ static void __attribute__((noinline)) init_service_new_stack()
     shutdown_completions = allocate_vector(heap_general(kh), SHUTDOWN_COMPLETIONS_SIZE);
     init_debug("pci_discover (for VGA)");
     pci_discover(); // early PCI discover to configure VGA console
+    init_clock();
     init_kernel_contexts(backed);
 
     /* interrupts */
@@ -494,7 +495,6 @@ static void __attribute__((noinline)) init_service_new_stack()
     // ipi..i guess this is safe because they are disabled?
     init_debug("init_scheduler");    
     init_scheduler(misc);
-    init_clock();               /* must precede platform init */
 
     /* platform detection and early init */
     init_debug("probing for KVM");

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -110,7 +110,7 @@ static void init_cpuinfos(heap backed)
 #endif
     }
 
-    cpu_setgs(0);
+    cpu_init(0);
 }
 
 void init_kernel_contexts(heap backed)

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -84,12 +84,7 @@ static inline __attribute__((always_inline)) cpuinfo cpuinfo_from_id(int cpu)
     return &cpuinfos[cpu];
 }
 
-static inline __attribute__((always_inline)) void cpu_setgs(int cpu)
-{
-    u64 addr = u64_from_pointer(cpuinfo_from_id(cpu));
-    write_msr(KERNEL_GS_MSR, 0); /* clear user GS */
-    write_msr(GS_MSR, addr);
-}
+void cpu_init(int cpu);
 
 static inline __attribute__((always_inline)) cpuinfo current_cpu(void)
 {

--- a/src/kernel/vdso-now.c
+++ b/src/kernel/vdso-now.c
@@ -106,3 +106,17 @@ vdso_now(clock_id id)
 
     return _now + _off;
 }
+
+VDSO int
+vdso_getcpu(unsigned *cpu, unsigned *node)
+{
+    if (__vdso_dat->platform_has_rdtscp) {
+        if (cpu)
+            asm volatile("rdtscp" : "=c" (*cpu) :: "eax", "edx");
+        if (node)
+            *node = 0;
+        return 0;
+    } else {
+        return -1;
+    }
+}

--- a/src/kernel/vdso.c
+++ b/src/kernel/vdso.c
@@ -49,12 +49,11 @@ do_vdso_gettimeofday(struct timeval * tv, void * tz)
 static sysreturn
 do_vdso_getcpu(unsigned * cpu, unsigned * node, void * tcache)
 {
-    cpuinfo ci = current_cpu();
-    if (cpu)
-        *cpu = ci->id;
-    if (node)
-        *node = 0;
-    return 0;
+    sysreturn rv = vdso_getcpu(cpu, node);
+    if (rv < 0)
+        return do_syscall(SYS_getcpu, cpu, node);
+    else
+        return rv;
 }
 
 static sysreturn

--- a/src/kernel/vdso.h
+++ b/src/kernel/vdso.h
@@ -21,3 +21,4 @@ VVAR_DECL(struct vdso_dat_struct, vdso_dat);
 struct pvclock_vcpu_time_info;
 VDSO u64 vdso_pvclock_now_ns(volatile struct pvclock_vcpu_time_info *);
 VDSO timestamp vdso_now(clock_id id);
+VDSO int vdso_getcpu(unsigned *cpu, unsigned *node);

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -35,6 +35,7 @@
 #define FS_MSR           0xc0000100
 #define GS_MSR           0xc0000101
 #define KERNEL_GS_MSR    0xc0000102
+#define TSC_AUX_MSR      0xc0000103
 
 #define C0_MP   0x00000002
 #define C0_EM   0x00000004


### PR DESCRIPTION
current_cpu() cannot be called from userspace because:
1)  it accesses the GS register, whose contents in user mode are usually different from the contents in kernel mode
2) it is supposed to return a pointer to kernel data (cpuinfo) that is not mapped for userspace access

This commit fixes the VDSO getcpu() implementation by storing the CPU ID in the TSC_AUX MSR, and retrieving it via the RDTSCP instruction.

For future reference, below is a C code snippet that exercises the VDSO getcpu() implementation:
```
extern void *_dl_vdso_vsym(const char *n, void *);
int (*__vdso_getcpu)(unsigned *cpu, unsigned *node, void *tcache) =
    _dl_vdso_vsym("__vdso_getcpu", NULL);
unsigned cpu;
__vdso_getcpu(&cpu, NULL, NULL);
```
Closes #1368.