### PR TITLE
Fix counting of sectors to load in stage1 for weird BIOS

### DIFF
--- a/platform/pc/boot/stage1.s
+++ b/platform/pc/boot/stage1.s
@@ -79,7 +79,7 @@ dap:
 
 readsectors:
         mov cx, [dap.sector_count]
-        mov ax, cx
+        mov bx, cx
         mov dx, 0x0080
         cmp cx, 0x0080
         cmovnb cx, dx       ; cx = min(dap.sector_count, 0x80)
@@ -95,8 +95,8 @@ loop:
         mov dl, 0x80
         int 0x13
         jc sector_read_error
-        sub ax, [dap.sector_count]
-        cmp ax, 0
+        sub bx, [dap.sector_count]
+        cmp bx, 0
         je done
         add [dap.lba], cx
         mov cx, 0x1000
@@ -104,8 +104,8 @@ loop:
         mov dx, 0x0
         mov [dap.offset], dx
         mov cx, 0x0080
-        cmp ax, cx
-        cmovb cx, ax 
+        cmp bx, cx
+        cmovb cx, bx 
         mov [dap.sector_count], cx
         jmp loop
 sector_read_error:


### PR DESCRIPTION
The stage1 code keeps the current count of sectors to load in AX, which
is currently always small and completely stored in the lower byte (AL). The
BIOS extended read sectors 13h AH=42h interrupt should store the return
code in AH. However, some hypervisor BIOS (e.g. Hyper-V) appear to set
the whole word (AX) as return code, clearing the count held in AL, causing
the loading code to return after a single read. This commit moves
the total sector count to BX, which is not used by the BIOS interrupt.