### PR TITLE
Fix log flush compaction blocking

### DIFF
--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -97,6 +97,8 @@ static inline boolean update_timer(void)
 
 static inline void sched_thread_pause(void)
 {
+    if (shutting_down)
+        return;
     nanos_thread nt = get_current_thread();
     if (nt)
         apply(nt->pause);

--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -417,7 +417,7 @@ static inline boolean log_write_internal(log tl, merge m)
     return true;
 }
 
-static void run_flush_completions(log tl)
+static void run_flush_completions(log tl, status s)
 {
     if (tl->flush_completions) {
         status_handler sh;
@@ -433,7 +433,7 @@ closure_function(1, 1, void, log_flush_complete,
 {
     /* would need to move these to runqueue if a flush is ever invoked from a tfs op */
     bound(tl)->dirty = false;
-    run_flush_completions(bound(tl));
+    run_flush_completions(bound(tl), s);
     bound(tl)->flushing = false;
     closure_finish();
 }
@@ -469,7 +469,7 @@ closure_function(2, 1, void, log_switch_complete,
         deallocate_u64((heap)fs->storage, ext->r.start, range_span(ext->r));
     }
 
-    run_flush_completions(old_tl);
+    run_flush_completions(old_tl, s);
 
     refcount_release(&to_be_destroyed->refcount);
     timm_dealloc(s);


### PR DESCRIPTION
There is a race condition where if log_flush starts a compaction and then the system shuts down, 
the log_flush from the sync operation will return immediately and not let the compaction (and
storage i/o) to finish. This change fixes that problem by checking for compaction in log_flush and
adding the completion to the flush_completions vector, which is now also run after compaction
is finished.
There is an additional small fix related to the situation where shutting down is waiting on i/o to complete
and the cpu enters runloop again and would crash because all threads are invalid.
