### PR TITLE
virtio-balloon driver

### DIFF
--- a/doc/virtio-balloon.txt
+++ b/doc/virtio-balloon.txt
@@ -1,0 +1,138 @@
+The physical memory footprint of a Nanos instance can be managed through the
+use of a balloon driver. Here are some quick notes to get the virtio-balloon
+device up and running under Nanos.
+
+The virtio balloon driver is built into the Nanos kernel by default. When
+starting qemu, enable the device by specifying "-device virtio-balloon-pci"
+(or ENABLE_BALLOON=1 on the commandline if booting via make).
+
+To manually manage the balloon properties and inspect memory statistics
+reported through the balloon "statsq", enable the QEMU Machine Protocol (QMP)
+interface by specifying "-qmp unix:qmp-sock,server,nowait" if using a unix
+socket interface (which we'll use in the example below) or "-qmp
+tcp:localhost:<port>,server,nowait" if using the telnet interface. Specifying
+ENABLE_QMP=1 on the commandline will invoke qemu with the former option.
+
+The following example will use the "qmp-shell" utility provided with qemu. You
+can find it in scripts/qmp/qmp-shell in the qemu source tree. You may need to
+first install the prerequisite qemu python package (in python/qemu). Or you
+may wish to forego qmp-shell and instead use the aforementioned telnet
+interface - see docs/virtio-balloon-stats.txt in the QEMU tree.
+
+First run webg on Nanos with virtio-balloon and QMP enabled:
+
+   $ make ENABLE_BALLOON=1 ENABLE_QMP=1 TARGET=webg run
+
+   [...]
+   en1: assigned 10.0.2.15
+   Server started on port 8080
+
+Then start qmp-shell:
+
+   $ qmp-shell ./qmp-sock
+   Welcome to the QMP low-level shell!
+   Connected to QEMU 3.1.0
+
+   (QEMU)
+
+Query the balloon device:
+
+   (QEMU) query-balloon
+   {"return": {"actual": 2147483648}}
+
+This reports the entire 2GB allocated for the VM on initialization, as the
+balloon is currently empty. Before we inflate the balloon, let's instruct QEMU
+to begin polling for memory stats from the balloon device.
+
+First validate the path of the virtio-balloon device:
+
+   (QEMU) qom-list path=/machine/peripheral-anon/
+
+   {"return": [{"name": "type", "type": "string"}, {"name": "device[0]",
+   "type": "child<virtio-balloon-pci>"}, {"name": " device[1]", "type":
+   "child<scsi-hd>"}, {"name": "device[2]", "type": "child<isa-debug-exit>"},
+   {"name": "device[3]", " type": "child<virtio-net-pci>"}]}
+
+Here we see the path is "/machine/peripheral-anon/device[0]". Now enable
+polling at 2 second intervals:
+
+   (QEMU) qom-set path=/machine/peripheral-anon/device[0] \
+   property=guest-stats-polling-interval value=2
+
+And let's see a snapshot of the latest stats:
+
+   (QEMU) qom-get path=/machine/peripheral-anon/device[0] property=guest-stats
+
+   {"return": {"stats": {"stat-htlb-pgalloc": 0, "stat-swap-out": 0,
+   "stat-available-memory": 2053791744, "stat-htlb-pgf ail": 0,
+   "stat-free-memory": 2053791744, "stat-minor-faults": 212,
+   "stat-major-faults": 22, "stat-total-memory": 2139226112, "stat-swap-in":
+   0, "stat-disk-caches": 9216000}, "last-update": 1616532297}}
+
+Now let's alter the balloon value and look at the effects:
+
+   (QEMU) balloon value=1000000000
+   {"return": {}}
+   (QEMU) qom-get path=/machine/peripheral-anon/device[0] property=guest-stats
+   {"return": {"stats": {"stat-htlb-pgalloc": 0, "stat-swap-out": 0,
+   "stat-available-memory": 902307840, "stat-htlb-pgfa il": 0,
+   "stat-free-memory": 902307840, "stat-minor-faults": 212,
+   "stat-major-faults": 22, "stat-total-memory": 2139226112, "stat-swap-in":
+   0, "stat-disk-caches": 9216000}, "last-update": 1616532413}}
+
+We can see here that the available / free memory shrank accordingly. If we set
+the balloon value back to its original value, we should see the effects of the
+balloon deflating:
+
+   (QEMU) balloon value=2147483648
+   {"return": {}}
+
+   (QEMU) qom-get path=/machine/peripheral-anon/device[0] property=guest-stats
+   {"return": {"stats": {"stat-htlb-pgalloc": 0, "stat-swap-out": 0,
+   "stat-available-memory": 2051547136, "stat-htlb-pgf ail": 0,
+   "stat-free-memory": 2051547136, "stat-minor-faults": 212,
+   "stat-major-faults": 22, "stat-total-memory": 2139226112, "stat-swap-in":
+   0, "stat-disk-caches": 9216000}, "last-update": 1616532581}}
+
+The available memory is back to the original value, save for some balloon page
+structures which have been cached in the virtio_balloon driver.
+
+Let's try something more aggressive:
+
+   (QEMU) balloon value=1
+   {"return": {}}
+   (QEMU) query-balloon
+   {"return": {"actual": 115343360}}
+   (QEMU) qom-get path=/machine/peripheral-anon/device[0] property=guest-stats
+   {"return": {"stats": {"stat-htlb-pgalloc": 0, "stat-swap-out": 0,
+   "stat-available-memory": 17760256, "stat-htlb-pgfai l": 0,
+   "stat-free-memory": 17760256, "stat-minor-faults": 214,
+   "stat-major-faults": 20, "stat-total-memory": 2139226112, "stat-swap-in":
+   0, "stat-disk-caches": 1384448}, "last-update": 1616533279}}
+
+The balloon is now inflated to the maximum extent, save for a minimum amount
+of free memory as defined by BALLOON_MEMORY_MINIMUM in src/config.h.
+
+If we apply some pressure on the memory system by sending web requests, we can
+see the effects of Nanos deflating the balloon to maintain a minimum amount of
+free memory:
+
+   $ ab -n 1000 -c 100 http://127.0.0.1:8080/
+   [...]
+
+   (QEMU) query-balloon
+   {"return": {"actual": 121634816}}
+   (QEMU) qom-get path=/machine/peripheral-anon/device[0] property=guest-stats
+   {"return": {"stats": {"stat-htlb-pgalloc": 0, "stat-swap-out": 0,
+   "stat-available-memory": 18685952, "stat-htlb-pgfai l": 0,
+   "stat-free-memory": 18685952, "stat-minor-faults": 1009,
+   "stat-major-faults": 20, "stat-total-memory": 2139226112, "stat-swap-in":
+   0, "stat-disk-caches": 1384448}, "last-update": 1616533311}}
+
+Note the increase in "actual" memory to maintain BALLOON_DEFLATE_THRESHOLD
+amount of free memory.
+
+Related links:
+
+https://wiki.qemu.org/Documentation/QMP
+https://github.com/qemu/qemu/blob/master/docs/virtio-balloon-stats.txt

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -67,6 +67,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/unix/vdso.c \
 	$(SRCDIR)/unix/pipe.c \
 	$(SRCDIR)/virtio/virtio.c \
+	$(SRCDIR)/virtio/virtio_balloon.c \
 	$(SRCDIR)/virtio/virtio_mmio.c \
 	$(SRCDIR)/virtio/virtio_net.c \
 	$(SRCDIR)/virtio/virtio_pci.c \
@@ -360,13 +361,17 @@ endif
 QEMU_TAP=	-netdev tap,id=n0,ifname=tap0,script=no,downscript=no
 QEMU_NET=	-device $(NETWORK)$(NETWORK_BUS),mac=7e:b8:7e:87:4a:ea,netdev=n0 $(QEMU_TAP)
 QEMU_USERNET=	-device $(NETWORK)$(NETWORK_BUS),netdev=n0 -netdev user,id=n0,hostfwd=tcp::8080-:8080,hostfwd=tcp::9090-:9090,hostfwd=udp::5309-:5309
+QEMU_BALLOON=   -device virtio-balloon-pci
+ifneq ($(ENABLE_QMP),)
+QEMU_QMP=	-qmp unix:$(ROOTDIR)/qmp-sock,server
+endif
 #QEMU_USERNET+=	-object filter-dump,id=filter0,netdev=n0,file=/tmp/nanos.pcap
 QEMU_FLAGS=
 #QEMU_FLAGS+=	-smp 4
-#QEMU_FLAGS+=	-d int -D int.log
+QEMU_FLAGS+=	-d trace:balloon_event,trace:virtio_balloon_bad_addr,trace:virtio_balloon_get_config,trace:virtio_balloon_handle_output,trace:virtio_balloon_set_config,trace:virtio_balloon_to_target -D $(ROOTDIR)/trace
 #QEMU_FLAGS+=	-s -S
 
-QEMU_COMMON=	$(QEMU_MACHINE) $(QEMU_MEMORY) $(QEMU_DISPLAY) $(QEMU_PCI) $(QEMU_SERIAL) $(QEMU_STORAGE) -device isa-debug-exit -no-reboot $(QEMU_FLAGS)
+QEMU_COMMON=	$(QEMU_MACHINE) $(QEMU_MEMORY) $(QEMU_BALLOON) $(QEMU_DISPLAY) $(QEMU_PCI) $(QEMU_SERIAL) $(QEMU_STORAGE) -device isa-debug-exit -no-reboot $(QEMU_FLAGS) $(QEMU_QMP)
 
 run: image
 	$(QEMU) $(QEMU_COMMON) $(QEMU_USERNET) $(QEMU_ACCEL) || exit $$(($$?>>1))

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -361,14 +361,17 @@ endif
 QEMU_TAP=	-netdev tap,id=n0,ifname=tap0,script=no,downscript=no
 QEMU_NET=	-device $(NETWORK)$(NETWORK_BUS),mac=7e:b8:7e:87:4a:ea,netdev=n0 $(QEMU_TAP)
 QEMU_USERNET=	-device $(NETWORK)$(NETWORK_BUS),netdev=n0 -netdev user,id=n0,hostfwd=tcp::8080-:8080,hostfwd=tcp::9090-:9090,hostfwd=udp::5309-:5309
+ifneq ($(ENABLE_BALLOON),)
 QEMU_BALLOON=   -device virtio-balloon-pci
+endif
 ifneq ($(ENABLE_QMP),)
-QEMU_QMP=	-qmp unix:$(ROOTDIR)/qmp-sock,server
+QEMU_QMP=	-qmp unix:$(ROOTDIR)/qmp-sock,server,nowait
+#QEMU_QMP=	-qmp tcp:localhost:4444,server,nowait
 endif
 #QEMU_USERNET+=	-object filter-dump,id=filter0,netdev=n0,file=/tmp/nanos.pcap
 QEMU_FLAGS=
 #QEMU_FLAGS+=	-smp 4
-QEMU_FLAGS+=	-d trace:balloon_event,trace:virtio_balloon_bad_addr,trace:virtio_balloon_get_config,trace:virtio_balloon_handle_output,trace:virtio_balloon_set_config,trace:virtio_balloon_to_target -D $(ROOTDIR)/trace
+#QEMU_FLAGS+=	-d int -D int.log
 #QEMU_FLAGS+=	-s -S
 
 QEMU_COMMON=	$(QEMU_MACHINE) $(QEMU_MEMORY) $(QEMU_BALLOON) $(QEMU_DISPLAY) $(QEMU_PCI) $(QEMU_SERIAL) $(QEMU_STORAGE) -device isa-debug-exit -no-reboot $(QEMU_FLAGS) $(QEMU_QMP)

--- a/platform/pc/pci.c
+++ b/platform/pc/pci.c
@@ -147,9 +147,9 @@ void pci_bar_write_8(struct pci_bar *b, u64 offset, u64 val)
         out64(b->addr + offset, val);
 }
 
