### PR TITLE
Configure MSI before allocating resources in attach_vtpci

### DIFF
--- a/src/virtio/virtio_pci.c
+++ b/src/virtio/virtio_pci.c
@@ -337,13 +337,13 @@ vtpci attach_vtpci(heap h, backed_heap page_allocator, pci_dev d, u64 feature_ma
         feature_mask |= VIRTIO_F_VERSION_1;
 
     dev->dev = d;
+    dev->msix_enabled = pci_enable_msix(dev->dev) > 0;
     if (feature_mask & VIRTIO_F_VERSION_1) {
         vtpci_modern_alloc_resources(dev);
     } else {
         vtpci_legacy_alloc_resources(dev);
     }
     pci_set_bus_master(dev->dev);
-    dev->msix_enabled = pci_enable_msix(dev->dev) > 0;
     pci_enable_io_and_memory(dev->dev);
 
     vtpci_set_status(dev, VIRTIO_CONFIG_STATUS_RESET);


### PR DESCRIPTION
The allocation of config resources requires knowing whether or not MSI is
supported in order to initialize with the correct offset.

Fixes nanovms/ops#945