### PR TITLE
x86_64: implement TSC calibration using PIT

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -462,6 +462,7 @@ void init_service(u64 rdi, u64 rsi)
 }
 
 extern boolean init_hpet(kernel_heaps kh);
+extern boolean init_tsc_timer(kernel_heaps kh);
 
 void detect_hypervisor(kernel_heaps kh)
 {
@@ -470,9 +471,12 @@ void detect_hypervisor(kernel_heaps kh)
         if (!xen_detect(kh)) {
             if (!hyperv_detect(kh)) {
                 init_debug("no hypervisor detected; assuming qemu full emulation");
-                if (!init_hpet(kh)) {
-                    halt("HPET initialization failed; no timer source\n");
-                }
+                if (init_tsc_timer(kh))
+                    init_debug("using calibrated TSC as timer source");
+                else if (init_hpet(kh))
+                    init_debug("using HPET as timer source");
+                else
+                    halt("timer initialization failed; no timer source");
             } else {
                 init_debug("hyper-v hypervisor detected");
             }

--- a/src/x86_64/clock.c
+++ b/src/x86_64/clock.c
@@ -1,6 +1,11 @@
 #include <kernel.h>
+#include <apic.h>
+#include <io.h>
 
 #define __vdso_dat (&(VVAR_REF(vdso_dat)))
+
+#define PIT_FREQUENCY   1193182ul   /* Hz */
+#define PIT_PERIOD_MSB  nanoseconds(256 * BILLION / PIT_FREQUENCY)
 
 clock_now platform_monotonic_now;
 clock_timer platform_timer;
@@ -13,4 +18,62 @@ void init_clock(void)
     cpuid(0x80000001, 0, regs);
     __vdso_dat->clock_src = VDSO_CLOCK_SYSCALL;
     __vdso_dat->platform_has_rdtscp = (regs[3] & U64_FROM_BIT(27)) != 0;
+}
+
+/* error refers to the time (expressed in TSC cycles) it takes to read the PIT counter value. */
+static boolean pit_wait_msb(u8 msb, u64 *error, u64 *tsc)
+{
+    u64 prev_tsc = 0;
+    int i = 0;
+    for (;;) {
+        *tsc = rdtsc();
+        *error = *tsc - prev_tsc;
+        in8(0x42);  /* LSB, ignored */
+        if (in8(0x42) != msb)
+            break;
+        if (++i > 10000)
+            return false;   /* The PIT is not counting as expected. */
+        prev_tsc = *tsc;
+    }
+    return true;
+}
+
+/* Calibrates the TSC using PIT channel 2. */
+static u64 tsc_calibrate(void)
+{
+    out8(0x61, (in8(0x61) & ~0x02) | 0x01); /* set gate high, disable speaker */
+    out8(0x43, 0xB0);   /* lobyte/hibyte access mode, operating mode 0, binary mode */
+    out8(0x42, 0xFF);   /* set initial count LSB */
+    out8(0x42, 0xFF);   /* set initial count MSB */
+    in8(0x42); in8(0x42);   /* dummy read (LSB/MSB) to ensure the PIT has started counting */
+    u64 start = rdtsc();
+    int i;
+    u64 error, tsc;
+    for (i = 0; i <= 0xFF;) {
+        if (!pit_wait_msb(0xFF - i, &error, &tsc))
+            return 0;
+        i++;
+        if (error < ((tsc - start) >> 11))  /* aim for an error lower than ~500 PPM */
+            break;
+    }
+    timestamp elapsed = i * PIT_PERIOD_MSB;
+    return (elapsed << 32) / (tsc - start);
+}
+
+closure_function(1, 0, timestamp, tsc_now,
+                 u64, scaling)
+{
+    return (((u128)rdtsc()) * bound(scaling)) >> 32;
+}
+
+boolean init_tsc_timer(kernel_heaps kh)
+{
+    u64 tsc_scaling = tsc_calibrate();
+    if (tsc_scaling) {
+        register_platform_clock_now(closure(heap_general(kh), tsc_now, tsc_scaling),
+                                    VDSO_CLOCK_TSC_STABLE);
+        return init_lapic_timer(&platform_timer, &platform_timer_percpu_init);
+    } else {
+        return false;
+    }
 }

--- a/src/x86_64/hpet.c
+++ b/src/x86_64/hpet.c
@@ -197,7 +197,6 @@ boolean init_hpet(kernel_heaps kh) {
 
     u64 femtoperiod = field_from_u64(hpet->capid, HPET_CAPID_COUNTER_CLOCK_PERIOD);
     if ((femtoperiod > HPET_MAXIMUM_INCREMENT_PERIOD) || !femtoperiod) {
-        msg_err("failed to initialize HPET; invalid femtoperiod\n");
         return false;
     }
 


### PR DESCRIPTION
This allows the kernel to run on hypervisors that don't expose a known paravirtualization interface and don't implement the HPET.
The HPET is now used only as a last resort, if the calibrated TSC cannot be used.
The "failed to initialize HPET; invalid femtoperiod" error message, which would appear when probing a non-existing HPET, is being removed because it may no longer be a fatal error.