### PR TITLE
revert id heap default allocation behavior to first-fit

### DIFF
--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -122,7 +122,6 @@ static u64 id_alloc_from_range(id_heap i, id_range r, u64 pages, range subrange)
     if (bit == INVALID_PHYSICAL)
         return bit;
 
-    r->next_bit = bit;
     i->allocated += pages << page_order(i);
     u64 result = (r->n.r.start + bit) << page_order(i);
     id_debug("allocated bit %ld, range page start %ld, returning 0x%lx\n",
@@ -168,9 +167,6 @@ closure_function(2, 1, void, dealloc_from_range,
         msg_err("heap %p: bitmap dealloc for range %R failed; leaking\n", i, q);
         return;
     }
-
-    if (bit < r->next_bit)
-        r->next_bit = bit;
 
     u64 deallocated = pages << page_order(i);
     assert(i->allocated >= deallocated);

--- a/test/unit/id_heap_test.c
+++ b/test/unit/id_heap_test.c
@@ -333,19 +333,14 @@ static boolean alloc_subrange_test(heap h)
     }
 
     for (int i = 0; i < pages_remaining; i++) {
-        switch (i) {
-        case 0:
-            expect -= PAGESIZE; /* next fit should pick up last remaining page */
-            break;
-        case 1:
-            expect = SUBRANGE_TEST_MIN; /* should wrap around and pick up skipped page from above */
-            break;
-        default:
-            expect = (15 * PAGESIZE) + 4 * (i - 2) * PAGESIZE;
-        }
+        if (i == 0)
+            expect = SUBRANGE_TEST_MIN; /* should pick up skipped page */
+        else
+            expect = (15 * PAGESIZE) + 4 * (i - 1) * PAGESIZE;
 
         if ((res = allocate_u64((heap)id, PAGESIZE)) != expect) {
-            msg_err("%s: remainder alloc returned 0x%lx, should be 0x%lx\n", __func__, res, expect);
+            msg_err("%s: remainder alloc returned 0x%lx, should be 0x%lx (iter %d)\n",
+                    __func__, res, expect, i);
             return false;
         }
     }


### PR DESCRIPTION
The id heap now defaults to first-fit allocation. Previously, the id heap
would default to starting the allocation search from the location of a
previous allocation or deallocation. This behavior was leading to excessive
fragmentation of resources, as could be easily demonstrated by making
alternating requests of 2M and 4K-sized pages from the physical heap. After a
4K allocation, a subsequent 2M allocation would start at the next 2M
boundary (to satisfy the id heap alignment property), and the preceding unused
space would not be considered for allocation unless the allocation search
wrapped within the id range or the next_bit was explicitly reset using
id_heap_set_next.

Next-fit behavior may still be induced by the calling code with use of
id_heap_set_next.