### PR TITLE
Reserve space in linker_script for vdso data

### DIFF
--- a/platform/pc/linker_script
+++ b/platform/pc/linker_script
@@ -44,6 +44,7 @@ SECTIONS
     {
         vvar_page = .; 
         __vdso_vdso_dat = vvar_page + 128;
+        . += 4096; /* reserve a page since the linker seems to discard this section */
     }
 
     .rodata ALIGN(4096): AT(ADDR(.rodata) - LOAD_OFFSET)

--- a/platform/virt/linker_script
+++ b/platform/virt/linker_script
@@ -35,6 +35,7 @@ SECTIONS
         {
             vvar_page = .;
             __vdso_vdso_dat = vvar_page + 128;
+            . += 4096; /* reserve a page since the linker seems to discard this section */
         }
 
         .rodata ALIGN(4096): AT(ADDR(.rodata) - LOAD_OFFSET)


### PR DESCRIPTION
I discovered that the linker seems to discard the .vvar section where __vdso_vdso_dat lives, causing this symbol to point inside the following section, rodata, so that changes made to the vdso_dat object would overwrite strings. I modified the linker_script to advance the location counter by a page to guarantee the space is reserved.