### PR TITLE
fix build under gcc 10

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -90,7 +90,7 @@ LCOV=		lcov
 GENHTML=	genhtml
 
 CFLAGS+=	-std=gnu11 -O3 -g
-CFLAGS+=	-Wall -Werror -Wno-char-subscripts
+CFLAGS+=	-Wall -Werror -Wno-char-subscripts -Wno-format-truncation -Wno-unknown-warning-option
 CFLAGS+=	-I$(OBJDIR)
 
 DEPFLAGS=	-MD -MP -MT $@

--- a/src/hyperv/vmbus/vmbus_reg.h
+++ b/src/hyperv/vmbus/vmbus_reg.h
@@ -69,7 +69,7 @@ CTASSERT(sizeof(struct vmbus_message) == VMBUS_MSG_SIZE);
 
 struct vmbus_evtflags {
 	u64		evt_flags[VMBUS_EVTFLAGS_MAX];
-} __packed;
+};
 CTASSERT(sizeof(struct vmbus_evtflags) == VMBUS_EVTFLAGS_SIZE);
 
 /*
@@ -79,7 +79,7 @@ CTASSERT(sizeof(struct vmbus_evtflags) == VMBUS_EVTFLAGS_SIZE);
 struct vmbus_mon_trig {
 	uint32_t	mt_pending;
 	uint32_t	mt_armed;
-} __packed;
+};
 
 #define VMBUS_MONTRIGS_MAX	4
 #define VMBUS_MONTRIG_LEN	32
@@ -97,7 +97,7 @@ struct vmbus_mnf {
 	struct hyperv_mon_param
 			mnf_param[VMBUS_MONTRIGS_MAX][VMBUS_MONTRIG_LEN];
 	uint8_t		mnf_rsvd4[1984];
-} __packed;
+};
 CTASSERT(sizeof(struct vmbus_mnf) == PAGESIZE);
 
 /*

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -882,7 +882,7 @@ static sysreturn mmap(void *addr, u64 length, int prot, int flags, int fd, u64 o
 
     u64 vmap_mmap_type;
     u32 allowed_flags;
-    fdesc desc;
+    fdesc desc = 0;
     if (flags & MAP_ANONYMOUS) {
         vmap_mmap_type = VMAP_MMAP_TYPE_ANONYMOUS;
         allowed_flags = anon_perms(p);

--- a/src/vmware/pvscsi.c
+++ b/src/vmware/pvscsi.c
@@ -400,7 +400,7 @@ closure_function(1, 0, void, intr_handler,
     pvscsi_process_cmp_ring(dev);
 }
 
-static void *pvscsi_ring_alloc(heap h, int num_pages, u64 *ppn_list)
+static void *pvscsi_ring_alloc(heap h, int num_pages, void *ppn_list)
 {
     // allocate ring memory
     void *ring = allocate_zero(h, num_pages * PAGESIZE);
@@ -413,8 +413,10 @@ static void *pvscsi_ring_alloc(heap h, int num_pages, u64 *ppn_list)
 
     // fill physical page numbers list
     u64 ppn = phys >> PAGELOG;
-    for (int i = 0; i < num_pages; i++)
-        ppn_list[i] = ppn + i;
+    for (int i = 0; i < num_pages; i++, ppn++) {
+        // possibly unaligned
+        runtime_memcpy(((u64*)ppn_list) + i, &ppn, sizeof(ppn));
+    }
 
     return ring;
 }

--- a/test/runtime/signal.c
+++ b/test/runtime/signal.c
@@ -502,11 +502,6 @@ static inline unsigned long get_fault_address(ucontext_t *context)
     return context->uc_mcontext.gregs[REG_CR2];
 }
 
-static inline unsigned long get_pc(ucontext_t *context)
-{
-    return context->uc_mcontext.gregs[REG_RIP];
-}
-
 static inline void set_pc(ucontext_t *context, unsigned long pc)
 {
     context->uc_mcontext.gregs[REG_RIP] = pc;
@@ -517,11 +512,6 @@ static inline void set_pc(ucontext_t *context, unsigned long pc)
 static inline unsigned long get_fault_address(ucontext_t *context)
 {
     return context->uc_mcontext.fault_address;
-}
-
-static inline unsigned long get_pc(ucontext_t *context)
-{
-    return context->uc_mcontext.pc;
 }
 
 static inline void set_pc(ucontext_t *context, unsigned long pc)


### PR DESCRIPTION
Rather than specify -Wno-address-of-packed-member to gcc, use runtime_memcpy to make safe accesses of possibly unaligned data. Remove the packed attribute for structs where 32 and 64-bit fields are already aligned.

Also, specify -Wno-unknown-warning-option to gcc to avoid warnings about possibly truncated string output.