### PR TITLE
Kernel clock: add NTP synchronization

### DIFF
--- a/klib/Makefile
+++ b/klib/Makefile
@@ -3,6 +3,7 @@ MBEDTLS_DIR=	$(VENDORDIR)/mbedtls
 
 PROGRAMS= \
 	cloud_init \
+	ntp \
 	radar \
 	test \
 	tls \
@@ -10,6 +11,9 @@ PROGRAMS= \
 SRCS-cloud_init= \
 	$(CURDIR)/cloud_azure.c \
 	$(CURDIR)/cloud_init.c \
+
+SRCS-ntp= \
+	$(CURDIR)/ntp.c \
 
 SRCS-radar= \
 	$(CURDIR)/radar.c \

--- a/klib/ntp.c
+++ b/klib/ntp.c
@@ -1,0 +1,284 @@
+#include <kernel.h>
+#include <lwip.h>
+
+#define NTP_SERVER_DEFAULT  "pool.ntp.org"
+#define NTP_PORT_DEFAULT    123
+
+#define NTP_EPOCH_DELTA 2208988800ul    /* Number of seconds between 1900 and 1970 */
+
+#define NTP_QUERY_INTERVAL_DEFAULT  (10 * seconds(60))
+#define NTP_QUERY_INTERVAL_MAX      (5120 * seconds(60))
+
+#define NTP_QUERY_ATTEMPTS  8
+
+#define NTP_MAX_SLEW_RATE   ((1ll << CLOCK_CALIBR_BITS) / 2000) /* 500 PPM */
+
+struct ntp_ts {
+    u32 seconds;
+    u32 fraction;
+};
+
+struct ntp_packet {
+    u8 mode:3;
+    u8 vn:3;
+    u8 li:2;
+    u8 stratum;
+    u8 poll;
+    u8 precision;
+    u32 root_delay;
+    u32 root_dispersion;
+    u32 reference_id;
+    struct ntp_ts reference_ts;
+    struct ntp_ts originate_ts;
+    struct ntp_ts receive_ts;
+    struct ntp_ts transmit_ts;
+} __attribute((packed));
+
+declare_closure_struct(0, 1, void, ntp_query_func,
+    u64, overruns);
+
+static struct {
+    char server_addr[256];
+    u16 server_port;
+    struct udp_pcb *pcb;
+    timer query_timer;
+    closure_struct(ntp_query_func, query_func);
+    boolean query_ongoing;
+    timestamp query_interval;
+    int query_errors;
+    timestamp last_raw;
+    void (*rprintf)(const char *format, ...);
+    timer (*register_timer)(clock_id id, timestamp val, boolean absolute, timestamp interval,
+            timer_handler n);
+    err_t (*dns_gethostbyname)(const char *hostname, ip_addr_t *addr,
+            dns_found_callback found, void *callback_arg);
+    struct pbuf *(*pbuf_alloc)(pbuf_layer layer, u16_t length, pbuf_type type);
+    u8 (*pbuf_free)(struct pbuf *p);
+    err_t(*udp_sendto)(struct udp_pcb *pcb, struct pbuf *p,
+            const ip_addr_t *dst_ip, u16_t dst_port);
+    void (*runtime_memset)(u8 *a, u8 b, bytes len);
+    timestamp (*now)(clock_id id);
+    void (*clock_adjust)(timestamp now, s64 temp_cal, timestamp sync_complete, s64 cal);
+} ntp;
+
+/* Calculates a division between a 128-bit value and a 64-bit value and returns a 64-bit quotient.
+ * If the quotient does not fit in 64 bits, -1ull is returned.
+ * Only one 64-bit division is executed, thus the result may not be as accurate as it could be.
+ */
+static u64 div128_64(u128 dividend, u64 divisor)
+{
+    if (dividend == 0)
+        return 0;
+    if (divisor == 0)
+        return -1ull;
+    u64 dividend_msb = (dividend >> 64) ? (64 + msb(dividend >> 64)) : msb(dividend);
+    if (dividend_msb <= 63)
+        return ((u64)dividend) / divisor;
+    u64 shift = dividend_msb - 63;
+    u64 div = ((u64)(dividend >> shift)) / divisor;
+    if (msb(div) >= 64 - shift)
+        return -1ull;
+    return (div << shift);
+}
+
+static void timestamp_to_ntptime(timestamp t, struct ntp_ts *ntptime)
+{
+    ntptime->seconds = PP_HTONL(NTP_EPOCH_DELTA + sec_from_timestamp(t));
+    ntptime->fraction = PP_HTONL((u32)t);
+}
+
+static timestamp ntptime_to_timestamp(struct ntp_ts *ntptime)
+{
+    return (seconds(PP_NTOHL(ntptime->seconds) - NTP_EPOCH_DELTA) + PP_NTOHL(ntptime->fraction));
+}
+
+static s64 ntptime_diff(struct ntp_ts *t1, struct ntp_ts *t2)
+{
+    return (seconds(PP_NTOHL(t1->seconds) - PP_NTOHL(t2->seconds)) +
+            PP_NTOHL(t1->fraction) - PP_NTOHL(t2->fraction));
+}
+
+static void ntp_query_complete(boolean success)
+{
+    if (success) {
+        ntp.query_errors = 0;
+        ntp.query_interval = NTP_QUERY_INTERVAL_DEFAULT;
+    } else  if ((++ntp.query_errors > NTP_QUERY_ATTEMPTS) &&
+            (ntp.query_interval < NTP_QUERY_INTERVAL_MAX)) {
+        ntp.query_interval *= 2;
+    }
+    if (ntp.query_timer == INVALID_ADDRESS)
+        ntp.query_timer = ntp.register_timer(CLOCK_ID_MONOTONIC_RAW, ntp.query_interval, false, 0,
+            (timer_handler)&ntp.query_func);
+}
+
+static void ntp_query(const ip_addr_t *server_addr)
+{
+    struct pbuf *p = ntp.pbuf_alloc(PBUF_TRANSPORT, sizeof(struct ntp_packet), PBUF_RAM);
+    if (p == 0)
+        return;
+    struct ntp_packet *pkt = p->payload;
+    ntp.runtime_memset(p->payload, 0, sizeof(*pkt));
+    pkt->vn = 3;    /* NTP version number */
+    pkt->mode = 3;  /* client mode */
+    timestamp_to_ntptime(ntp.now(CLOCK_ID_REALTIME), &pkt->transmit_ts);
+    err_t err = ntp.udp_sendto(ntp.pcb, p, server_addr, ntp.server_port);
+    if (err != ERR_OK) {
+        ntp.rprintf("%s: failed to send request: %d\n", __func__, err);
+        ntp_query_complete(false);
+    }
+    ntp.pbuf_free(p);
+    ntp.query_ongoing = true;
+    if (ntp.query_timer == INVALID_ADDRESS)
+        ntp.query_timer = ntp.register_timer(CLOCK_ID_MONOTONIC_RAW, ntp.query_interval, false, 0,
+            (timer_handler)&ntp.query_func);
+}
+
+static void ntp_input(void *z, struct udp_pcb *pcb, struct pbuf *p,
+                      const ip_addr_t *addr, u16 port)
+{
+    ntp.query_ongoing = false;
+    struct ntp_packet *pkt = p->payload;
+    boolean success;
+    if (p->len != sizeof(*pkt)) {
+        ntp.rprintf("%s: invalid response length %d\n", __func__, p->len);
+        success = false;
+        goto done;
+    }
+    timestamp wallclock_now = ntp.now(CLOCK_ID_REALTIME);
+    timestamp origin = ntptime_to_timestamp(&pkt->originate_ts);
+    /* round trip delay */
+    timestamp rtd = wallclock_now - origin - ntptime_diff(&pkt->transmit_ts, &pkt->receive_ts);
+    s64 offset = ntptime_to_timestamp(&pkt->transmit_ts) - wallclock_now + rtd / 2;
+    u128 offset_calibr = ((u128)((offset >= 0) ? offset : -offset)) << CLOCK_CALIBR_BITS;
+    s64 temp_cal, cal;
+    timestamp raw = ntp.now(CLOCK_ID_MONOTONIC_RAW);
+
+    /* Apply maximum slew rate until local time is synchronized with NTP time. */
+    timestamp sync_complete;
+    if (offset == 0) {
+        temp_cal = 0;
+        sync_complete = raw;
+    } else {
+        timestamp sync_time = div128_64(offset_calibr, NTP_MAX_SLEW_RATE);
+        if (sync_time == -1ull) {
+            ntp.rprintf("%s: time offset too large, ignoring\n", __func__);
+            success = false;
+            goto done;
+        }
+        temp_cal = NTP_MAX_SLEW_RATE;
+        sync_complete = raw + sync_time;
+        if (offset < 0)
+            temp_cal = -temp_cal;
+    }
+
+    /* If at least 2 samples have been received from the NTP server, calculate a calibration value
+     * to be applied after the local time is synchronized with the NTP time. */
+    raw -= rtd / 2;
+    if ((ntp.last_raw != 0) && (raw > ntp.last_raw)) {
+        cal = (s64)div128_64(offset_calibr, raw - ntp.last_raw);
+        if ((cal < 0) || (cal > NTP_MAX_SLEW_RATE))
+            cal = NTP_MAX_SLEW_RATE;
+        if (offset < 0)
+            cal = -cal;
+    } else {
+        cal = 0;
+    }
+    ntp.last_raw = raw;
+
+    ntp.clock_adjust(wallclock_now + offset, temp_cal, sync_complete, cal);
+    success = true;
+  done:
+    ntp_query_complete(success);
+    ntp.pbuf_free(p);
+}
+
+static void ntp_dns_cb(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
+{
+    if (ipaddr) {
+        ntp_query(ipaddr);
+    } else {
+        ntp.rprintf("%s: failed to resolve hostname %s\n", __func__, name);
+        ntp_query_complete(false);
+    }
+}
+
+define_closure_function(0, 1, void, ntp_query_func,
+                        u64, overruns)
+{
+    ntp.query_timer = INVALID_ADDRESS;
+    if (ntp.query_ongoing) {
+        ntp.rprintf("NTP: failed to receive server response\n", __func__);
+        ntp_query_complete(false);
+    }
+    ip_addr_t server_addr;
+    err_t err = ntp.dns_gethostbyname(ntp.server_addr, &server_addr, ntp_dns_cb, 0);
+    if (err == ERR_OK)
+        ntp_query(&server_addr);
+    else if (err != ERR_INPROGRESS) {
+        ntp.rprintf("%s: failed to resolve hostname: %d\n", __func__, err);
+        ntp_query_complete(false);
+    }
+}
+
+int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
+{
+    ntp.rprintf = get_sym("rprintf");
+    if (!ntp.rprintf)
+        return KLIB_INIT_FAILED;
+    tuple (*get_root_tuple)(void) = get_sym("get_root_tuple");
+    symbol (*intern)(string name) = get_sym("intern");
+    void *(*table_find)(table z, void *c) = get_sym("table_find");
+    void (*memcopy)(void *a, const void *b, unsigned long len) = get_sym("runtime_memcpy");
+    struct udp_pcb *(*udp_new)(void) = get_sym("udp_new");
+    void (*udp_recv)(struct udp_pcb *pcb, udp_recv_fn recv, void *recv_arg) = get_sym("udp_recv");
+    if (!get_root_tuple || !intern || !table_find || !memcopy || !udp_new || !udp_recv ||
+            !(ntp.register_timer = get_sym("kern_register_timer")) ||
+            !(ntp.dns_gethostbyname = get_sym("dns_gethostbyname")) ||
+            !(ntp.pbuf_alloc = get_sym("pbuf_alloc")) || !(ntp.pbuf_free = get_sym("pbuf_free")) ||
+            !(ntp.udp_sendto = get_sym("udp_sendto")) ||
+            !(ntp.runtime_memset = get_sym("runtime_memset")) ||
+            !(ntp.now = get_sym("now")) || !(ntp.clock_adjust = get_sym("clock_adjust"))) {
+        ntp.rprintf("NTP: kernel symbols not found\n");
+        return KLIB_INIT_FAILED;
+    }
+    tuple root = get_root_tuple();
+    if (!root) {
+        ntp.rprintf("NTP: failed to get root tuple\n");
+        return KLIB_INIT_FAILED;
+    }
+    buffer server_addr = table_find(root, sym_intern(ntp_address, intern));
+    if (server_addr) {
+        bytes len = buffer_length(server_addr);
+        if (len >= sizeof(ntp.server_addr)) {
+            ntp.rprintf("NTP: invalid server address\n");
+            return KLIB_INIT_FAILED;
+        }
+        memcopy(ntp.server_addr, buffer_ref(server_addr, 0), len);
+        ntp.server_addr[len] = '\0';
+    } else {
+        memcopy(ntp.server_addr, NTP_SERVER_DEFAULT, sizeof(NTP_SERVER_DEFAULT));
+    }
+    value server_port = table_find(root, sym_intern(ntp_port, intern));
+    if (server_port) {
+        u64 port;
+        if (!u64_from_value(server_port, &port) || (port > U16_MAX)) {
+            ntp.rprintf("NTP: invalid server port\n");
+            return KLIB_INIT_FAILED;
+        }
+        ntp.server_port = port;
+    } else {
+        ntp.server_port = NTP_PORT_DEFAULT;
+    }
+    ntp.pcb = udp_new();
+    if (!ntp.pcb) {
+        ntp.rprintf("NTP: failed to create PCB\n");
+        return KLIB_INIT_FAILED;
+    }
+    udp_recv(ntp.pcb, ntp_input, 0);
+    init_closure(&ntp.query_func, ntp_query_func);
+    ntp.query_interval = NTP_QUERY_INTERVAL_DEFAULT;
+    ntp.query_timer = ntp.register_timer(CLOCK_ID_MONOTONIC_RAW, seconds(5), false, 0,
+        (timer_handler)&ntp.query_func);
+    return KLIB_INIT_OK;
+}

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -188,6 +188,12 @@ kernel_heaps get_kernel_heaps(void)
 }
 KLIB_EXPORT(get_kernel_heaps);
 
