### PR TITLE
Collection of debug fixes and enhancements

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,5 +1,5 @@
 set architecture i386:x86-64
 display/i $pc
 target remote :1234
-symbol-file ./output/platform/pc/bin/kernel.img
+symbol-file ./output/platform/pc/bin/kernel.elf
 

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -867,7 +867,7 @@ static sysreturn netsock_shutdown(struct sock *sock, int how)
         shut_tx = 1;
         break;
     default:
-        msg_warn("Wrong value passed for direction sock %d, type %d\n", sockfd, s->type);
+        msg_warn("Wrong value passed for direction sock %d, type %d\n", sock->fd, s->sock.type);
         return -EINVAL;
     }
     switch (s->sock.type) {
@@ -1110,7 +1110,7 @@ static sysreturn netsock_bind(struct sock *sock, struct sockaddr *addr,
         net_debug("calling udp_bind, pcb %p, port %d\n", s->info.udp.lw, port);
         err = udp_bind(s->info.udp.lw, &ipaddr, port);
     } else {
-	msg_warn("unsupported socket type %d\n", s->type);
+	msg_warn("unsupported socket type %d\n", s->sock.type);
 	return -EINVAL;
     }
     return lwip_to_errno(err);
@@ -1256,7 +1256,7 @@ static sysreturn netsock_connect(struct sock *sock, struct sockaddr *addr,
         } else if (s->info.tcp.state == TCP_SOCK_OPEN) {
             err = ERR_ISCONN;
         } else if (s->info.tcp.state == TCP_SOCK_LISTENING) {
-            msg_warn("attempt to connect on listening socket fd = %d; ignored\n", sockfd);
+            msg_warn("attempt to connect on listening socket fd = %d; ignored\n", sock->fd);
             err = ERR_ARG;
         } else {
             err = connect_tcp(s, &ipaddr, port);

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -48,7 +48,7 @@ void print_frame_trace_from_here();
     do {                                            \
         if (!(x)) {                                 \
             print_frame_trace_from_here();          \
-            halt("assertion " #x " failed in " __FILE__ ": %s() on line %d; halt\n", __func__, __LINE__); \
+            halt("assertion " #x " failed at " __FILE__ ":%d  in %s(); halt\n", __LINE__, __func__); \
         }                                           \
     } while(0)
 #endif

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -140,7 +140,7 @@ define_closure_function(1, 1, context, default_fault_handler,
 
     thread current_thread = current;
     if (!current_thread) {
-        rprintf("\nPage fault outside of thread context\n");
+        rprintf("\nPage fault outside of thread context (vaddr 0x%lx)\n", vaddr);
         goto bug;
     }
 


### PR DESCRIPTION
This change fixes several things: it points the gdbinit script to the full
symbol image, it updates outdated fields in msg_warn in netsyscall, it
changes the assertion message to a file:line format for better editor
compatibility, and adds virtual address to a message in the fault handler