### PR TITLE
NTP: add dynamic adjustment and configurability of poll interval

### DIFF
--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -83,6 +83,8 @@ static inline void console(const char *s)
 #define MIN(x, y) __compare((x), (y), <)
 #define MAX(x, y) __compare((x), (y), >)
 
+#define ABS(x) (((x) >= 0) ? (x) : -(x))
+
 #define offsetof(__t, __e) u64_from_pointer(&((__t)0)->__e)
 
 #define check_flags_and_clear(x, f) ({boolean match = ((x) & (f)) != 0; (x) &= ~(f); match;})

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -62,10 +62,14 @@ static inline timestamp timer_expiry(timer t)
         break;
     }
 
-    /* Not entirely correct, because clock_get_drift() takes a raw timestamp as
-     * argument, but should be a reasonable approximation. */
-    expiry -= clock_get_drift(expiry - __vdso_dat->last_drift);
-
+    s64 drift;
+    if (expiry > __vdso_dat->last_raw + __vdso_dat->last_drift)
+        /* Not entirely correct, because clock_get_drift() takes a raw timestamp as
+         * argument, but should be a reasonable approximation. */
+        drift = clock_get_drift(expiry - __vdso_dat->last_drift);
+    else
+        drift = __vdso_dat->last_drift;
+    expiry -= drift;
 #endif
 
     return expiry;


### PR DESCRIPTION
The first commit fixes a bug that showed up when executing runtime tests with NTP enabled.
The second commit changes the NTP klib so that the poll interval is adjusted dynamically between a minimum and a maximum value, based on the measured jitter of offset values between the local time and the NTP time, using an algorithm similar to that of the NTP reference implementation, whose purpose is to maximize clock precision while minimizing network traffic overhead.
The minimum and maximum poll interval values are expressed as bit order of the number of seconds, and are set by default to 6 (i.e. 64 seconds) and 10 (i.e. 1024 seconds) respectively. These values are configurable via the "ntp_poll_min" and "ntp_poll_max" manifest options, respectively, whose allowed values range from 4 (i.e. 16 seconds) to 17 (i.e. 36.4 hours).