### PR TITLE
TCP receive: poll loopback interface after calling tcp_recved()

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -445,6 +445,9 @@ static sysreturn sock_read_bh_internal(netsock s, thread t, void * dest,
                 fdesc_notify_events(&s->sock.f); /* reset a triggered EPOLLIN condition */
         }
     } while(s->sock.type == SOCK_STREAM && length > 0 && p != INVALID_ADDRESS); /* XXX simplify expression */
+    if (s->sock.type == SOCK_STREAM)
+        /* Calls to tcp_recved() may have enqueued new packets in the loopback interface. */
+        netsock_check_loop();
 
     rv = xfer_total;
   out:


### PR DESCRIPTION
When a high amount of TCP data is sent to the loopback interface, the TCP transmit window length may become zero, which blocks the transmitting thread. When later the receiving thread reads the incoming data from the interface, the transmit window length becomes non-zero again as a consequence of the receiving thread calling tcp_recved(), but in order for this to be detected by the transmitting thread, the loopback interface needs to be polled.
This PR adds a call to netsock_check_loop() in sock_read_bh_internal(), so that any thread blocked while transmitting to the loopback interfce can be unblocked.
The netsock runtime tests now include a new test that would block indefinitely if the above issue was not addressed.