+tuple get_root_tuple(void)
+{
+    return filesystem_getroot(root_fs);
+}
+KLIB_EXPORT(get_root_tuple);
+
 tuple get_environment(void)
 {
     return table_find(filesystem_getroot(root_fs), sym(environment));
@@ -315,7 +321,7 @@ u64 random_seed(void)
         return seed;
     if (have_rdrand && hw_seed(&seed, false))
         return seed;
-    return (u64)now(CLOCK_ID_MONOTONIC);
+    return (u64)now(CLOCK_ID_MONOTONIC_RAW);
 }
 
 static void init_hwrand(void)

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -263,6 +263,7 @@ void mm_service(void);
 
 kernel_heaps get_kernel_heaps(void);
 
+tuple get_root_tuple(void);
 tuple get_environment(void);
 
 boolean first_boot(void);

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -264,4 +264,5 @@ void init_klib(kernel_heaps kh, void *fs, tuple config_root, tuple klib_md)
     if (table_find(get_environment(), sym(RADAR_KEY)))
         load_klib("/klib/radar", closure(h, radar_loaded));
     load_klib("/klib/cloud_init", closure(h, klib_optional_loaded));
+    load_klib("/klib/ntp", closure(h, klib_optional_loaded));
 }

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -87,7 +87,7 @@ static inline boolean update_timer(void)
     timestamp next = timer_check(runloop_timers);
     if (last_timer_update && next == last_timer_update)
         return false;
