### PR TITLE
add flush method to storage interfaces with implementations for virtio_storage and virtio_scsi

### DIFF
--- a/platform/pc/boot/stage2.c
+++ b/platform/pc/boot/stage2.c
@@ -282,6 +282,7 @@ void newstack()
                       infinity,
                       get_stage2_disk_read(h, fs_offset),
                       closure(h, stage2_empty_write),
+                      0 /* no flush */,
                       false,
                       closure(h, filesystem_initialized, h, backed, bh));
     

--- a/src/boot/uefi.c
+++ b/src/boot/uefi.c
@@ -227,8 +227,8 @@ efi_status efi_main(void *image_handle, efi_system_table system_table)
                    bootfs_part->lba_start, bootfs_part->nsectors);
         init_pagecache(&general, &general, 0, PAGESIZE);
         create_filesystem(&general, SECTOR_SIZE, bootfs_part->nsectors * SECTOR_SIZE,
-                        closure(&general, uefi_blkdev_read, block_io, bootfs_part->lba_start), 0, 0,
-                        closure(&general, uefi_bootfs_complete, &general, &aligned_heap));
+                          closure(&general, uefi_blkdev_read, block_io, bootfs_part->lba_start), 0, 0, 0,
+                          closure(&general, uefi_bootfs_complete, &general, &aligned_heap));
     }
     UBS->free_pool(handle_buffer);
     return EFI_LOAD_ERROR;  /* should never reach here */

