### PR TITLE
Reserve extension during flush_log_extension

### DIFF
--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -250,6 +250,7 @@ closure_function(4, 1, void, flush_log_extension_complete,
     deallocate_sg_list(bound(sg));
     apply(bound(complete), s);
     refcount_release(&ext->tl->refcount);
+    refcount_release(&ext->refcount);
     if (bound(release))
         close_log_extension(ext);
     closure_finish();
@@ -257,6 +258,7 @@ closure_function(4, 1, void, flush_log_extension_complete,
 
 static void flush_log_extension(log_ext ext, boolean release, status_handler complete)
 {
+    refcount_reserve(&ext->refcount);
     refcount_reserve(&ext->tl->refcount);
     filesystem fs = ext->tl->fs;
     buffer b = ext->staging;


### PR DESCRIPTION
There is a scenario in which a fileystem rebuild creates a number of new log
extensions and multiple flush_log_extensions calls and a eventually a
log_extend_link which will call flush_log_extension again to close one of the
new log extensions before it has finished its first flush_log_extension
and thus a use-after-free that leads to a crash.
The change bumps the refcount on the extension for a flush_log_extension.
