### PR TITLE
Fix SMP startup-related problems

### DIFF
--- a/platform/pc/boot/longmode.inc
+++ b/platform/pc/boot/longmode.inc
@@ -1,0 +1,24 @@
+    %define CR4_PAE (1<<5)
+    %define CR4_PGE (1<<7)
+    %define CR4_OSFXSR (1<<9)
+    %define CR4_OSXMMEXCPT (1<<10)
+    %define CR4_OSXSAVE (1<<18)
+
+    %macro PREPARE_LONG_MODE 1
+    mov %1, CR4_PAE | CR4_PGE | CR4_OSFXSR | CR4_OSXMMEXCPT ;| CR4_OSXSAVE
+    mov cr4, %1
+
+    mov ecx, 0xC0000080 ; Read from the EFER MSR.
+    rdmsr
+    or %1, 0x00000900  ; Set the LME bit and nxe
+    wrmsr
+    %endmacro
+
+    %macro ENTER_LONG_MODE 1
+    mov %1, cr0        ; Activate long mode -
+    or %1, 0x80000001  ; - by enabling paging and protection simultaneously.
+    and %1, ~0x4       ; clear EM
+    or %1, 0x2         ; set MP
+    mov cr0, %1
+    %endmacro
+

--- a/platform/pc/boot/longmode.inc
+++ b/platform/pc/boot/longmode.inc
@@ -1,24 +1,33 @@
+    %define CR0_PE (1<<0)
+    %define CR0_MP (1<<1)
+    %define CR0_EM (1<<2)
+    %define CR0_PG (1<<31)
+
     %define CR4_PAE (1<<5)
     %define CR4_PGE (1<<7)
     %define CR4_OSFXSR (1<<9)
     %define CR4_OSXMMEXCPT (1<<10)
     %define CR4_OSXSAVE (1<<18)
 
+    %define MSR_EFER 0xC0000080
+    %define EFER_LME (1<<8)
+    %define EFER_NXE (1<<11)
+
     %macro PREPARE_LONG_MODE 1
     mov %1, CR4_PAE | CR4_PGE | CR4_OSFXSR | CR4_OSXMMEXCPT ;| CR4_OSXSAVE
     mov cr4, %1
 
-    mov ecx, 0xC0000080 ; Read from the EFER MSR.
+    mov ecx, MSR_EFER ; Read from the EFER MSR.
     rdmsr
-    or %1, 0x00000900  ; Set the LME bit and nxe
+    or %1, EFER_LME | EFER_NXE  ; Set the LME bit and nxe
     wrmsr
     %endmacro
 
     %macro ENTER_LONG_MODE 1
     mov %1, cr0        ; Activate long mode -
-    or %1, 0x80000001  ; - by enabling paging and protection simultaneously.
-    and %1, ~0x4       ; clear EM
-    or %1, 0x2         ; set MP
+    or %1, CR0_PG | CR0_PE  ; - by enabling paging and protection simultaneously.
+    and %1, ~CR0_EM       ; clear EM
+    or %1, CR0_MP         ; set MP
     mov cr0, %1
     %endmacro
 

--- a/platform/pc/boot/service32.s
+++ b/platform/pc/boot/service32.s
@@ -330,24 +330,11 @@ bios_tty_write:
 	pop ebp
 	ret
 
+%include "longmode.inc"
 
-        %define CR4_PAE (1<<5)
-        %define CR4_PGE (1<<7)
-        %define CR4_OSFXSR (1<<9)
-        %define CR4_OSXMMEXCPT (1<<10)        
-        %define CR4_OSXSAVE (1<<18)                
-        
-global run64        
+global run64      
 run64:
-        mov eax, cr4     
-        or eax, CR4_PAE
-        mov cr4, eax  
-
-        mov ecx, 0xC0000080 ; EFER MSR.
-        
-        rdmsr      
-        or eax, 1 << 8      ; Set the LM-bit which is the 9th bit (bit 8).
-        wrmsr
+		PREPARE_LONG_MODE eax
 
         pop edx                 ; return
         pop edx                 ; entry
@@ -355,10 +342,7 @@ run64:
         push eax
         push eax
 
-        mov eax, cr0    
-        or eax, 1 << 31 | 1 ; Set the PG-bit and the PM bit 
-        mov cr0, eax
-        
+		ENTER_LONG_MODE eax
         ;; 64 bit compatibility into the proper long mode
         lgdt [GDT64.Pointer]    ; Load the 64-bit global descriptor table.
         jmp GDT64.Code:setup64

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -446,9 +446,11 @@ void __attribute__((noreturn)) kernel_shutdown(int status)
 u64 total_processors = 1;
 
 #ifdef SMP_ENABLE
