### PR TITLE
TCP sockets: allow reading from socket after connection closure

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1097,11 +1097,8 @@ static err_t tcp_input_lower(void *z, struct tcp_pcb *pcb, struct pbuf *p, err_t
 	    msg_err("incoming queue full\n");
             return ERR_BUF;     /* XXX verify */
         }
-        wakeup_sock(s, WAKEUP_SOCK_RX);
-    } else {
-        s->info.tcp.state = TCP_SOCK_UNDEFINED;
-        wakeup_sock(s, WAKEUP_SOCK_EXCEPT);
     }
+    wakeup_sock(s, WAKEUP_SOCK_RX);
 
     return ERR_OK;
 }


### PR DESCRIPTION
If data has been received from a TCP socket and is buffered in the kernel, the application should be able to read this data even after the remote peer closes the connection (the read() syscall should return 0 only after all buffered data has been read).
The existing code was making read() return 0 unconditionally for a socket whose TCP connection has been closed by the remote peer, even if there is buffered data to be read. This PR fixes the issue.