### PR TITLE
Discover and map ACPI tables and use MADT for SMP startup

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -212,7 +212,7 @@ static void count_processors()
         init_debug("ACPI reports %d processors", present_processors);
     } else {
         present_processors = 1;
-        init_debug("ACPI MADT not found, default to 1 processor");
+        rprintf("warning: ACPI MADT not found, default to 1 processor");
     }
     /* config override */
     present_processors = MIN(present_processors, MAX_CPUS);

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -190,6 +190,7 @@ void halt(char *format, ...)
 }
 
 u64 total_processors = 1;
+u64 present_processors = 1;
 
 void start_secondary_cores(kernel_heaps kh)
 {

--- a/src/drivers/acpi.h
+++ b/src/drivers/acpi.h
@@ -15,4 +15,87 @@
 
 #define ACPI_SCI_IRQ    9
 
+/* ACPI table signatures */
+#define ACPI_SIG_MADT   0x43495041  // "APIC"
+
+/* MADT controller types */
+#define ACPI_MADT_LAPIC     0
+#define ACPI_MADT_IOAPIC    1
+#define ACPI_MADT_LAPICx2   9
+
+#define MADT_LAPIC_ENABLED  1
+/* ACPI table structures */
+typedef struct acpi_rsdp {
+    u8 sig[8];
+    u8 checksum;
+    u8 oem_id[6];
+    u8 rev;
+    u32 rsdt_addr;
+    u32 length;
+    u64 xsdt_addr;
+    u8 ext_checksum;
+    u8 res[3];
+} __attribute__((packed)) *acpi_rsdp;
+
+typedef struct acpi_header {
+    u8 sig[4];
+    u32 length;
+    u8 rev;
+    u8 checksum;
+    u8 oem_id[6];
+    u8 oem_table_id[8];
+    u32 oem_rev;
+    u8 creator_id[4];
+    u8 creator_rev[4];
+} __attribute__((packed)) *acpi_header;
+
+typedef struct acpi_rsdt {
+    struct acpi_header h;
+} __attribute__((packed)) *acpi_rsdt;
+
+typedef struct acpi_madt {
+    struct acpi_header h;
+    u32 lapic_addr;
+    u32 flags;
+} __attribute__((packed)) *acpi_madt;
+
+typedef struct acpi_lapic {
+    u8 type;
+    u8 length;
+    u8 uid;
+    u8 id;
+    u32 flags;
+} __attribute__((packed)) *acpi_lapic;
+
+typedef struct acpi_lapic_x2 {
+    u8 type;
+    u8 length;
+    u8 res[2];
+    u32 id;
+    u32 flags;
+    u32 uid;
+} __attribute__((packed)) *acpi_lapic_x2;
+
+typedef struct acpi_ioapic {
+    u8 type;
+    u8 length;
+    u8 id;
+    u8 res;
+    u32 addr;
+    u32 gsi_base;
+} __attribute__((packed)) *acpi_ioapic;
+
+static inline boolean acpi_checksum(void *a, u8 len)
+{
+    u8 *addr = a;
+    u8 sum = 0;
+    while (len--)
+        sum += *addr++;
+    return sum == 0;
+}
+
+typedef closure_type(madt_handler, void, u8, void *);
+
 void init_acpi(kernel_heaps kh);
+void *acpi_get_table(u32 sig);
+void acpi_walk_madt(acpi_madt madt, madt_handler mh);

--- a/src/drivers/acpi.h
+++ b/src/drivers/acpi.h
@@ -97,5 +97,6 @@ static inline boolean acpi_checksum(void *a, u8 len)
 typedef closure_type(madt_handler, void, u8, void *);
 
 void init_acpi(kernel_heaps kh);
+void init_acpi_tables(kernel_heaps kh);
 void *acpi_get_table(u32 sig);
 void acpi_walk_madt(acpi_madt madt, madt_handler mh);

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -37,7 +37,7 @@ void *allocate_stack(heap h, u64 size)
 void deallocate_stack(heap h, u64 size, void *stack)
 {
     u64 padsize = pad(size, h->pagesize);
-    deallocate(h, stack, padsize);
+    deallocate(h, u64_from_pointer(stack) - padsize + STACK_ALIGNMENT, padsize);
 }
 
 kernel_context allocate_kernel_context(heap h)

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -232,6 +232,7 @@ void kernel_unlock();
 
 extern u64 idle_cpu_mask;
 extern u64 total_processors;
+extern u64 present_processors;
 extern void xsave(context f);
 
 void cpu_init(int cpu);

--- a/src/x86_64/acpi.c
+++ b/src/x86_64/acpi.c
@@ -156,9 +156,10 @@ static boolean find_rsdt(kernel_heaps kh)
     edba_pa = (*(u16 *)(va + 0x40e))<<4;
     unmap(va, PAGESIZE);
     u64 edba_pa_map = edba_pa & ~PAGEMASK;
-    u64 edba_map_len = pad((edba_pa - edba_pa_map) + EDBA_SEARCH_LENGTH, PAGESIZE);
+    u64 edba_off = edba_pa & PAGEMASK;
+    u64 edba_map_len = pad(edba_off + EDBA_SEARCH_LENGTH, PAGESIZE);
     map(va, edba_pa_map, edba_map_len, pageflags_memory());
-    rsdt_pa = find_rsdt_addr(va + (edba_pa - edba_pa_map), EDBA_SEARCH_LENGTH);
+    rsdt_pa = find_rsdt_addr(va + edba_off, EDBA_SEARCH_LENGTH);
     unmap(va, edba_map_len);
     if (rsdt_pa == INVALID_PHYSICAL)
         goto out;

--- a/src/x86_64/acpi.c
+++ b/src/x86_64/acpi.c
@@ -197,10 +197,9 @@ void *acpi_get_table(u32 sig)
     return table_find(acpi_tables, pointer_from_u64((u64)sig));
 }
 
