### PR TITLE
reduce kernel image size and footprint

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -1,8 +1,8 @@
 SUBDIR=		boot
 LWIPDIR=	$(VENDORDIR)/lwip
-PROGRAMS=	kernel.img
+PROGRAMS=	kernel.elf
 
-SRCS-kernel.img= \
+SRCS-kernel.elf= \
 	$(CURDIR)/service.c \
 	$(CURDIR)/pci.c \
 	$(OBJDIR)/gitversion.c \
@@ -168,7 +168,7 @@ CFLAGS+=$(INCLUDES)
 # Enable tracing by specifying TRACE=ftrace on command line
 ifeq ($(TRACE),ftrace)
 CFLAGS+= -DCONFIG_FTRACE -pg
-SRCS-kernel.img+= \
+SRCS-kernel.elf+= \
 	$(SRCDIR)/unix/ftrace.c \
 	$(ARCHDIR)/ftrace.s
 endif
@@ -188,9 +188,10 @@ VDSO_CFLAGS=    -DKERNEL -DBUILD_VDSO -I$(INCLUDES) -I$(OBJDIR) -I$(SRCDIR) -fPI
 VDSO_LDFLAGS=   -nostdlib -fPIC -shared --build-id=none --hash-style=both --eh-frame-hdr -T$(ARCHDIR)/vdso.lds
 VDSO_DEPS=      $(patsubst %.o,%.d,$(VDSO_OBJS))
 OBJDUMPFLAGS=	-d -S -M intel-mnemonic
+STRIPFLAGS=	-g
 
 DEPFILES+=      $(VDSO_DEPS)
-CLEANFILES+=    $(foreach f,gitversion.c frame.inc kernel.dis kernel.img src/unix/ftrace.* $(ARCHDIR)/ftrace.*,$(OBJDIR)/$f) $(VDSO_OBJDIR)/vdso.so $(VDSO_OBJDIR)/vdso-image.c $(VDSO_OBJS) $(VDSO_DEPS)
+CLEANFILES+=    $(foreach f,gitversion.c frame.inc kernel.dis kernel.elf src/unix/ftrace.* $(ARCHDIR)/ftrace.*,$(OBJDIR)/$f) $(VDSO_OBJDIR)/vdso.so $(VDSO_OBJDIR)/vdso-image.c $(VDSO_OBJS) $(VDSO_DEPS) $(KERNEL)
 CLEANDIRS+=     $(foreach d,output/platform output src src/aws src/hyperv vdso/src/$(ARCH) vdso/src vdso vendor vendor/lwip vendor/lwip/src platform,$(OBJDIR)/$d)
 
 msg_vdsogen=    VDSOGEN	$@
@@ -229,7 +230,7 @@ mkfs vdsogen:
 boot:
 	$(Q) $(MAKE) -C boot
 
-kernel: $(PROG-kernel.img) $(OBJDIR)/kernel.dis
+kernel: $(KERNEL) $(OBJDIR)/kernel.dis
 
 target:
 ifeq ($(TARGET),)
@@ -264,7 +265,7 @@ release: mkfs boot kernel
 $(VDSOGEN):
 	@$(MAKE) -C $(ROOTDIR)/tools vdsogen
 
-$(OBJDIR)/kernel.dis: $(PROG-kernel.img)
+$(OBJDIR)/kernel.dis: $(PROG-kernel.elf)
 	$(call cmd,objdump)
 
 $(VDSO_OBJDIR)/%.o: $(VDSO_SRCDIR)/%.c
@@ -277,7 +278,10 @@ $(VDSO_OBJDIR)/vdso.so: $(VDSO_OBJS)
 $(VDSO_OBJDIR)/vdso-image.c: $(VDSOGEN) $(VDSO_OBJDIR)/vdso.so
 	$(call cmd,vdsogen)
 
-$(PROG-kernel.img): linker_script $(VDSO_OBJDIR)/vdso-image.c
+$(PROG-kernel.elf): linker_script $(VDSO_OBJDIR)/vdso-image.c
+
+$(KERNEL): $(PROG-kernel.elf)
+	$(call cmd,strip)
 
 $(OBJDIR)/gitversion.c: $(ROOTDIR)/.git/index $(ROOTDIR)/.git/HEAD
 	$(call cmd,version)

--- a/platform/pc/boot/def32.h
+++ b/platform/pc/boot/def32.h
@@ -14,10 +14,6 @@ typedef u32 word;
 #define u64_from_pointer(__a) ((u64)(u32)(__a))
 #define physical_from_virtual(__x) u64_from_pointer(__x)
 
