### PR TITLE
mcache: serve large allocations from parent heap

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -61,10 +61,8 @@ static heap allocate_tagged_region(kernel_heaps kh, u64 tag)
 
     /* reserve area in virtual_huge */
     assert(id_heap_set_area(heap_virtual_huge(kh), tag_base, tag_length, true, true));
-
-    /* tagged mcache range of 32 to 1M bytes (131072 table buckets) */
     build_assert(TABLE_MAX_BUCKETS * sizeof(void *) <= 1 << 20);
-    return allocate_mcache(h, backed, 5, 20, PAGESIZE_2M);
+    return allocate_mcache(h, backed, 5, MAX_MCACHE_ORDER, PAGESIZE_2M);
 }
 
 #define BOOTSTRAP_REGION_SIZE_KB	2048
@@ -645,11 +643,11 @@ static void init_kernel_heaps()
     heaps.backed = physically_backed(&bootstrap, (heap)heaps.virtual_page, (heap)heaps.physical, PAGESIZE, true);
     assert(heaps.backed != INVALID_ADDRESS);
 
-    heaps.general = allocate_mcache(&bootstrap, (heap)heaps.backed, 5, 20, PAGESIZE_2M);
+    heaps.general = allocate_mcache(&bootstrap, (heap)heaps.backed, 5, MAX_MCACHE_ORDER, PAGESIZE_2M);
     assert(heaps.general != INVALID_ADDRESS);
 
     heaps.locked = locking_heap_wrapper(&bootstrap,
-        allocate_mcache(&bootstrap, (heap)heaps.backed, 5, 20, PAGESIZE_2M));
+        allocate_mcache(&bootstrap, (heap)heaps.backed, 5, MAX_MCACHE_ORDER, PAGESIZE_2M));
     assert(heaps.locked != INVALID_ADDRESS);
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -50,6 +50,9 @@
 #define PAGECACHE_DRAIN_CUTOFF (64 * MB)
 #define PAGECACHE_SCAN_PERIOD_SECONDS 5
 
+/* must be large enough for vendor code that use malloc/free interface */
+#define MAX_MCACHE_ORDER 16
+
 /* ftrace buffer size */
 #define DEFAULT_TRACE_ARRAY_SIZE        (512ULL << 20)
 

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -11,4 +11,6 @@
 #include <lwip/dhcp.h>
 #include <lwip/dns.h>
 
+#define MAX_LWIP_ALLOC_ORDER 16
+
 status direct_connect(heap h, ip_addr_t *addr, u16 port, connection_handler ch);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -58,6 +58,9 @@ void lwip_debug(char * format, ...)
 
 void *lwip_allocate(u64 size)
 {
+    /* To maintain the malloc/free interface with mcache, allocations must stay
+       within the range of objcaches and not fall back to parent allocs. */
+    assert(size <= U64_FROM_BIT(MAX_LWIP_ALLOC_ORDER));
     void *p = allocate_zero(lwip_heap, size);
     return ((p != INVALID_ADDRESS) ? p : 0);
 }
@@ -195,6 +198,6 @@ void init_net(kernel_heaps kh)
 {
     heap h = heap_general(kh);
     heap backed = heap_backed(kh);
-    lwip_heap = allocate_mcache(h, backed, 5, 11, PAGESIZE);
+    lwip_heap = allocate_mcache(h, backed, 5, MAX_LWIP_ALLOC_ORDER, PAGESIZE_2M);
     lwip_init();
 }


### PR DESCRIPTION
The mcache previously only allowed allocations up to 2^max_order in size. With this change, allocations of larger sizes are served directly from the mcache parent heap. Such fallback allocations cannot be deallocated with a size parameter of -1ull (which is allowed for compatibility with vendor code that expects a malloc/free allocator interface). Assertions have been added to these malloc-type wrappers to make sure that the 2^max_order limit is not exceeded.

Now that the mcache can serve arbitrarily large allocations, the max_order for general mcaches in the kernel has been lowered from 1MB to 64kB; allocations larger than 64kB occur rarely in the kernel (only a few on program load), and larger objcache sizes lead to significant waste of memory (objcache meta stored within parent page allocations results in the loss of one object per page).
