### PR TITLE
Network: add support for DHCPv6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ include rules.mk
 
 THIRD_PARTY= $(LWIPDIR)/.vendored $(MBEDTLS_DIR)/.vendored
 
-$(LWIPDIR)/.vendored: GITFLAGS= --depth 1  https://github.com/nanovms/lwip.git -b STABLE-2_1_2_RELEASE
+$(LWIPDIR)/.vendored: GITFLAGS= --depth 1  https://github.com/nanovms/lwip.git -b STABLE-2_1_x
 $(MBEDTLS_DIR)/.vendored: GITFLAGS= --depth 1 https://github.com/nanovms/mbedtls.git
 
 image: $(THIRD_PARTY) tools

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -126,6 +126,7 @@ SRCS-lwip= \
 	$(LWIPDIR)/src/core/ipv4/ip4_addr.c \
 	$(LWIPDIR)/src/core/ipv4/ip4_frag.c \
 	$(LWIPDIR)/src/core/ipv4/ip4.c \
+	$(LWIPDIR)/src/core/ipv6/dhcp6.c \
 	$(LWIPDIR)/src/core/ipv6/ethip6.c \
 	$(LWIPDIR)/src/core/ipv6/icmp6.c \
 	$(LWIPDIR)/src/core/ipv6/ip6.c \

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -88,6 +88,7 @@ SRCS-lwip= \
 	$(LWIPDIR)/src/core/ipv4/ip4_addr.c \
 	$(LWIPDIR)/src/core/ipv4/ip4_frag.c \
 	$(LWIPDIR)/src/core/ipv4/ip4.c \
+	$(LWIPDIR)/src/core/ipv6/dhcp6.c \
 	$(LWIPDIR)/src/core/ipv6/ethip6.c \
 	$(LWIPDIR)/src/core/ipv6/icmp6.c \
 	$(LWIPDIR)/src/core/ipv6/ip6.c \

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -11,6 +11,7 @@
 #include <lwip/etharp.h>
 #include <lwip/ethip6.h>
 #include <lwip/dhcp.h>
+#include <lwip/dhcp6.h>
 #include <lwip/dns.h>
 #include <lwip/mld6.h>
 #include <lwip/nd6.h>

--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -75,6 +75,7 @@ typedef unsigned long size_t;
 #define LWIP_DNS 1
 
 #define LWIP_IPV6   1
+#define LWIP_IPV6_DHCP6 1
 
 typedef unsigned long u64_t;
 typedef unsigned u32_t;


### PR DESCRIPTION
The DHCPv6 client is enabled on a given network interface if no static IPv6 address is provided for that interface in the manifest.
Depends on https://github.com/nanovms/lwip/pull/1, which adds stateful DHCPv6 support to lwIP.