+/* Value comes from LDMXCSR instruction reference in Intel Architectures SDM */
+#define MXCSR_DEFAULT   0x1f80
 /* hvm does not always properly initialize mxcsr register */
 static void init_mxcsr() {
-    u32 m = 0x1f80;
+    u32 m = MXCSR_DEFAULT;
     asm("ldmxcsr %0":: "m"(m));
 }
 

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -446,10 +446,18 @@ void __attribute__((noreturn)) kernel_shutdown(int status)
 u64 total_processors = 1;
 
 #ifdef SMP_ENABLE
+/* hvm does not always properly initialize mxcsr register */
+static void init_mxcsr() {
+    u32 m = 0x1f80;
+    asm("ldmxcsr %0":: "m"(m));
+}
+
 static void new_cpu()
 {
     if (platform_timer_percpu_init)
         apply(platform_timer_percpu_init);
+
+    init_mxcsr();
 
     /* For some reason, we get a spurious wakeup from hlt on linux/kvm
        after AP start. Spin here to cover it (before moving on to runloop). */
@@ -572,6 +580,7 @@ static void __attribute__((noinline)) init_service_new_stack()
     unmap(PAGESIZE, INITIAL_MAP_SIZE - PAGESIZE);
     set_syscall_handler(syscall_enter);
 #ifdef SMP_ENABLE
+    init_mxcsr();
     init_debug("starting APs");
     start_cpu(misc, heap_backed(kh), TARGET_EXCLUSIVE_BROADCAST, new_cpu);
     kernel_delay(milliseconds(200));   /* temp, til we check tables to know what we have */
@@ -770,14 +779,6 @@ void init_service(u64 rdi, u64 rsi)
         initial_pages_region->length = INITIAL_PAGES_SIZE;
         mov_to_cr("cr3", pgdir);
     }
-    u64 cr;
-    mov_from_cr("cr0", cr);
-    cr |= C0_MP;
-    cr &= ~C0_EM;
-    mov_to_cr("cr0", cr);
-    mov_from_cr("cr4", cr);
-    cr |= CR4_OSFXSR | CR4_OSXMMEXCPT /* | CR4_OSXSAVE */;
-    mov_to_cr("cr4", cr);
     init_kernel_heaps();
     if (cmdline)
         cmdline_parse(cmdline);

--- a/rules.mk
+++ b/rules.mk
@@ -35,8 +35,10 @@ GO=		go
 MKDIR=		mkdir -p
 ifeq ($(ARCH),x86_64)
 AS=		nasm
+ASDEPFLAGS= -MD $(patsubst %.o,%.d,$@) -MP -MT $@
 else
 AS=		$(CROSS_COMPILE)as
+ASDEPFLAGS=
 endif
 
 ifneq ($(CROSS_COMPILE),)
@@ -120,7 +122,7 @@ msg_cc=		CC	$@
 cmd_cc=		$(CC) $(DEPFLAGS) $(CFLAGS) $(CFLAGS-$(<F)) -c $< -o $@
 
 msg_as=		AS	$@
-cmd_as=		$(AS) $(AFLAGS) $(AFLAGS-$(<F)) $< -o $@
+cmd_as=		$(AS) $(ASDEPFLAGS) $(AFLAGS) $(AFLAGS-$(<F)) $< -o $@
 
 msg_go=		GO	$@
 cmd_go=		$(GO_ENV) $(GO) build $(GOFLAGS) -o $@ $^
@@ -205,7 +207,7 @@ cleandepend:
 
 .SUFFIXES:
 
-$(OBJDIR)/%.o: $(ROOTDIR)/%.s
+$(OBJDIR)/%.o: $(ROOTDIR)/%.s $(OBJDIR)/%.d
 	@$(MKDIR) $(dir $@)
 	$(call cmd,as)
 


### PR DESCRIPTION
This change fixes several problems related to SMP startup. The long mode
assembly has been unified between the bootstrap and other processors so
a consistent set of flags is set on cr4 and cr0. This fixes UD2 exceptions
happening because XSAVE was enabled only on the APs. Moving the assembly
to a separate file also necessitated a change to the Makefiles so that
include dependencies were used for assembly files. Also, a workaround
was added to initialize the MXCSR register, since HVM did not always do
this properly for SMP which could result in SIMD exceptions.