### PR TITLE
kernel_shutdown(): fix stall when called from interrupt context

### DIFF
--- a/src/aarch64/kernel_machine.c
+++ b/src/aarch64/kernel_machine.c
@@ -1,4 +1,5 @@
 #include <kernel.h>
+#include <gic.h>
 
 //#define TAG_HEAP_DEBUG
 #ifdef TAG_HEAP_DEBUG
@@ -67,4 +68,9 @@ void init_cpuinfo_machine(cpuinfo ci, heap backed)
 void clone_frame_pstate(context dest, context src)
 {
     runtime_memcpy(dest, src, sizeof(u64) * FRAME_N_PSTATE);
+}
+
+void interrupt_exit(void)
+{
+    gic_eoi(gic_dispatch_int());
 }

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -356,6 +356,11 @@ void __attribute__((noreturn)) kernel_shutdown(int status)
             vector_foreach(shutdown_completions, h)
                 enqueue_irqsafe(runqueue,
                                 closure(locked, do_shutdown_handler, h, status, m));
+            cpuinfo ci = current_cpu();
+            if (ci->state == cpu_interrupt) {
+                interrupt_exit();
+                get_running_frame(ci)[FRAME_FULL] = false;
+            }
         }
         runloop();
     }

--- a/src/x86_64/kernel_machine.c
+++ b/src/x86_64/kernel_machine.c
@@ -7,6 +7,11 @@ void send_ipi(u64 cpu, u8 vector)
     apic_ipi(cpu, 0, vector);
 }
 
+void interrupt_exit(void)
+{
+    lapic_eoi();
+}
+
 heap allocate_tagged_region(kernel_heaps kh, u64 tag)
 {
     heap h = heap_general(kh);


### PR DESCRIPTION
If kernel_shutdown() is called from interrupt context, it should exit this context before calling runloop(), otherwise if a shutdown handler needs interrupts to work (e.g. for flushing filesystem data to disk), the handler will never complete because pending interrupts will not be processed.
This change implements interrupt_exit() for both x86_64 and aarch64, and adds a call to interrupt_exit() from kernel_shutdown().