-void pci_setup_non_msi_irq(pci_dev dev, int idx, thunk h, const char *name)
+void pci_setup_non_msi_irq(pci_dev dev, thunk h, const char *name)
 {
-    pci_plat_debug("%s: idx %d, h %F, name %s\n", __func__, idx, h, name);
+    pci_plat_debug("%s: h %F, name %s\n", __func__, h, name);
 
     /* For maximum portability, the GSI should be retrieved via the ACPI _PRT method. */
     unsigned int gsi = pci_cfgread(dev, PCIR_INTERRUPT_LINE, 1);

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -525,4 +525,6 @@ void detect_devices(kernel_heaps kh, storage_attach sa)
 
     /* misc / platform */
     init_acpi(kh);
+
+    init_virtio_balloon(kh);
 }

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -297,9 +297,12 @@ QEMU_TAP=	-netdev tap,id=n0,ifname=tap0,script=no,downscript=no
 #QEMU_NET=	-device $(NETWORK)$(NETWORK_BUS),mac=7e:b8:7e:87:4a:ea,netdev=n0,modern-pio-notify $(QEMU_TAP)
 QEMU_NET=	-device $(NETWORK)$(NETWORK_BUS),mac=7e:b8:7e:87:4a:ea,netdev=n0 $(QEMU_TAP)
 QEMU_USERNET=	-device $(NETWORK)$(NETWORK_BUS),netdev=n0 -netdev user,id=n0,hostfwd=tcp::8080-:8080,hostfwd=tcp::9090-:9090,hostfwd=udp::5309-:5309 -object filter-dump,id=filter0,netdev=n0,file=/tmp/nanos.pcap
