### PR TITLE
exec_elf(): allow changing access protections for program sections

### DIFF
--- a/test/runtime/mmap.c
+++ b/test/runtime/mmap.c
@@ -779,6 +779,14 @@ void mprotect_test(void)
     }
 
     __munmap(addr, 5 * PAGESIZE);
+
+    addr = (u8 *)round_down_page(mprotect_test);
+    if (mprotect(addr, PAGESIZE, PROT_WRITE) == 0) {
+        fprintf(stderr, "%s: could enable write access to program code\n", __func__);
+        exit(EXIT_FAILURE);
+    } else if (errno != EACCES) {
+        handle_err("mprotect(PROT_WRITE): unexpected error");
+    }
 }
 
 const unsigned char test_sha[2][32] = {


### PR DESCRIPTION
In Linux it is permissible to call mprotect() on an address mapped from a program's ELF sections. In particular, mprotect() can be used to change a code section to be writable.
The .NET runtime, as of version 5.0.102, relies on this feature, and errors out with `Failed to create CoreCLR, HRESULT: 0x80004005` if unable to change the access protections of a mapping (https://github.com/nanovms/ops-examples/issues/47).
This commit changes exec_elf() to allow read, write and exec access to all the program sections loaded from the ELF file, unless the exec_protection manifest flag is present.
A new test case has been added to the mmap test suite, to check that write access cannot be enabled on the code section of a program when the exec_protection manifest option is present.