-    s64 delta = next - now(CLOCK_ID_MONOTONIC);
+    s64 delta = next - now(CLOCK_ID_MONOTONIC_RAW);
     timestamp timeout = delta > (s64)runloop_timer_min ? MIN(delta, runloop_timer_max) : runloop_timer_min;
     sched_debug("set platform timer: delta %lx, timeout %lx\n", delta, timeout);
     last_timer_update = current_cpu()->last_timer_update = next + timeout - delta;
@@ -182,7 +182,7 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
     if (kern_try_lock()) {
         /* invoke expired timer callbacks */
         ci->state = cpu_kernel;
-        timer_service(runloop_timers, now(CLOCK_ID_MONOTONIC));
+        timer_service(runloop_timers, now(CLOCK_ID_MONOTONIC_RAW));
 
         while ((t = dequeue(runqueue)) != INVALID_ADDRESS)
             run_thunk(t, cpu_kernel);
@@ -230,7 +230,7 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
         }
         if (t != INVALID_ADDRESS) {
             if (!timer_updated && (total_processors > 1)) {
-                timestamp here = now(CLOCK_ID_MONOTONIC);
+                timestamp here = now(CLOCK_ID_MONOTONIC_RAW);
                 s64 timeout = ci->last_timer_update - here;
                 if ((timeout < 0) || (timeout > runloop_timer_max)) {
                     sched_debug("setting CPU scheduler timer\n");

--- a/src/kernel/vdso-now.c
+++ b/src/kernel/vdso-now.c
@@ -104,7 +104,7 @@ vdso_now(clock_id id)
     if (_now == VDSO_NO_NOW)
         return VDSO_NO_NOW;
 
-    return _now + _off;
+    return _now + clock_get_drift(_now) + _off;
 }
 
 VDSO int

--- a/src/kernel/vdso.h
+++ b/src/kernel/vdso.h
@@ -11,6 +11,11 @@ struct vdso_dat_struct {
     vdso_clock_id clock_src;
     timestamp rtc_offset;
     u64 pvclock_offset;
+    s64 temp_cal;   /* temporary calibration value (valid until sync_complete) */
+    timestamp sync_complete;    /* time at which temporary calibration ceases to take effect */
+    s64 cal;    /* calibration value (from monotonic raw to monotonic); 0 means no drift */
+    s64 last_drift; /* last calculated drift from monotonic raw to monotonic */
+    timestamp last_raw; /* time at which last_drift has been calculated */
     u8 platform_has_rdtscp;
 } __attribute((packed));
 

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -41,7 +41,7 @@ void sys_timeouts_init(void)
     for (int i = 0; i < n; i++) {
         struct net_lwip_timer * t = (struct net_lwip_timer *)&net_lwip_timers[i];
         timestamp interval = milliseconds(t->interval_ms);
-        register_timer(runloop_timers, CLOCK_ID_MONOTONIC, interval, false, interval,
+        register_timer(runloop_timers, CLOCK_ID_MONOTONIC_RAW, interval, false, interval,
                        closure(lwip_heap, dispatch_lwip_timer, t->handler, t->name));
 #ifdef LWIP_DEBUG
         lwip_debug("registered %s timer with period of %ld ms\n", t->name, t->interval_ms);
@@ -126,6 +126,11 @@ int lwip_strncmp(const char *x, const char *y, unsigned long len)
 }
 
 KLIB_EXPORT(dns_gethostbyname);
+KLIB_EXPORT(pbuf_alloc);
+KLIB_EXPORT(pbuf_free);
+KLIB_EXPORT(udp_new);
+KLIB_EXPORT(udp_sendto);
+KLIB_EXPORT(udp_recv);
 
 #define MAX_ADDR_LEN 20
 static boolean get_config_addr(tuple root, symbol s, ip4_addr_t *addr)

--- a/src/runtime/clock.h
+++ b/src/runtime/clock.h
@@ -1,3 +1,6 @@
+/* Number of fractional bits in fixed-point clock calibration value. */
+#define CLOCK_CALIBR_BITS   32
+
 /* these need to map to linux values */
 typedef enum {
     CLOCK_ID_REALTIME = 0,
@@ -72,29 +75,63 @@ rdtsc_precise(void)
     asm volatile("cpuid" ::: "%rax", "%rbx", "%rcx", "%rdx"); /* serialize execution */
     return _rdtsc();
 }
+
+static inline s64 clock_calculate_drift(timestamp interval, s64 cal)
+{
+    if (cal >= 0)
+        return ((interval * cal) >> CLOCK_CALIBR_BITS);
+    else
+        return -((interval * -cal) >> CLOCK_CALIBR_BITS);
+}
+
+static inline s64 clock_get_drift(timestamp raw)
+{
+    if (!__vdso_dat->temp_cal && !__vdso_dat->cal)
+        return 0;
+    s64 drift = __vdso_dat->last_drift;
+    if (raw > __vdso_dat->sync_complete) {
+        if (__vdso_dat->last_raw > __vdso_dat->sync_complete) {
+            drift += clock_calculate_drift(raw - __vdso_dat->last_raw, __vdso_dat->cal);
+        } else {
+            drift += clock_calculate_drift(__vdso_dat->sync_complete - __vdso_dat->last_raw,
+                __vdso_dat->temp_cal);
+            drift += clock_calculate_drift(raw - __vdso_dat->sync_complete, __vdso_dat->cal);
+        }
+    } else {
+        drift += clock_calculate_drift(raw - __vdso_dat->last_raw, __vdso_dat->temp_cal);
+    }
+    return drift;
+}
+
+static inline s64 clock_update_drift(timestamp raw)
+{
+    s64 drift = clock_get_drift(raw);
+    __vdso_dat->last_drift = drift;
+    __vdso_dat->last_raw = raw;
+    return drift;
+}
 #endif
 
 /* This is all kernel-only below here */
 static inline timestamp now(clock_id id)
 {
-#if defined(STAGE3) || defined(BUILD_VDSO)
-    u64 rtc_offset = __vdso_dat->rtc_offset;
-#else
-    u64 rtc_offset = 0;
-#endif
+    timestamp t = apply(platform_monotonic_now);
 
+#if defined(STAGE3) || defined(BUILD_VDSO)
+    if (id == CLOCK_ID_MONOTONIC_RAW)
+        return t;
+    t += clock_update_drift(t);
     switch (id) {
-    case CLOCK_ID_MONOTONIC:
-    case CLOCK_ID_MONOTONIC_RAW:
-    case CLOCK_ID_MONOTONIC_COARSE:
-    case CLOCK_ID_BOOTTIME:
-        return apply(platform_monotonic_now);
     case CLOCK_ID_REALTIME:
     case CLOCK_ID_REALTIME_COARSE:
-        return apply(platform_monotonic_now) + rtc_offset;
+        t += __vdso_dat->rtc_offset;
+        break;
     default:
-        return 0;
+        break;
     }
+#endif
+
+    return t;
 }
 
 static inline timestamp uptime(void)
@@ -103,6 +140,7 @@ static inline timestamp uptime(void)
 }
 
 u64 rtc_gettimeofday(void);
+void rtc_settimeofday(u64 seconds);
 
 static inline void register_platform_clock_now(clock_now cn, vdso_clock_id id)
 {
@@ -110,8 +148,13 @@ static inline void register_platform_clock_now(clock_now cn, vdso_clock_id id)
 #if defined(STAGE3) || defined(BUILD_VDSO)
     __vdso_dat->clock_src = id;
     __vdso_dat->rtc_offset = (rtc_gettimeofday() << 32) - apply(cn);
+    __vdso_dat->temp_cal = __vdso_dat->cal = 0;
+    __vdso_dat->sync_complete = 0;
+    __vdso_dat->last_raw = __vdso_dat->last_drift = 0;
 #endif
 }
+
+void clock_adjust(timestamp wallclock_now, s64 temp_cal, timestamp sync_complete, s64 cal);
 
 #if defined(STAGE3) || defined(BUILD_VDSO)
 #undef __vdso_dat

--- a/src/runtime/clock.h
+++ b/src/runtime/clock.h
@@ -102,16 +102,17 @@ static inline timestamp uptime(void)
     return now(CLOCK_ID_BOOTTIME);
 }
 
+u64 rtc_gettimeofday(void);
+
 static inline void register_platform_clock_now(clock_now cn, vdso_clock_id id)
 {
     platform_monotonic_now = cn;
 #if defined(STAGE3) || defined(BUILD_VDSO)
     __vdso_dat->clock_src = id;
+    __vdso_dat->rtc_offset = (rtc_gettimeofday() << 32) - apply(cn);
 #endif
 }
 
 #if defined(STAGE3) || defined(BUILD_VDSO)
 #undef __vdso_dat
 #endif
-
-u64 rtc_gettimeofday(void);

--- a/src/runtime/pqueue.c
+++ b/src/runtime/pqueue.c
@@ -71,6 +71,13 @@ void *pqueue_peek(pqueue q)
     return INVALID_ADDRESS;
 }
 
