### PR TITLE
Add pbuf_free after udp sends

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -655,6 +655,7 @@ static sysreturn socket_write_udp(netsock s, void *source, u64 length,
         err = udp_sendto(s->info.udp.lw, pbuf, &ipaddr, port);
     else
         err = udp_send(s->info.udp.lw, pbuf);
+    pbuf_free(pbuf);
     if (err != ERR_OK) {
         net_debug("lwip error %d\n", err);
         return lwip_to_errno(err);


### PR DESCRIPTION
As discussed in #1381, a pbuf_free is required after a pbuf_alloc and udp_send or udp_sendto or else the the pbuf gets leaked. I also verified this with sending enough data to udploop that it would eventually crash nanos without the fix, and likewise does not crash with the fix.
