### PR TITLE
Network socket fixes

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1675,7 +1675,6 @@ static sysreturn netsock_listen(struct sock *sock, int backlog)
     set_lwip_error(s, ERR_OK);
     tcp_arg(lw, s);
     tcp_accept(lw, accept_tcp_from_lwip);
-    tcp_err(lw, lwip_tcp_conn_err);
     return 0;    
 }
 

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -377,18 +377,18 @@ static sysreturn sock_read_bh_internal(netsock s, thread t, void * dest,
     assert(length > 0);
     assert(s->sock.type == SOCK_STREAM || s->sock.type == SOCK_DGRAM);
 
-    if (flags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -ERESTARTSYS;
-        goto out;
-    }
-
     if (s->sock.type == SOCK_STREAM && s->info.tcp.state != TCP_SOCK_OPEN) {
-        rv = -ENOTCONN;         /* XXX or 0? */
+        rv = 0;
         goto out;
     }
 
     if (err != ERR_OK) {
         rv = lwip_to_errno(err);
+        goto out;
+    }
+
+    if (flags & BLOCKQ_ACTION_NULLIFY) {
+        rv = -ERESTARTSYS;
         goto out;
     }
 
@@ -518,7 +518,8 @@ closure_function(1, 6, sysreturn, socket_read,
     net_debug("sock %d, type %d, thread %ld, dest %p, length %ld, offset %ld\n",
 	      s->sock.fd, s->sock.type, t->tid, dest, length, offset);
     if (s->sock.type == SOCK_STREAM && s->info.tcp.state != TCP_SOCK_OPEN)
-        return io_complete(completion, t, -ENOTCONN);
+        return io_complete(completion, t,
+            (s->info.tcp.state == TCP_SOCK_UNDEFINED) ? 0 : -ENOTCONN);
 
     blockq_action ba = closure(s->sock.h, sock_read_bh, s, t, dest, length, 0,
             0, completion);
@@ -534,11 +535,6 @@ static sysreturn socket_write_tcp_bh_internal(netsock s, thread t, void * buf,
               s->sock.fd, t->tid, buf, remain, flags, err);
     assert(remain > 0);
 
-    if (flags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -ERESTARTSYS;
-        goto out;
-    }
-
     if (err != ERR_OK) {
         rv = lwip_to_errno(err);
         goto out;
@@ -546,6 +542,11 @@ static sysreturn socket_write_tcp_bh_internal(netsock s, thread t, void * buf,
 
     if (s->sock.type == SOCK_STREAM && s->info.tcp.state != TCP_SOCK_OPEN) {
         rv = -ENOTCONN;
+        goto out;
+    }
+
+    if (flags & BLOCKQ_ACTION_NULLIFY) {
+        rv = -ERESTARTSYS;
         goto out;
     }
 
@@ -904,6 +905,7 @@ static sysreturn netsock_shutdown(struct sock *sock, int how)
             /* Shutting down both TX and RX is equivalent to calling
              * tcp_close(), so the pcb should not be referenced anymore. */
             s->info.tcp.lw = 0;
+            s->info.tcp.state = TCP_SOCK_UNDEFINED;
         }
         netsock_check_loop();
         break;
@@ -1097,6 +1099,7 @@ static err_t tcp_input_lower(void *z, struct tcp_pcb *pcb, struct pbuf *p, err_t
         }
         wakeup_sock(s, WAKEUP_SOCK_RX);
     } else {
+        s->info.tcp.state = TCP_SOCK_UNDEFINED;
         wakeup_sock(s, WAKEUP_SOCK_EXCEPT);
     }
 
@@ -1556,7 +1559,7 @@ static sysreturn netsock_recvfrom(struct sock *sock, void *buf, u64 len,
 {
     netsock s = (netsock) sock;
     if (sock->type == SOCK_STREAM && s->info.tcp.state != TCP_SOCK_OPEN)
-        return set_syscall_error(current, ENOTCONN);
+        return set_syscall_error(current, (s->info.tcp.state == TCP_SOCK_UNDEFINED) ? 0 : ENOTCONN);
 
     if (len == 0)
         return 0;
@@ -1591,7 +1594,7 @@ static sysreturn netsock_recvmsg(struct sock *sock, struct msghdr *msg,
     netsock s = (netsock) sock;
 
     if ((sock->type == SOCK_STREAM) && (s->info.tcp.state != TCP_SOCK_OPEN)) {
-        return set_syscall_error(current, ENOTCONN);
+        return set_syscall_error(current, (s->info.tcp.state == TCP_SOCK_UNDEFINED) ? 0 : ENOTCONN);
     }
     total_len = 0;
     for (int i = 0; i < msg->msg_iovlen; i++) {
@@ -1696,17 +1699,17 @@ closure_function(5, 1, sysreturn, accept_bh,
     thread t = bound(t);
     sysreturn rv = 0;
 
-    if (bqflags & BLOCKQ_ACTION_NULLIFY) {
-        rv = -ERESTARTSYS;
-        goto out;
-    }
-
     err_t err = get_lwip_error(s);
     net_debug("sock %d, target thread %ld, lwip err %d\n", s->sock.fd, t->tid,
             err);
 
     if (err != ERR_OK) {
         rv = lwip_to_errno(err);
+        goto out;
+    }
+
+    if (bqflags & BLOCKQ_ACTION_NULLIFY) {
+        rv = -ERESTARTSYS;
         goto out;
     }
 

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -2,6 +2,7 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -80,11 +81,106 @@ static void netsock_test_fionread(void)
     test_assert(close(fd) == 0);
 }
 
+/* Connect to TCP server and then close connection right away. */
+static void *netsock_test_connclose_thread(void *arg)
+{
+    int port = (long)arg;
+    int fd;
+    struct sockaddr_in addr;
+
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    test_assert(fd > 0);
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    test_assert(connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    test_assert(close(fd) == 0);
+    return NULL;
+}
+
+/* Connect to TCP server and wait for connection to be closed. */
+static void *netsock_test_connwait_thread(void *arg)
+{
+    int port = (long)arg;
+    int fd;
+    struct sockaddr_in addr;
+    uint8_t buf[8];
+
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    test_assert(fd > 0);
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    test_assert(connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    test_assert(read(fd, buf, sizeof(buf)) == 0);
+    test_assert(close(fd) == 0);
+    return NULL;
+}
+
+/* Tests behavior of syscalls invoked on a socket after the connection has been closed. */
+static void netsock_test_connclosed(void)
+{
+    int fd, conn_fd;
+    struct sockaddr_in addr;
+    const int port = 1234;
+    pthread_t pt;
+    uint8_t buf[8];
+    struct iovec iov;
+    struct msghdr msg;
+    int ret;
+
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    test_assert(fd > 0);
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    test_assert(bind(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    test_assert(listen(fd, 1) == 0);
+
+    /* Test connection closed by peer. */
+    ret = pthread_create(&pt, NULL, netsock_test_connclose_thread,
+        (void *)(long)port);
+    test_assert(ret == 0);
+    conn_fd = accept(fd, NULL, NULL);
+    test_assert(conn_fd > 0);
+    test_assert(read(conn_fd, buf, sizeof(buf)) == 0);
+    test_assert(recv(conn_fd, buf, sizeof(buf), 0) == 0);
+    test_assert(recvfrom(conn_fd, buf, sizeof(buf), 0, NULL, 0) == 0);
+    memset(&iov, 0, sizeof(iov));
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    test_assert(recvmsg(conn_fd, &msg, 0) == 0);
+    test_assert(pthread_join(pt, NULL) == 0);
+    test_assert(close(conn_fd) == 0);
+
+    /* Test connection closed via shutdown(). */
+    ret = pthread_create(&pt, NULL, netsock_test_connwait_thread,
+        (void *)(long)port);
+    test_assert(ret == 0);
+    conn_fd = accept(fd, NULL, NULL);
+    test_assert(conn_fd > 0);
+    test_assert(shutdown(conn_fd, SHUT_RDWR) == 0);
+    test_assert(read(conn_fd, buf, sizeof(buf)) == 0);
+    test_assert(recv(conn_fd, buf, sizeof(buf), 0) == 0);
+    test_assert(recvfrom(conn_fd, buf, sizeof(buf), 0, NULL, 0) == 0);
+    memset(&iov, 0, sizeof(iov));
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    test_assert(recvmsg(conn_fd, &msg, 0) == 0);
+    test_assert(pthread_join(pt, NULL) == 0);
+    test_assert(close(conn_fd) == 0);
+
+    test_assert(close(fd) == 0);
+}
+
 int main(int argc, char **argv)
 {
     setbuf(stdout, NULL);
 
     netsock_test_fionread();
+    netsock_test_connclosed();
     printf("Network socket tests OK\n");
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The second commit fixes handling of socket connections closed by the remote peer (both if a syscall is ongoing when the connection is closed, and if a syscall is invoked after connection closure).
The first commit fixes a memory corruption bug that surfaced when running the runtime test modified by the second commit.