+ifneq ($(ENABLE_BALLOON),)
 QEMU_BALLOON=   -device virtio-balloon-pci
+endif
 ifneq ($(ENABLE_QMP),)
-QEMU_QMP=	-qmp unix:$(ROOTDIR)/qmp-sock,server
+QEMU_QMP=	-qmp unix:$(ROOTDIR)/qmp-sock,server,nowait
+#QEMU_QMP=	-qmp tcp:localhost:4444,server,nowait
 endif
 
 # for enabling the ARM Angel interface and passing exit codes from the program

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -64,11 +64,12 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/unix/pipe.c \
 	$(SRCDIR)/unix/vdso.c \
 	$(SRCDIR)/virtio/virtio.c \
-	$(SRCDIR)/virtio/virtio_storage.c \
-	$(SRCDIR)/virtio/virtio_scsi.c \
-	$(SRCDIR)/virtio/virtio_net.c \
+	$(SRCDIR)/virtio/virtio_balloon.c \
 	$(SRCDIR)/virtio/virtio_mmio.c \
+	$(SRCDIR)/virtio/virtio_net.c \
 	$(SRCDIR)/virtio/virtio_pci.c \
+	$(SRCDIR)/virtio/virtio_scsi.c \
+	$(SRCDIR)/virtio/virtio_storage.c \
 	$(SRCDIR)/virtio/virtqueue.c \
 	$(SRCDIR)/virtio/scsi.c \
 	$(VDSO_OBJDIR)/vdso-image.c \
@@ -296,6 +297,10 @@ QEMU_TAP=	-netdev tap,id=n0,ifname=tap0,script=no,downscript=no
 #QEMU_NET=	-device $(NETWORK)$(NETWORK_BUS),mac=7e:b8:7e:87:4a:ea,netdev=n0,modern-pio-notify $(QEMU_TAP)
 QEMU_NET=	-device $(NETWORK)$(NETWORK_BUS),mac=7e:b8:7e:87:4a:ea,netdev=n0 $(QEMU_TAP)
 QEMU_USERNET=	-device $(NETWORK)$(NETWORK_BUS),netdev=n0 -netdev user,id=n0,hostfwd=tcp::8080-:8080,hostfwd=tcp::9090-:9090,hostfwd=udp::5309-:5309 -object filter-dump,id=filter0,netdev=n0,file=/tmp/nanos.pcap
