### PR TITLE
Add objcache-compatible heap debug

### DIFF
--- a/src/runtime/heap/heap.h
+++ b/src/runtime/heap/heap.h
@@ -11,6 +11,7 @@ struct heap {
 
 heap debug_heap(heap m, heap p);
 heap mem_debug(heap m, heap p, u64 padsize);
+heap mem_debug_objcache(heap meta, heap parent, u64 objsize, u64 pagesize);
 
 static inline u64 heap_allocated(heap h)
 {
@@ -29,6 +30,7 @@ static inline u64 heap_free(heap h)
 
 heap wrap_freelist(heap meta, heap parent, bytes size);
 heap allocate_objcache(heap meta, heap parent, bytes objsize, bytes pagesize);
+heap allocate_wrapped_objcache(heap meta, heap parent, bytes objsize, bytes pagesize, heap wrapper);
 boolean objcache_validate(heap h);
 heap objcache_from_object(u64 obj, bytes parent_pagesize);
 heap allocate_mcache(heap meta, heap parent, int min_order, int max_order, bytes pagesize);

--- a/src/runtime/heap/mem_debug.c
+++ b/src/runtime/heap/mem_debug.c
@@ -62,7 +62,9 @@ static void set_pattern(void *v, bytes sz, void *p, bytes psz)
     for (s64 ssz = sz; ssz > 0; ssz -= psz, bp += psz)
         runtime_memcpy(bp, p, MIN(psz, ssz));
 }
+#endif
 
+#if defined(MEMDBG_OVERRUN)
 static boolean check_pattern(void *v, bytes sz, void *p, bytes psz)
 {
     u8 *bp = v;
@@ -142,7 +144,7 @@ static void mem_debug_dealloc(heap h, u64 a, bytes b)
 heap mem_debug(heap meta, heap parent, u64 padsize)
 {
     build_assert(PAD_MIN > sizeof(mem_debug_hdr));
-    mem_debug_heap mdh = allocate(meta, sizeof(*mdh));
+    mem_debug_heap mdh = allocate_zero(meta, sizeof(*mdh));
     mdh->parent = parent;
     mdh->h.pagesize = parent->pagesize;
     mdh->h.alloc = mem_debug_alloc;
@@ -153,7 +155,7 @@ heap mem_debug(heap meta, heap parent, u64 padsize)
 
 heap mem_debug_objcache(heap meta, heap parent, u64 objsize, u64 pagesize)
 {
-    mem_debug_heap mdh = allocate(meta, sizeof(*mdh));
+    mem_debug_heap mdh = allocate_zero(meta, sizeof(*mdh));
     u64 newsize;
     u64 padding = objsize >= PAGESIZE ? PAGESIZE : PAD_MIN;
 
@@ -209,7 +211,7 @@ static void mem_debug_backed_dealloc(heap h, u64 a, bytes b)
 
 backed_heap mem_debug_backed(heap meta, backed_heap parent, u64 padsize)
 {
-    mem_debug_backed_heap mbh = allocate(meta, sizeof(*mbh));
+    mem_debug_backed_heap mbh = allocate_zero(meta, sizeof(*mbh));
     mbh->parent = parent;
     mbh->bh.h.pagesize = parent->h.pagesize;
     mbh->bh.h.alloc = mem_debug_backed_alloc;

--- a/src/runtime/heap/objcache.c
+++ b/src/runtime/heap/objcache.c
@@ -455,6 +455,8 @@ heap allocate_objcache(heap meta, heap parent, bytes objsize, bytes pagesize)
 heap allocate_wrapped_objcache(heap meta, heap parent, bytes objsize, bytes pagesize, heap wrapper)
 {
     objcache o = (objcache)allocate_objcache(meta, parent, objsize, pagesize);
+    if (o == INVALID_ADDRESS)
+        return INVALID_ADDRESS;
     o->wrapper_heap = wrapper;
     return (heap)o;
 }

--- a/src/runtime/heap/objcache.c
+++ b/src/runtime/heap/objcache.c
@@ -448,6 +448,7 @@ heap allocate_objcache(heap meta, heap parent, bytes objsize, bytes pagesize)
     o->objs_per_page = objs_per_page;
     o->total_objs = 0;
     o->alloced_objs = 0;
+    o->wrapper_heap = 0;
 
     return (heap)o;
 }

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -608,7 +608,6 @@ closure_function(3, 1, void, vmap_remove_intersection,
 
     if (!head && !tail) {
         rangemap_remove_node(pvmap, node);
-        deallocate_vmap(pvmap, match);
     } else if (head) {
         /* truncate node at start */
         assert(rangemap_reinsert(pvmap, node, irange(rn.start, ri.start)));
@@ -635,6 +634,8 @@ closure_function(3, 1, void, vmap_remove_intersection,
         k.node.r = ri;
         apply(bound(unmap), &k);
     }
+    if (!head && !tail)
+        deallocate_vmap(pvmap, match);
 }
 
 closure_function(4, 1, void, vmap_paint_gap,


### PR DESCRIPTION
This PR adds support for the objcache to the mem debug heap wrapper since the objcache was not
previously compatible with it. The objcache implementation had to change slightly since a pointer to
the objcache is cached in each page, bypassing the wrapper. The footer can now store either the
objcache pointer or the wrapper pointer depending on how the objcache is created.

By applying the debug wrapper to the objcaches in the mcache, I discovered a use-after-free problem
in vmap_remove_intersection where the node match could be deallocated before it gets used for 
unmapping.

Since I had to touch objcache.c, I updated it to spaces only in order to eliminate the mixture of tabs
and spaces. It makes the diff very noisy however, so I suggest viewing that file with leading/trailing whitespace
changes turned off.

There's also some minor cleanup in mem_debug.c