### PR TITLE
Fix missing uuid and label during log_extend_link

### DIFF
--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -306,6 +306,11 @@ static void log_extension_init(log_ext ext)
     assert(push_buffer(ext->staging, alloca_wrap_buffer(tfs_magic, TFS_MAGIC_BYTES)));
     push_varint(ext->staging, TFS_VERSION);
     push_varint(ext->staging, range_span(ext->sectors));
+    if (ext->sectors.start == 0) {
+        assert(buffer_write(ext->staging, ext->tl->fs->uuid, UUID_LEN));
+        assert(buffer_write_cstring(ext->staging, ext->tl->fs->label));
+        push_u8(ext->staging, '\0');   /* label string terminator */
+    }
 }
 
 /* complete linkage in (now disembodied - thus long arg list) previous extension */
@@ -324,11 +329,6 @@ closure_function(3, 1, void, log_extend_link,
     /* add link to close out old extension and commit */
     log_ext old_ext = bound(old_ext);
     buffer b = old_ext->staging;
-    if (old_ext->sectors.start == 0) {
-        assert(buffer_write(b, old_ext->tl->fs->uuid, UUID_LEN));
-        assert(buffer_write_cstring(b, old_ext->tl->fs->label));
-        push_u8(b, '\0');   /* label string terminator */
-    }
     push_u8(b, LOG_EXTENSION_LINK);
     push_varint(b, bound(sectors).start);
     push_varint(b, range_span(bound(sectors)));
@@ -872,10 +872,10 @@ log log_create(heap h, filesystem fs, boolean initialize, status_handler sh)
         halt("no tlog write support\n");
 #else
         fs->root = allocate_tuple();
-        log_ext init_ext = tl->current;
-        log_extension_init(init_ext);
         buffer uuid = alloca_wrap_buffer(fs->uuid, UUID_LEN);
         random_buffer(uuid);
+        log_ext init_ext = tl->current;
+        log_extension_init(init_ext);
         log_ext new_ext = log_ext_new(tl);
         assert(new_ext != INVALID_ADDRESS);
         log_extension_init(new_ext);


### PR DESCRIPTION
The first log_ext in the log stores the uuid and label of the fs.
Currently these fields are pushed on the header in log_create, but
this means that when the log_ext is rewritten as in an fs rebuild, these
fields are then missing which are not detected until reboot. This change
moves adding these fields to the header into log_extend_link which makes
sure they are pushed every time, as log_extend_link is always called
on creation as well as when the log needs to be rewritten.