### PR TITLE
Radar: add /api/v1 prefix to server URL endpoints; add imageName and privateIP attributes in JSON messages

### DIFF
--- a/klib/radar.c
+++ b/klib/radar.c
@@ -263,7 +263,7 @@ static void telemetry_crash_report(void)
         }
     }
     buffer_write_cstring(b, "\"}\r\n");
-    if (!telemetry_send("/crashes", b, 0)) {
+    if (!telemetry_send("/api/v1/crashes", b, 0)) {
         deallocate_buffer(b);
         goto error;
     }
@@ -316,7 +316,7 @@ static void telemetry_boot(void)
     if (ops_ver)
         kfunc(bprintf)(b, ",\"opsVersion\":\"%b\"", ops_ver);
     buffer_write_cstring(b, "}\r\n");
-    if (!telemetry_send("/boots", b, vh)) {
+    if (!telemetry_send("/api/v1/boots", b, vh)) {
         deallocate_closure(vh);
         goto err_free_buf;
     }
@@ -343,7 +343,7 @@ define_closure_function(0, 1, void, telemetry_stats,
             kfunc(bprintf)(b, "%ld%s", telemetry.stats_mem_used[i],
                     (i < RADAR_STATS_BATCH_SIZE - 1) ? "," : "");
         buffer_write_cstring(b, "]}\r\n");
-        if (!telemetry_send("/machine-stats", b, 0)) {
+        if (!telemetry_send("/api/v1/machine-stats", b, 0)) {
             kfunc(rprintf)("%s: failed to send stats\n", __func__);
             deallocate_buffer(b);
         }

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -14,3 +14,5 @@
 #define MAX_LWIP_ALLOC_ORDER 16
 
 status direct_connect(heap h, ip_addr_t *addr, u16 port, connection_handler ch);
+
+struct netif *netif_get_default(void);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -125,6 +125,13 @@ int lwip_strncmp(const char *x, const char *y, unsigned long len)
     return 0;
 }
 
+struct netif *netif_get_default(void)
+{
+    return netif_default;
+}
+KLIB_EXPORT(netif_get_default);
+
+KLIB_EXPORT(ipaddr_ntoa);
 KLIB_EXPORT(dns_gethostbyname);
 KLIB_EXPORT(pbuf_alloc);
 KLIB_EXPORT(pbuf_free);


### PR DESCRIPTION
The /api/v1 prefix is needed to match the current Radar server configuration.
The "privateIP" attribute is a string representation of the IP address assigned to the default network interface.
The "imageName" attribute is sent if a "RADAR_IMAGE_NAME" environment variable is present.