### PR TITLE
Add support for Oracle VM Virtualbox

### DIFF
--- a/platform/pc/pci.c
+++ b/platform/pc/pci.c
@@ -1,4 +1,5 @@
 #include <kernel.h>
+#include <apic.h>
 #include <pci.h>
 #include <io.h>
 
@@ -148,7 +149,12 @@ void pci_bar_write_8(struct pci_bar *b, u64 offset, u64 val)
 
 void pci_setup_non_msi_irq(pci_dev dev, int idx, thunk h, const char *name)
 {
-    halt("%s: need platform pci irq mappings\n", __func__);
+    pci_plat_debug("%s: idx %d, h %F, name %s\n", __func__, idx, h, name);
+
+    /* For maximum portability, the GSI should be retrieved via the ACPI _PRT method. */
+    unsigned int gsi = pci_cfgread(dev, PCIR_INTERRUPT_LINE, 1);
+
+    ioapic_register_int(gsi, h, name);
 }
 
 void pci_platform_init_bar(pci_dev dev)

--- a/src/drivers/ata.c
+++ b/src/drivers/ata.c
@@ -350,6 +350,10 @@ boolean ata_probe(struct ata *dev)
     dev->irq_enabled = false;
 
     // identify
+    if (ata_wait(dev, 0) < 0) {
+        msg_err("drive busy\n");
+        return false;
+    }
     ata_out8(dev, ATA_COMMAND, ATA_ATA_IDENTIFY);
     if (ata_wait(dev, ATA_S_READY | ATA_S_DRQ) < 0) {
         ata_debug("%s: IDENTIFY timeout\n", __func__);

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -209,6 +209,9 @@ boolean reserve_interrupt(u64 irq);
 void register_interrupt(int vector, thunk t, const char *name);
 void unregister_interrupt(int vector);
 
+u64 allocate_shirq(void);
+void register_shirq(int vector, thunk t, const char *name);
+
 void kern_lock(void);
 boolean kern_try_lock(void);
 void kern_unlock(void);

--- a/src/kernel/pci.h
+++ b/src/kernel/pci.h
@@ -13,6 +13,8 @@
 #define PCICAP_ID       0x0
 #define PCICAP_NEXTPTR  0x1
 
+#define PCIR_INTERRUPT_LINE 0x3C
+
 /* PCI config register */
 #define PCIR_VENDOR     0x00
 #define PCIR_DEVICE     0x02

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -65,6 +65,7 @@ struct _closure_common {
 
 #define bound(v) (__self->v)
 #define closure_self() (&(__self->__apply))
+#define closure_member(name, var, member)   ((struct _closure_##name *)(var))->member
 
 /* XXX type safety, possibly tag */
 static inline void deallocate_closure(void *p)

--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -33,6 +33,9 @@ typedef closure_type(vqfinish, void, u64);
  */
 #define VIRTIO_F_NOTIFY_ON_EMPTY U64_FROM_BIT(24)
 
+/* Arbitrary descriptor layouts. */
+#define VIRTIO_F_ANY_LAYOUT     U64_FROM_BIT(27)
+
 /* Support for indirect buffer descriptors. */
 #define VIRTIO_F_RING_INDIRECT_DESC	U64_FROM_BIT(28)
 
@@ -75,6 +78,11 @@ typedef struct vtdev {
 u32 vtdev_cfg_read_4(vtdev dev, u64 offset);
 void vtdev_cfg_read_mem(vtdev dev, void *dest, bytes len);
 void vtdev_set_status(vtdev dev, u8 status);
+
+static inline boolean vtdev_is_modern(vtdev dev)
+{
+    return (dev->features & VIRTIO_F_VERSION_1) != 0;
+}
 
 static inline void virtio_attach(heap h, backed_heap page_allocator,
                                  enum vtio_transport transport, vtdev d)

--- a/src/virtio/virtio_pci.c
+++ b/src/virtio/virtio_pci.c
@@ -178,7 +178,7 @@ void vtpci_set_status(vtpci dev, u8 status)
 
 boolean vtpci_is_modern(vtpci dev)
 {
-    return (dev->virtio_dev.features & VIRTIO_F_VERSION_1) != 0;
+    return vtdev_is_modern(&dev->virtio_dev);
 }
 
 static void vtpci_modern_write_8(struct pci_bar *b, bytes offset, u64 val)

--- a/src/x86_64/acpi.c
+++ b/src/x86_64/acpi.c
@@ -75,11 +75,9 @@ closure_function(1, 1, boolean, piix4acpi_probe,
     if (dev == INVALID_ADDRESS)
         return false;
     dev->d = d;
-    u64 irq = allocate_interrupt();
-    assert(irq != INVALID_PHYSICAL);
-    acpi_debug("%s: irq %d", __func__, irq);
-    register_interrupt(irq, init_closure(&dev->irq_handler, piix4acpi_irq, dev), "PIIX4 ACPI");
-    ioapic_set_int(ACPI_SCI_IRQ, irq);
+    acpi_debug("%s", __func__);
+    ioapic_register_int(ACPI_SCI_IRQ, init_closure(&dev->irq_handler, piix4acpi_irq, dev),
+                        "PIIX4 ACPI");
     pci_bar_init(dev->d, &dev->pm_bar, PIIX4ACPI_PM_BAR, 0, 0);
     pci_cfgwrite(dev->d, PIIX4ACPI_PMREGMISC_R, 1, PIIX4ACPI_PMIOSE);
     pci_bar_write_2(&dev->pm_bar, ACPI_PM1_EN, ACPI_PM1_PWRBTN_EN);

--- a/src/x86_64/apic.h
+++ b/src/x86_64/apic.h
@@ -69,6 +69,7 @@ int cpuid_from_apicid(u8 aid);
 
 void ioapic_set_int(unsigned int gsi, u64 v);
 boolean ioapic_int_is_free(unsigned int gsi);
+void ioapic_register_int(unsigned int gsi, thunk h, const char *name);
 
 extern apic_iface apic_if;
 

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -195,6 +195,10 @@ struct cpuinfo_machine {
 
     /* Stack for interrupts */
     void *int_stack;
+
+    /* Monotonic clock timestamp when the lapic timer is supposed to fire; used to re-arm the timer
+     * when it fires too early (based on what the monotonic clock source says). */
+    timestamp lapic_timer_expiry;
 };
 
 typedef struct cpuinfo *cpuinfo;


### PR DESCRIPTION
To create a virtual hard disk file (vdi file format) for VirtualBox from a raw image, the following command can be used:
```
vboxmanage convertdd disk.raw disk.vdi
```
When creating a virtual machine from the VirtualBox GUI:
- select "Other" as OS type, and "Other/Unknown (64-bit)" as OS version
- specify at least 256 MB as memory size
- select the vdi file created above as hard disk image

After creating the virtual machine, modify the following settings:
- System -> Acceleration -> Paravirtualization Interface: select "KVM"
- Network -> Adapter 1 -> Advanced -> Adapter Type: select "Paravirtualized Network (virtio-net)"

Tested with VirtualBox version 6.1.18.
Closes #1400.