+QEMU_BALLOON=   -device virtio-balloon-pci
+ifneq ($(ENABLE_QMP),)
+QEMU_QMP=	-qmp unix:$(ROOTDIR)/qmp-sock,server
+endif
 
 # for enabling the ARM Angel interface and passing exit codes from the program
 QEMU_FLAGS+=	-semihosting
@@ -309,7 +314,7 @@ QEMU_FLAGS+=	-semihosting
 
 #QEMU_FLAGS+=	-monitor telnet:127.0.0.1:9999,server,nowait
 
-QEMU_COMMON=	$(QEMU_MACHINE) $(QEMU_MEMORY) $(QEMU_KERNEL) $(QEMU_DISPLAY) $(QEMU_PCI) $(QEMU_SERIAL) $(QEMU_STORAGE) -no-reboot $(QEMU_FLAGS)
+QEMU_COMMON=	$(QEMU_MACHINE) $(QEMU_MEMORY) $(QEMU_BALLOON) $(QEMU_KERNEL) $(QEMU_DISPLAY) $(QEMU_PCI) $(QEMU_SERIAL) $(QEMU_STORAGE) -no-reboot $(QEMU_FLAGS) $(QEMU_QMP)
 
 run: image
 	$(QEMU) $(QEMU_COMMON) $(QEMU_USERNET) $(QEMU_ACCEL)

--- a/platform/virt/pci.c
+++ b/platform/virt/pci.c
@@ -97,12 +97,11 @@ MK_PCI_BAR_WRITE(1, 8)
 MK_PCI_BAR_WRITE(2, 16)
 MK_PCI_BAR_WRITE(4, 32)
 
-void pci_setup_non_msi_irq(pci_dev dev, int idx, thunk h, const char *name)
+void pci_setup_non_msi_irq(pci_dev dev, thunk h, const char *name)
 {
     /* queue index ignored; virtio ints are shared */
     u64 v = GIC_SPI_INTS_START + VIRT_PCIE_IRQ_BASE + (dev->slot % VIRT_PCIE_IRQ_NUM);
-    pci_plat_debug("%s: dev %p, idx %d, irq %d, handler %F, name %s\n",
-                   __func__, dev, idx, v, h, name);
+    pci_plat_debug("%s: dev %p, irq %d, handler %F, name %s\n", __func__, dev, v, h, name);
     register_interrupt(v, h, name);
 }
 

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -293,4 +293,5 @@ void detect_devices(kernel_heaps kh, storage_attach sa)
     init_virtio_network(kh);
     init_virtio_blk(kh, sa);
     init_virtio_scsi(kh, sa);
+    init_virtio_balloon(kh);
 }

--- a/src/config.h
+++ b/src/config.h
@@ -49,6 +49,12 @@
 #define PAGECACHE_DRAIN_CUTOFF (64 * MB)
 #define PAGECACHE_SCAN_PERIOD_SECONDS 5
 
+/* don't go below this minimum amount of physical memory when inflating balloon */
+#define BALLOON_MEMORY_MINIMUM (16 * MB)
+
+/* attempt to deflate balloon when physical memory is below this threshold */
+#define BALLOON_DEFLATE_THRESHOLD (16 * MB)
+
 /* must be large enough for vendor code that use malloc/free interface */
 #define MAX_MCACHE_ORDER 16
 

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -11,6 +11,7 @@
    resuming a kernel context is the exception, not the norm. */
 
 static kernel_context spare_kernel_context;
