### PR TITLE
Radar: add more robust retry mechanisms

### DIFF
--- a/src/runtime/symbol.c
+++ b/src/runtime/symbol.c
@@ -15,6 +15,7 @@ symbol intern_u64(u64 u)
     print_number(b, u, 10, 0);
     return intern(b);
 }
+KLIB_EXPORT(intern_u64);
 
 symbol intern(string name)
 {

--- a/src/x86_64/machine.h
+++ b/src/x86_64/machine.h
@@ -13,7 +13,7 @@
 #define KMEM_BASE   0xffff800000000000ull
 #define USER_LIMIT  0x0000800000000000ull
 
-#ifdef KERNEL
+#if defined(KERNEL) || defined(KLIB)
 #define VA_TAG_BASE   KMEM_BASE
 #define VA_TAG_OFFSET 39
 #define VA_TAG_WIDTH  8


### PR DESCRIPTION
The radar klib now checks the server response to crash reports, and retries sending a crash report if the response is not received or does not contain an OK status code.
A retry mechanism is implemented for boot reports as well, so that a boot report is resent if no valid boot ID has been received.
Finally, a retry is triggered if connection to the server fails when sending either a crash or a boot report.