### PR TITLE
enable C0_WP in cpu_init

### DIFF
--- a/src/x86_64/mp.c
+++ b/src/x86_64/mp.c
@@ -29,7 +29,7 @@ void cpu_init(int cpu)
     cr |= CR4_PGE | CR4_OSFXSR | CR4_OSXMMEXCPT;
     mov_to_cr("cr4", cr);
     mov_from_cr("cr0", cr);
-    cr |= C0_MP;
+    cr |= C0_MP | C0_WP;
     cr &= ~C0_EM;
     mov_to_cr("cr0", cr);
     u64 addr = u64_from_pointer(cpuinfo_from_id(cpu));


### PR DESCRIPTION
This enables write protection while running at CPL 0. Any attempts to write to
a read-only page at kernel level will cause a fault. To comply with this
restriction, map_and_zero() and init_vsyscall() have been updated to first map
read-only pages as writable, initialize the page data and then update the map
flags to remove the writable flag.