### PR TITLE
Miscellaneous optimizations

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2481,6 +2481,8 @@ void count_syscall(thread t, sysreturn rv)
     t->syscall_time = 0;
 }
 
+static boolean debugsyscalls;
+
 void syscall_debug(context f)
 {
     u64 call = f[FRAME_VECTOR];
@@ -2498,8 +2500,6 @@ void syscall_debug(context f)
         t->last_syscall = call;
         t->syscall_enter_ts = now(CLOCK_ID_MONOTONIC);
     }
-    // should we cache this for performance?
-    void *debugsyscalls = table_find(t->p->process_root, sym(debugsyscalls));
     struct syscall *s = t->p->syscalls + call;
     if (debugsyscalls) {
         if (s->name)
@@ -2660,6 +2660,7 @@ void _register_syscall(struct syscall *m, int n, sysreturn (*f)(), const char *n
 
 void configure_syscalls(process p)
 {
+    debugsyscalls = !!table_find(p->process_root, sym(debugsyscalls));
     syscall_defer = !!table_find(p->process_root, sym(syscall_defer));
     void *notrace = table_find(p->process_root, sym(notrace));
     if (notrace) {

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -103,20 +103,18 @@ void register_thread_syscalls(struct syscall *map)
 
 void thread_log_internal(thread t, const char *desc, ...)
 {
-    if (table_find(t->p->process_root, sym(trace))) {
-        if (syscall_notrace(t->p, t->syscall))
-            return;
-        vlist ap;
-        vstart (ap, desc);        
-        buffer b = little_stack_buffer(512);
-        bprintf(b, "%n%d ", (int) ((MAX(MIN(t->tid, 20), 1) - 1) * 4), t->tid);
-        if (t->name[0] != '\0')
-            bprintf(b, "[%s] ", t->name);
-        buffer f = alloca_wrap_buffer(desc, runtime_strlen(desc));
-        vbprintf(b, f, &ap);
-        push_u8(b, '\n');
-        buffer_print(b);
-    }
+    if (syscall_notrace(t->p, t->syscall))
+        return;
+    vlist ap;
+    vstart (ap, desc);
+    buffer b = little_stack_buffer(512);
+    bprintf(b, "%n%d ", (int) ((MAX(MIN(t->tid, 20), 1) - 1) * 4), t->tid);
+    if (t->name[0] != '\0')
+        bprintf(b, "[%s] ", t->name);
+    buffer f = alloca_wrap_buffer(desc, runtime_strlen(desc));
+    vbprintf(b, f, &ap);
+    push_u8(b, '\n');
+    buffer_print(b);
 }
 
 static inline void check_stop_conditions(thread t)

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -358,6 +358,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     p->itimers = allocate_vector(h, 3);
     p->aio_ids = create_id_heap(h, h, 0, S32_MAX, 1, false);
     p->aio = allocate_vector(h, 8);
+    p->trace = !!table_find(root, sym(trace));
     return p;
 }
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -425,6 +425,7 @@ typedef struct process {
     vector            itimers;      /* unix_timer by ITIMER_ type */
     id_heap           aio_ids;
     vector            aio;
+    boolean           trace;
 } *process;
 
 typedef struct sigaction *sigaction;
@@ -748,7 +749,7 @@ void truncate_file_maps(process p, fsfile f, u64 new_length);
 const char *string_from_mmap_type(int type);
 
 void thread_log_internal(thread t, const char *desc, ...);
-#define thread_log(__t, __desc, ...) do {if (!__t ) break; thread_log_internal(__t, __desc, ##__VA_ARGS__);} while (0)
+#define thread_log(__t, __desc, ...) do {if (!__t || !__t->p->trace) break; thread_log_internal(__t, __desc, ##__VA_ARGS__);} while (0)
 
 void thread_sleep_interruptible(void) __attribute__((noreturn));
 void thread_sleep_uninterruptible(void) __attribute__((noreturn));

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -247,8 +247,9 @@ static boolean force_entry(u64 b, u64 v, physical p, int level,
 	write_pte(pte_phys, p, flags, invalidate);
 	return true;
     } else {
-	if (*pointer_from_pteaddr(pte_phys) & PAGE_PRESENT) {
-            if (pt_entry_is_fat(level, *pointer_from_pteaddr(pte_phys))) {
+        u64 pte = *pointer_from_pteaddr(pte_phys);
+        if (pte & PAGE_PRESENT) {
+            if (pt_entry_is_fat(level, pte)) {
                 rputs("\nforce_entry fail: attempting to map a 4K page over an "
                         "existing 2M mapping\n");
                 return false;
@@ -258,7 +259,7 @@ static boolean force_entry(u64 b, u64 v, physical p, int level,
                remove and free them when possible. This will avoid the
                occasional invalidate caused by lingering mid
                directories without entries */
-	    return force_entry(page_from_pte(*pointer_from_pteaddr(pte_phys)), v, p, level + 1,
+	    return force_entry(page_from_pte(pte), v, p, level + 1,
                                fat, flags, invalidate);
 	} else {
 	    if (flags == 0)	/* only lookup for unmap */


### PR DESCRIPTION
This PR implements a couple of optimizations in an effort to decrease the number of calls to table_find() and kern_pointer_from_pteaddr(), which show up in ftrace logs as taking a significant amount of time when running heavy disk I/O workloads.