### PR TITLE
support static configuration and DHCP on multiple network interfaces

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -336,7 +336,7 @@ STORAGE=	virtio-scsi
 STORAGE_BUS=	,bus=pci.2,addr=0x0
 NETWORK=	virtio-net
 NETWORK_BUS=	,bus=pci.3,addr=0x0
-
+NETWORK_BUS_2=  ,bus=pci.3,addr=0x1
 QEMU_MACHINE=	-machine $(MACHINE_TYPE)
 QEMU_MEMORY=	-m 2G
 QEMU_PCI=	-device pcie-root-port,port=0x10,chassis=1,id=pci.1,bus=$(PCI_BUS),multifunction=on,addr=0x3 \
@@ -372,6 +372,10 @@ endif
 QEMU_TAP=	-netdev tap,id=n0,ifname=tap0,script=no,downscript=no
 QEMU_NET=	-device $(NETWORK)$(NETWORK_BUS),mac=7e:b8:7e:87:4a:ea,netdev=n0 $(QEMU_TAP)
 QEMU_USERNET=	-device $(NETWORK)$(NETWORK_BUS),netdev=n0 -netdev user,id=n0,hostfwd=tcp::8080-:8080,hostfwd=tcp::9090-:9090,hostfwd=udp::5309-:5309
+ifneq ($(ENABLE_SECOND_IFACE),)
+QEMU_NET+=	-device $(NETWORK)$(NETWORK_BUS_2),mac=7e:b8:7e:87:4b:ea,netdev=n1 -netdev tap,id=n1,ifname=tap1,script=no,downscript=no
+QEMU_USERNET+=  -device $(NETWORK)$(NETWORK_BUS_2),netdev=n1 -netdev user,id=n1
+endif
 ifneq ($(ENABLE_BALLOON),)
 QEMU_BALLOON=   -device virtio-balloon-pci
 endif


### PR DESCRIPTION
While multiple network interfaces are detected and enabled by Nanos, static and dynamic IP configuration have been limited to the first interface. This adds support for configuration of any interface by moving its configuration into a root-level tuple under the interface name. For example, `en2:(ipaddr:192.168.43.2 netmask:255.255.255.0 gateway:192.168.43.1)` gives static configuration for the second virtio-net interface. Other supported attributes in the interface tuple are 'mtu', used to specify the interface MTU size, and 'default', for selecting an interface as the default egress interface when no route is found.

DHCP is run on detected interfaces that don't have static IP configuration.

To ease transition for ops and existing installations, interface configuration for en1 may still be specified on the root tuple, though this usage is now deprecated.

Note that multiple interfaces may be tested under QEMU by specifying "ENABLE_SECOND_IFACE=1" on the make commandline.

This should hopefully address configuration of the second interface in https://github.com/nanovms/ops/issues/1009.