### PR TITLE
Backed heap: add alloc_map() and dealloc_unmap() functions

### DIFF
--- a/src/kernel/backed_heap.c
+++ b/src/kernel/backed_heap.c
@@ -1,66 +1,119 @@
 #include <kernel.h>
 #include <page.h>
 
-typedef struct backed {
-    struct heap h;
-    heap physical;
-    heap virtual;
-} *backed;
+#define backed_heap_lock(bh)    u64 _flags = spin_lock_irq(&(bh)->lock)
+#define backed_heap_unlock(bh)  spin_unlock_irq(&(bh)->lock, _flags)
 
-void physically_backed_dealloc_virtual(heap h, u64 x, bytes length)
+void physically_backed_dealloc_virtual(backed_heap bh, u64 x, bytes length)
 {
-    backed b = (backed)h;       /* XXX need to keep track of heap type... */
-    u64 padlen = pad(length, h->pagesize);
-    if ((x & (h->pagesize-1))) {
+    u64 padlen = pad(length, bh->h.pagesize);
+    if (x & (bh->h.pagesize - 1)) {
 	msg_err("attempt to free unaligned area at %lx, length %x; leaking\n", x, length);
 	return;
     }
 
     unmap(x, padlen);
-    deallocate(b->virtual, pointer_from_u64(x), padlen);
+    deallocate(bh->virtual, pointer_from_u64(x), padlen);
+}
+
+static inline void *backed_alloc_map(backed_heap bh, bytes len, u64 *phys)
+{
+    len = pad(len, bh->h.pagesize);
+    void *virt;
+    u64 p = allocate_u64(bh->physical, len);
+    if (p != INVALID_PHYSICAL) {
+        virt = allocate(bh->virtual, len);
+        if (virt != INVALID_ADDRESS) {
+            map(u64_from_pointer(virt), p, len, PAGE_WRITABLE | PAGE_NO_EXEC);
+            if (phys)
+                *phys = p;
+        } else {
+            deallocate_u64(bh->physical, p, len);
+        }
+    } else {
+        virt = INVALID_ADDRESS;
+    }
+    return virt;
+}
+
+static inline void backed_dealloc_unmap(backed_heap bh, void *virt, u64 phys, bytes len)
+{
+    if (u64_from_pointer(virt) & (bh->h.pagesize - 1)) {
+        msg_err("attempt to free unaligned area at %lx, length %x; leaking\n", virt, len);
+        return;
+    }
+    if (phys == 0) {
+        phys = physical_from_virtual(virt);
+        assert(phys != INVALID_PHYSICAL);
+    }
+    len = pad(len, bh->h.pagesize);
+    unmap(u64_from_pointer(virt), len);
+    deallocate_u64(bh->physical, phys, len);
+    deallocate(bh->virtual, virt, len);
 }
 
 static void physically_backed_dealloc(heap h, u64 x, bytes length)
 {
-    backed b = (backed)h;
-    u64 padlen = pad(length, h->pagesize);
-    if ((x & (h->pagesize-1))) {
-	msg_err("attempt to free unaligned area at %lx, length %x; leaking\n", x, length);
-	return;
-    }
-
-    u64 phys = physical_from_virtual(pointer_from_u64(x));
-    assert(phys != INVALID_PHYSICAL);
-    unmap(x, padlen);
-    deallocate(b->physical, phys, padlen);
-    deallocate(b->virtual, pointer_from_u64(x), padlen);
+    backed_dealloc_unmap((backed_heap)h, pointer_from_u64(x), 0, length);
 }
 
 static u64 physically_backed_alloc(heap h, bytes length)
 {
-    backed b = (backed)h;
-    u64 len = pad(length, h->pagesize);
-    u64 p = allocate_u64(b->physical, len);
-
-    if (p != INVALID_PHYSICAL) {
-        u64 v = allocate_u64(b->virtual, len);
-        if (v != INVALID_PHYSICAL) {
-            map(v, p, len, PAGE_WRITABLE | PAGE_NO_EXEC);
-            return v;
-        }
-    }
-    return INVALID_PHYSICAL; 
+    return u64_from_pointer(backed_alloc_map((backed_heap)h, length, 0));
 }
 
-heap physically_backed(heap meta, heap virtual, heap physical, u64 pagesize)
+static u64 backed_alloc_locking(heap h, bytes length)
 {
-    backed b = allocate(meta, sizeof(struct backed));
+    backed_heap bh = (backed_heap)h;
+    backed_heap_lock(bh);
+    u64 x = physically_backed_alloc(h, length);
+    backed_heap_unlock(bh);
+    return x;
+}
+
+static void backed_dealloc_locking(heap h, u64 x, bytes length)
+{
+    backed_heap bh = (backed_heap)h;
+    backed_heap_lock(bh);
+    physically_backed_dealloc(h, x, length);
+    backed_heap_unlock(bh);
+}
+
+static void *backed_alloc_map_locking(backed_heap bh, bytes len, u64 *phys)
+{
+    void *virt;
+    backed_heap_lock(bh);
+    virt = backed_alloc_map(bh, len, phys);
+    backed_heap_unlock(bh);
+    return virt;
+}
+
+void backed_dealloc_unmap_locking(backed_heap bh, void *virt, u64 phys, bytes len)
+{
+    backed_heap_lock(bh);
+    backed_dealloc_unmap(bh, virt, phys, len);
+    backed_heap_unlock(bh);
+}
+
+backed_heap physically_backed(heap meta, heap virtual, heap physical, u64 pagesize, boolean locking)
+{
+    backed_heap b = allocate(meta, sizeof(struct backed_heap));
     if (b == INVALID_ADDRESS)
         return INVALID_ADDRESS;
-    b->h.alloc = physically_backed_alloc;
-    b->h.dealloc = physically_backed_dealloc;
+    if (locking) {
+        b->h.alloc = backed_alloc_locking;
+        b->h.dealloc = backed_dealloc_locking;
+        b->alloc_map = backed_alloc_map_locking;
+        b->dealloc_unmap = backed_dealloc_unmap_locking;
+        spin_lock_init(&b->lock);
+    } else {
+        b->h.alloc = physically_backed_alloc;
+        b->h.dealloc = physically_backed_dealloc;
+        b->alloc_map = backed_alloc_map;
+        b->dealloc_unmap = backed_dealloc_unmap;
+    }
     b->physical = physical;
     b->virtual = virtual;
     b->h.pagesize = pagesize;
-    return (heap)b;
+    return b;
 }

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -218,8 +218,9 @@ extern queue bhqueue;
 extern queue runqueue;
 extern timerheap runloop_timers;
 
-heap physically_backed(heap meta, heap virtual, heap physical, u64 pagesize);
-void physically_backed_dealloc_virtual(heap h, u64 x, bytes length);
+backed_heap physically_backed(heap meta, heap virtual, heap physical, u64 pagesize,
+                              boolean locking);
+void physically_backed_dealloc_virtual(backed_heap bh, u64 x, bytes length);
 heap locking_heap_wrapper(heap meta, heap parent);
 
 void print_stack(context c);

--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -62,7 +62,7 @@ typedef struct vtdev {
     u64 dev_features;              // device features
     u64 features;                  // negotiated features
 
-    heap contiguous;
+    backed_heap contiguous;
     heap general;
 
     enum vtio_transport {
@@ -76,7 +76,7 @@ u32 vtdev_cfg_read_4(vtdev dev, u64 offset);
 void vtdev_cfg_read_mem(vtdev dev, void *dest, bytes len);
 void vtdev_set_status(vtdev dev, u8 status);
 
-static inline void virtio_attach(heap h, heap page_allocator,
+static inline void virtio_attach(heap h, backed_heap page_allocator,
                                  enum vtio_transport transport, vtdev d)
 {
     d->general = h;
@@ -117,5 +117,5 @@ typedef struct vqmsg *vqmsg;
 
 vqmsg allocate_vqmsg(virtqueue vq);
 void deallocate_vqmsg(virtqueue vq, vqmsg m);
-void vqmsg_push(virtqueue vq, vqmsg m, void * addr, u32 len, boolean write);
+void vqmsg_push(virtqueue vq, vqmsg m, u64 phys_addr, u32 len, boolean write);
 void vqmsg_commit(virtqueue vq, vqmsg m, vqfinish completion);

--- a/src/virtio/virtio_mmio.c
+++ b/src/virtio/virtio_mmio.c
@@ -130,7 +130,7 @@ define_closure_function(1, 2, void, vtmmio_notify,
     vtmmio_set_u32(bound(dev), notify_offset, queue_index);
 }
 
-boolean attach_vtmmio(heap h, heap page_allocator, vtmmio d, u64 feature_mask)
+boolean attach_vtmmio(heap h, backed_heap page_allocator, vtmmio d, u64 feature_mask)
 {
     virtio_mmio_debug("attaching device at 0x%lx, irq %d", d->membase, d->irq);
     vtmmio_set_status(d, VIRTIO_CONFIG_STATUS_DRIVER);

--- a/src/virtio/virtio_mmio.h
+++ b/src/virtio/virtio_mmio.h
@@ -59,6 +59,6 @@ typedef closure_type(vtmmio_probe, void, vtmmio);
 
 void vtmmio_probe_devs(vtmmio_probe probe);
 void vtmmio_set_status(vtmmio dev, u8 status);
-boolean attach_vtmmio(heap h, heap page_allocator, vtmmio d, u64 feature_mask);
+boolean attach_vtmmio(heap h, backed_heap page_allocator, vtmmio d, u64 feature_mask);
 status vtmmio_alloc_virtqueue(vtmmio dev, const char *name, int idx, queue sched_queue,
                               struct virtqueue **result);

--- a/src/virtio/virtio_pci.c
+++ b/src/virtio/virtio_pci.c
@@ -283,7 +283,7 @@ define_closure_function(1, 2, void, vtpci_notify,
     pci_bar_write_2(&bound(dev)->notify_config, notify_offset, queue_index);
 }
 
-vtpci attach_vtpci(heap h, heap page_allocator, pci_dev d, u64 feature_mask)
+vtpci attach_vtpci(heap h, backed_heap page_allocator, pci_dev d, u64 feature_mask)
 {
     struct vtpci *dev = allocate(h, sizeof(struct vtpci));
     assert(dev != INVALID_ADDRESS);

--- a/src/virtio/virtio_pci.h
+++ b/src/virtio/virtio_pci.h
@@ -88,7 +88,7 @@ struct vtpci {
 #define VIRTIO_PCI_VRING_ALIGN	4096
 
 boolean vtpci_probe(pci_dev d, int virtio_dev_id);
-vtpci attach_vtpci(heap h, heap page_allocator, pci_dev d, u64 feature_mask);
+vtpci attach_vtpci(heap h, backed_heap page_allocator, pci_dev d, u64 feature_mask);
 status vtpci_alloc_virtqueue(vtpci dev, const char *name, int idx, queue sched_queue, struct virtqueue **result);
 void vtpci_set_status(vtpci dev, u8 status);
 boolean vtpci_is_modern(vtpci dev);


### PR DESCRIPTION
alloc_map() allocates memory from both the virtual and the physical heap, and returns to the caller both the virtual and the physical address; dealloc_unmap() takes as arguments both the virtual and the physical address to deallocate.
These new functions can be used as alternatives to alloc() and dealloc() when the caller wants to use the physical address, and allow avoiding calls to physical_from_virtual() (both when passing a physical address to a device, and when deallocating memory), which show up in ftrace logs as taking a significant amount of time when running heavy I/O workloads.
In addition, the backed heap now implements internal locking, which can be enabled when a heap is created, so that both locking and non-locking versions can be used.

In the virtIO code, vqmsg_push() now takes a physical address (instead of a virtual address) as argument; this allows avoiding calls to physical_from_virtual() when the vqmsg_push() caller already knows the physical address to be used in a virtqueue message. The SCSI, storage and network virtIO drivers now use the new alloc_map() and dealloc_map() functions of
the backed heap, so they can pass to vqmsg_push() the physical addresses being allocated.