### PR TITLE
Resume original thread after running blockq action

### DIFF
--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -132,6 +132,7 @@ static void blockq_apply_bi_locked(blockq bq, blockq_item bi, u64 flags)
                  (flags & BLOCKQ_ACTION_NULLIFY) ? "nullify " : "",
                  (flags & BLOCKQ_ACTION_TIMEDOUT) ? "timedout" : "");
 
+    thread ot = current;
     thread_resume(bi->t);
     rv = apply(bi->a, flags);
     blockq_debug("   - returned %ld\n", rv);
@@ -141,6 +142,7 @@ static void blockq_apply_bi_locked(blockq bq, blockq_item bi, u64 flags)
     if ((flags & (BLOCKQ_ACTION_NULLIFY | BLOCKQ_ACTION_TIMEDOUT)) ||
         (rv != BLOCKQ_BLOCK_REQUIRED))
         blockq_item_finish(bq, bi);
+    thread_resume(ot);
 }
 
 /*

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -142,7 +142,8 @@ static void blockq_apply_bi_locked(blockq bq, blockq_item bi, u64 flags)
     if ((flags & (BLOCKQ_ACTION_NULLIFY | BLOCKQ_ACTION_TIMEDOUT)) ||
         (rv != BLOCKQ_BLOCK_REQUIRED))
         blockq_item_finish(bq, bi);
-    thread_resume(ot);
+    if (ot)
+        thread_resume(ot);
 }
 
 /*

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -313,7 +313,6 @@ closure_function(1, 2, void, epoll_wait_notify,
         return;
     }
 
-    thread_resume(w->t);
     struct epoll_event *e = buffer_ref(w->user_events, w->user_events->end);
     e->data = efd->data;
     e->events = report;
@@ -576,7 +575,6 @@ closure_function(1, 2, void, select_notify,
     if (t && t != w->t)
         return;
 
-    thread_resume(w->t);
     assert(w->epoll_type == EPOLL_TYPE_SELECT);
     int count = 0;
     /* XXX need thread safe / cas bitmap ops */
@@ -820,7 +818,6 @@ closure_function(1, 2, void, poll_notify,
     if (t && t != w->t)
         return;
 
-    thread_resume(w->t);
     struct pollfd *pfd = buffer_ref(w->poll_fds, efd->data * sizeof(struct pollfd));
     fetch_and_add(&w->poll_retcount, 1);
     pfd->revents = events;


### PR DESCRIPTION
This change removes some unnecessary thread_resume calls in poll.c and
adds a thread_resume with the original thread in blockq_apply_bi_locked.
This is necessary because a call to wake from the blockq in a syscall would
switch current to the waking thread and any references to current in the
original syscall (such as to set the return value) would use the new thread
instead of the old one and thus return the wrong value from a syscall.