+void pqueue_reorder(pqueue q)
+{
+    /* Floyd's heap construction algorithm */
+    for (index i = vector_length(q->body) / 2; i > 0; i--)
+        heal(q, i);
+}
+
 pqueue allocate_pqueue(heap h, boolean(*sort)(void *, void *))
 {
     pqueue p = allocate(h, sizeof(struct pqueue));

--- a/src/runtime/pqueue.h
+++ b/src/runtime/pqueue.h
@@ -4,3 +4,4 @@ void deallocate_pqueue(pqueue q);
 void pqueue_insert(pqueue q, void *v);
 void *pqueue_peek(pqueue q);
 void *pqueue_pop(pqueue q);
+void pqueue_reorder(pqueue q);

--- a/src/runtime/random.c
+++ b/src/runtime/random.c
@@ -79,7 +79,7 @@ static struct chacha20_s chacha20inst;
 void init_random()
 {
     assert(CHACHA20_KEYBYTES*8 >= CHACHA_MINKEYLEN);
-    chacha20_randomstir(&chacha20inst, now(CLOCK_ID_MONOTONIC));
+    chacha20_randomstir(&chacha20inst, now(CLOCK_ID_MONOTONIC_RAW));
 }
 
 void
@@ -89,7 +89,7 @@ arc4rand(void *ptr, bytes len)
     bytes length;
     u8 *p;
 
-    timestamp t = now(CLOCK_ID_MONOTONIC);
+    timestamp t = now(CLOCK_ID_MONOTONIC_RAW);
     u64 now_sec = sec_from_timestamp(t);
     if ((chacha20->numbytes > CHACHA20_RESEED_BYTES) || (now_sec > chacha20->t_reseed))
         chacha20_randomstir(chacha20, t);

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -68,6 +68,11 @@ void timer_service(timerheap th, timestamp here)
     }
 }
 
