### PR TITLE
Stop and prevent user threads from running on exit 

### DIFF
--- a/src/aarch64/interrupt.c
+++ b/src/aarch64/interrupt.c
@@ -223,7 +223,7 @@ void irq_handler(void)
     int_debug("%s: enter\n", __func__);
 
     /* re-enqueue interrupted user thread */
-    if (ci->state == cpu_user) {
+    if (ci->state == cpu_user && !shutting_down) {
         int_debug("int sched %F\n", f[FRAME_RUN]);
         schedule_frame(f);
     }

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -245,7 +245,7 @@ extern vector shutdown_completions;
 typedef closure_type(shutdown_handler, void, int, merge);
 extern int shutdown_vector;
 extern boolean shutting_down;
-void wakeup_cpu_all();
+void wakeup_or_interrupt_cpu_all();
 
 typedef closure_type(halt_handler, void, int);
 extern halt_handler vm_halt;

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -244,6 +244,8 @@ void detect_devices(kernel_heaps kh, storage_attach sa);
 extern vector shutdown_completions;
 typedef closure_type(shutdown_handler, void, int, merge);
 extern int shutdown_vector;
+extern boolean shutting_down;
+void wakeup_cpu_all();
 
 typedef closure_type(halt_handler, void, int);
 extern halt_handler vm_halt;

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -117,12 +117,15 @@ NOTRACE void __attribute__((noreturn)) kernel_sleep(void)
     }
 }
 
-void wakeup_cpu_all()
+void wakeup_or_interrupt_cpu_all()
 {
     cpuinfo ci = current_cpu();
-    for (int i = 0; i < total_processors; i++)
-        if (i != ci->id)
+    for (int i = 0; i < total_processors; i++) {
+        if (i != ci->id) {
+            atomic_clear_bit(&idle_cpu_mask, i);
             send_ipi(i, wakeup_vector);
+        }
+    }
 }
 
 static void wakeup_cpu(u64 cpu)

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -117,6 +117,14 @@ NOTRACE void __attribute__((noreturn)) kernel_sleep(void)
     }
 }
 
+void wakeup_cpu_all()
+{
+    cpuinfo ci = current_cpu();
+    for (int i = 0; i < total_processors; i++)
+        if (i != ci->id)
+            send_ipi(i, wakeup_vector);
+}
+
 static void wakeup_cpu(u64 cpu)
 {
     if (atomic_test_and_clear_bit(&idle_cpu_mask, cpu)) {

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2058,19 +2058,11 @@ void exit(int code)
 
 sysreturn exit_group(int status)
 {
-    thread t;
-    process p = current->p;
-
-    vector v = allocate_vector(heap_general(get_kernel_heaps()), 8);
-    spin_lock(&p->threads_lock);
-    threads_to_vector(current->p, v);
-    spin_unlock(&p->threads_lock);
-
+    /* Set shutting_down to prevent user threads from being scheduled
+     * and then try to interrupt the other cpus back into runloop
+     * so they will idle while running kernel_shutdown */
     shutting_down = true;
     wakeup_or_interrupt_cpu_all();
-    vector_foreach(v, t)
-        exit_thread(t);
-    deallocate_vector(v);
     kernel_shutdown(status);
 }
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2066,8 +2066,10 @@ sysreturn exit_group(int status)
     threads_to_vector(current->p, v);
     spin_unlock(&p->threads_lock);
 
+    shutting_down = true;
+    wakeup_cpu_all();
     vector_foreach(v, t)
-            exit_thread(t);
+        exit_thread(t);
     deallocate_vector(v);
     kernel_shutdown(status);
 }
@@ -2328,6 +2330,8 @@ static boolean debugsyscalls;
 
 void syscall_debug(context f)
 {
+    if (shutting_down)
+        goto out;
     u64 call = f[FRAME_VECTOR];
     thread t = pointer_from_u64(f[FRAME_THREAD]);
     u64 arg0 = f[SYSCALL_FRAME_ARG0]; /* aliases retval on arm; cache arg */

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2067,7 +2067,7 @@ sysreturn exit_group(int status)
     spin_unlock(&p->threads_lock);
 
     shutting_down = true;
-    wakeup_cpu_all();
+    wakeup_or_interrupt_cpu_all();
     vector_foreach(v, t)
         exit_thread(t);
     deallocate_vector(v);

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -215,7 +215,7 @@ void common_handler()
               f, f[FRAME_RIP], f[FRAME_CR2]);
 
     /* enqueue an interrupted user thread, unless the page fault handler should take care of it */
-    if (ci->state == cpu_user && i >= INTERRUPT_VECTOR_START) {
+    if (ci->state == cpu_user && i >= INTERRUPT_VECTOR_START && !shutting_down) {
         int_debug("int sched %F\n", f[FRAME_RUN]);
         schedule_frame(f);
     }


### PR DESCRIPTION
In SMP, user threads may still be running on cpus other than the one calling
exit_group. A boolean, shutting_down, is used by runloop and interrupt
handlers to know to skip any user thread scheduling steps. This now gets set
in exit_group, followed by a no-op interrupt to send the cpus back into
runloop where they can no longer schedule user threads and will idle while
shutdown completes.