### PR TITLE
Add epoll custom edge trigger handling and customize eventfd handling

### DIFF
--- a/src/unix/eventfd.c
+++ b/src/unix/eventfd.c
@@ -11,6 +11,17 @@ struct efd {
     u64 counter;
 };
 
+closure_function(0, 2, u64, efd_edge_handler,
+                u64, events, u64, lastevents)
+{
+    /* A read or a write acts as an edge */
+    if (events & EPOLLIN)
+        lastevents &= ~EPOLLIN;
+    if (events & EPOLLOUT)
+        lastevents &= ~EPOLLOUT;
+    return lastevents;
+}
+
 closure_function(5, 1, sysreturn, efd_read_bh,
                  struct efd *, efd, thread, t, void *, buf, u64, length, io_completion, completion,
                  u64, flags)
@@ -161,6 +172,7 @@ int do_eventfd2(unsigned int count, int flags)
     efd->f.write = closure(h, efd_write, efd);
     efd->f.events = closure(h, efd_events, efd);
     efd->f.close = closure(h, efd_close, efd);
+    efd->f.edge_trigger_handler = closure(h, efd_edge_handler);
     efd->h = h;
     efd->flags = flags;
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -322,6 +322,7 @@ typedef struct fdesc {
     closure_type(events, u32, thread);
     closure_type(ioctl, sysreturn, unsigned long request, vlist ap);
     closure_type(close, sysreturn, thread t, io_completion completion);
+    closure_type(edge_trigger_handler, u64, u64 events, u64 lastevents);
 
     u64 refcnt;
     int type;
@@ -550,6 +551,7 @@ static inline void init_fdesc(heap h, fdesc f, int type)
     f->sg_write = 0;
     f->close = 0;
     f->events = 0;
+    f->edge_trigger_handler = 0;
     f->ioctl = 0;
     f->refcnt = 1;
     f->type = type;


### PR DESCRIPTION
Linux has different definitions for what constitutes an edge with EPOLLET in epoll,
which can vary by file descriptor type. This change allows each file type to implement
an optional handler to determine where edges are, otherwise the original edge tracking
code gets used. This change also implements a handler for eventfd, which has edges
for each read or write of an eventfd file, not just when the counter changes the
read or write ability.