### PR TITLE
pc: init_service(): set CR4 and CR0 when booting without stage2

### DIFF
--- a/platform/pc/boot/longmode.inc
+++ b/platform/pc/boot/longmode.inc
@@ -14,7 +14,7 @@
     %define EFER_NXE (1<<11)
 
     %macro PREPARE_LONG_MODE 1
-    mov %1, CR4_PAE | CR4_PGE | CR4_OSFXSR | CR4_OSXMMEXCPT ;| CR4_OSXSAVE
+    mov %1, CR4_PAE
     mov cr4, %1
 
     mov ecx, MSR_EFER ; Read from the EFER MSR.
@@ -26,8 +26,6 @@
     %macro ENTER_LONG_MODE 1
     mov %1, cr0        ; Activate long mode -
     or %1, CR0_PG | CR0_PE  ; - by enabling paging and protection simultaneously.
-    and %1, ~CR0_EM       ; clear EM
-    or %1, CR0_MP         ; set MP
     mov cr0, %1
     %endmacro
 

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -46,6 +46,7 @@
 #define C0_WP   0x00010000
 
 #define CR4_PAE         (1 << 5)
+#define CR4_PGE         (1 << 7)
 #define CR4_OSFXSR      (1 << 9)
 #define CR4_OSXMMEXCPT  (1 << 10)
 #define CR4_OSXSAVE     (1 << 18)

--- a/src/x86_64/mp.c
+++ b/src/x86_64/mp.c
@@ -25,6 +25,14 @@ static void (*start_callback)();
 
 void cpu_init(int cpu)
 {
+    u64 cr;
+    mov_from_cr("cr4", cr);
+    cr |= CR4_PGE | CR4_OSFXSR | CR4_OSXMMEXCPT;
+    mov_to_cr("cr4", cr);
+    mov_from_cr("cr0", cr);
+    cr |= C0_MP;
+    cr &= ~C0_EM;
+    mov_to_cr("cr0", cr);
     u64 addr = u64_from_pointer(cpuinfo_from_id(cpu));
     write_msr(KERNEL_GS_MSR, 0); /* clear user GS */
     write_msr(GS_MSR, addr);


### PR DESCRIPTION
When the kernel ELF file is loaded directly by the hypervisor in long mode, the boot process does not go through stage1 and stage2. Thus, appropriate settings for the CR4 and CR0 registers of the bootstrap processor must be enforced in the kernel code. This change moves initialization of CR4 and CR0 from the PREPARE_LONG_MODE and ENTER_LONG_MODE assembly macros to the cpu_init() function. Now the assembly macros only do what is strictly necessary to enter long mode.
This fixes UD2 exceptions being triggered when running under AWS Firecracker.