### PR TITLE
Darwin rdtscp workaround

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -295,6 +295,8 @@ VDSO_LDFLAGS+=  -undefined dynamic_lookup
 LD=             x86_64-elf-ld
 OBJDUMP=        x86_64-elf-objdump
 REL_OS=		darwin
+# disable rdtscp as a workaround on mac since it can't pass the instruction through
+# see https://bugs.launchpad.net/qemu/+bug/1894836
 QEMU_ACCEL=	-accel $(ACCEL) -cpu host,-rdtscp
 ACCEL?=		hvf
 else

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -295,7 +295,7 @@ VDSO_LDFLAGS+=  -undefined dynamic_lookup
 LD=             x86_64-elf-ld
 OBJDUMP=        x86_64-elf-objdump
 REL_OS=		darwin
-QEMU_ACCEL=	-accel $(ACCEL) -cpu host
+QEMU_ACCEL=	-accel $(ACCEL) -cpu host,-rdtscp
 ACCEL?=		hvf
 else
 # XXX already defined?


### PR DESCRIPTION
The rdtscp instruction currently causes a crash running in hvf on mac
even though the host cpu supports it. This disables the instruction as a
workaround. According to https://bugs.launchpad.net/qemu/+bug/1894836 
this is a problem with hvf not being able to deal with the instruction, but
qemu still reports it as available in cpuid.

Fixes #1427 