### PR TITLE
Virtqueue messages: update buffer end when pushing a descriptor

### DIFF
--- a/src/virtio/virtqueue.c
+++ b/src/virtio/virtqueue.c
@@ -142,6 +142,7 @@ void vqmsg_push(virtqueue vq, vqmsg m, u64 phys_addr, u32 len, boolean write)
     d->len = len;
     d->flags = write ? VRING_DESC_F_WRITE : 0;
     d->next = 0;
+    buffer_produce(m->descv, sizeof(struct vring_desc));
     m->count++;
     virtqueue_debug_verbose("%s: vq %s, vqmsg %p, phys_addr 0x%lx, len 0x%x, %s, m->count now %d\n",
                             __func__, vq->name, m, phys_addr, len, write ? "write" : "read", m->count);


### PR DESCRIPTION
When a new descriptor is added to the set of descriptors of a virtqueue message, the descriptor buffer should be updated so that its end pointer reflects the new buffer length, otherwise if a buffer extension is required the existing descriptors are not copied into the newly extended buffer, which results in random descriptor data being sent to the virtIO device.