### PR TITLE
Go tests: remove references to Mkfs and set base volume size

### DIFF
--- a/test/go/common.go
+++ b/test/go/common.go
@@ -18,7 +18,6 @@ func defaultConfig() lepton.Config {
 
 	c.Boot = "../../output/test/go/boot.img"
 	c.Kernel = "../../output/test/go/kernel.img"
-	c.Mkfs = "../../output/tools/bin/mkfs"
 	c.NameServer = "8.8.8.8"
 
 	c.Env = make(map[string]string)

--- a/test/go/go_test.go
+++ b/test/go/go_test.go
@@ -24,6 +24,7 @@ func prepareTestImage(finalImage string) {
 	c := defaultConfig()
 	writeFile(filepath)
 
+	c.BaseVolumeSz = "32M"
 	c.Files = append(c.Files, "/lib/x86_64-linux-gnu/libnss_dns.so.2")
 	c.Files = append(c.Files, "/etc/ssl/certs/ca-certificates.crt")
 	c.Files = append(c.Files, filepath)

--- a/test/go/node_test.go
+++ b/test/go/node_test.go
@@ -58,7 +58,6 @@ func TestNodeHelloWorld(t *testing.T) {
 	c.RunConfig.Memory = "2G"
 	c.Boot = "../../output/test/go/boot.img"
 	c.Kernel = "../../output/test/go/kernel.img"
-	c.Mkfs = "../../output/tools/bin/mkfs"
 	c.Env = make(map[string]string)
 	c.RunConfig.Imagename = "image"
 


### PR DESCRIPTION
With https://github.com/nanovms/ops/pull/887, Ops no longer uses the mkfs tool to create image files, and for this reason the lepton.Config struct no longer contains the Mkfs field.
In addition, when creating an image whose program needs to write to the filesystem, a base volume size has to be configured, otherwise there is no free space in the filesystem to create new files.