### PR TITLE
optimize for space when building stage2 bootloader

### DIFF
--- a/klib/Makefile
+++ b/klib/Makefile
@@ -135,7 +135,7 @@ DEFINES= \
 	-DKLIB \
 	-DMBEDTLS_USER_CONFIG_FILE=\"mbedtls_conf.h\" \
 
-CFLAGS+=	$(KERNCFLAGS) $(INCLUDES) -fPIC $(DEFINES)
+CFLAGS+=	$(KERNCFLAGS) -O3 $(INCLUDES) -fPIC $(DEFINES)
 
 # TODO should add stack protection to klibs...
 CFLAGS+=	-fno-stack-protector

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -163,7 +163,7 @@ INCLUDES=\
 
 AFLAGS+=-I$(ARCHDIR)/
 
-CFLAGS+=$(KERNCFLAGS) -DKERNEL -fno-pic -mcmodel=kernel
+CFLAGS+=$(KERNCFLAGS) -DKERNEL -O3 -fno-pic -mcmodel=kernel
 CFLAGS+=-Wno-address # lwIP build sadness
 CFLAGS+=$(INCLUDES)
 

--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -27,7 +27,7 @@ SRCS-stage2.elf= \
 	$(SRCDIR)/tfs/tfs.c \
 	$(SRCDIR)/tfs/tlog.c
 
-CFLAGS+=	$(KERNCFLAGS) -DBOOT -DPAGE_USE_FLUSH -fno-pic
+CFLAGS+=	$(KERNCFLAGS) -Os -DBOOT -DPAGE_USE_FLUSH -fno-pic
 CFLAGS+= \
 	-I$(CURDIR) \
 	-I$(SRCDIR) \

--- a/platform/pc/boot/service32.s
+++ b/platform/pc/boot/service32.s
@@ -343,6 +343,11 @@ run64:
         push eax
 
 		ENTER_LONG_MODE eax
+[BITS 64]
+        ;; clear %rsi; init_service in stage3 expects it to be clear when entering from stage2
+        xor rsi, rsi
+[BITS 32]
+
         ;; 64 bit compatibility into the proper long mode
         lgdt [GDT64.Pointer]    ; Load the 64-bit global descriptor table.
         jmp GDT64.Code:setup64

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -126,7 +126,7 @@ INCLUDES=\
 
 AFLAGS+=-I$(ARCHDIR)
 
-CFLAGS+=$(KERNCFLAGS) -DKERNEL -march=armv8-a+nofp+nosimd -mcpu=cortex-a72 -ffixed-x18 -fno-pic
+CFLAGS+=$(KERNCFLAGS) -DKERNEL -O3 -march=armv8-a+nofp+nosimd -mcpu=cortex-a72 -ffixed-x18 -fno-pic
 CFLAGS+=-Wno-address # lwIP build sadness
 CFLAGS+=$(INCLUDES)
 

--- a/rules.mk
+++ b/rules.mk
@@ -90,7 +90,7 @@ GCOV=		gcov
 LCOV=		lcov
 GENHTML=	genhtml
 
-CFLAGS+=	-std=gnu11 -O3 -g
+CFLAGS+=	-std=gnu11 -g
 CFLAGS+=	-Wall -Werror -Wno-char-subscripts -Wno-format-truncation -Wno-unknown-warning-option
 CFLAGS+=	-I$(OBJDIR)
 

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -263,7 +263,7 @@ SRCS-readv = \
 	$(SRCDIR)/unix_process/ssp.c
 LDFLAGS-readv=		-static
 
-CFLAGS+=	-DENABLE_MSG_DEBUG
+CFLAGS+=	-O3 -DENABLE_MSG_DEBUG
 CFLAGS+=	-I$(ARCHDIR) \
 		-I$(SRCDIR) \
 		-I$(SRCDIR)/http \

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -22,7 +22,7 @@ SRCS-bitmap_test= \
 	$(CURDIR)/bitmap_test.c \
 	$(RUNTIME)\
 	$(SRCDIR)/unix_process/unix_process_runtime.c
-	
+
 SRCS-buffer_test= \
 	$(CURDIR)/buffer_test.c \
 	$(RUNTIME)\
@@ -118,7 +118,8 @@ SRCS-vector_test= \
 	$(SRCDIR)/unix_process/unix_process_runtime.c
 
 
-CFLAGS+=	-I$(ARCHDIR) \
+CFLAGS+=	-O3 \
+		-I$(ARCHDIR) \
 		-I$(SRCDIR) \
 		-I$(SRCDIR)/http \
 		-I$(SRCDIR)/kernel \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -31,7 +31,8 @@ SRCS-mkfs= \
 
 SRCS-vdsogen=	$(CURDIR)/vdsogen.c
 
-CFLAGS+=-I$(ARCHDIR) \
+CFLAGS+=-O3 \
+	-I$(ARCHDIR) \
 	-I$(SRCDIR) \
 	-I$(SRCDIR)/kernel \
 	-I$(SRCDIR)/runtime \


### PR DESCRIPTION
The stage2 build was previously being built with -O3, which could, on occasion, result in a stage2 image that exceeds 64kB. Sizes larger than 64kB are problematic for Xen-based VMs such as AWS t2 instances (for more detail on this issue, see #1383). Building the stage2 bootloader with -Os results in a much smaller executable (e.g. 46kB vs 64kB - a 27% reduction - on a Debian 9 / gcc 8.3.0 build).

Additionally, a bug is resolved in run64 (where stage2 transitions control to the 64-bit kernel) where %rsi, the second function argument in the ABI calling convention, which is used in init_service to detect parameters on direct loading (e.g. AWS firecracker), was not being zeroed.
