### PR TITLE
sigaltstack: do not validate ss->ss_sp if SS_DISABLE is specified

### DIFF
--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -594,14 +594,16 @@ sysreturn sigaltstack(const stack_t *ss, stack_t *oss)
     // it doesn't seem possible to re-enable without setting
     // a new stack....so we think this is a valid interpretation
     if (ss) {
-        if (!validate_user_memory(ss, sizeof(stack_t), false) ||
-            !validate_user_memory(ss->ss_sp, ss->ss_size, true))
+        if (!validate_user_memory(ss, sizeof(stack_t), false)) {
             return -EFAULT;
+        }
         if (thread_is_on_altsigstack(t)) {
             return -EPERM;
         }
         if (ss->ss_flags & SS_DISABLE) {
             t->signal_stack = 0;
+        } else if (!validate_user_memory(ss->ss_sp, ss->ss_size, true)) {
+            return -EFAULT;
         } else {
             if (ss->ss_flags) { /* unknown flags */
                 return -EINVAL;


### PR DESCRIPTION
According to sigaltstack(2):

"To disable an existing stack, specify ss.ss_flags as SS_DISABLE.  In this case, the kernel ignores any other flags in ss.ss_flags and the remaining fields in ss."

The nanos implementation, however, was calling validate_user_memory on ss->ss_sp regardless of the presence of SS_DISABLE, which was causing an -EFAULT return on valid arguments. With this fix, sigaltstack only validates ss->ss_sp if SS_DISABLE is not set.