### PR TITLE
Fix go test problems

### DIFF
--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,0 +1,3 @@
+module e2e
+
+go 1.13

--- a/test/go/go.mod
+++ b/test/go/go.mod
@@ -2,4 +2,4 @@ module github.com/nanovms/nanos/test/go
 
 go 1.13
 
-require github.com/nanovms/ops v0.0.0-20210126164802-3bca6edc0845
+require github.com/nanovms/ops v0.0.0-20210408190622-0dc76ec84cd2

--- a/test/go/go_test.go
+++ b/test/go/go_test.go
@@ -26,8 +26,6 @@ func prepareTestImage(finalImage string) {
 	writeFile(filepath)
 
 	c.BaseVolumeSz = "32M"
-	c.Files = append(c.Files, "/lib/x86_64-linux-gnu/libnss_dns.so.2")
-	c.Files = append(c.Files, "/etc/ssl/certs/ca-certificates.crt")
 	c.Files = append(c.Files, filepath)
 
 	c.Args = append(c.Args, "longargument")


### PR DESCRIPTION
This fixes the overwriting existing files error in go_test.go, updates the go.mod for go_test, and creates a go.mod for e2e which is now required for newer versions of go.