### PR TITLE
Klibs: radar: add sending of disk space utilization metrics 

### DIFF
--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -223,7 +223,6 @@ closure_function(1, 3, void, attach_storage,
     } else {
         rootfs_init(0, offset, r, w, length);
     }
-    closure_finish();
 }
 
 void kernel_runtime_init(kernel_heaps kh)

--- a/src/kernel/storage.c
+++ b/src/kernel/storage.c
@@ -239,3 +239,16 @@ tuple storage_get_mountpoint(tuple root)
     storage_unlock();
     return mount_dir;
 }
+
+void storage_iterate(volume_handler vh)
+{
+    apply(vh, 0, "root", storage.root_fs);
+    storage_lock();
+    list_foreach(&storage.volumes, e) {
+        volume v = struct_from_list(e, volume, l);
+        if (v->fs)
+            apply(vh, v->uuid, v->label, v->fs);
+    }
+    storage_unlock();
+}
+KLIB_EXPORT(storage_iterate);

--- a/src/runtime/extra_prints.c
+++ b/src/runtime/extra_prints.c
@@ -43,6 +43,7 @@ void print_uuid(buffer b, u8 *uuid)
     for (int i = 10; i < 16; i++)
         bprintf(b, "%02x", uuid[i]);
 }
+KLIB_EXPORT(print_uuid);
 
 /* just a little tool for debugging */
 void print_csum_buffer(buffer s, buffer b)

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -257,6 +257,14 @@ static inline boolean set_area(id_heap i, u64 base, u64 length, boolean validate
     boolean fail = false;
     rmnode_handler nh = stack_closure(set_intersection, q, &fail, validate, allocate);
     boolean result = rangemap_range_lookup(i->ranges, q, nh);
+    if (validate && !fail) {
+        if (allocate) {
+            i->allocated += length;
+        } else {
+            assert(i->allocated >= length);
+            i->allocated -= length;
+        }
+    }
     return result && !fail;
 }
 

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -70,3 +70,6 @@ void storage_sync(status_handler sh);
 
 struct filesystem *storage_get_fs(tuple root);
 tuple storage_get_mountpoint(tuple root);
+
+typedef closure_type(volume_handler, void, u8 *, const char *, struct filesystem *);
+void storage_iterate(volume_handler vh);

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -1239,11 +1239,19 @@ u64 fs_blocksize(filesystem fs)
 {
     return U64_FROM_BIT(fs->blocksize_order);
 }
+KLIB_EXPORT(fs_blocksize);
 
 u64 fs_totalblocks(filesystem fs)
 {
     return fs->storage->total;
 }
+KLIB_EXPORT(fs_totalblocks);
+
+u64 fs_usedblocks(filesystem fs)
+{
+    return fs->storage->allocated;
+}
+KLIB_EXPORT(fs_usedblocks);
 
 u64 fs_freeblocks(filesystem fs)
 {

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -105,6 +105,7 @@ tuple filesystem_getroot(filesystem fs);
 
 u64 fs_blocksize(filesystem fs);
 u64 fs_totalblocks(filesystem fs);
+u64 fs_usedblocks(filesystem fs);
 u64 fs_freeblocks(filesystem fs);
 
 extern const char *gitversion;


### PR DESCRIPTION
Disk space usage data are sent to the same server endpoint (/api/v1/machine-stats) as used for memory usage data, and with the same periodicity (i.e. 5 minutes). The JSON string sent to the endpoint now contains an additional "diskUsage" attribute, whose value is an array of JSON objects (one for each disk mounted by the instance); each array element contains 3 attributes:
- "volume": a string that identifies the volume; for the root volume, the string value is "root"; for any additional volumes, the string value is the volume label if present, or the volume UUID if the label is not present
- "used": the number of bytes used by the filesystem (file contents and meta-data) in the volume
- "total": the total number of bytes in the storage space of the volume, i.e. the upper limit for the "used" attribute value

Example of a JSON string containing both memory and disk usage data:
```
"{"bootID":1,"memUsed":[112705536,112705536,112705536,112705536,
112705536],"diskUsage":[{"volume":"root","used":10438656,"total":
12582912},{"volume":"mnt","used":107836416,"total":232783872}]}"
```
In the above example, the root volume usage is ~10 MB out of a total of ~12 MB, and there is an additional volume, labeled "mnt", whose filesystem occupies ~107 MB out of ~230 MB.

Example of a substring representing a volume without a label, which is thus identified by its UUID:
```
{"volume":"2375a5a1-2d36-15cf-ea6b-2fa01df2ccde","used":524800,
"total":5248000}
```