+struct mm_stats mm_stats;
 
 context allocate_frame(heap h)
 {

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -34,6 +34,14 @@ typedef struct cpuinfo {
 
 extern struct cpuinfo cpuinfos[];
 
+/* subsume with introspection */
+struct mm_stats {
+    word minor_faults;
+    word major_faults;
+};
+
+extern struct mm_stats mm_stats;
+
 static inline cpuinfo cpuinfo_from_id(int cpu)
 {
     assert(cpu >= 0 && cpu < MAX_CPUS);
@@ -85,6 +93,16 @@ static inline __attribute__((always_inline)) context frame_from_kernel_context(k
 static inline __attribute__((always_inline)) void *stack_from_kernel_context(kernel_context c)
 {
     return ((void*)c->stackbase) + KERNEL_STACK_SIZE - STACK_ALIGNMENT;
+}
+
+static inline void count_minor_fault(void)
+{
+    fetch_and_add(&mm_stats.minor_faults, 1);
+}
+
+static inline void count_major_fault(void)
+{
+    fetch_and_add(&mm_stats.major_faults, 1);
 }
 
 void runloop_internal() __attribute__((noreturn));

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -219,6 +219,9 @@ void kern_unlock(void);
 void init_scheduler(heap);
 void mm_service(void);
 
+typedef closure_type(balloon_deflater, u64, u64);
+void mm_register_balloon_deflater(balloon_deflater deflater);
+
 kernel_heaps get_kernel_heaps(void);
 
 tuple get_root_tuple(void);

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1268,9 +1268,14 @@ void *pagecache_get_zero_page(void)
     return global_pagecache->zero_page;
 }
 
-int pagecache_get_page_order()
+int pagecache_get_page_order(void)
 {
     return global_pagecache->page_order;
+}
+
+u64 pagecache_get_occupancy(void)
+{
+    return global_pagecache->total_pages << pagecache_get_page_order();
 }
 
 pagecache_volume pagecache_allocate_volume(u64 length, int block_order)

--- a/src/kernel/pagecache.h
+++ b/src/kernel/pagecache.h
@@ -12,9 +12,11 @@ void pagecache_sync_node(pagecache_node pn, status_handler complete);
 
 void pagecache_sync_volume(pagecache_volume pv, status_handler complete);
 
-void *pagecache_get_zero_page();
+void *pagecache_get_zero_page(void);
 
-int pagecache_get_page_order();
+int pagecache_get_page_order(void);
+
+u64 pagecache_get_occupancy(void);
 
 u64 pagecache_drain(u64 drain_bytes);
 

--- a/src/kernel/pci.h
+++ b/src/kernel/pci.h
@@ -170,7 +170,7 @@ void pci_enable_io_and_memory(pci_dev dev);
 u64 pci_setup_msix(pci_dev dev, int msi_slot, thunk h, const char *name);
 void pci_teardown_msix(pci_dev dev, int msi_slot);
 void pci_disable_msix(pci_dev dev);
-void pci_setup_non_msi_irq(pci_dev dev, int idx, thunk h, const char *name);
+void pci_setup_non_msi_irq(pci_dev dev, thunk h, const char *name);
 
 static inline u64 pci_msix_table_addr(pci_dev dev)
 {

--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -180,7 +180,6 @@ closure_function(3, 0, void, startup,
         rprintf("Debug http server started on port 9090\n");
     }
 #endif
-
     value p = table_find(root, sym(program));
     assert(p);
     tuple pro = resolve_path(root, split(general, p, '/'));

--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -180,6 +180,7 @@ closure_function(3, 0, void, startup,
         rprintf("Debug http server started on port 9090\n");
     }
 #endif
+
     value p = table_find(root, sym(program));
     assert(p);
     tuple pro = resolve_path(root, split(general, p, '/'));

--- a/src/runtime/heap/heap.h
+++ b/src/runtime/heap/heap.h
@@ -22,6 +22,11 @@ static inline u64 heap_total(heap h)
     return h->total ? h->total(h) : INVALID_PHYSICAL;
 }
 
+static inline u64 heap_free(heap h)
+{
+    return heap_total(h) - heap_allocated(h);
+}
+
 heap wrap_freelist(heap meta, heap parent, bytes size);
 heap allocate_objcache(heap meta, heap parent, bytes objsize, bytes pagesize);
 boolean objcache_validate(heap h);

--- a/src/virtio/virtio.h
+++ b/src/virtio/virtio.h
@@ -1,5 +1,6 @@
+void init_virtio_balloon(kernel_heaps kh);
+void init_virtio_blk(kernel_heaps kh, storage_attach a);
 void init_virtio_network(kernel_heaps kh);
 void init_virtio_scsi(kernel_heaps kh, storage_attach a);
-void init_virtio_blk(kernel_heaps kh, storage_attach a);
 
 void virtio_mmio_parse(kernel_heaps kh, const char *str, int len);

--- a/src/virtio/virtio_balloon.c
+++ b/src/virtio/virtio_balloon.c
@@ -1,0 +1,302 @@
+#include <kernel.h>
+#include <storage.h>
+
+#include "virtio_internal.h"
+#include "virtio_mmio.h"
+#include "virtio_pci.h"
+
+//#define VIRTIO_BALLOON_DEBUG
+//#define VIRTIO_BALLOON_VERBOSE
+#ifdef VIRTIO_BALLOON_DEBUG
+#define virtio_balloon_debug(x, ...) do {rprintf("VTBLN: " x, ##__VA_ARGS__);} while(0)
+#ifdef VIRTIO_BALLOON_VERBOSE
+#define virtio_balloon_verbose virtio_balloon_debug
+#else
+#define virtio_balloon_verbose(x, ...)
+#endif
+#else
+#define virtio_balloon_debug(x, ...)
+#define virtio_balloon_verbose(x, ...)
+#endif
+
+/* Virtio interface is always 4K pages. */
+#define VIRTIO_BALLOON_PAGE_ORDER PAGELOG
+
+/* These are units that we allocate from the physical heap. */
+#define VIRTIO_BALLOON_ALLOC_ORDER 21
+#define VIRTIO_BALLOON_ALLOC_SIZE U64_FROM_BIT(VIRTIO_BALLOON_ALLOC_ORDER)
+#define VIRTIO_BALLOON_PAGES_PER_ALLOC U64_FROM_BIT(VIRTIO_BALLOON_ALLOC_ORDER - \
+                                                    VIRTIO_BALLOON_PAGE_ORDER)
+
+#define VIRTIO_BALLOON_F_MUST_TELL_HOST 1
+#define VIRTIO_BALLOON_F_STATS_VQ       2
+#define VIRTIO_BALLOON_F_DEFLATE_ON_OOM 4
+
+struct virtio_balloon {
+    heap general;
+    backed_heap backed;
+    id_heap physical;
+    vtdev dev;
+    virtqueue inflateq;
+    virtqueue deflateq;
+    virtqueue statsq;
+    u32 actual_pages;
+    struct list in_balloon;
+    struct list free;
+} virtio_balloon;
+
+/* XXX alignment requirement? */
+typedef struct balloon_page {
+    u32 addrs[VIRTIO_BALLOON_PAGES_PER_ALLOC]; /* must be first */
+    struct list l;
+    u64 phys;
+} *balloon_page;
+
+struct virtio_balloon_config {
+    /* explicitly little endian */
+    u32 num_pages;
+    u32 actual;
+} __attribute__((packed));
+
+#define VIRTIO_BALLOON_R_NUM_PAGES (offsetof(struct virtio_balloon_config *, num_pages))
+#define VIRTIO_BALLOON_R_ACTUAL    (offsetof(struct virtio_balloon_config *, actual))
+
+static inline boolean balloon_must_tell_host(void)
+{
+    return (virtio_balloon.dev->features & VIRTIO_BALLOON_F_MUST_TELL_HOST) != 0;
+}
+
+static u64 phys_base_from_balloon_page(balloon_page bp)
+{
+    return bp->addrs[0] << PAGELOG;
+}
+
+static void update_actual_pages(s64 delta)
+{
+    assert(delta > 0 || virtio_balloon.actual_pages >= -delta);
+    virtio_balloon.actual_pages += delta;
+    virtio_balloon_verbose("%s: delta %ld, now %ld\n", __func__, delta, virtio_balloon.actual_pages);
+    vtdev_cfg_write_4(virtio_balloon.dev, VIRTIO_BALLOON_R_ACTUAL,
+                      htole32(virtio_balloon.actual_pages));
+}
+
+closure_function(1, 1, void, inflate_complete,
+                 balloon_page, bp,
+                 u64, len)
+{
+    balloon_page bp = bound(bp);
+    virtio_balloon_verbose("%s: balloon_page %p (phys base 0x%lx)\n", __func__, bp,
+                           phys_base_from_balloon_page(bp));
+    list_insert_after(&virtio_balloon.in_balloon, &bp->l);
+    update_actual_pages(VIRTIO_BALLOON_PAGES_PER_ALLOC);
+    closure_finish();
+}
+
+static balloon_page allocate_balloon_page(void)
+{
+    list l = list_get_next(&virtio_balloon.free);
+    if (l) {
+        list_delete(l);
+        return struct_from_list(l, balloon_page, l);
+    }
+    u64 bp_phys;
+    balloon_page bp = alloc_map(virtio_balloon.backed, sizeof(struct balloon_page), &bp_phys);
+    assert(bp != INVALID_ADDRESS);
+    bp->phys = bp_phys;
+    return bp;
+}
+
+static u64 virtio_balloon_inflate(u64 n_balloon_pages)
+{
+    virtqueue vq = virtio_balloon.inflateq;
+    virtio_balloon_debug("%s: n_balloon_pages %d\n", __func__, n_balloon_pages);
+
+    u64 inflated = 0;
+    while (inflated < n_balloon_pages) {
+        /* XXX: cannot take fragmentation into account... */
+        if (heap_free((heap)virtio_balloon.physical) <
+            (BALLOON_MEMORY_MINIMUM + VIRTIO_BALLOON_ALLOC_SIZE))
+            break;
+        u64 phys = allocate_u64((heap)virtio_balloon.physical, VIRTIO_BALLOON_ALLOC_SIZE);
+        if (phys == INVALID_PHYSICAL) {
+            /* We shouldn't get down to the minimum. This ought to be an error
+               or assertion failure, however we can't completely account for
+               effects of fragmentation in the physical id heap. Emit a
+               warning and quit inflating for now. */
+            msg_err("failed to allocate balloon page from physical heap\n");
+            break;
+        }
+
+        balloon_page bp = allocate_balloon_page();
+        assert(bp != INVALID_ADDRESS);
+        vqmsg m = allocate_vqmsg(vq);
+        assert(m != INVALID_ADDRESS);
+        u32 base_pfn = phys >> VIRTIO_BALLOON_PAGE_ORDER;
+        for (int i = 0; i < VIRTIO_BALLOON_PAGES_PER_ALLOC; i++)
+            bp->addrs[i] = base_pfn + i;
+        vqmsg_push(vq, m, bp->phys, sizeof(bp->addrs), false);
+        vqfinish c = closure(virtio_balloon.general, inflate_complete, bp);
+        assert(c != INVALID_ADDRESS);
+        virtio_balloon_verbose("   alloc: phys 0x%lx, bp %p, complete %p, phys heap free: %ld\n",
+                               phys, bp, c, heap_free((heap)virtio_balloon.physical));
+        vqmsg_commit(vq, m, c);
+        inflated++;
+    }
+
+    return inflated;
+}
+
+static void return_balloon_page_memory(balloon_page bp)
+{
+    u64 phys_base = phys_base_from_balloon_page(bp);
+    virtio_balloon_verbose("%s: balloon_page %p (phys base 0x%lx)\n", __func__, bp, phys_base);
+    deallocate_u64((heap)virtio_balloon.physical, phys_base, VIRTIO_BALLOON_ALLOC_SIZE);
+    virtio_balloon_verbose("   phys heap free: %ld\n", heap_free((heap)virtio_balloon.physical));
+}
+
+closure_function(1, 1, void, deflate_complete,
+                 balloon_page, bp,
+                 u64, len)
+{
+    balloon_page bp = bound(bp);
+    virtio_balloon_verbose("%s: bp %p, len %ld\n", __func__, bound(bp), len);
+    if (balloon_must_tell_host())
+        return_balloon_page_memory(bound(bp));
+    list_insert_before(&virtio_balloon.free, &bp->l);
+    update_actual_pages(-VIRTIO_BALLOON_PAGES_PER_ALLOC);
+    closure_finish();
+}
+
+static u64 virtio_balloon_deflate(u64 n_balloon_pages)
+{
+    virtqueue vq = virtio_balloon.deflateq;
+    virtio_balloon_debug("%s: n_balloon_pages %ld\n", __func__, n_balloon_pages);
+    u64 deflated = 0;
+    while (deflated < n_balloon_pages) {
+        list l = list_get_next(&virtio_balloon.in_balloon);
+        if (!l)
+            break;
+        list_delete(l);
+        balloon_page bp = struct_from_list(l, balloon_page, l);
+        vqmsg m = allocate_vqmsg(vq);
+        assert(m != INVALID_ADDRESS);
+        vqmsg_push(vq, m, bp->phys, sizeof(bp->addrs), false);
+        vqfinish c = closure(virtio_balloon.general, deflate_complete, bp);
+        assert(c != INVALID_ADDRESS);
+        vqmsg_commit(vq, m, c);
+        if (!balloon_must_tell_host())
+            return_balloon_page_memory(bp);
+        deflated++;
+    }
+    return deflated;
+}
+
+void virtio_balloon_update(void)
+{
+    u32 num_pages = le32toh(vtdev_cfg_read_4(virtio_balloon.dev, VIRTIO_BALLOON_R_NUM_PAGES));
+    virtio_balloon_debug("%s: num_pages %d, actual %d\n", __func__, num_pages,
+                        virtio_balloon.actual_pages);
+    s32 delta = num_pages - virtio_balloon.actual_pages;
+    if (delta > 0) {
+        u64 inflate = (delta + VIRTIO_BALLOON_PAGES_PER_ALLOC - 1) >>
+            (VIRTIO_BALLOON_ALLOC_ORDER - VIRTIO_BALLOON_PAGE_ORDER);
+        u64 inflated = virtio_balloon_inflate(inflate);
+        assert(inflated != INVALID_PHYSICAL);
+        virtio_balloon_debug("   inflated balloon by %ld pages (%ld MB)\n",
+                             inflated * VIRTIO_BALLOON_PAGES_PER_ALLOC,
+                             inflated << (VIRTIO_BALLOON_ALLOC_ORDER - 20));
+        if (inflated < inflate) {
+            /* XXX set up timer to retry... */
+            rprintf("%ld balloon pages left to inflate\n", inflate - inflated);
+        }
+    } else if (delta < 0) {
+        u64 deflate = (-delta) >> (VIRTIO_BALLOON_ALLOC_ORDER - VIRTIO_BALLOON_PAGE_ORDER);
+        u64 deflated = virtio_balloon_deflate(deflate);
+        assert(deflated != INVALID_PHYSICAL);
+        virtio_balloon_debug("   deflated balloon by %ld pages (%ld MB)\n",
+                             deflated * VIRTIO_BALLOON_PAGES_PER_ALLOC,
+                             deflated << (VIRTIO_BALLOON_ALLOC_ORDER - 20));
+    }
+    virtio_balloon_debug("   physical heap free: %ld\n",
+                         heap_free((heap)virtio_balloon.physical));
+}
+
+closure_function(1, 0, void, virtio_balloon_config_change,
+                 vtdev, v)
+{
+    virtio_balloon_debug("%s\n", __func__);
+    virtio_balloon_update();
+}
+
+closure_function(0, 1, u64, virtio_balloon_deflater,
+                 u64, deflate_bytes)
+{
+    virtio_balloon_debug("%s: deflate of %ld bytes requested\n", __func__, deflate_bytes);
+    u64 deflate = ((deflate_bytes + MASK(VIRTIO_BALLOON_ALLOC_ORDER))
+                   >> VIRTIO_BALLOON_ALLOC_ORDER);
+    u64 deflated = virtio_balloon_deflate(deflate);
+    assert(deflated != INVALID_PHYSICAL);
+    virtio_balloon_debug("   deflated balloon by %ld pages (%ld MB)\n",
+                             deflated * VIRTIO_BALLOON_PAGES_PER_ALLOC,
+                             deflated << (VIRTIO_BALLOON_ALLOC_ORDER - 20));
+    return deflated << VIRTIO_BALLOON_ALLOC_ORDER;
+}
+
+static boolean virtio_balloon_attach(heap general, backed_heap backed, id_heap physical, vtdev v)
+{
+    virtio_balloon_debug("   dev_features 0x%lx, features 0x%lx\n",
+                         v->dev_features, v->features);
+    thunk t = closure(general, virtio_balloon_config_change, v);
+    assert(t != INVALID_ADDRESS);
+    status s = virtio_register_config_change_handler(v, t, runqueue);
+    if (!is_ok(s))
+        goto fail;
+    s = virtio_alloc_virtqueue(v, "virtio balloon inflateq", 0, runqueue,
+                               &virtio_balloon.inflateq);
+    if (!is_ok(s))
+        goto fail;
+    s = virtio_alloc_virtqueue(v, "virtio balloon deflateq", 1, runqueue,
+                               &virtio_balloon.deflateq);
+    if (!is_ok(s))
+        goto fail;
+    /* XXX: statsq */
+    virtio_balloon.general = general;
+    virtio_balloon.backed = backed;
+    virtio_balloon.physical = physical;
+    virtio_balloon.dev = v;
+    virtio_balloon.actual_pages = 0;
+    list_init(&virtio_balloon.in_balloon);
+    list_init(&virtio_balloon.free);
+    virtio_balloon_debug("   virtqueues allocated, setting driver status OK\n");
+    vtdev_set_status(v, VIRTIO_CONFIG_STATUS_DRIVER_OK);
+    update_actual_pages(0);
+    virtio_balloon_update();
+    balloon_deflater bd = closure(general, virtio_balloon_deflater);
+    assert(bd != INVALID_ADDRESS);
+    mm_register_balloon_deflater(bd);
+    return true;
+  fail:
+    rprintf("%s: failed to attach: %v\n", __func__, s);
+    return false;
+}
+
+closure_function(3, 1, boolean, vtpci_balloon_probe,
+                 heap, general, backed_heap, backed, id_heap, physical,
+                 pci_dev, d)
+{
+    virtio_balloon_debug("%s\n", __func__);
+    if (!vtpci_probe(d, VIRTIO_ID_BALLOON))
+        return false;
+
+    virtio_balloon_debug("   attaching\n", __func__);
+    vtdev v = (vtdev)attach_vtpci(bound(general), bound(backed), d,
+                                  VIRTIO_BALLOON_F_MUST_TELL_HOST);
+    return virtio_balloon_attach(bound(general), bound(backed), bound(physical), v);
+}
+
+void init_virtio_balloon(kernel_heaps kh)
+{
+    virtio_balloon_debug("%s\n", __func__);
+    heap h = heap_locked(kh);
+    register_pci_driver(closure(h, vtpci_balloon_probe, h, kh->backed, heap_physical(kh)));
+}

--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -76,6 +76,7 @@ typedef struct vtdev {
 } *vtdev;
 
 u32 vtdev_cfg_read_4(vtdev dev, u64 offset);
+void vtdev_cfg_write_4(vtdev dev, u64 offset, u32 value);
 void vtdev_cfg_read_mem(vtdev dev, void *dest, bytes len);
 void vtdev_set_status(vtdev dev, u8 status);
 
@@ -94,6 +95,7 @@ static inline void virtio_attach(heap h, backed_heap page_allocator,
 
 status virtio_alloc_virtqueue(vtdev dev, const char *name, int idx, queue sched_queue,
                               struct virtqueue **result);
+status virtio_register_config_change_handler(vtdev dev, thunk handler, queue sched_queue);
 
 status virtqueue_alloc(vtdev dev,
                        const char *name,

--- a/src/virtio/virtio_pci.c
+++ b/src/virtio/virtio_pci.c
@@ -301,7 +301,7 @@ closure_function(3, 0, void, vtpci_config_change_msix_irq,
                  vtpci, dev, thunk, handler, queue, sched_queue)
 {
     virtio_pci_debug("%s: dev %p, queueing config change handler %F to queue %p\n",
-                     bound(dev), bound(handler), bound(sched_queue));
+                     __func__, bound(dev), bound(handler), bound(sched_queue));
     enqueue(bound(sched_queue), bound(handler));
 }
 

--- a/src/virtio/virtio_pci.h
+++ b/src/virtio/virtio_pci.h
@@ -44,6 +44,7 @@ enum {
     VTPCI_REG_QUEUE_SELECT,
     VTPCI_REG_QUEUE_SIZE,
     VTPCI_REG_QUEUE_MSIX_VECTOR,
+    VTPCI_REG_CONFIG_MSIX_VECTOR,
     VTPCI_REG_ISR_STATUS,
     VTPCI_REG_MAX
 };
@@ -67,8 +68,11 @@ struct vtpci {
 
     closure_struct(vtpci_notify, notify);
 
-    int vtpci_nvqs;
-    struct virtqueue *vtpci_vqs;
+    /* for non-MSIX */
+    thunk non_msix_handler;
+    vector vq_handlers;         /* queue handler thunks */
+    thunk config_handler;
+    queue config_sched_queue;
 };
 
 /* VirtIO ABI version, this must match exactly. */
@@ -92,6 +96,7 @@ struct vtpci {
 boolean vtpci_probe(pci_dev d, int virtio_dev_id);
 vtpci attach_vtpci(heap h, backed_heap page_allocator, pci_dev d, u64 feature_mask);
 status vtpci_alloc_virtqueue(vtpci dev, const char *name, int idx, queue sched_queue, struct virtqueue **result);
+status vtpci_register_config_change_handler(vtpci dev, thunk handler, queue sched_queue);
 void vtpci_set_status(vtpci dev, u8 status);
 boolean vtpci_is_modern(vtpci dev);
 


### PR DESCRIPTION
This adds a driver for the virtio-balloon device, allowing the monitor to manage the memory footprint of a Nanos instance by inflating and deflating balloon pages. The driver responds to changes applied to the balloon device's PCI config space, which is managed by registration of a handler via a newly-added vtpci_register_config_change_handler interface. An interface has also been added to allow mm_service() to deflate balloon pages when memory resources are at a minimum.

To accommodate config change interrupts for non-MSIX platforms, the non-MSIX vtpci interrupt handler is now registered only once per device and, upon invocation, dispatches queue and config change handlers based on pending bits in the ISR status register.

This driver supports the "statsq," if offered by the device, which reports memory usage, page faults and pagecache usage to the monitor when requested.

Resolves #660 