--- a/src/drivers/ata-pci.c
+++ b/src/drivers/ata-pci.c
@@ -328,7 +328,7 @@ closure_function(3, 1, boolean, ata_pci_probe,
     assert(irq != INVALID_PHYSICAL);
     ioapic_set_int(ATA_IRQ(ATA_PRIMARY), irq);
     register_interrupt(irq, (thunk)&dev->irq_handler, "ata pci");
-    apply(bound(a), (block_io)&dev->read, (block_io)&dev->write,
+    apply(bound(a), (block_io)&dev->read, (block_io)&dev->write, 0 /* TODO: flush */,
           ata_get_capacity(dev->ata));
     return true;
 }

--- a/src/drivers/nvme.c
+++ b/src/drivers/nvme.c
@@ -459,7 +459,7 @@ closure_function(4, 0, void, nvme_ns_attach,
     block_io w = closure(n->general, nvme_io, n, ns_id, true);
     if (w != INVALID_ADDRESS) {
         nvme_debug("attaching disk (NS ID %d, capacity %ld bytes)", ns_id, disk_size);
-        apply(bound(a), r, w, disk_size);
+        apply(bound(a), r, w, 0 /* TODO: flush */, disk_size);
     } else {
         msg_err("failed to allocate write closure\n");
         deallocate_closure(r);

--- a/src/hyperv/storvsc/storvsc.c
+++ b/src/hyperv/storvsc/storvsc.c
@@ -730,7 +730,7 @@ closure_function(5, 0, void, storvsc_read_capacity_done,
 
     block_io in = closure(s->general, storvsc_read, s);
     block_io out = closure(s->general, storvsc_write, s);
-    apply(bound(a), in, out, s->capacity);
+    apply(bound(a), in, out, 0 /* TODO: flush */, s->capacity);
   out:
     closure_finish();
 }

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -208,7 +208,8 @@ typedef closure_type(connection_handler, buffer_handler, buffer_handler);
 typedef closure_type(value_handler, void, value);
 typedef closure_type(io_status_handler, void, status, bytes);
 typedef closure_type(block_io, void, void *, range, status_handler);
-typedef closure_type(storage_attach, void, block_io, block_io, u64);
+typedef closure_type(block_flush, void, status_handler);
+typedef closure_type(storage_attach, void, block_io, block_io, block_flush, u64);
 
 #include <sg.h>
 

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -74,7 +74,7 @@ struct filesystem;
 void init_volumes(heap h);
 void storage_set_root_fs(struct filesystem *root_fs);
 void storage_set_mountpoints(tuple mounts);
-boolean volume_add(u8 *uuid, char *label, block_io r, block_io w, u64 size);
+boolean volume_add(u8 *uuid, char *label, block_io r, block_io w, block_flush flush, u64 size);
 void storage_when_ready(thunk complete);
 void storage_sync(status_handler sh);
 

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -801,7 +801,10 @@ closure_function(3, 1, void, log_flush_completed,
         bound(sync_complete) = true;
         pagecache_sync_volume(bound(fs)->pv, (status_handler)closure_self());
     } else {
-        apply(bound(completion), s);
+        if (bound(fs)->flush)
+            apply(bound(fs)->flush, bound(completion));
+        else
+            apply(bound(completion), s);
         closure_finish();
     }
 }
@@ -1250,6 +1253,7 @@ void create_filesystem(heap h,
                        u64 size,
                        block_io read,
                        block_io write,
+                       block_flush flush,
                        const char *label,
                        filesystem_complete complete)
 {
@@ -1272,6 +1276,7 @@ void create_filesystem(heap h,
     assert(fs->pv != INVALID_ADDRESS);
 #ifndef TFS_READ_ONLY
     fs->w = write;
+    fs->flush = flush;
     fs->storage = create_id_heap(h, h, 0, size >> fs->blocksize_order, 1, false);
     assert(fs->storage != INVALID_ADDRESS);
     fs->temp_log = 0;

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -27,6 +27,7 @@ void create_filesystem(heap h,
                        u64 size,
                        block_io read,
                        block_io write,
+                       block_flush flush,
                        const char *label,
                        filesystem_complete complete);
 void destroy_filesystem(filesystem fs);

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -26,6 +26,7 @@ typedef struct filesystem {
     void *zero_page;
     block_io r;
     block_io w;
+    block_flush flush;
     pagecache_volume pv;
     log tl;
     log temp_log;

--- a/src/virtio/scsi.h
+++ b/src/virtio/scsi.h
@@ -73,6 +73,7 @@ struct scsi_sense_data_extra {
 
 #define SCSI_CMD_TEST_UNIT_READY        0x00
 #define SCSI_CMD_INQUIRY                0x12
+#define SCSI_CMD_SYNCHRONIZE_CACHE_10   0x35
 #define SCSI_CMD_READ_16                0x88
 #define SCSI_CMD_WRITE_16               0x8a
 #define SCSI_CMD_SERVICE_ACTION         0x9e
@@ -316,6 +317,17 @@ struct scsi_res_report_luns
     u32 length;
     u32 reserved;
     u64 lundata[256];
+} __attribute__((packed));
+
+struct scsi_cdb_synchronize_cache_10
+{
+    u8 opcode;
+    u8 byte2;
+#define SSC_IMMED 0x02
+    u32 addr;
+    u8 group;
+    u16 length;
+    u8 control;
 } __attribute__((packed));
 
 int scsi_data_len(u8 cmd);

--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -4,6 +4,30 @@
 #include "virtio_mmio.h"
 #include "virtio_pci.h"
 
+u8 vtdev_cfg_read_1(vtdev dev, u64 offset)
+{
+    switch (dev->transport) {
+    case VTIO_TRANSPORT_MMIO:
+        return vtmmio_get_u8((vtmmio)dev, VTMMIO_OFFSET_CONFIG + offset);
+    case VTIO_TRANSPORT_PCI:
+        return pci_bar_read_1(&((vtpci)dev)->device_config, offset);
+    default:
+        return 0;
+    }
+}
+
+void vtdev_cfg_write_1(vtdev dev, u64 offset, u8 value)
+{
+    switch (dev->transport) {
+    case VTIO_TRANSPORT_MMIO:
+        vtmmio_set_u8((vtmmio)dev, VTMMIO_OFFSET_CONFIG + offset, value);
+        break;
+    case VTIO_TRANSPORT_PCI:
+        pci_bar_write_1(&((vtpci)dev)->device_config, offset, value);
+        break;
+    }
+}
+
 u32 vtdev_cfg_read_4(vtdev dev, u64 offset)
 {
     switch (dev->transport) {
@@ -21,8 +45,10 @@ void vtdev_cfg_write_4(vtdev dev, u64 offset, u32 value)
     switch (dev->transport) {
     case VTIO_TRANSPORT_MMIO:
         vtmmio_set_u32((vtmmio)dev, VTMMIO_OFFSET_CONFIG + offset, value);
+        break;
     case VTIO_TRANSPORT_PCI:
         pci_bar_write_4(&((vtpci)dev)->device_config, offset, value);
+        break;
     }
 }
 

--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -75,7 +75,9 @@ typedef struct vtdev {
     vtdev_notify notify;
 } *vtdev;
 
+u8 vtdev_cfg_read_1(vtdev dev, u64 offset);
 u32 vtdev_cfg_read_4(vtdev dev, u64 offset);
+void vtdev_cfg_write_1(vtdev dev, u64 offset, u8 value);
 void vtdev_cfg_write_4(vtdev dev, u64 offset, u32 value);
 void vtdev_cfg_read_mem(vtdev dev, void *dest, bytes len);
 void vtdev_set_status(vtdev dev, u8 status);

--- a/src/virtio/virtio_mmio.h
+++ b/src/virtio/virtio_mmio.h
@@ -41,6 +41,12 @@ typedef struct vtmmio_dev {
     vector vq_handlers;
 } *vtmmio;
 
+#define vtmmio_get_u8(dev, offset) (*((volatile u8 *)((dev)->vbase + offset)))
+
+#define vtmmio_set_u8(dev, offset, value)  do {    \
+    *(volatile u8 *)((dev)->vbase + offset) = value; \
+} while (0)
+
 #define vtmmio_get_u32(dev, offset) (*((volatile u32 *)((dev)->vbase + offset)))
 
 #define vtmmio_set_u32(dev, offset, value)  do {    \

--- a/src/vmware/pvscsi.c
+++ b/src/vmware/pvscsi.c
@@ -255,7 +255,7 @@ closure_function(5, 0, void, pvscsi_read_capacity_done,
 
     block_io in = closure(s->general, pvscsi_read, d);
     block_io out = closure(s->general, pvscsi_write, d);
-    apply(bound(a), in, out, d->capacity);
+    apply(bound(a), in, out, 0 /* TODO: flush */, d->capacity);
   out:
     closure_finish();
 }

--- a/src/xen/xenblk.c
+++ b/src/xen/xenblk.c
@@ -430,7 +430,8 @@ closure_function(2, 3, boolean, xenblk_probe,
     }
     xenblk_debug("attaching disk, capacity %ld bytes", xbd->capacity);
     apply(bound(sa), init_closure(&xbd->read, xenblk_io, xbd, false),
-          init_closure(&xbd->write, xenblk_io, xbd, true), xbd->capacity);
+          init_closure(&xbd->write, xenblk_io, xbd, true),
+          0 /* TODO: flush */, xbd->capacity);
     return true;
   dealloc_reqs:
     deallocate_vector(xbd->rreqs);

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -278,8 +278,7 @@ int main(int argc, char **argv)
                       SECTOR_SIZE,
                       infinity,
                       closure(h, bread, fd, get_fs_offset(fd, PARTITION_ROOTFS, false)),
-                      0, /* no write */
-                      false,
+                      0, 0, 0, /* no write, flush or label */
                       closure(h, fsc, h, target_dir, options));
     return EXIT_SUCCESS;
 }

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -698,8 +698,9 @@ int main(int argc, char **argv)
             }
         }
         if (boot) {
-            create_filesystem(h, SECTOR_SIZE, BOOTFS_SIZE, 0,
+            create_filesystem(h, SECTOR_SIZE, BOOTFS_SIZE, 0 /* no read */,
                               closure(h, bwrite, out, offset),
+                              0 /* no flush */,
                               "", closure(h, fsc, h, out, boot, target_root));
             offset += BOOTFS_SIZE;
 
@@ -715,6 +716,7 @@ int main(int argc, char **argv)
                       infinity,
                       0, /* no read -> new fs */
                       closure(h, bwrite, out, offset),
+                      0, /* no flush */
                       label,
                       closure(h, fsc, h, out, root, target_root));
 


### PR DESCRIPTION
This extends the block device interface to add a "flush" method. A flush is issued as a final step in the chain of operations initiated by filesystem_flush, used by the various paths that synchronize storage devices. Flush implementations are included for virtio-storage (which issues a VIRTIO_BLK_T_FLUSH command) and virtio-scsi (which issues a SYNCHRONIZE_CACHE SCSI command) drivers; other storage drivers will require flush implementations to be added later.

As part of the virtio-storage implementation, the VIRTIO_BLK_F_FLUSH and VIRTIO_BLK_F_CONFIG_WCE features are negotiated. A flush method is created and writeback cache mode is set depending on negotiation of respective features. This improves the virtio-storage performance drastically, which now out-performs the virtio-scsi driver in the bulk write test by over 10% in one Linux/KVM-based test setup. This speedup is to be expected, as noted in the OASIS virtio spec, because the virtio-blk device involves much less overhead than the virtio-scsi device.

(Note that the overall performance for the write test will appear to drop slightly when compared to that of previous commits. This is because the storage flush operation is now included as part of the measured duration.)

Resolves #1484, #1483 and alleviates the symptoms found in #1473 (although another factor requires more work on tlog).
