### PR TITLE
storage_rw_internal: remove gratuitous buffer alignment check

### DIFF
--- a/src/virtio/virtio_storage.c
+++ b/src/virtio/virtio_storage.c
@@ -121,13 +121,6 @@ static inline void storage_rw_internal(storage st, boolean write, void * buf,
     char * err = 0;
     virtio_blk_debug("virtio_%s: block range %R cap %ld\n", write ? "write" : "read", sectors, st->capacity);
 
-    /* XXX so no, not page aligned but what? 16? */
-    if ((u64_from_pointer(buf) & 15)) {
-        msg_err("misaligned buf: %p\n", buf);
-        err = "write buffer not properly aligned";
-        goto out_inval;
-    }
-
     u64 start_sector = sectors.start;
     u64 nsectors = range_span(sectors);
     if (nsectors == 0) {


### PR DESCRIPTION
The "misaligned buf" error found in https://github.com/nanovms/nanos/issues/1473 results from a klog write of the klog.dump buffer (src/kernel/log.c) tripping an alignment check in virtio_storage.c:storage_rw_internal. This check and its comment seem dubious, however, and such an alignment requirement doesn't seem to be backed up by anything in the virtio spec. (Possibly the 16 byte virtqueue descriptor alignment was mistakenly interpreted as a buffer alignment.) Removing the check allows the write to continue with no apparent errors from qemu.
