### PR TITLE
Add udp network console option

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -14,6 +14,7 @@ SRCS-kernel.img= \
 	$(SRCDIR)/drivers/console.c \
 	$(SRCDIR)/drivers/dmi.c \
 	$(SRCDIR)/drivers/nvme.c \
+	$(SRCDIR)/drivers/netconsole.c \
 	$(SRCDIR)/drivers/storage.c \
 	$(SRCDIR)/drivers/vga.c \
 	$(SRCDIR)/gdb/gdbstub.c \

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -159,6 +159,7 @@ closure_function(4, 2, void, fsstarted,
     symbol booted = sym(booted);
     if (!table_find(root, booted))
         filesystem_write_eav(fs, root, booted, null_value);
+    config_console(filesystem_getroot(root_fs));
 }
 
 /* This is very simplistic and uses a fixed drain threshold. This

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -159,7 +159,7 @@ closure_function(4, 2, void, fsstarted,
     symbol booted = sym(booted);
     if (!table_find(root, booted))
         filesystem_write_eav(fs, root, booted, null_value);
-    config_console(filesystem_getroot(root_fs));
+    config_console(root);
 }
 
 /* This is very simplistic and uses a fixed drain threshold. This

--- a/src/drivers/console.c
+++ b/src/drivers/console.c
@@ -2,6 +2,7 @@
 #include "serial.h"
 #include "console.h"
 #include "vga.h"
+#include "netconsole.h"
 
 static void serial_console_write(void *d, const char *s, bytes count)
 {
@@ -11,7 +12,8 @@ static void serial_console_write(void *d, const char *s, bytes count)
 }
 
 struct console_driver serial_console_driver = {
-    .write = serial_console_write
+    .write = serial_console_write,
+    .name = "serial"
 };
 
 struct console_driver *console_drivers[4] = {
@@ -24,6 +26,8 @@ void console_write(const char *s, bytes count)
 {
     spin_lock(&write_lock);
     for (struct console_driver **pd = console_drivers; *pd; pd++) {
+        if ((*pd)->disabled)
+            continue;
         (*pd)->write(*pd, s, count);
     }
     spin_unlock(&write_lock);
@@ -46,4 +50,38 @@ void init_console(kernel_heaps kh)
 {
     heap h = heap_general(kh);
     vga_pci_register(kh, closure(h, attach_console));
+    netconsole_register(kh, closure(h, attach_console));
+}
+
+void config_console(tuple root)
+{
+    buffer b;
+    vector v = vector_from_tuple(transient, table_find(root, sym(consoles)));
+
+    if (v == 0)
+        return;
+    vector_foreach(v, b) {
+        if (buffer_length(b) < 2)
+            goto error;
+        u8 op = pop_u8(b);
+        switch(op) {
+        case '+':
+        case '-':
+            for (struct console_driver **pd = console_drivers; *pd; pd++) {
+                if (!buffer_compare_with_cstring(b, (*pd)->name))
+                    continue;
+                (*pd)->disabled = op == '-';
+                if ((*pd)->config)
+                    (*pd)->config(*pd, root);
+                break;
+            }
+            break;
+        default:
+            goto error;
+        }
+    }
+    return;
+error:
+    rprintf("%s: error parsing consoles from manifest\n", __FUNCTION__);
+    return;
 }

--- a/src/drivers/console.c
+++ b/src/drivers/console.c
@@ -49,8 +49,9 @@ closure_function(0, 1, void, attach_console,
 void init_console(kernel_heaps kh)
 {
     heap h = heap_general(kh);
-    vga_pci_register(kh, closure(h, attach_console));
-    netconsole_register(kh, closure(h, attach_console));
+    console_attach a = closure(h, attach_console);
+    vga_pci_register(kh, a);
+    netconsole_register(kh, a);
 }
 
 void config_console(tuple root)
@@ -82,6 +83,6 @@ void config_console(tuple root)
     }
     return;
 error:
-    rprintf("%s: error parsing consoles from manifest\n", __FUNCTION__);
+    msg_err("error parsing consoles from manifest\n");
     return;
 }

--- a/src/drivers/console.h
+++ b/src/drivers/console.h
@@ -1,7 +1,11 @@
 struct console_driver {
     void (*write)(void *d, const char *s, bytes count);
+    void (*config)(void *d, tuple r);
+    char *name;
+    boolean disabled;
 };
 
 typedef closure_type(console_attach, void, struct console_driver *);
 
 void init_console(kernel_heaps kh);
+void config_console(tuple root);

--- a/src/drivers/netconsole.c
+++ b/src/drivers/netconsole.c
@@ -1,0 +1,88 @@
+#include <kernel.h>
+#include <lwip.h>
+#include "console.h"
+#include "netconsole.h"
+
+typedef struct netconsole_driver {
+    struct console_driver c;
+    heap h;
+    struct udp_pcb *pcb;
+    ip_addr_t dst_ip;
+    u16 port;
+    boolean setup;
+} *netconsole_driver;
+
+#define MAX_PAYLOAD 1472
+#define DEFAULT_IP "10.0.2.2"
+#define DEFAULT_PORT 4444
+
+static void netconsole_write(void *_d, const char *s, bytes count)
+{
+    netconsole_driver nd = _d;
+    if (!nd->setup)
+        return;
+    bytes off = 0;
+    while (count > 0) {
+        bytes len = count < MAX_PAYLOAD ? count : MAX_PAYLOAD;
+        struct pbuf *pb = pbuf_alloc(PBUF_TRANSPORT, len, PBUF_RAM);
+        if (pb == 0)
+            return;
+        runtime_memcpy(pb->payload, s + off, len);
+        udp_sendto(nd->pcb, pb, &nd->dst_ip, nd->port);
+        pbuf_free(pb);
+        count -= len;
+        off += len;
+    }
+}
+
+static void netconsole_config(void *_d, tuple r)
+{
+    netconsole_driver nd = _d;
+
+    if ((nd->pcb = udp_new()) == 0) {
+        rprintf("%s: failed to allocate pcb\n", __FUNCTION__);
+        return;
+    }
+
+    buffer dst_ip = table_find(r, sym(netconsole_ip));
+    char *s = dst_ip ? buffer_ref(dst_ip, 0) : DEFAULT_IP;
+    bytes len = dst_ip ? buffer_length(dst_ip) : runtime_strlen(DEFAULT_IP);
+
+    if (len > IPADDR_STRLEN_MAX) {
+        rprintf("%s: ip address too long\n", __FUNCTION__);
+        return;
+    }
+
+    char b[IPADDR_STRLEN_MAX+1];
+    runtime_memcpy(b, s, len);
+    s[len] = 0;
+    if (!ipaddr_aton(s, &nd->dst_ip)) {
+        rprintf("%s: failed to translate ip address\n", __FUNCTION__);
+        return;
+    }
+
+    buffer dst_port = table_find(r, sym(netconsole_port));
+    u64 port = DEFAULT_PORT;
+    if (dst_port && !parse_int(dst_port, 10, &port)) {
+        rprintf("%s: failed to parse port\n", __FUNCTION__);
+        return;
+    }
+    if (port >= U64_FROM_BIT(16)) {
+        rprintf("%s: port out of range\n", __FUNCTION__);
+        return;
+    }
+    nd->port = (u16)port;
+    nd->setup = true;
+}
+
+void netconsole_register(kernel_heaps kh, console_attach a)
+{
+    heap h = heap_general(kh);
+    netconsole_driver nd = allocate_zero(h, sizeof(struct netconsole_driver));
+    assert(nd != INVALID_ADDRESS);
+    nd->c.write = netconsole_write;
+    nd->c.name = "net";
+    nd->c.disabled = true;
+    nd->c.config = netconsole_config;
+    apply(a, &nd->c);
+}

--- a/src/drivers/netconsole.c
+++ b/src/drivers/netconsole.c
@@ -12,7 +12,7 @@ typedef struct netconsole_driver {
     boolean setup;
 } *netconsole_driver;
 
-#define MAX_PAYLOAD 1472
+#define MAX_PAYLOAD 512
 #define DEFAULT_IP "10.0.2.2"
 #define DEFAULT_PORT 4444
 

--- a/src/drivers/netconsole.h
+++ b/src/drivers/netconsole.h
@@ -1,0 +1,1 @@
+void netconsole_register(kernel_heaps h, console_attach a);

--- a/src/drivers/vga.c
+++ b/src/drivers/vga.c
@@ -180,9 +180,10 @@ closure_function(2, 1, boolean, vga_pci_probe,
         return false;
 
     vga_debug("%s: VGA PCI\n", __func__);
-    struct vga_console_driver *d = allocate(bound(general), sizeof(*d));
+    struct vga_console_driver *d = allocate_zero(bound(general), sizeof(*d));
     assert(d != INVALID_ADDRESS);
     d->c.write = vga_console_write;
+    d->c.name = "vga";
     d->crtc_addr = 0x3d4;
     d->buffer = pointer_from_u64(VGA_BUF_BASE);
     d->buffer_size = VGA_BUF_SIZE / sizeof(*d->buffer);


### PR DESCRIPTION
This change adds a new console driver that outputs console messages
via UDP to a specific IP address and port. It also adds support for
enabling or disabling console drivers via the manifest. The vga and serial
consoles remain enabled by default, while the new net console is
disabled by default. There is also a new console driver function, config,
that is called for each driver once the manifest is available for parsing.
The new manifest option "consoles" takes an array of the names of the
console drivers preceded by '+' or '-' to enable or disable, respectively.
The default IP 10.0.2.2 is for qemu and default port 4444. The user can
use netcat or similar to receive the packets on the host. The destination
can be changed with "netconsole_ip" and "netconsole_port" fields in the
manifest.