### PR TITLE
Unify and abstract tfs sector map operations

### DIFF
--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -59,7 +59,9 @@ boolean log_write_eav(log tl, tuple e, symbol a, value v);
 void log_flush(log tl, status_handler completion);
 void log_destroy(log tl);
 void flush(filesystem fs, status_handler);
+u64 filesystem_allocate_storage(filesystem fs, u64 nblocks);
 boolean filesystem_reserve_storage(filesystem fs, range storage_blocks);
+boolean filesystem_free_storage(filesystem fs, range storage_blocks);
 void filesystem_storage_op(filesystem fs, sg_list sg, merge m, range blocks, block_io op);
     
 void filesystem_log_rebuild(filesystem fs, log new_tl, status_handler sh);


### PR DESCRIPTION
Tfs (and tlog) reserve, allocate, and free from the id heap for the sector
map with a few different operations: allocate_u64/deallocate_u64 and
id_heap_set_area, depending on the situation. This can be a problem if
deallocate_u64 is used on a part of the bitmap set by id_heap_set_area
as they might have different alignment requirements. This change adds
a couple new operations for managing the sector heap to go with
filesystem_reserve_storage for allocation and freeing. The free function
uses id_heap_set_area instead of deallocate to note free sectors so
there are no alignment requirements.