### PR TITLE
PC platform vm_exit(): fix handling of reboot_on_exit flag

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -34,7 +34,7 @@
 #define init_debug(x, ...)
 #endif
 
-static filesystem root_fs;
+extern filesystem root_fs;
 
 #define BOOTSTRAP_REGION_SIZE_KB	2048
 static u8 bootstrap_region[BOOTSTRAP_REGION_SIZE_KB << 10];


### PR DESCRIPTION
The PC platform code that handles a VM exit should reference the root_fs global variable (defined in kernel/init.c), which holds a
pointer to the root filesystem, instead of a static variable that is never set.