### PR TITLE
lwIP options: define IPV6_FRAG_COPYHEADER

### DIFF
--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -76,6 +76,7 @@ typedef unsigned long size_t;
 
 #define LWIP_IPV6   1
 #define LWIP_IPV6_DHCP6 1
+#define IPV6_FRAG_COPYHEADER    1
 
 typedef unsigned long u64_t;
 typedef unsigned u32_t;


### PR DESCRIPTION
This is needed to correctly handle reassembly of fragmented IPv6 packets in 64-bit platforms. Bug spotted by an assertion failure at lwip/src/core/ipv6/ip6_frag.c:118.