### PR TITLE
Refactor cpu state assignment locations

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -186,6 +186,7 @@ define_closure_function(1, 0, void, run_thread,
 {
     thread t = bound(t);
     dispatch_signals(t);
+    current_cpu()->state = cpu_user;
     run_thread_frame(t);
 }
 
@@ -198,6 +199,7 @@ define_closure_function(1, 0, void, pause_thread,
 define_closure_function(1, 0, void, run_sighandler,
                         thread, t)
 {
+    current_cpu()->state = cpu_user;
     run_thread_frame(bound(t));
 }
 


### PR DESCRIPTION
The scheduler was setting the cpu state in run_thunk before calling the
thunk, but this can be a problem if something in the thunk causes a state
change (such as a page fault). This change refactors the state assignment
into the thunks themselves. This means that now the cpu state is set to
user right before the frame return, rather than before performing other
operations such as signal handling. Thunks from the bh and run queue
should be kernel state, which is set by the scheduler upon entry, so the
only thunk update required are the two that will run user code.