### PR TITLE
Update test go files for lepton refactoring

### DIFF
--- a/test/go/common.go
+++ b/test/go/common.go
@@ -7,14 +7,15 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"time"
 	"testing"
+	"time"
 
-	"github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/config"
+	"github.com/nanovms/ops/qemu"
 )
 
-func defaultConfig() lepton.Config {
-	var c lepton.Config
+func defaultConfig() config.Config {
+	var c config.Config
 
 	c.Boot = "../../output/test/go/boot.img"
 	c.Kernel = "../../output/test/go/kernel.img"
@@ -46,8 +47,8 @@ func sortString(s string) string {
 
 const START_WAIT_TIMEOUT = time.Second * 30
 
-func runAndWaitForString(rconfig *lepton.RunConfig, timeout time.Duration, text string, t *testing.T) lepton.Hypervisor {
-	hypervisor := lepton.HypervisorInstance()
+func runAndWaitForString(rconfig *config.RunConfig, timeout time.Duration, text string, t *testing.T) qemu.Hypervisor {
+	hypervisor := qemu.HypervisorInstance()
 	if hypervisor == nil {
 		t.Fatal("No hypervisor found on $PATH")
 	}

--- a/test/go/go_test.go
+++ b/test/go/go_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nanovms/ops/config"
 	"github.com/nanovms/ops/lepton"
 )
 

--- a/test/go/go_test.go
+++ b/test/go/go_test.go
@@ -46,7 +46,7 @@ func prepareTestImage(finalImage string) {
 func TestArgsAndEnv(t *testing.T) {
 	const finalImage = "image"
 	prepareTestImage(finalImage)
-	rconfig := lepton.RuntimeConfig(finalImage, []string{"8080"}, true)
+	rconfig := config.RuntimeConfig(finalImage, []string{"8080"}, true)
 	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
 	defer hypervisor.Stop()
 
@@ -81,7 +81,7 @@ func TestArgsAndEnv(t *testing.T) {
 func TestFileSystem(t *testing.T) {
 	const finalImage = "image"
 	prepareTestImage(finalImage)
-	rconfig := lepton.RuntimeConfig(finalImage, []string{"8080"}, true)
+	rconfig := config.RuntimeConfig(finalImage, []string{"8080"}, true)
 	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
 	defer hypervisor.Stop()
 
@@ -100,7 +100,7 @@ func TestFileSystem(t *testing.T) {
 }
 
 func validateResponse(t *testing.T, finalImage string, expected string) {
-	rconfig := lepton.RuntimeConfig(finalImage, []string{"8080"}, true)
+	rconfig := config.RuntimeConfig(finalImage, []string{"8080"}, true)
 	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
 	defer hypervisor.Stop()
 
@@ -129,7 +129,7 @@ func TestInstancePersistence(t *testing.T) {
 func TestHTTP(t *testing.T) {
 	const finalImage = "image"
 	prepareTestImage(finalImage)
-	rconfig := lepton.RuntimeConfig(finalImage, []string{"8080"}, true)
+	rconfig := config.RuntimeConfig(finalImage, []string{"8080"}, true)
 	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
 	defer hypervisor.Stop()
 

--- a/test/go/node_test.go
+++ b/test/go/node_test.go
@@ -9,11 +9,12 @@ import (
 	"path"
 	"testing"
 
+	"github.com/nanovms/ops/config"
 	api "github.com/nanovms/ops/lepton"
 )
 
-func unWarpConfig(file string) *api.Config {
-	var c api.Config
+func unWarpConfig(file string) *config.Config {
+	var c config.Config
 	if file != "" {
 		data, err := ioutil.ReadFile(file)
 		if err != nil {


### PR DESCRIPTION
The lepton package in ops has been refactored into different packages now to accommodate different hypervisors which broke test's common.go file and some go tests. This change updates these files with the new packages.