### PR TITLE
Allocate tfs file and log extents upfront

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test test-noaccel: image
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst futex futexrobust getdents getrandom hw hwg hws io_uring klibs mkdir mmap netlink netsock pipe readv rename sendfile signal socketpair time unlink thread_test tlbshootdown vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws io_uring klibs mkdir mmap netlink netsock pipe readv rename sendfile signal socketpair time unlink thread_test tlbshootdown vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -498,7 +498,7 @@ closure_function(6, 1, void, pagecache_write_sg_finish,
     if (!is_ok(s) || bound(complete)) {
         /* TODO: We handle storage errors after the syscall write
            completion has been applied. This means that storage
-           allocation and I/O errors aren't being propagated back to
+           I/O errors other than ENOSPC aren't being propagated back to
            the syscalls that caused them and are therefore imprecise.
            For now, we take note of any write error and stash it in
            the volume to be returned on a subsequent call.
@@ -506,12 +506,7 @@ closure_function(6, 1, void, pagecache_write_sg_finish,
            As of now, we do not automatically clear a pending error
            condition after reporting. Some logic will need to be added
            to clear specific conditions and allow the application to
-           recover from an error (e.g. test for and clear a pending
-           FS_STATUS_NOSPACE after an extent has been deleted).
-
-           This is clearly a stop-gap, meant to prevent endless,
-           runaway writes on common conditions like storage
-           exhaustion. */
+           recover from an error. */
 
         if (!is_ok(s)) {
             pagecache_debug("%s: %s error: %v\n", __func__, bound(complete) ? "write" : "read", s);
@@ -616,11 +611,6 @@ closure_function(1, 3, void, pagecache_write_sg,
     if (q.end > pn->length)
         pn->length = q.end;
 
-    /* prepare pages for writing */
-    merge m = allocate_merge(pc->h, closure(pc->h, pagecache_write_sg_finish,
-        get_current_thread(), pn, q, sg, completion, false));
-    status_handler sh = apply_merge(m);
-
     u64 start_offset = q.start & MASK(pc->page_order);
     u64 end_offset = q.end & MASK(pc->page_order);
     range r = range_rshift(q, pc->page_order);
@@ -634,6 +624,12 @@ closure_function(1, 3, void, pagecache_write_sg,
             return;
         }
     }
+
+    /* prepare pages for writing */
+    merge m = allocate_merge(pc->h, closure(pc->h, pagecache_write_sg_finish,
+        get_current_thread(), pn, q, sg, completion, false));
+    status_handler sh = apply_merge(m);
+
     /* initiate reads for rmw start and/or end */
     if (start_offset != 0) {
         touch_or_fill_page_by_num_nodelocked(pn, q.start >> pc->page_order, m, false);

--- a/src/kernel/pagecache.h
+++ b/src/kernel/pagecache.h
@@ -2,6 +2,8 @@ typedef struct pagecache_volume *pagecache_volume;
 
 typedef struct pagecache_node *pagecache_node;
 
+typedef closure_type(pagecache_node_reserve, status, range);
+
 void pagecache_set_node_length(pagecache_node pn, u64 length);
 
 u64 pagecache_get_node_length(pagecache_node pn);
@@ -20,7 +22,7 @@ u64 pagecache_get_occupancy(void);
 
 u64 pagecache_drain(u64 drain_bytes);
 
-pagecache_node pagecache_allocate_node(pagecache_volume pv, sg_io fs_read, sg_io fs_write);
+pagecache_node pagecache_allocate_node(pagecache_volume pv, sg_io fs_read, sg_io fs_write, pagecache_node_reserve fs_reserve);
 
 void pagecache_deallocate_node(pagecache_node pn);
 

--- a/src/kernel/pagecache_internal.h
+++ b/src/kernel/pagecache_internal.h
@@ -83,6 +83,7 @@ typedef struct pagecache_node {
     sg_io cache_write;
     sg_io fs_read;
     sg_io fs_write;
+    pagecache_node_reserve fs_reserve;
 } *pagecache_node;
 
 typedef struct pagecache_shared_map {

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -427,7 +427,11 @@ static fs_status create_extent(filesystem fs, range blocks, boolean uninited, ex
     u64 nblocks = MAX(range_span(blocks), MIN_EXTENT_SIZE >> fs->blocksize_order);
 
     tfs_debug("create_extent: blocks %R, uninited %d, nblocks %ld\n", blocks, uninited, nblocks);
-
+    if (!filesystem_reserve_log_space(fs, &fs->next_extend_log_offset, 0, 0) ||
+        !filesystem_reserve_log_space(fs, &fs->next_new_log_offset, 0, 0)) {
+        msg_err("out of storage allocating %ld blocks\n", nblocks);
+        return FS_STATUS_NOSPACE;
+    }
     u64 start_block = filesystem_allocate_storage(fs, nblocks);
     if (start_block == u64_from_pointer(INVALID_ADDRESS)) {
         /* In lieu of precise error handling up the stack, report here... */
@@ -565,7 +569,7 @@ static u64 write_extent(fsfile f, extent ex, sg_list sg, range blocks, merge m)
     return i.end;
 }
 
-static fs_status fill_gap(fsfile f, sg_list sg, range blocks, merge m, u64 *edge)
+static fs_status fill_gap(fsfile f, sg_list sg, range blocks, merge m, u64 *edge, boolean write)
 {
     blocks = irangel(blocks.start, MIN(MAX_EXTENT_SIZE >> f->fs->blocksize_order,
                                        range_span(blocks)));
@@ -579,7 +583,8 @@ static fs_status fill_gap(fsfile f, sg_list sg, range blocks, merge m, u64 *edge
         destroy_extent(f->fs, ex);
         return fss;
     }
-    write_extent(f, ex, sg, blocks, m);
+    if (write)
+        write_extent(f, ex, sg, blocks, m);
     *edge = blocks.end;
     return FS_STATUS_OK;
 }
@@ -603,7 +608,7 @@ static fs_status update_extent_length(fsfile f, extent ex, u64 new_length)
     return FS_STATUS_OK;
 }
 
-static u64 extend(fsfile f, extent ex, sg_list sg, range blocks, merge m)
+static u64 extend(fsfile f, extent ex, sg_list sg, range blocks, merge m, boolean write)
 {
     u64 free = ex->allocated - range_span(ex->node.r);
     range r = irangel(ex->node.r.end, free);
@@ -611,6 +616,8 @@ static u64 extend(fsfile f, extent ex, sg_list sg, range blocks, merge m)
     tfs_debug("   %s: node %R, free 0x%lx (%R), i %R\n", __func__, ex->node.r, free, r, i);
     if (range_span(i) == 0)
         return blocks.start;
+    if (!write)
+        goto out;
     assert(blocks.start >= ex->node.r.end); // XXX temp
     assert(ex->node.r.end <= i.start); // XXX temp
     range z = irange(ex->node.r.end, i.start);
@@ -630,6 +637,87 @@ static u64 extend(fsfile f, extent ex, sg_list sg, range blocks, merge m)
     return i.end;
 }
 
+static status extents_range_handler(filesystem fs, fsfile f, range blocks, boolean write, sg_list sg, merge m)
+{
+    tfs_debug("%s: file %p blocks %R write %d sg %p\n", __func__, f, blocks, write, sg);
+
+    rmnode prev;            /* prior to edge, but could be extended */
+    rmnode next;            /* intersecting or succeeding */
+    prev = rangemap_lookup_max_lte(f->extentmap, blocks.start);
+    if (prev == INVALID_ADDRESS) {
+        /* gap */
+        next = rangemap_first_node(f->extentmap);
+    } else if (prev->r.end > blocks.start) {
+        /* intersection */
+        next = prev;
+        prev = INVALID_ADDRESS;
+    } else {
+        next = rangemap_next_node(f->extentmap, prev);
+    }
+
+    do {
+        tfs_debug("   prev %p, next %p\n", prev, next);
+        u64 limit = next == INVALID_ADDRESS ? blocks.end : MIN(blocks.end, next->r.start);
+        if (!write || sg) {
+            if (blocks.start < limit) {
+                /* try to extend previous node */
+                if (prev != INVALID_ADDRESS && prev->r.end < limit) {
+                    tfs_debug("   extent start 0x%lx, limit 0x%lx\n", blocks.start, limit);
+                    blocks.start = extend(f, (extent)prev, sg, irange(blocks.start, limit), m, write);
+                }
+
+                /* fill space */
+                while (blocks.start < limit) {
+                    tfs_debug("   fill start 0x%lx, limit 0x%lx\n", blocks.start, limit);
+                    fs_status fss = fill_gap(f, sg, irange(blocks.start, limit), m, &blocks.start, write);
+                    if (fss != FS_STATUS_OK) {
+                        return timm("result", "unable to create extent",
+                                 "fsstatus", "%d", fss);
+                    }
+                }
+            }
+        } else {
+            /* zero: skip to start of next node */
+            blocks.start = limit;
+        }
+
+        prev = next;
+        if (next != INVALID_ADDRESS) {
+            extent ex = (extent)next;
+            next = rangemap_next_node(f->extentmap, next);
+
+            if (write && !sg && range_contains(blocks, ex->node.r)) {
+                blocks.start = ex->node.r.end;
+                remove_extent_from_file(f, ex);
+                destroy_extent(fs, ex);
+                prev = INVALID_ADDRESS; /* prev isn't used in zero, but just to be safe */
+            } else if (blocks.end > ex->node.r.start) {
+                /* TODO: improve write_extent to trim extent on zero */
+                if (write)
+                    blocks.start = write_extent(f, ex, sg, blocks, m);
+                else
+                    blocks.start = range_intersection(blocks, ex->node.r).end;
+            }
+        }
+        assert(blocks.start <= blocks.end); // XXX tmp
+    } while (range_span(blocks) > 0);
+
+    return STATUS_OK;
+}
+
+closure_function(2, 1, status, filesystem_check_or_reserve_extent,
+                 filesystem, fs, fsfile, f,
+                 range, q)
+{
+    filesystem fs = bound(fs);
+    fsfile f = bound(f);
+    assert(range_span(q) > 0);
+    range blocks = range_rshift_pad(q, fs->blocksize_order);
+    tfs_debug("%s: file %p range %R blocks %R\n", __func__, f, q, blocks);
+
+    return extents_range_handler(fs, f, blocks, false, 0, 0);
+}
+
 closure_function(2, 3, void, filesystem_storage_write,
                  filesystem, fs, fsfile, f,
                  sg_list, sg, range, q, status_handler, complete)
@@ -646,66 +734,9 @@ closure_function(2, 3, void, filesystem_storage_write,
     merge m = allocate_merge(fs->h, complete);
     status_handler sh = apply_merge(m);
 
-    rmnode prev;            /* prior to edge, but could be extended */
-    rmnode next;            /* intersecting or succeeding */
-    prev = rangemap_lookup_max_lte(f->extentmap, blocks.start);
-    if (prev == INVALID_ADDRESS) {
-        /* gap */
-        next = rangemap_first_node(f->extentmap);
-    } else if (prev->r.end > blocks.start) {
-        /* intersection */
-        next = prev;
-        prev = INVALID_ADDRESS;
-    } else {
-        next = rangemap_next_node(f->extentmap, prev);
-    }
-
-    status s = STATUS_OK;
-    do {
-        tfs_debug("   prev %p, next %p\n", prev, next);
-        u64 limit = next == INVALID_ADDRESS ? blocks.end : MIN(blocks.end, next->r.start);
-        if (sg) {
-            if (blocks.start < limit) {
-                /* try to extend previous node */
-                if (prev != INVALID_ADDRESS && prev->r.end < limit) {
-                    tfs_debug("   extent start 0x%lx, limit 0x%lx\n", blocks.start, limit);
-                    blocks.start = extend(f, (extent)prev, sg, irange(blocks.start, limit), m);
-                }
-
-                /* fill space */
-                while (blocks.start < limit) {
-                    tfs_debug("   fill start 0x%lx, limit 0x%lx\n", blocks.start, limit);
-                    fs_status fss = fill_gap(f, sg, irange(blocks.start, limit), m, &blocks.start);
-                    if (fss != FS_STATUS_OK) {
-                        s = timm("result", "unable to create extent",
-                                 "fsstatus", "%d", fss);
-                        goto out;
-                    }
-                }
-            }
-        } else {
-            /* zero: skip to start of next node */
-            blocks.start = limit;
-        }
-
-        prev = next;
-        if (next != INVALID_ADDRESS) {
-            extent ex = (extent)next;
-            next = rangemap_next_node(f->extentmap, next);
-
-            if (!sg && range_contains(blocks, ex->node.r)) {
-                blocks.start = ex->node.r.end;
-                remove_extent_from_file(f, ex);
-                destroy_extent(fs, ex);
-                prev = INVALID_ADDRESS; /* prev isn't used in zero, but just to be safe */
-            } else if (blocks.end > ex->node.r.start) {
-                /* TODO: improve write_extent to trim extent on zero */
-                blocks.start = write_extent(f, ex, sg, blocks, m);
-            }
-        }
-        assert(blocks.start <= blocks.end); // XXX tmp
-    } while (range_span(blocks) > 0);
-
+    status s = extents_range_handler(fs, f, blocks, true, sg, m);
+    if (s != STATUS_OK)
+        goto out;
     if (fsfile_get_length(f) < q.end) {
         tfs_debug("   append; update length to %ld\n", q.end);
         fs_status fss = filesystem_truncate(fs, f, q.end);
@@ -1068,6 +1099,16 @@ tuple filesystem_symlink(filesystem fs, tuple parent, const char *name,
 
 fs_status filesystem_delete(filesystem fs, tuple parent, symbol sym)
 {
+    tuple t = lookup(parent, sym);
+    assert(t);
+    fsfile f = fsfile_from_node(fs, t);
+    if (f) {
+        rangemap_foreach(f->extentmap, n) {
+            extent ex = (extent)n;
+            remove_extent_from_file(f, ex);
+            destroy_extent(fs, ex);
+        }
+    }
     return fs_set_dir_entry(fs, parent, sym, 0);
 }
 
@@ -1132,8 +1173,13 @@ fsfile allocate_fsfile(filesystem fs, tuple md)
 #else
     0;
 #endif
-    pagecache_node pn = pagecache_allocate_node(fs->pv, fs_read, fs_write);
-
+    pagecache_node_reserve fs_reserve =
+#ifndef TFS_READ_ONLY
+        closure(fs->h, filesystem_check_or_reserve_extent, fs, f);
+#else
+    0;
+#endif
+    pagecache_node pn = pagecache_allocate_node(fs->pv, fs_read, fs_write, fs_reserve);
     if (pn == INVALID_ADDRESS) {
         deallocate(fs->h, f, sizeof(struct fsfile));
         return INVALID_ADDRESS;
@@ -1181,6 +1227,22 @@ void filesystem_get_uuid(filesystem fs, u8 *uuid)
     runtime_memcpy(uuid, fs->uuid, UUID_LEN);
 }
 
+boolean filesystem_reserve_log_space(filesystem fs, u64 *next_offset, u64 *offset, u64 size)
+{
+    if (size == 0)
+        size = TFS_LOG_DEFAULT_EXTENSION_SIZE >> fs->blocksize_order;
+    if (*next_offset == INVALID_PHYSICAL) {
+        *next_offset = filesystem_allocate_storage(fs, size);
+        if (*next_offset == INVALID_PHYSICAL)
+            return false;
+    }
+    if (offset) {
+        *offset = *next_offset;
+        *next_offset = filesystem_allocate_storage(fs, size);
+    }
+    return true;
+}
+
 void create_filesystem(heap h,
                        u64 blocksize,
                        u64 size,
@@ -1222,6 +1284,8 @@ void create_filesystem(heap h,
         runtime_memcpy(fs->label, label, label_len);
         fs->label[label_len] = '\0';
     }
+    fs->next_extend_log_offset = INVALID_PHYSICAL;
+    fs->next_new_log_offset = INVALID_PHYSICAL;
     fs->tl = log_create(h, fs, label != 0, closure(h, log_complete, complete, fs));
 }
 

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -616,8 +616,6 @@ static u64 extend(fsfile f, extent ex, sg_list sg, range blocks, merge m, boolea
     tfs_debug("   %s: node %R, free 0x%lx (%R), i %R\n", __func__, ex->node.r, free, r, i);
     if (range_span(i) == 0)
         return blocks.start;
-    if (!write)
-        goto out;
     assert(blocks.start >= ex->node.r.end); // XXX temp
     assert(ex->node.r.end <= i.start); // XXX temp
     range z = irange(ex->node.r.end, i.start);
@@ -627,6 +625,8 @@ static u64 extend(fsfile f, extent ex, sg_list sg, range blocks, merge m, boolea
             "fsstatus", "%d", s));
         goto out;
     }
+    if (!write)
+        goto out;
     if (range_span(z) > 0) {
         tfs_debug("      zero %R\n", z);
         write_extent(f, ex, 0, z, m);

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -29,6 +29,8 @@ typedef struct filesystem {
     pagecache_volume pv;
     log tl;
     log temp_log;
+    u64 next_extend_log_offset;
+    u64 next_new_log_offset;
     tuple root;
 } *filesystem;
 
@@ -66,6 +68,8 @@ void filesystem_storage_op(filesystem fs, sg_list sg, merge m, range blocks, blo
     
 void filesystem_log_rebuild(filesystem fs, log new_tl, status_handler sh);
 void filesystem_log_rebuild_done(filesystem fs, log new_tl);
+
+boolean filesystem_reserve_log_space(filesystem fs, u64 *next_offset, u64 *offset, u64 size);
 
 typedef closure_type(buffer_status, buffer, status);
 fsfile allocate_fsfile(filesystem fs, tuple md);

--- a/test/e2e/nginx_1.15.6/config.json
+++ b/test/e2e/nginx_1.15.6/config.json
@@ -6,5 +6,6 @@
   },
   "Boot": "../../../output/test/e2e/boot.img",
   "Kernel": "../../../output/test/e2e/kernel.img",
-  "Mkfs": "../../../output/tools/bin/mkfs"
+  "Mkfs": "../../../output/tools/bin/mkfs",
+  "BaseVolumeSz": "30m"
 }

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -9,6 +9,7 @@ PROGRAMS= \
 	fadvise \
 	fcntl \
 	fst \
+	fs_full \
 	ftrace \
 	futex \
 	futexrobust \
@@ -88,6 +89,11 @@ SRCS-fcntl= \
 	$(CURDIR)/fcntl.c \
 	$(SRCDIR)/unix_process/ssp.c
 LDFLAGS-fcntl=		-static
+
+SRCS-fs_full= \
+	$(CURDIR)/fs_full.c \
+	$(SRCDIR)/unix_process/ssp.c
+LDFLAGS-fs_full=	-static
 
 SRCS-ftrace= \
 	$(CURDIR)/ftrace.c \

--- a/test/runtime/fs_full.c
+++ b/test/runtime/fs_full.c
@@ -32,7 +32,7 @@ int write_blocks(int fd, int nb)
         while (p < (uint64_t *)(buf + sizeof(buf))) {
             if (*p++ != b) {
                 printf("block %d does not match expected pattern in validation\n", b);
-                break;
+                return b;
             }
         }
     }
@@ -68,9 +68,9 @@ int main(int argc, char **argv)
     assert(statfs(argv[0], &statbuf) == 0);
     uint64_t bfree = statbuf.f_bfree;
     uint64_t btotal = statbuf.f_blocks;
-    printf("total bytes: %lu free bytes: %lu (actual: %lu)\n", btotal * 512, bfree * 512, statbuf.f_bfree*512);
+    printf("total bytes: %lu free bytes: %lu\n", btotal * 512, bfree * 512);
     /* create big file test */
-    fd = open(BIGDATA, O_CREAT|O_RDWR | 0644);
+    fd = open(BIGDATA, O_CREAT|O_RDWR, 0644);
     assert(fd >= 0);
     uint64_t bwritten = write_blocks(fd, bfree);
     assert(statfs(argv[0], &statbuf) == 0);

--- a/test/runtime/fs_full.c
+++ b/test/runtime/fs_full.c
@@ -1,0 +1,107 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/vfs.h>
+#include <assert.h>
+#include <errno.h>
+
+#define BIGDATA "/bigfile"
+#define NEWFILE "/newfile"
+
+int write_blocks(int fd, int nb)
+{
+    uint8_t buf[512];
+    int b;
+    for (b = 0; b < nb; b++) {
+        uint64_t *p = (uint64_t *)buf;
+        while (p < (uint64_t *)(buf + sizeof(buf)))
+            *p++ = b;
+        if (write(fd, buf, sizeof(buf)) <= 0) {
+            printf("failed writing at block %d err '%s'\n", b, strerror(errno));
+            assert(errno == ENOSPC);
+            break;
+        }
+        if (pread(fd, buf, sizeof(buf), 512 * b) != sizeof(buf)) {
+            printf("failed to read written block %d err '%s'\n", b, strerror(errno));
+            break;
+        }
+        p = (uint64_t *)buf;
+        while (p < (uint64_t *)(buf + sizeof(buf))) {
+            if (*p++ != b) {
+                printf("block %d does not match expected pattern in validation\n", b);
+                break;
+            }
+        }
+    }
+    return b;
+}
+
+int check_blocks(int fd, int nb)
+{
+    uint8_t buf[512];
+    int b;
+    for (b = 0; b < nb; b++) {
+        if (read(fd, buf, sizeof(buf)) <= 0) {
+            printf("failed reading at block %d err '%s'\n", b, strerror(errno));
+            break;
+        }
+        uint64_t *p = (uint64_t *)buf;
+        while (p < (uint64_t *)(buf + sizeof(buf))) {
+            if (*p++ != b) {
+                printf("block %d does not match expected pattern\n", b);
+                return b;
+            }
+        }
+    }
+    return b;
+}
+
+int main(int argc, char **argv)
+{
+    struct statfs statbuf;
+    int fd;
+
+    setbuf(stdout, NULL);
+    assert(statfs(argv[0], &statbuf) == 0);
+    uint64_t bfree = statbuf.f_bfree;
+    uint64_t btotal = statbuf.f_blocks;
+    printf("total bytes: %lu free bytes: %lu (actual: %lu)\n", btotal * 512, bfree * 512, statbuf.f_bfree*512);
+    /* create big file test */
+    fd = open(BIGDATA, O_CREAT|O_RDWR | 0644);
+    assert(fd >= 0);
+    uint64_t bwritten = write_blocks(fd, bfree);
+    assert(statfs(argv[0], &statbuf) == 0);
+    assert(bfree - bwritten < bfree/10);
+    close(fd);
+    /* check that still can't write to a new file */
+    fd = open(NEWFILE, O_CREAT|O_RDWR, 0644);
+    if (fd >= 0) {
+        assert(write_blocks(fd, 32) == 0);
+        close(fd);
+    }
+    /* verify big file */
+    fd = open(BIGDATA, O_RDWR);
+    assert(fd >= 0);
+    assert(check_blocks(fd, bwritten) == bwritten);
+    close(fd);
+    assert(statfs(argv[0], &statbuf) == 0);
+    assert(statbuf.f_bfree < bfree/10);
+    assert(statbuf.f_blocks == btotal);
+    printf("after creating big file: total bytes: %lu free bytes: %lu\n", statbuf.f_blocks * 512, statbuf.f_bfree * 512);
+    assert(remove(BIGDATA) == 0);
+    assert(statfs(argv[0], &statbuf) == 0);
+    assert((bfree - statbuf.f_bfree) < bfree/10);
+    printf("after delete big file: total bytes: %lu free bytes: %lu\n", statbuf.f_blocks * 512, statbuf.f_bfree * 512);
+
+    /* check that we can now write to a new file */
+    fd = open(NEWFILE, O_CREAT|O_RDWR, 0644);
+    assert(fd >= 0);
+    assert(write_blocks(fd, 32) == 32);
+    close(fd);
+    assert(open(BIGDATA, O_RDWR) < 0);
+    printf("filesystem full test successful\n");
+    return 0;
+}

--- a/test/runtime/fs_full.manifest
+++ b/test/runtime/fs_full.manifest
@@ -1,0 +1,14 @@
+(
+    children:(
+	      fs_full:(contents:(host:output/test/runtime/bin/fs_full))
+	      )
+    # filesystem path to elf for kernel to run
+    program:/fs_full
+#    trace:t
+#    debugsyscalls:t
+#    futex_trace:t
+    fault:t
+    arguments:[fs_full]
+    environment:(USER:bobby PWD:/)
+    imagesize:128M
+)


### PR DESCRIPTION
Nanos currently allocates new tfs extents in the second half of the pagecache write, after the write syscall has already
returned success. If the storage runs out of space, the volume is flagged with a write error and no further writes can
occur, including log writes necessary to free up storage space. This PR separates extent allocation from writing the
extent so that extents are now allocated in the first part of pagecache_write which allows it to return an error to the
write syscall and set ENOSPC which avoids flagging the volume with a write error. This is done by modifying the
pagecache interface to take a reservation function which is used in the first phase. Another side effect of doing 
storage reservations up front is that extents are now allocated to the size of the write, up to the extent maximum, 
instead of happening in pagecache page size chunks, so this reduces the size of metadata, particularly when
using mkfs tools which use large writes.

This PR also includes a new runtime
test for generating and testing a disk full condition. Note: the test is not yet added to the runtime-tests list because it
sometimes panics in an unrelated area which needs to be addressed separately.

The new test also revealed a problem with log extension allocation in that when the disk is filled, a subsequent log
flush may not have enough space to write outstanding changes and needs a new log extension which cannot be
allocated and so the metadata would be lost. This problem is addressed by reserving space for two log extensions
ahead of time. If space for two log extensions is not available, a write will return an ENOSPC condition. Two log
extensions are required because a new log can be created via new_log or extend, and both may occur when
performing a log flush, but it does mean that at least 1MB of space will always need to be available to perform writes
to a disk.

This changeset also fixes a problem when deleting a file where the extent metadata was not removed, which
did not actually free space allowing those deleted extents would be re-read on a subsequent fs load.

Finally, the new code revealed that the nginx e2e test did not have enough disk space. That manifest has been
adjusted to create a slightly larger volume.