### PR TITLE
Handle large error adjustments in ntp

### DIFF
--- a/klib/ntp.c
+++ b/klib/ntp.c
@@ -15,7 +15,7 @@
 
 #define NTP_MAX_SLEW_RATE   ((1ll << CLOCK_CALIBR_BITS) / 2000) /* 500 PPM */
 
-#define NTP_CLOCK_RESET_THRESHOLD   60
+#define NTP_RESET_THRESHOLD_MIN 60  /* 60 seconds */
 
 struct ntp_ts {
     u32 seconds;
@@ -48,6 +48,7 @@ static struct {
     timer query_timer;
     closure_struct(ntp_query_func, query_func);
     boolean query_ongoing;
+    u64 reset_threshold;
 
     /* interval values expressed as bit order of number of seconds */
     int pollmin, pollmax;
@@ -170,7 +171,8 @@ static void ntp_input(void *z, struct udp_pcb *pcb, struct pbuf *p,
     ntp.runtime_memcpy(&t2, &pkt->receive_ts, sizeof(t2));
     timestamp rtd = wallclock_now - origin - ntptime_diff(&t1, &t2);
     s64 offset = ntptime_to_timestamp(&t1) - wallclock_now + rtd / 2;
-    if (sec_from_timestamp(offset < 0 ? -offset : offset) > NTP_CLOCK_RESET_THRESHOLD) {
+    if (ntp.reset_threshold > 0 &&
+            sec_from_timestamp(offset < 0 ? -offset : offset) > ntp.reset_threshold) {
         ntp.clock_reset_rtc(wallclock_now + offset);
         ntp.last_offset = 0;
         ntp.last_raw = 0;
@@ -345,6 +347,16 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
             }
             ntp.pollmin = interval;
         }
+    }
+    ntp.reset_threshold = 0;
+    value reset_thresh = table_find(root, sym_intern(ntp_reset_threshold, intern));
+    if (reset_thresh) {
+        u64 thresh;
+        if (!u64_from_value(reset_thresh, &thresh) || (thresh > 0 && thresh < NTP_RESET_THRESHOLD_MIN)) {
+            ntp.rprintf("NTP: invalid reset threshold\n");
+            return KLIB_INIT_FAILED;
+        }
+        ntp.reset_threshold = thresh;
     }
     ntp.pcb = udp_new();
     if (!ntp.pcb) {

--- a/klib/ntp.c
+++ b/klib/ntp.c
@@ -170,8 +170,7 @@ static void ntp_input(void *z, struct udp_pcb *pcb, struct pbuf *p,
     ntp.runtime_memcpy(&t2, &pkt->receive_ts, sizeof(t2));
     timestamp rtd = wallclock_now - origin - ntptime_diff(&t1, &t2);
     s64 offset = ntptime_to_timestamp(&t1) - wallclock_now + rtd / 2;
-    s64 sec = sec_from_timestamp(offset < 0 ? -offset : offset);
-    if (sec > NTP_CLOCK_RESET_THRESHOLD) {
+    if (sec_from_timestamp(offset < 0 ? -offset : offset) > NTP_CLOCK_RESET_THRESHOLD) {
         ntp.clock_reset_rtc(wallclock_now + offset);
         ntp.last_offset = 0;
         ntp.last_raw = 0;

--- a/klib/ntp.c
+++ b/klib/ntp.c
@@ -70,7 +70,7 @@ static struct {
     void (*runtime_memset)(u8 *a, u8 b, bytes len);
     timestamp (*now)(clock_id id);
     void (*clock_adjust)(timestamp now, s64 temp_cal, timestamp sync_complete, s64 cal);
-    void (*clock_reset)(timestamp now);
+    void (*clock_reset_rtc)(timestamp now);
 } ntp;
 
 /* Calculates a division between a 128-bit value and a 64-bit value and returns a 64-bit quotient.
@@ -172,7 +172,7 @@ static void ntp_input(void *z, struct udp_pcb *pcb, struct pbuf *p,
     s64 offset = ntptime_to_timestamp(&t1) - wallclock_now + rtd / 2;
     s64 sec = sec_from_timestamp(offset < 0 ? -offset : offset);
     if (sec > NTP_CLOCK_RESET_THRESHOLD) {
-        ntp.clock_reset(wallclock_now + offset);
+        ntp.clock_reset_rtc(wallclock_now + offset);
         ntp.last_offset = 0;
         ntp.last_raw = 0;
         success = true;
@@ -284,7 +284,7 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
             !(ntp.runtime_memcpy = get_sym("runtime_memcpy")) ||
             !(ntp.runtime_memset = get_sym("runtime_memset")) ||
             !(ntp.now = get_sym("now")) || !(ntp.clock_adjust = get_sym("clock_adjust")) ||
-            !(ntp.clock_reset = get_sym("clock_reset"))) {
+            !(ntp.clock_reset_rtc = get_sym("clock_reset_rtc"))) {
         ntp.rprintf("NTP: kernel symbols not found\n");
         return KLIB_INIT_FAILED;
     }

--- a/klib/ntp.c
+++ b/klib/ntp.c
@@ -349,7 +349,7 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
         }
     }
     ntp.reset_threshold = 0;
-    value reset_thresh = table_find(root, sym_intern(ntp_reset_threshold, intern));
+    value reset_thresh = get(root, sym_intern(ntp_reset_threshold, intern));
     if (reset_thresh) {
         u64 thresh;
         if (!u64_from_value(reset_thresh, &thresh) || (thresh > 0 && thresh < NTP_RESET_THRESHOLD_MIN)) {

--- a/src/kernel/clock.c
+++ b/src/kernel/clock.c
@@ -45,7 +45,7 @@ closure_function(0, 1, boolean, timer_id_rtc,
     return false;
 }
 
-void clock_reset(timestamp wallclock_now)
+void clock_reset_rtc(timestamp wallclock_now)
 {
     clock_debug("%s: now %T, wallclock_now %T\n",
                 __func__, now(CLOCK_ID_REALTIME), wallclock_now);
@@ -53,4 +53,4 @@ void clock_reset(timestamp wallclock_now)
     timer_adjust(runloop_timers, stack_closure(timer_id_rtc), wallclock_now - now(CLOCK_ID_REALTIME));
     reset_clock_vdso_dat();
 }
-KLIB_EXPORT(clock_reset);
+KLIB_EXPORT(clock_reset_rtc);

--- a/src/kernel/clock.c
+++ b/src/kernel/clock.c
@@ -35,3 +35,22 @@ void clock_adjust(timestamp wallclock_now, s64 temp_cal, timestamp sync_complete
     rtc_settimeofday(sec_from_timestamp(wallclock_now));
 }
 KLIB_EXPORT(clock_adjust);
+
+closure_function(0, 1, boolean, timer_id_rtc,
+                timer, t)
+{
+    if (t->id == CLOCK_ID_REALTIME || t->id == CLOCK_ID_REALTIME_ALARM) {
+        return true;
+    }
+    return false;
+}
+
+void clock_reset(timestamp wallclock_now)
+{
+    clock_debug("%s: now %T, wallclock_now %T\n",
+                __func__, now(CLOCK_ID_REALTIME), wallclock_now);
+    rtc_settimeofday(sec_from_timestamp(wallclock_now));
+    timer_adjust(runloop_timers, stack_closure(timer_id_rtc), wallclock_now - now(CLOCK_ID_REALTIME));
+    reset_clock_vdso_dat();
+}
+KLIB_EXPORT(clock_reset);

--- a/src/kernel/clock.c
+++ b/src/kernel/clock.c
@@ -39,7 +39,14 @@ KLIB_EXPORT(clock_adjust);
 closure_function(0, 1, boolean, timer_id_rtc,
                 timer, t)
 {
-    return t->id == CLOCK_ID_REALTIME || t->id == CLOCK_ID_REALTIME_ALARM;
+    switch (t->id) {
+    case CLOCK_ID_REALTIME:
+    case CLOCK_ID_REALTIME_COARSE:
+    case CLOCK_ID_REALTIME_ALARM:
+        return true;
+    default:
+        return false;
+    }
 }
 
 void clock_reset_rtc(timestamp wallclock_now)

--- a/src/kernel/clock.c
+++ b/src/kernel/clock.c
@@ -39,10 +39,7 @@ KLIB_EXPORT(clock_adjust);
 closure_function(0, 1, boolean, timer_id_rtc,
                 timer, t)
 {
-    if (t->id == CLOCK_ID_REALTIME || t->id == CLOCK_ID_REALTIME_ALARM) {
-        return true;
-    }
-    return false;
+    return t->id == CLOCK_ID_REALTIME || t->id == CLOCK_ID_REALTIME_ALARM;
 }
 
 void clock_reset_rtc(timestamp wallclock_now)

--- a/src/runtime/clock.h
+++ b/src/runtime/clock.h
@@ -126,7 +126,7 @@ static inline void register_platform_clock_now(clock_now cn, vdso_clock_id id)
 }
 
 void clock_adjust(timestamp wallclock_now, s64 temp_cal, timestamp sync_complete, s64 cal);
-void clock_reset(timestamp wallclock_now);
+void clock_reset_rtc(timestamp wallclock_now);
 #if defined(KERNEL) || defined(BUILD_VDSO)
 #undef __vdso_dat
 #endif

--- a/src/runtime/clock.h
+++ b/src/runtime/clock.h
@@ -105,21 +105,28 @@ static inline timestamp uptime(void)
 u64 rtc_gettimeofday(void);
 void rtc_settimeofday(u64 seconds);
 
+#if defined(KERNEL) || defined(BUILD_VDSO)
+static inline void reset_clock_vdso_dat()
+{
+    u64 rt = rtc_gettimeofday();
+    __vdso_dat->rtc_offset = rt ? (rt << 32) - apply(platform_monotonic_now) : 0;
+    __vdso_dat->temp_cal = __vdso_dat->cal = 0;
+    __vdso_dat->sync_complete = 0;
+    __vdso_dat->last_raw = __vdso_dat->last_drift = 0;
+}
+#endif
+
 static inline void register_platform_clock_now(clock_now cn, vdso_clock_id id)
 {
     platform_monotonic_now = cn;
 #if defined(KERNEL) || defined(BUILD_VDSO)
     __vdso_dat->clock_src = id;
-    u64 rt = rtc_gettimeofday();
-    __vdso_dat->rtc_offset = rt ? (rt << 32) - apply(cn) : 0;
-    __vdso_dat->temp_cal = __vdso_dat->cal = 0;
-    __vdso_dat->sync_complete = 0;
-    __vdso_dat->last_raw = __vdso_dat->last_drift = 0;
+    reset_clock_vdso_dat();
 #endif
 }
 
 void clock_adjust(timestamp wallclock_now, s64 temp_cal, timestamp sync_complete, s64 cal);
-
+void clock_reset(timestamp wallclock_now);
 #if defined(KERNEL) || defined(BUILD_VDSO)
 #undef __vdso_dat
 #endif

--- a/src/runtime/pqueue.c
+++ b/src/runtime/pqueue.c
@@ -78,6 +78,13 @@ void pqueue_reorder(pqueue q)
         heal(q, i);
 }
 
+void pqueue_walk(pqueue q, pqueue_element_handler h)
+{
+    void *e;
+    vector_foreach(q->body, e)
+        apply(h, e);
+}
+
 pqueue allocate_pqueue(heap h, boolean(*sort)(void *, void *))
 {
     pqueue p = allocate(h, sizeof(struct pqueue));

--- a/src/runtime/pqueue.c
+++ b/src/runtime/pqueue.c
@@ -78,11 +78,13 @@ void pqueue_reorder(pqueue q)
         heal(q, i);
 }
 
-void pqueue_walk(pqueue q, pqueue_element_handler h)
+boolean pqueue_walk(pqueue q, pqueue_element_handler h)
 {
     void *e;
     vector_foreach(q->body, e)
-        apply(h, e);
+        if (!apply(h, e))
+            return false;
+    return true;
 }
 
 pqueue allocate_pqueue(heap h, boolean(*sort)(void *, void *))

--- a/src/runtime/pqueue.h
+++ b/src/runtime/pqueue.h
@@ -5,5 +5,5 @@ void pqueue_insert(pqueue q, void *v);
 void *pqueue_peek(pqueue q);
 void *pqueue_pop(pqueue q);
 void pqueue_reorder(pqueue q);
-typedef closure_type(pqueue_element_handler, void, void *);
-void pqueue_walk(pqueue q, pqueue_element_handler h);
+typedef closure_type(pqueue_element_handler, boolean, void *);
+boolean pqueue_walk(pqueue q, pqueue_element_handler h);

--- a/src/runtime/pqueue.h
+++ b/src/runtime/pqueue.h
@@ -5,3 +5,5 @@ void pqueue_insert(pqueue q, void *v);
 void *pqueue_peek(pqueue q);
 void *pqueue_pop(pqueue q);
 void pqueue_reorder(pqueue q);
+typedef closure_type(pqueue_element_handler, void, void *);
+void pqueue_walk(pqueue q, pqueue_element_handler h);

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -70,7 +70,7 @@ void timer_service(timerheap th, timestamp here)
     }
 }
 
-closure_function(2, 1, void, timer_adjust_handler,
+closure_function(2, 1, boolean, timer_adjust_handler,
                 timer_select, sel, s64, amt,
                 void *, v)
 {
@@ -78,6 +78,7 @@ closure_function(2, 1, void, timer_adjust_handler,
 
     if (apply(bound(sel), t))
         t->expiry += bound(amt);
+    return true;
 }
 
 void timer_adjust(timerheap th, timer_select sel, s64 amt)

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -70,6 +70,22 @@ void timer_service(timerheap th, timestamp here)
     }
 }
 
+closure_function(2, 1, void, timer_adjust_handler,
+                timer_select, sel, s64, amt,
+                void *, v)
+{
+    timer t = v;
+
+    if (apply(bound(sel), t))
+        t->expiry += bound(amt);
+}
+
+void timer_adjust(timerheap th, timer_select sel, s64 amt)
+{
+    pqueue_walk(th->pq, stack_closure(timer_adjust_handler, sel, amt));
+    timer_reorder(th);
+}
+
 void timer_reorder(timerheap th)
 {
     pqueue_reorder(th->pq);

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -70,23 +70,6 @@ void timer_service(timerheap th, timestamp here)
     }
 }
 
-closure_function(2, 1, boolean, timer_adjust_handler,
-                timer_select, sel, s64, amt,
-                void *, v)
-{
-    timer t = v;
-
-    if (apply(bound(sel), t))
-        t->expiry += bound(amt);
-    return true;
-}
-
-void timer_adjust(timerheap th, timer_select sel, s64 amt)
-{
-    pqueue_walk(th->pq, stack_closure(timer_adjust_handler, sel, amt));
-    timer_reorder(th);
-}
-
 void timer_reorder(timerheap th)
 {
     pqueue_reorder(th->pq);

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -105,9 +105,12 @@ static inline timestamp timer_check(timerheap th)
     return infinity;
 }
 
+typedef closure_type(timer_select, boolean, timer);
+
 timerheap allocate_timerheap(heap h, const char *name);
 void timer_service(timerheap th, timestamp here);
 void timer_reorder(timerheap th);
+void timer_adjust(timerheap th, timer_select sel, s64 amt);
 void print_timestamp(buffer, timestamp);
 
 #define THOUSAND         (1000ull)

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -110,7 +110,6 @@ typedef closure_type(timer_select, boolean, timer);
 timerheap allocate_timerheap(heap h, const char *name);
 void timer_service(timerheap th, timestamp here);
 void timer_reorder(timerheap th);
-void timer_adjust(timerheap th, timer_select sel, s64 amt);
 void print_timestamp(buffer, timestamp);
 
 #define THOUSAND         (1000ull)


### PR DESCRIPTION
This PR adds the ability for the ntp klib to handle large errors in local vs ntp server time by resetting the 
rtc_offset, normally only set at boot, to an offset from the new time value. A large time reset will also
reset any current in-progress time adjustments. This change does not affect the monotonic time in
any way, so the only adjustments to existing timers is to update any based on the RTC with the difference
between the old and new offsets.  As a side effect of needing to adjust the timers, this also adds a way
to walk through the entries in a pqueue. Since ntp slewing is slow, the default threshold to reset the rtc
is any time difference greater than one minute.