### PR TITLE
x86 exception stack: change size from 32 KB to 64 KB

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -7,7 +7,7 @@
 
 #define STAGE2_STACK_SIZE  (128 * KB)  /* stage2 stack is recycled, too */
 #define KERNEL_STACK_SIZE  (128 * KB)  /* must match value in crt0.s */
-#define EXCEPT_STACK_SIZE  (32 * KB)
+#define EXCEPT_STACK_SIZE  (64 * KB)
 #define INT_STACK_SIZE     (32 * KB)
 #define BH_STACK_SIZE      (32 * KB)
 #define SYSCALL_STACK_SIZE (32 * KB)

--- a/src/runtime/format.c
+++ b/src/runtime/format.c
@@ -172,7 +172,7 @@ KLIB_EXPORT(rsnprintf);
 void rprintf(const char *format, ...)
 {
     /* What's a reasonable limit here? This needs to be reentrant. */
-    buffer b = little_stack_buffer(32768);
+    buffer b = little_stack_buffer(16 * KB);
     vlist a;
     vstart(a, format);
     buffer f = alloca_wrap_buffer(format, runtime_strlen(format));


### PR DESCRIPTION
The exception stack is being overflowed in the rprintf() function when executing an exception handler on x86, which means that when an unhandled fault occurs, the register dump and frame and stack traces that are supposed to be printed on the console are often replaced by those associated to this stack overflow, with a generic "frame xxxx already full" message that hides the original fault.
This commit increase the exception stack size from 32 KB to 64 KB, and in addition decreases the stack size requirements of the rprintf() function.