### PR TITLE
TFS log: fix flushing of tuple staging buffer in mkfs

### DIFF
--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -550,12 +550,11 @@ static void log_set_dirty(log tl)
 /* mkfs: flush on close */
 static void log_set_dirty(log tl)
 {
+    tl->dirty = true;
     if (buffer_length(tl->tuple_staging) >=
             bytes_from_sectors(tl->fs, range_span(tl->current->sectors))) {
         log_flush(tl, 0);
-        return;
     }
-    tl->dirty = true;
 }
 #endif
 


### PR DESCRIPTION
When a filesystem being created by mkfs contains a large number of files, the first call to log_write() or log_write_eav() can extend the log tuple staging buffer beyond the size of a log extension. If this happens, log_flush() is called (by log_set_dirty()) when the `dirty` member of struct log is still set to false; as a result, the log is not flushed, and the next calls to log_write() or log_write_eav() return error; this causes filesystem creation to fail.
This PR fixes the issue by setting `dirty` to true at the beginning of log_set_dirty(), so that if log_flush() is called the log is actually flushed.