### PR TITLE
stage1: minimize number of INT 13H BIOS calls to load stage2

### DIFF
--- a/platform/pc/boot/stage1.s
+++ b/platform/pc/boot/stage1.s
@@ -70,8 +70,8 @@ dap:
         db 0x10
         db 0
         .sector_count dw STAGE2SIZE/sectorsize
-        .offset       dw stage2
-        .segment      dw 0
+        .offset       dw 0
+        .segment      dw (stage2 >> 4)
         .lba          dq 1
 
 
@@ -83,11 +83,6 @@ readsectors:
         mov dx, 0x0080
         cmp cx, 0x0080
         cmovnb cx, dx       ; cx = min(dap.sector_count, 0x80)
-        mov edx, 0x10000
-        sub edx, [dap.offset]
-        shr dx, 0x9
-        cmp dx, cx
-        cmovb cx, dx      ; cx = min(cx, (0x10000 - dap.offset) >> 0x9)
         mov [dap.sector_count], cx
 loop:
         mov si, dap
@@ -101,8 +96,6 @@ loop:
         add [dap.lba], cx
         mov cx, 0x1000
         add [dap.segment], cx
-        mov dx, 0x0
-        mov [dap.offset], dx
         mov cx, 0x0080
         cmp bx, cx
         cmovb cx, bx 


### PR DESCRIPTION
For some reason, issuing more than one INT 13H call in stage1 when running on Xen locks up the VM (the BIOS never returns from the second INT 13H call).
This change minimizes the number of INT 13H calls needed to load stage2, by setting the dap.offset field to 0 and adjusting dap.segment to align with the beginning of stage2: in this way, stage1 can issue INT 13H calls with a sector count up to 0x80 even if the destination buffer is not aligned to a multiple of 0x10000, while still satisfying the constraint that the buffer fits in a single segment.
This change allows booting Nanos on AWS t2 instances, on the condition that the stage2 size does not grow beyond 64 kB.