### PR TITLE
Always invalidate pages on pagetable additions

### DIFF
--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -183,6 +183,8 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
                 queue_length(bhqueue), queue_length(runqueue), queue_length(ci->thread_queue),
                 idle_cpu_mask, ci->have_kernel_lock ? " locked" : "");
     ci->state = cpu_kernel;
+    /* Make sure TLB entries are appropriately flushed before doing any work */
+    page_invalidate_flush();
 
     /* bhqueue is for operations outside the realm of the kernel lock,
        e.g. storage I/O completions */
@@ -247,8 +249,6 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
                     ci->last_timer_update = here + runloop_timer_max;
                 }
             }
-           /* Make sure TLB entries are appropriately flushed before
-             * returning to userspace */
             page_invalidate_flush();
             run_thunk(t, cpu_user);
         }

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -249,7 +249,6 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
                     ci->last_timer_update = here + runloop_timer_max;
                 }
             }
-            page_invalidate_flush();
             run_thunk(t, cpu_user);
         }
     }

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -198,17 +198,17 @@ static void write_pte(u64 target, physical to, u64 flags, boolean * invalidate)
 #endif
 	return;
     }
-    /* invalidate when changing any pte that was marked as present */
-    if (*pteptr & _PAGE_PRESENT) {
+    /* Unconditionally invalidate in case this cpu's TLB is not up-to-date. The
+     * TLB can be outdated in SMP situations where another cpu has marked the
+     * PTE as not present but this cpu hasn't processed the shootdown yet. */
+    *invalidate = true;
 #ifdef PTE_DEBUG
-        rputs("   invalidate, old ");
-        print_u64(*pteptr);
-        rputs(", new ");
-        print_u64(new);
-        rputs("\n");
+    rputs("   invalidate, old ");
+    print_u64(*pteptr);
+    rputs(", new ");
+    print_u64(new);
+    rputs("\n");
 #endif
-	*invalidate = true;
-    }
     *pteptr = new;
 #ifdef PTE_DEBUG
     rputs("\n");


### PR DESCRIPTION
The old code only invalidated pages if the PAGE_PRESENT flag was set in the
PTE, but if the current cpu hasn't processed the tlb shootdown from
another cpu clearing the present flag, the old incorrect translation could
still be in the TLB. This change unconditionally sets invalidate to guarantee
the current cpu does not have any stale entries in the TLB. A second small
change is to move the page_invalidate_flush to the top of runloop to catch
a cpu coming from an interrupt handler that may not have processed a
shootdown yet.