-void init_acpi(kernel_heaps kh)
+void init_acpi_tables(kernel_heaps kh)
 {
     heap h = heap_general(kh);
-    register_pci_driver(closure(h, piix4acpi_probe, h));
     acpi_tables = allocate_table(h, identity_key, pointer_equal);
     if (find_rsdt(kh)) {
         u32 *t, *te;
@@ -212,4 +211,10 @@ void init_acpi(kernel_heaps kh)
             acpi_debug("%s: mapped acpi table %.4s at %p", __func__, tp, tp);
         }
     }
+}
+
+void init_acpi(kernel_heaps kh)
+{
+    heap h = heap_general(kh);
+    register_pci_driver(closure(h, piix4acpi_probe, h));
 }

--- a/src/x86_64/acpi.c
+++ b/src/x86_64/acpi.c
@@ -28,6 +28,9 @@
 #define acpi_debug(x, ...)
 #endif
 
+static acpi_rsdt rsdt;
+static table acpi_tables;
+
 declare_closure_struct(1, 0, void, piix4acpi_irq,
                        struct piix4acpi *, dev);
 declare_closure_struct(1, 1, void, piix4acpi_powerdown,
@@ -85,8 +88,128 @@ closure_function(1, 1, boolean, piix4acpi_probe,
     return true;
 }
 
+static void *map_acpi_table(kernel_heaps kh, u64 paddr, u64 plen)
+{
+    u64 off, base, len, v;
+    heap vh = (heap)heap_virtual_page(kh);
+
+    off = paddr & PAGEMASK;
+    base = paddr & ~PAGEMASK;
+again:
+    len = pad(paddr + plen - base, PAGESIZE);
+    v = allocate_u64(vh, len);
+    map(v, base, len, pageflags_memory());
+    u32 *t = pointer_from_u64(v + off);
+    u32 tlen = t[1]; /* length of table stored in the second u32 */
+
+    /* The table actual length may be longer than requested length,
+     * so repeat the mapping process if necessary */
+    if (len - off < tlen) {
+        unmap(v, len);
+        deallocate_u64(vh, v, len);
+        plen = tlen;
+        goto again;
+    }
+    return pointer_from_u64(v + off);
+}
+
+static u64 find_rsdt_addr(u64 va, u64 len)
+{
+    assert((va & MASK(4)) == 0);
+    for (u64 i = va; i < va + len; i += 16) {
+        acpi_rsdp rsdp = pointer_from_u64(i);
+        if (runtime_memcmp(&rsdp->sig, "RSD PTR ", sizeof(rsdp->sig)) != 0)
+            continue;
+        if (!acpi_checksum(rsdp, 20)) {
+            acpi_debug("%s: RSDP failed checksum", __func__);
+            continue;
+        }
+        return rsdp->rsdt_addr;
+    }
+    return INVALID_PHYSICAL;
+}
+
+/* ACPI spec says the RSDP is found in the first KB of EBDA or
+ * in the BIOS ROM space between 0xe0000 and 0xfffff */
+#define BIOS_SEARCH_LENGTH (128*KB)
+#define BIOS_SEARCH_ADDR 0xe0000
+#define EDBA_SEARCH_LENGTH (1*KB)
+static boolean find_rsdt(kernel_heaps kh)
+{
+    u64 va, edba_pa, rsdt_pa;
+    heap vh = (heap)heap_virtual_page(kh);
+
+    va = allocate_u64(vh, BIOS_SEARCH_LENGTH);
+    assert(va != INVALID_PHYSICAL);
+
+    /* Search BIOS ROM */
+    map(va, BIOS_SEARCH_ADDR, BIOS_SEARCH_LENGTH, pageflags_memory());
+    rsdt_pa = find_rsdt_addr(va, BIOS_SEARCH_LENGTH);
+    unmap(va, BIOS_SEARCH_LENGTH);
+    if (rsdt_pa != INVALID_PHYSICAL)
+        goto found;
+
+    /* Search EDBA as a backup. The EDBA segment location is found at
+     * 40:0Eh per ACPI spec */
+    map(va, 0, PAGESIZE, pageflags_memory());
+    edba_pa = (*(u16 *)(va + 0x40e))<<4;
+    unmap(va, PAGESIZE);
+    u64 edba_pa_map = edba_pa & ~PAGEMASK;
+    u64 edba_map_len = pad((edba_pa - edba_pa_map) + EDBA_SEARCH_LENGTH, PAGESIZE);
+    map(va, edba_pa_map, edba_map_len, pageflags_memory());
+    rsdt_pa = find_rsdt_addr(va + (edba_pa - edba_pa_map), EDBA_SEARCH_LENGTH);
+    unmap(va, edba_map_len);
+    if (rsdt_pa == INVALID_PHYSICAL)
+        goto out;
+found:
+    rsdt = map_acpi_table(kh, rsdt_pa, PAGESIZE);
+    if (runtime_memcmp(rsdt->h.sig, "RSDT", 4) != 0) {
+        acpi_debug("%s: RSDT has invalid signature\n", __func__);
+        rsdt = 0;
+        goto out;
+    }
+    if (!acpi_checksum(rsdt, rsdt->h.length)) {
+        acpi_debug("%s: RSDT failed checksum", __func__);
+        rsdt = 0;
+        goto out;
+    }
+out:
+    deallocate_u64(vh, va, BIOS_SEARCH_LENGTH);
+    if (rsdt) {
+        acpi_debug("%s: mapped RSDT at %p", __func__, rsdt);
+        return true;
+    } else {
+        acpi_debug("%s: could not find valid RSDT", __func__);
+        return false;
+    }
+}
+
+void acpi_walk_madt(acpi_madt madt, madt_handler mh)
+{
+    u8 *p = (u8 *)(madt + 1);
+    u8 *pe = (u8 *)madt + madt->h.length;
+    for (; p < pe; p += p[1])
+        apply(mh, p[0], p);
+}
+
+void *acpi_get_table(u32 sig)
+{
+    return table_find(acpi_tables, pointer_from_u64((u64)sig));
+}
+
 void init_acpi(kernel_heaps kh)
 {
     heap h = heap_general(kh);
     register_pci_driver(closure(h, piix4acpi_probe, h));
+    acpi_tables = allocate_table(h, identity_key, pointer_equal);
+    if (find_rsdt(kh)) {
+        u32 *t, *te;
+        t = (u32 *)(rsdt + 1);
+        te = pointer_from_u64(u64_from_pointer(rsdt) + rsdt->h.length);
+        for (; t < te; t++) {
+            u32 *tp = map_acpi_table(kh, *t, PAGESIZE);
+            table_set(acpi_tables, pointer_from_u64((u64)*tp), tp);
+            acpi_debug("%s: mapped acpi table %.4s at %p", __func__, tp, tp);
+        }
+    }
 }

--- a/src/x86_64/apic.h
+++ b/src/x86_64/apic.h
@@ -65,6 +65,7 @@ boolean init_lapic_timer(clock_timer *ct, thunk *per_cpu_init);
 void apic_ipi(u32 target, u64 flags, u8 vector);
 void apic_per_cpu_init(void);
 void apic_enable(void);
+int cpuid_from_apicid(u8 aid);
 
 void ioapic_set_int(unsigned int gsi, u64 v);
 boolean ioapic_int_is_free(unsigned int gsi);

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -3,6 +3,7 @@
 #include <region.h>
 #include <apic.h>
 #include <symtab.h>
+#include <drivers/acpi.h>
 
 //#define INT_DEBUG
 #ifdef INT_DEBUG
@@ -341,6 +342,9 @@ void init_interrupts(kernel_heaps kh)
 {
     heap general = heap_general(kh);
     cpuinfo ci = current_cpu();
+
+    /* Read ACPI tables for MADT access */
+    init_acpi_tables(kh);
 
     /* Exception handlers */
     handlers = allocate_zero(general, n_interrupt_vectors * sizeof(thunk));

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -106,7 +106,9 @@ static inline void wait_for_interrupt(void)
 }
 
 void triple_fault(void) __attribute__((noreturn));
-void start_cpu(heap stackheap, int index, void (*ap_entry)());
+void start_cpu(int index);
+void allocate_apboot(heap stackheap, void (*ap_entry)());
+void deallocate_apboot(heap stackheap);
 void install_idt(void);
 
 #define IST_EXCEPTION 1

--- a/src/x86_64/mp.c
+++ b/src/x86_64/mp.c
@@ -4,7 +4,6 @@
 #include <apic.h>
 
 static void *apboot = INVALID_ADDRESS;
-extern int apic_id_map[MAX_CPUS];
 extern u8 apinit, apinit_end;
 extern void *ap_pagetable, *ap_idt_pointer, *ap_stack;
 void *ap_stack;
@@ -47,8 +46,8 @@ static void __attribute__((noinline)) ap_new_stack()
 
     u64 id = apic_id();
     mp_debug_u64(id);
-    int cid = fetch_and_add(&total_processors, 1);
-    apic_id_map[cid] = id;
+    int cid = cpuid_from_apicid(id);
+    fetch_and_add(&total_processors, 1);
     cpu_init(cid);
     cpuinfo ci = current_cpu();
 
@@ -68,38 +67,43 @@ static void __attribute__((noinline)) ap_new_stack()
 void ap_start()
 {
     apic_per_cpu_init();
-    int id = 0;
-    for (int i = 0, aid = apic_id(); i < MAX_CPUS; i++) {
-        if (aid == apic_id_map[i]) {
-            id = i;
-            break;
-        }
-    }
+    int id = cpuid_from_apicid(apic_id());
     switch_stack(stack_from_kernel_context(get_kernel_context(cpuinfo_from_id(id))), ap_new_stack);
 }
 
-void start_cpu(heap stackheap, int index, void (*ap_entry)()) {
-    if (apboot == INVALID_ADDRESS) {
-        start_callback = ap_entry;
-        apboot = pointer_from_u64(AP_BOOT_START);
-        map((u64)apboot, (u64)apboot, PAGESIZE,
-            pageflags_writable(pageflags_exec(pageflags_memory())));
+void allocate_apboot(heap stackheap, void (*ap_entry)())
+{
+    start_callback = ap_entry;
+    apboot = pointer_from_u64(AP_BOOT_START);
+    map((u64)apboot, (u64)apboot, PAGESIZE,
+        pageflags_writable(pageflags_exec(pageflags_memory())));
 
-        asm("sidt %0": "=m"(ap_idt_pointer));
-        mov_from_cr("cr3", ap_pagetable);
-        // just one function call
+    asm("sidt %0": "=m"(ap_idt_pointer));
+    mov_from_cr("cr3", ap_pagetable);
+    // just one function call
 
-        void *rsp = allocate_stack(stackheap, 4 * PAGESIZE);
-        ap_stack = rsp;
+    void *rsp = allocate_stack(stackheap, 4 * PAGESIZE);
+    ap_stack = rsp;
 
-        runtime_memcpy(apboot, &apinit, &apinit_end - &apinit);
-    }
+    runtime_memcpy(apboot, &apinit, &apinit_end - &apinit);
+}
 
+void deallocate_apboot(heap stackheap)
+{
+    deallocate_stack(stackheap, 4 * PAGESIZE, ap_stack);
+    unmap((u64)apboot, PAGESIZE);
+}
+
+#define AP_START_TIMEOUT_MS 200
+void start_cpu(int index) {
     u8 vector = (((u64)apboot) >> 12) & 0xff;
+
+    int nproc = total_processors;
     apic_ipi(index, ICR_TYPE_INIT, 0);
-    kernel_delay(microseconds(10));
+    kernel_delay(milliseconds(10));
     apic_ipi(index, ICR_TYPE_STARTUP, vector);
     kernel_delay(microseconds(200));
     apic_ipi(index, ICR_TYPE_STARTUP, vector);
-    kernel_delay(microseconds(200));    
+    for (u64 to = 0; total_processors != nproc + 1 && to < AP_START_TIMEOUT_MS; to++)
+        kernel_delay(milliseconds(1));
 }


### PR DESCRIPTION
This PR adds support for finding and mapping in the ACPI tables and then using the MADT to discover APIC information including the number of processors in the system (stored in present_processors) and how they map to LAPIC IDs. Each ACPI table is mapped individually as they may not be laid out in a contiguous fashion. AP startup has also changed to use the information from the MADT so now the APs are started one at a time with a unicast IPI instead of broadcast. There are some other minor fixes such as unmapping the apboot memory (which is at virtual address of 0) after AP startup so that null pointer derefs will page fault properly, updating the deallocate_stack function to take the same pointer as returned by allocate_stack, and fixing one of the wait times in AP startup to match the MP spec.