### PR TITLE
Net: add IPv6 address configuration

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -126,6 +126,7 @@ SRCS-lwip= \
 	$(LWIPDIR)/src/core/ipv4/ip4_addr.c \
 	$(LWIPDIR)/src/core/ipv4/ip4_frag.c \
 	$(LWIPDIR)/src/core/ipv4/ip4.c \
+	$(LWIPDIR)/src/core/ipv6/ethip6.c \
 	$(LWIPDIR)/src/core/ipv6/icmp6.c \
 	$(LWIPDIR)/src/core/ipv6/ip6.c \
 	$(LWIPDIR)/src/core/ipv6/ip6_addr.c \

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -88,6 +88,7 @@ SRCS-lwip= \
 	$(LWIPDIR)/src/core/ipv4/ip4_addr.c \
 	$(LWIPDIR)/src/core/ipv4/ip4_frag.c \
 	$(LWIPDIR)/src/core/ipv4/ip4.c \
+	$(LWIPDIR)/src/core/ipv6/ethip6.c \
 	$(LWIPDIR)/src/core/ipv6/icmp6.c \
 	$(LWIPDIR)/src/core/ipv6/ip6.c \
 	$(LWIPDIR)/src/core/ipv6/ip6_addr.c \

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -7,9 +7,13 @@
 #include <lwip/tcp.h>
 #include <lwip/timeouts.h>
 #include <lwip/ip4_frag.h>
+#include <lwip/ip6_frag.h>
 #include <lwip/etharp.h>
+#include <lwip/ethip6.h>
 #include <lwip/dhcp.h>
 #include <lwip/dns.h>
+#include <lwip/mld6.h>
+#include <lwip/nd6.h>
 
 #define MAX_LWIP_ALLOC_ORDER 16
 


### PR DESCRIPTION
This PR makes IPv6 networking fully functional by adding automatic creation of a link-local IPv6 address and servicing the lwIP timers that are needed for proper IPv6 operation.
In addition, manual configuration of a global IPv6 address is now supported, via the "ip6addr" manifest attribute, which takes the
string representation of an IPv6 address, for example: `ip6addr: 1234:2345:3456:4567:5678:6789:7890:890a`

At startup, the kernel now prints on the serial output the IPv6 address(es) being set up, in addition to the IPv4 address. Example output without a global IPv6 address:
```
en1: assigned 10.0.2.15
en1: assigned FE80::5054:FF:FE12:3456
```
In the above output, FE80::5054:FF:FE12:3456 is the link-local IPv6 address created automatically by the kernel.
Example output with a global IPv6 address:
```
en1: assigned 10.0.2.15
en1: assigned FE80::5054:FF:FE12:3456
en1: assigned 1234:2345:3456:4567:5678:6789:7890:890A
```