### PR TITLE
Page cache fixes

### DIFF
--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -259,7 +259,7 @@ void kernel_runtime_init(kernel_heaps kh)
     init_debug("kernel_runtime_init");
     init_runtime(misc, locked);
     init_sg(locked);
-    init_pagecache(locked, locked, (heap)heap_physical(kh), PAGESIZE);
+    init_pagecache(locked, backed, (heap)heap_physical(kh), PAGESIZE);
     unmap(0, PAGESIZE);         /* unmap zero page */
     init_extra_prints();
     init_pci(kh);

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -391,6 +391,7 @@ static pagecache_page allocate_page_nodelocked(pagecache_node pn, u64 offset)
     pp->kvirt = p;
     pp->node = pn;
     pp->l.next = pp->l.prev = 0;
+    pp->evicted = false;
 #ifdef KERNEL
     pp->phys = physical_from_virtual(p);
 #endif


### PR DESCRIPTION
Using the locked heap as storage medium for cache pages means that any pages evicted from the cache do not actually release physical memory, because the locked heap uses an underlying mcache, which does not deallocate memory from the parent heap. This PR changes the page cache initialization code to use the backed heap instead of the locked heap, so that evicted pages actually release physical memory.
Other fixes in this PR:
- the `evicted` struct member is now properly initialized when a page is allocated
- the unnecessary incrementing of the page refcount when reading an already allocated page is being removed
- the unnecessary allocation of a page after the end of the range in a write request is being fixed