### PR TITLE
Syscalls: stat(): set st_blocks and st_blksize for regular files

### DIFF
--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -43,6 +43,15 @@ void fsfile_set_length(fsfile f, u64 length)
     pagecache_set_node_length(f->cache_node, length);
 }
 
+u64 fsfile_get_blocks(fsfile f)
+{
+    u64 blocks = 0;
+    rangemap_foreach(f->extentmap, n) {
+        blocks += range_span(n->r);
+    }
+    return blocks;
+}
+
 tuple fsfile_get_meta(fsfile f)
 {
     return f->md;

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -57,6 +57,7 @@ void filesystem_set_mtime(filesystem fs, tuple t, timestamp tim);
 
 u64 fsfile_get_length(fsfile f);
 void fsfile_set_length(fsfile f, u64);
+u64 fsfile_get_blocks(fsfile f);    /* returns the number of allocated blocks */
 fsfile fsfile_from_node(filesystem fs, tuple n);
 fsfile file_lookup(filesystem fs, vector v);
 void filesystem_read_entire(filesystem fs, tuple t, heap bufheap, buffer_handler c, status_handler s);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1397,8 +1397,11 @@ static void fill_stat(int type, filesystem fs, tuple n, struct stat *s)
     s->st_ino = u64_from_pointer(n);
     if (type == FDESC_TYPE_REGULAR) {
         fsfile f = fsfile_from_node(fs, n);
-        if (f)
+        if (f) {
             s->st_size = fsfile_get_length(f);
+            s->st_blocks = fsfile_get_blocks(f);
+        }
+        s->st_blksize = PAGESIZE;   /* "preferred" block size for efficient filesystem I/O */
     }
     if (n) {
         struct timespec ts;

--- a/test/runtime/write.c
+++ b/test/runtime/write.c
@@ -89,6 +89,18 @@ void basic_write_test()
         printf("basic write fail: string mismatch\n");
         exit(EXIT_FAILURE);
     }
+
+    struct stat s;
+    rv = fstat(fd, &s);
+    if (rv < 0) {
+        perror("stat");
+        goto out_fail;
+    }
+    if (s.st_blocks < 1) {
+        printf("invalid number of allocated blocks: %ld\n", s.st_blocks);
+        goto out_fail;
+    }
+
     close(fd);
     writetest_debug("basic write test passed\n");
     return;


### PR DESCRIPTION
st_blocks contains the number of 512-byte blocks allocated for a file, while st_blocksize contains the "preferred" block size for efficient filesystem I/O.