-// a super sad hack to allow us to write to the bss in elf.c as
-// phy instead of virt
-#define vpzero(__v, __p, __s) zero(pointer_from_u64(__p), __s)
-
 static inline void *tag(void *v, u16 tval)
 {
     *((u8 *)v-1) = tval;

--- a/platform/pc/boot/stage2.c
+++ b/platform/pc/boot/stage2.c
@@ -202,7 +202,7 @@ static void setup_page_tables()
 
 static u64 working_saved_base;
 
-closure_function(0, 4, void, kernel_elf_map,
+closure_function(0, 4, u64, kernel_elf_map,
                  u64, vaddr, u64, paddr, u64, size, pageflags, flags)
 {
     stage2_debug("%s: vaddr 0x%lx, paddr 0x%lx, size 0x%lx, flags 0x%lx\n",
@@ -215,6 +215,7 @@ closure_function(0, 4, void, kernel_elf_map,
         zero(pointer_from_u64(paddr), size);
     }
     map(vaddr, paddr, size, flags);
+    return paddr;
 }
 
 closure_function(0, 1, status, kernel_read_complete,

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -1,10 +1,10 @@
 LWIPDIR=	$(VENDORDIR)/lwip
-PROGRAMS=	kernel.img
+PROGRAMS=	kernel.elf
 
 # XXX temp
 WITHOUT_SSP=	1
 
-SRCS-kernel.img= \
+SRCS-kernel.elf= \
 	$(CURDIR)/service.c \
 	$(CURDIR)/pci.c \
 	$(OBJDIR)/gitversion.c \
@@ -131,7 +131,7 @@ CFLAGS+=$(INCLUDES)
 # Enable tracing by specifying TRACE=ftrace on command line
 ifeq ($(TRACE),ftrace)
 CFLAGS+= -DCONFIG_FTRACE -pg
-SRCS-kernel.img+= \
+SRCS-kernel.elf+= \
 	$(SRCDIR)/unix/ftrace.c \
 	$(ARCHDIR)/ftrace.s
 endif
@@ -149,9 +149,10 @@ VDSO_CFLAGS=    -DKERNEL -DBUILD_VDSO -I$(INCLUDES) -I$(OBJDIR) -I$(SRCDIR) -fPI
 VDSO_LDFLAGS=   -nostdlib -fPIC -shared --build-id=none --hash-style=both --eh-frame-hdr -T$(ARCHDIR)/vdso.lds
 VDSO_DEPS=      $(patsubst %.o,%.d,$(VDSO_OBJS))
 OBJDUMPFLAGS=	-d -S
+STRIPFLAGS=	-g
 
 DEPFILES+=      $(VDSO_DEPS)
-CLEANFILES+=    $(foreach f,gitversion.c frame.inc kernel.dis bin/kernel.img src/unix/ftrace.* $(ARCHDIR)/ftrace.*,$(OBJDIR)/$f) $(VDSO_OBJDIR)/vdso.so $(VDSO_OBJDIR)/vdso-image.c $(VDSO_OBJDIR)/vdso-offset.h $(VDSO_OBJS) $(VDSO_DEPS) $(BOOTIMG)
+CLEANFILES+=    $(foreach f,gitversion.c frame.inc kernel.dis bin/kernel.elf src/unix/ftrace.* $(ARCHDIR)/ftrace.*,$(OBJDIR)/$f) $(VDSO_OBJDIR)/vdso.so $(VDSO_OBJDIR)/vdso-image.c $(VDSO_OBJDIR)/vdso-offset.h $(VDSO_OBJS) $(VDSO_DEPS) $(BOOTIMG) $(KERNEL)
 CLEANDIRS+=     $(foreach d,output/platform output src vdso/src/$(ARCH) vdso/src vdso vendor vendor/lwip vendor/lwip/src platform,$(OBJDIR)/$d)
 
 OBJCOPYFLAGS	= -S -O binary
@@ -192,15 +193,12 @@ endif
 
 all: $(KERNEL) kernel.dis
 
-contgen:
+mkfs vdsogen:
 	$(Q) $(MAKE) -C $(ROOTDIR)/tools $@
 
-mkfs vdsogen: contgen
-	$(Q) $(MAKE) -C $(ROOTDIR)/tools $@
+kernel: $(KERNEL) $(OBJDIR)/kernel.dis
 
-kernel: contgen $(KERNEL) $(OBJDIR)/kernel.dis $(KERNEL)
-
-target: contgen
+target:
 ifeq ($(TARGET),)
 	@echo TARGET variable not specified
 	@false
@@ -211,7 +209,7 @@ ifneq ($(NANOS_TARGET_ROOT),)
 TARGET_ROOT_OPT=	-r $(NANOS_TARGET_ROOT)
 endif
 
-image: contgen mkfs kernel target $(BOOTIMG)
+image: mkfs kernel target $(BOOTIMG)
 ifeq ($(IMAGE),)
 	@echo IMAGE variable not specified
 	@false
@@ -250,7 +248,10 @@ $(VDSO_OBJDIR)/vdso-offset.h: $(VDSO_OBJDIR)/vdso.so
 
 $(OBJDIR)/src/$(ARCH)/unix_machine.o: $(VDSO_OBJDIR)/vdso-offset.h
 
-$(KERNEL): linker_script $(VDSO_OBJDIR)/vdso-image.c
+$(PROG-kernel.elf): linker_script $(VDSO_OBJDIR)/vdso-image.c
+
+$(KERNEL): $(PROG-kernel.elf)
+	$(call cmd,strip)
 
 $(OBJDIR)/gitversion.c: $(ROOTDIR)/.git/index $(ROOTDIR)/.git/HEAD
 	$(call cmd,version)

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -368,9 +368,6 @@ static inline void frame_set_sp(context f, u64 sp)
             rv;                                                         \
         })
 
-/* vestige from pc land */
-#define vpzero(__v, __p, __y) zero(pointer_from_u64(__v), __y)
-
 /* IPI */
 static inline void machine_halt(void)
 {

--- a/src/config.h
+++ b/src/config.h
@@ -1,10 +1,9 @@
 /* identity-mapped space for initial page tables */
 #define INITIAL_PAGES_SIZE (64 * KB)
 
-/* the stage2 secondary working heap - this needs to be large enough
-   to accomodate all tfs allocations when loading the kernel - it gets
-   recycled in stage3, so be generous */
-#define STAGE2_WORKING_HEAP_SIZE (128 * MB)
+/* The stage2 working heap needs to be large enough to accomodate all tfs
+   allocations when loading the kernel. It gets recycled on stage3 entry. */
+#define STAGE2_WORKING_HEAP_SIZE (4 * MB)
 
 #define STAGE2_STACK_SIZE  (128 * KB)  /* stage2 stack is recycled, too */
 #define KERNEL_STACK_SIZE  (128 * KB)  /* must match value in crt0.s */

--- a/src/kernel/elf64.h
+++ b/src/kernel/elf64.h
@@ -186,7 +186,8 @@ typedef struct {
     for (int __i = 0; __i< __e->e_shnum; __i++) \
         for (Elf64_Shdr *__s = (void *)__e + __e->e_shoff + (__i * __e->e_shentsize); __s ; __s = 0) \
 
-typedef closure_type(elf_map_handler, void, u64 /* vaddr */, u64 /* paddr, -1ull if bss */, u64 /* size */, pageflags /* flags */);
+/* returns virtual address to access map (e.g. vaddr or identity in stage2) */
+typedef closure_type(elf_map_handler, u64, u64 /* vaddr */, u64 /* paddr, -1ull if bss */, u64 /* size */, pageflags /* flags */);
 typedef closure_type(elf_sym_handler, void, char *, u64, u64, u8);
 void elf_symbols(buffer elf, elf_sym_handler each);
 void walk_elf(buffer elf, range_handler rh);

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -47,7 +47,7 @@ closure_function(1, 1, void, klib_elf_walk,
     klib_debug("%s: kl %s, r %R, load_range %R\n", __func__, kl->name, r, kl->load_range);
 }
 
-closure_function(1, 4, void, klib_elf_map,
+closure_function(1, 4, u64, klib_elf_map,
                  klib, kl,
                  u64, vaddr, u64, paddr, u64, size, pageflags, flags)
 {
@@ -71,6 +71,7 @@ closure_function(1, 4, void, klib_elf_map,
     map(vaddr, paddr, size, flags);
     if (is_bss)
         zero(pointer_from_u64(vaddr), size);
+    return vaddr;
 }
 
 closure_function(2, 1, status, load_klib_complete,

--- a/src/x86_64/def64.h
+++ b/src/x86_64/def64.h
@@ -28,9 +28,6 @@ typedef u64 bytes;
 
 #define pointer_from_u64(__a) ((void *)(__a))
 #define u64_from_pointer(__a) ((u64)(__a))
-// a super sad hack to allow us to write to the bss in elf.c as
-// phy instead of virt
-#define vpzero(__v, __p, __y) zero(pointer_from_u64(__v), __y)
 
 #define field_from_u64(u, f) (((u) >> f ## _SHIFT) & MASK(f ## _BITS))
 


### PR DESCRIPTION
These changes are aimed at lowering the minimum memory requirements to run a Nanos instance. The kernel image file is stripped of debug info (while retaining symbols), reducing the size of the pc kernel image from 7.9M to 1M, or ~87%. Reducing the image size also speeds up the image boot time, as the kernel load in stage2 consumes a significant portion of this time.

Also, the stage2 working heap size has been reduced to 4MB, which is sufficient for loading a boot filesystem of at least 2M in size. With these changes, a webg instance can run in a qemu VM with 128MB of memory. Further optimizations, such as more judicious use of 2M size pages (such as in the mcache), could further lower this minimum requirement.

This also resolves a bug where a section of an ELF file (.strtab in the found case) that shares a page with a loadable segment could be corrupted by the zeroing of the BSS area in the segment. Instead of mapping this partial page from the ELF buffer and zeroing the remainder, the loadable bits are copied into the space allocated and mapped for the BSS section.
