### PR TITLE
Convert process threads vector to rbtree

### DIFF
--- a/src/gdb/gdbstub.c
+++ b/src/gdb/gdbstub.c
@@ -375,7 +375,9 @@ buffer_handler init_gdb(heap h,
     g->out = allocate_buffer(h, 256); 
     g->in = allocate_buffer(h, 256);
     g->h = h;
-    g->t = vector_get(p->threads, 0);
+    spin_lock(&p->threads_lock);
+    g->t = struct_from_field(rbtree_find_first(p->threads), thread, n);
+    spin_unlock(&p->threads_lock);
     thread_frame(g->t)[FRAME_FAULT_HANDLER] = u64_from_pointer(closure(h, gdb_handle_exception, g));
     reset_parser(g);
     return closure(h, gdbserver_input, g);

--- a/src/runtime/list.h
+++ b/src/runtime/list.h
@@ -3,7 +3,7 @@ typedef struct list {
     struct list * next;
 } *list;
 
-#define struct_from_list(l, s, f) ((s)pointer_from_u64(u64_from_pointer(l) - offsetof(s, f)))
+#define struct_from_list(l, s, f) struct_from_field(l, s, f)
 #define list_foreach(l, e) \
     for (list __next, e = list_begin(l); __next = e->next, e != list_end(l); e = __next)
 #define list_foreach_reverse(l, e) \

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -228,6 +228,8 @@ void __stack_chk_guard_init();
 
 #define _countof(a) (sizeof(a) / sizeof(*(a)))
 
+#define struct_from_field(l, s, f) ((s)pointer_from_u64(u64_from_pointer(l) - offsetof(s, f)))
+
 #ifdef KERNEL
 typedef struct export_sym {
     const char *name;

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -355,8 +355,8 @@ sysreturn get_robust_list(int pid, void *head, u64 *len)
     if (pid == 0)
         t = current;
     else
-        t = vector_get(current->p->threads, pid);
-    if (t == 0)
+        t = thread_from_tid(current->p, pid);
+    if (t == INVALID_ADDRESS)
         return -ESRCH;
     *hp = t->robust_list;
     *len = sizeof(**hp);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2219,10 +2219,16 @@ void exit(int code)
 sysreturn exit_group(int status)
 {
     thread t;
-    vector_foreach(current->p->threads, t) {
-        if (t)
+    process p = current->p;
+
+    vector v = allocate_vector(heap_general(get_kernel_heaps()), 8);
+    spin_lock(&p->threads_lock);
+    threads_to_vector(current->p, v);
+    spin_unlock(&p->threads_lock);
+
+    vector_foreach(v, t)
             exit_thread(t);
-    }
+    deallocate_vector(v);
     kernel_shutdown(status);
 }
 


### PR DESCRIPTION
Previously, a process keeps a list of thread pointers in a vector, indexed
by thread id. This means that as each new thread is created and the id
gets incremented, this vector grows unbounded, even if threads are
deleted, which eventually leads to a failed memory allocation to
grow the vector.
This change puts thread pointers in an rbtree instead, with thread id as
the key. While this makes simple iteration over the thread list more
complicated, it still allows the tid to be incremented for new threads,
avoiding problems with tid reuse and old thread references in the user
program while maintaining a fast lookup by id.