### PR TITLE
Remove unnecessary Mkfs line from e2e test config files

### DIFF
--- a/test/e2e/go/config.json
+++ b/test/e2e/go/config.json
@@ -4,6 +4,5 @@
         "Ports": ["8080"]
     },
     "Boot": "../../../output/test/e2e/boot.img",
-    "Kernel": "../../../output/test/e2e/kernel.img",
-    "Mkfs": "../../../output/tools/bin/mkfs"
+    "Kernel": "../../../output/test/e2e/kernel.img"
 }

--- a/test/e2e/nginx_1.15.6/config.json
+++ b/test/e2e/nginx_1.15.6/config.json
@@ -5,6 +5,5 @@
     "Ports": ["8084"]
   },
   "Boot": "../../../output/test/e2e/boot.img",
-  "Kernel": "../../../output/test/e2e/kernel.img",
-  "Mkfs": "../../../output/tools/bin/mkfs"
+  "Kernel": "../../../output/test/e2e/kernel.img"
 }

--- a/test/e2e/node_v11.5.0/config.json
+++ b/test/e2e/node_v11.5.0/config.json
@@ -4,6 +4,5 @@
         "Ports": ["8083"]
     },
     "Boot": "../../../output/test/e2e/boot.img",
-    "Kernel": "../../../output/test/e2e/kernel.img",
-    "Mkfs": "../../../output/tools/bin/mkfs"
+    "Kernel": "../../../output/test/e2e/kernel.img"
 }

--- a/test/e2e/php_7.3.5/config.json
+++ b/test/e2e/php_7.3.5/config.json
@@ -4,6 +4,5 @@
         "Ports": ["9501"]
     },
     "Boot": "../../../output/test/e2e/boot.img",
-    "Kernel": "../../../output/test/e2e/kernel.img",
-    "Mkfs": "../../../output/tools/bin/mkfs"
+    "Kernel": "../../../output/test/e2e/kernel.img"
 }

--- a/test/e2e/python_3.6.7/config.json
+++ b/test/e2e/python_3.6.7/config.json
@@ -4,6 +4,5 @@
         "Ports": ["8000"]
   },
   "Boot": "../../../output/test/e2e/boot.img",
-  "Kernel": "../../../output/test/e2e/kernel.img",
-  "Mkfs": "../../../output/tools/bin/mkfs"
+  "Kernel": "../../../output/test/e2e/kernel.img"
 }

--- a/test/e2e/ruby_2.5.1/config.json
+++ b/test/e2e/ruby_2.5.1/config.json
@@ -8,6 +8,5 @@
         "Ports": ["4567"]
     },
     "Boot": "../../../output/test/e2e/boot.img",
-    "Kernel": "../../../output/test/e2e/kernel.img",
-    "Mkfs": "../../../output/tools/bin/mkfs"
+    "Kernel": "../../../output/test/e2e/kernel.img"
 }

--- a/test/e2e/rust/config.json
+++ b/test/e2e/rust/config.json
@@ -4,6 +4,5 @@
         "Ports": ["8080"]
     },
     "Boot": "../../../output/test/e2e/boot.img",
-    "Kernel": "../../../output/test/e2e/kernel.img",
-    "Mkfs": "../../../output/tools/bin/mkfs"
+    "Kernel": "../../../output/test/e2e/kernel.img"
 }


### PR DESCRIPTION
ops now handles mkfs on its own and does not recognize the Mkfs line anymore.