+void timer_reorder(timerheap th)
+{
+    pqueue_reorder(th->pq);
+}
+
 void print_timestamp(string b, timestamp t)
 {
     u32 s= t>>32;

--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -556,7 +556,7 @@ static void log_set_dirty(log tl)
     }
     tl->dirty = true;
     assert(!tl->flush_timer);
-    tl->flush_timer = register_timer(runloop_timers, CLOCK_ID_MONOTONIC,
+    tl->flush_timer = register_timer(runloop_timers, CLOCK_ID_MONOTONIC_RAW,
                                      seconds(TFS_LOG_FLUSH_DELAY_SECONDS), false, 0,
                                      closure(tl->h, log_flush_timer_expired, tl));
 }

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -328,9 +328,10 @@ int blockq_transfer_waiters(blockq dest, blockq src, int n)
         if (bi->timeout) {
             timestamp remain;
             timer_handler t = bi->timeout->t;
+            clock_id id = bi->timeout->id;
             remove_timer(bi->timeout, &remain);
             bi->timeout = remain == 0 ? 0 :
-                register_timer(runloop_timers, CLOCK_ID_MONOTONIC, remain, false, 0,
+                register_timer(runloop_timers, id, remain, false, 0,
                     init_closure(&bi->timeout_func, blockq_item_timeout, dest,
                         bi));
             assert(t);

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -1873,7 +1873,7 @@ NOTRACE void
 ftrace_cpu_deinit(cpuinfo ci)
 {
     rbuf_disable(&global_rbuf);
-    timestamp t = now(CLOCK_ID_MONOTONIC);
+    timestamp t = now(CLOCK_ID_MONOTONIC_RAW);
     while (ci->graph_idx > 0) {
         struct ftrace_graph_entry * stack_ent =
                 &(ci->graph_stack[--ci->graph_idx]);
@@ -1910,7 +1910,7 @@ ftrace_thread_switch(thread out, thread in)
     rbuf_disable(&global_rbuf);
 
     /* complete any outstanding function calls for outgoing thread */
-    timestamp t = now(CLOCK_ID_MONOTONIC);
+    timestamp t = now(CLOCK_ID_MONOTONIC_RAW);
     cpuinfo ci = current_cpu();
     while (ci->graph_idx > 0) {
         struct ftrace_graph_entry * stack_ent =
@@ -1986,7 +1986,7 @@ prepare_ftrace_return(unsigned long self, unsigned long * parent,
     stack_ent = &(ci->graph_stack[depth]);
     stack_ent->retaddr = old;
     stack_ent->func = self;
-    stack_ent->entry_ts = now(CLOCK_ID_MONOTONIC);
+    stack_ent->entry_ts = now(CLOCK_ID_MONOTONIC_RAW);
     stack_ent->fp = frame_pointer;
     stack_ent->depth = depth;
     stack_ent->has_child = 0;
@@ -2034,7 +2034,7 @@ ftrace_return_to_handler(unsigned long frame_pointer)
     if (stack_ent->fp != frame_pointer)
         frame_halt(stack_ent, frame_pointer);
 
-    stack_ent->return_ts = now(CLOCK_ID_MONOTONIC);
+    stack_ent->return_ts = now(CLOCK_ID_MONOTONIC_RAW);
     stack_ent->flush = 0;
     retaddr = stack_ent->retaddr;
 

--- a/src/unix/mktime.c
+++ b/src/unix/mktime.c
@@ -22,20 +22,20 @@ static int is_leap_year(int year) {
 }
 
 int mktime(struct tm *tm) {
-    int days = 365 * (tm->tm_year - 1970);
+    int days = 365 * (tm->tm_year - 70);
 
-    for (int i = 1970; i < tm->tm_year; i++) {
-        if (is_leap_year(i)) {
+    for (int i = 70; i < tm->tm_year; i++) {
+        if (is_leap_year(1900 + i)) {
             days++;
         }
     }
 
-    if (is_leap_year(tm->tm_year) && tm->tm_mon > 2) {
+    if (is_leap_year(1900 + tm->tm_year) && tm->tm_mon >= 2) {
         days++;
     }
 
-    for (int i = 1; i < tm->tm_mon; i++) {
-        days += days_in_month(i);
+    for (int i = 0; i < tm->tm_mon; i++) {
+        days += days_in_month(i + 1);
     }
 
     days += (tm->tm_mday - 1);
@@ -60,6 +60,8 @@ struct tm *gmtime_r(u64 *timep, struct tm *result) {
     result->tm_mon = 0;
     while (true) {
         int d = days_in_month(result->tm_mon + 1);
+        if ((result->tm_mon == 1) && is_leap_year(1900 + result->tm_year))
+            d++;
         if (days >= d) {
             result->tm_mon++;
             days -= d;

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2474,7 +2474,7 @@ void count_syscall(thread t, sysreturn rv)
         fetch_and_add(&ss->errors, 1);
     u64 us;
     if (t->syscall_enter_ts)
-        us = usec_from_timestamp(now(CLOCK_ID_MONOTONIC) - t->syscall_enter_ts) + t->syscall_time;
+        us = usec_from_timestamp(now(CLOCK_ID_MONOTONIC_RAW) - t->syscall_enter_ts) + t->syscall_time;
     else
         us = t->syscall_time;
     fetch_and_add(&ss->usecs, us);
@@ -2498,7 +2498,7 @@ void syscall_debug(context f)
     if (do_syscall_stats) {
         assert(t->last_syscall == -1);
         t->last_syscall = call;
-        t->syscall_enter_ts = now(CLOCK_ID_MONOTONIC);
+        t->syscall_enter_ts = now(CLOCK_ID_MONOTONIC_RAW);
     }
     struct syscall *s = t->p->syscalls + call;
     if (debugsyscalls) {

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -327,7 +327,7 @@ thread create_thread(process p)
     init_closure(&t->deferred_syscall, resume_syscall, t);
     t->sysctx = false;
     t->utime = t->stime = 0;
-    t->start_time = now(CLOCK_ID_MONOTONIC);
+    t->start_time = now(CLOCK_ID_MONOTONIC_RAW);
     t->last_syscall = -1;
 
     // XXX sigframe

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -371,7 +371,7 @@ void thread_enter_user(thread in)
 void thread_enter_system(thread t)
 {
     if (!t->sysctx) {
-        timestamp here = now(CLOCK_ID_MONOTONIC);
+        timestamp here = now(CLOCK_ID_MONOTONIC_RAW);
         timestamp diff = here - t->start_time;
         t->utime += diff;
         t->start_time = here;
@@ -384,7 +384,7 @@ void thread_pause(thread t)
 {
     if (get_current_thread() != &t->thrd)
         return;
-    timestamp diff = now(CLOCK_ID_MONOTONIC) - t->start_time;
+    timestamp diff = now(CLOCK_ID_MONOTONIC_RAW) - t->start_time;
     if (t->sysctx) {
         t->stime += diff;
     }
@@ -399,7 +399,7 @@ void thread_resume(thread t)
     count_syscall_resume(t);
     if (get_current_thread() == &t->thrd)
         return;
-    t->start_time = now(CLOCK_ID_MONOTONIC);
+    t->start_time = now(CLOCK_ID_MONOTONIC_RAW);
     set_current_thread(&t->thrd);
 }
 
@@ -407,7 +407,7 @@ static timestamp utime_updated(thread t)
 {
     timestamp ts = t->utime;
     if (!t->sysctx)
-        ts += now(CLOCK_ID_MONOTONIC) - t->start_time;
+        ts += now(CLOCK_ID_MONOTONIC_RAW) - t->start_time;
     return ts;
 }
 
@@ -415,7 +415,7 @@ static timestamp stime_updated(thread t)
 {
     timestamp ts = t->stime;
     if (t->sysctx)
-        ts += now(CLOCK_ID_MONOTONIC) - t->start_time;
+        ts += now(CLOCK_ID_MONOTONIC_RAW) - t->start_time;
     return ts;
 }
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -700,7 +700,7 @@ extern boolean do_syscall_stats;
 static inline void count_syscall_save(thread t)
 {
     if (do_syscall_stats && !t->syscall_complete) {
-        t->syscall_time += usec_from_timestamp(now(CLOCK_ID_MONOTONIC) - t->syscall_enter_ts);
+        t->syscall_time += usec_from_timestamp(now(CLOCK_ID_MONOTONIC_RAW) - t->syscall_enter_ts);
         t->syscall_enter_ts = 0;
     }
 }
@@ -708,7 +708,7 @@ static inline void count_syscall_save(thread t)
 static inline void count_syscall_resume(thread t)
 {
     if (do_syscall_stats && !t->syscall_complete && t->syscall_enter_ts == 0)
-        t->syscall_enter_ts = now(CLOCK_ID_MONOTONIC);
+        t->syscall_enter_ts = now(CLOCK_ID_MONOTONIC_RAW);
 }
 
 static inline void count_syscall_noreturn(thread t)

--- a/src/x86_64/clock.c
+++ b/src/x86_64/clock.c
@@ -20,5 +20,4 @@ void init_clock(void)
     cpuid(0x80000001, 0, regs);
     __vdso_dat->clock_src = VDSO_CLOCK_SYSCALL;
     __vdso_dat->platform_has_rdtscp = (regs[3] & U64_FROM_BIT(27)) != 0;
-    __vdso_dat->rtc_offset = rtc_gettimeofday() << 32;
 }

--- a/src/x86_64/clock.c
+++ b/src/x86_64/clock.c
@@ -21,3 +21,23 @@ void init_clock(void)
     __vdso_dat->clock_src = VDSO_CLOCK_SYSCALL;
     __vdso_dat->platform_has_rdtscp = (regs[3] & U64_FROM_BIT(27)) != 0;
 }
+
+timestamp kern_now(clock_id id)
+{
+    return now(id);
+}
+KLIB_EXPORT_RENAME(kern_now, now);
+
+void clock_adjust(timestamp wallclock_now, s64 temp_cal, timestamp sync_complete, s64 cal)
+{
+    timestamp here = now(CLOCK_ID_MONOTONIC_RAW);
+    if (__vdso_dat->last_raw == 0)
+        __vdso_dat->last_raw = here;
+    __vdso_dat->temp_cal = temp_cal;
+    __vdso_dat->sync_complete = sync_complete;
+    __vdso_dat->cal = cal;
+    clock_update_drift(here);
+    timer_reorder(runloop_timers);
+    rtc_settimeofday(sec_from_timestamp(wallclock_now));
+}
+KLIB_EXPORT(clock_adjust);

--- a/src/x86_64/rtc.c
+++ b/src/x86_64/rtc.c
@@ -5,7 +5,7 @@
 
 #define RTC_COMMAND 0x70
 #define RTC_DATA 0x71
-#define RTC_NMI_DISABLE (1 << 8)
+#define RTC_NMI_DISABLE (1 << 7)
 #define RTC_NMI_ENABLE 0
 #define RTC_SECONDS 0x00
 #define RTC_MINUTES 0x02

--- a/src/x86_64/rtc.c
+++ b/src/x86_64/rtc.c
@@ -36,8 +36,8 @@ u64 rtc_gettimeofday(void) {
     tm.tm_min = bcd2bin(rtc_read(RTC_MINUTES));
     tm.tm_hour = bcd2bin(rtc_read(RTC_HOURS));
     tm.tm_mday = bcd2bin(rtc_read(RTC_DAY_OF_MONTH));
-    tm.tm_mon = bcd2bin(rtc_read(RTC_MONTH));
-    tm.tm_year = bcd2bin(rtc_read(RTC_YEAR)) + 2000;
+    tm.tm_mon = bcd2bin(rtc_read(RTC_MONTH)) - 1;
+    tm.tm_year = bcd2bin(rtc_read(RTC_YEAR)) + 100; /* assume we are in the 21st century */
 
 
     return mktime(&tm);


### PR DESCRIPTION
This change adds a new klib that periodically retrieves the time from an NTP server and synchronizes the kernel clock.
Clock synchronization is done gradually (by applying calibration parameters set via clock_adjust()) so as not to create any discontinuity in the wall clock time. The CLOCK_ID_MONOTONIC clock is now different from CLOCK_ID_MONOTONIC_RAW, and is calculated by applying calibration values obtained when comparing the local time with the time retrieved via NTP. Since retrieving the monotonic time is now slightly less efficient because of the calibration step, various pieces of code in the kernel have been converted to use CLOCK_ID_MONOTONIC_RAW instead.
When the local time is adjusted via clock_adjust(), the kernel timer queue is re-ordered so that any changes in timer expiry times resulting by clock calibration parameter changes are taken into account. In addition, the RTC is updated to reflect the correct time.