### PR TITLE
Go tests: replace ops/config package import with ops/types

### DIFF
--- a/test/go/common.go
+++ b/test/go/common.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nanovms/ops/config"
 	"github.com/nanovms/ops/qemu"
+	"github.com/nanovms/ops/types"
 )
 
-func defaultConfig() config.Config {
-	var c config.Config
+func defaultConfig() types.Config {
+	var c types.Config
 
 	c.Boot = "../../output/test/go/boot.img"
 	c.Kernel = "../../output/test/go/kernel.img"
@@ -47,7 +47,7 @@ func sortString(s string) string {
 
 const START_WAIT_TIMEOUT = time.Second * 30
 
-func runAndWaitForString(rconfig *config.RunConfig, timeout time.Duration, text string, t *testing.T) qemu.Hypervisor {
+func runAndWaitForString(rconfig *types.RunConfig, timeout time.Duration, text string, t *testing.T) qemu.Hypervisor {
 	hypervisor := qemu.HypervisorInstance()
 	if hypervisor == nil {
 		t.Fatal("No hypervisor found on $PATH")

--- a/test/go/go_test.go
+++ b/test/go/go_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nanovms/ops/config"
 	"github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/types"
 )
 
 func writeFile(path string) {
@@ -47,7 +47,7 @@ func prepareTestImage(finalImage string) {
 func TestArgsAndEnv(t *testing.T) {
 	const finalImage = "image"
 	prepareTestImage(finalImage)
-	rconfig := config.RuntimeConfig(finalImage, []string{"8080"}, true)
+	rconfig := types.RuntimeConfig(finalImage, []string{"8080"}, true)
 	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
 	defer hypervisor.Stop()
 
@@ -82,7 +82,7 @@ func TestArgsAndEnv(t *testing.T) {
 func TestFileSystem(t *testing.T) {
 	const finalImage = "image"
 	prepareTestImage(finalImage)
-	rconfig := config.RuntimeConfig(finalImage, []string{"8080"}, true)
+	rconfig := types.RuntimeConfig(finalImage, []string{"8080"}, true)
 	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
 	defer hypervisor.Stop()
 
@@ -101,7 +101,7 @@ func TestFileSystem(t *testing.T) {
 }
 
 func validateResponse(t *testing.T, finalImage string, expected string) {
-	rconfig := config.RuntimeConfig(finalImage, []string{"8080"}, true)
+	rconfig := types.RuntimeConfig(finalImage, []string{"8080"}, true)
 	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
 	defer hypervisor.Stop()
 
@@ -130,7 +130,7 @@ func TestInstancePersistence(t *testing.T) {
 func TestHTTP(t *testing.T) {
 	const finalImage = "image"
 	prepareTestImage(finalImage)
-	rconfig := config.RuntimeConfig(finalImage, []string{"8080"}, true)
+	rconfig := types.RuntimeConfig(finalImage, []string{"8080"}, true)
 	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
 	defer hypervisor.Stop()
 

--- a/test/go/node_test.go
+++ b/test/go/node_test.go
@@ -9,12 +9,12 @@ import (
 	"path"
 	"testing"
 
-	"github.com/nanovms/ops/config"
+	"github.com/nanovms/ops/types"
 	api "github.com/nanovms/ops/lepton"
 )
 
-func unWarpConfig(file string) *config.Config {
-	var c config.Config
+func unWarpConfig(file string) *types.Config {
+	var c types.Config
 	if file != "" {
 		data, err := ioutil.ReadFile(file)
 		if err != nil {


### PR DESCRIPTION
The "config" package has been renamed to "types" in ops.