### PR TITLE
Perform immediate shutdown after page fault panics

### DIFF
--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -228,7 +228,8 @@ define_closure_function(1, 1, context, default_fault_handler,
 //        init_tcp_gdb(heap_general(get_kernel_heaps()), p, 9090);
 //        thread_sleep_uninterruptible();
     }
-    halt("halt\n");
+    /* XXX need a safe, polling storage driver to try to save crash dump here */
+    vm_exit(VM_EXIT_FAULT);
 }
 
 void init_thread_fault_handler(thread t)


### PR DESCRIPTION
Currently the page fault handler calls halt to try to perform an orderly
shutdown and save crash dump information to disk on panic, but this is often
a problem if a bad page fault occurs in certain kernel code paths, such as
the page cache, where spinlocks are held. Since the spinlocks aren't
cleaned up, the shutdown code accessing the pagecache will generate
an assertion failure (with lock debugging) or deadlock. This change
performs an immediate shutdown to prevent a deadlock or assertion
panic loop. However, this precludes saving crash dump information
for page faults.

We would need an alternative, polling, storage driver in order to bypass the
pagecache and work with interrupts off to save the crash dump.