### PR TITLE
Handle null tuple pointer in format_tuple

### DIFF
--- a/src/runtime/extra_prints.c
+++ b/src/runtime/extra_prints.c
@@ -113,7 +113,12 @@ void print_root(buffer b, tuple z)
 
 static void format_tuple(buffer dest, struct formatter_state *s, vlist *v)
 {
-    print_tuple(dest, varg(*v, tuple));
+    tuple t = varg(*v, tuple);
+    if (!t) {
+        bprintf(dest, "(none)");
+        return;
+    }
+    print_tuple(dest, t);
 }
 
 static void format_value(buffer dest, struct formatter_state *s, vlist *v)


### PR DESCRIPTION
Simple fix to avoid crashing when passing a null pointer to format_tuple.  I discovered this when I had a manifest with an incorrect program filename and nanos crashed trying to print out the error that the program was not found.