### PR TITLE
Add option to print out names of files that are not found

### DIFF
--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -20,8 +20,10 @@ static kernel_heaps init_heaps;
 
 //#define MAX_BLOCK_IO_SIZE PAGE_SIZE
 #define MAX_BLOCK_IO_SIZE (64 * 1024)
+#define SHUTDOWN_COMPLETIONS_SIZE 8
 
 static struct kernel_heaps heaps;
+static vector shutdown_completions;
 
 closure_function(2, 3, void, offset_block_io,
                  u64, offset, block_io, io,
@@ -314,7 +316,10 @@ void kernel_runtime_init(kernel_heaps kh)
     runloop();
 }
 
-vector shutdown_completions;
+void add_shutdown_completion(shutdown_handler h)
+{
+    vector_push(shutdown_completions, h);
+}
 
 closure_function(1, 1, void, sync_complete,
                  u8, code,

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -271,9 +271,8 @@ void start_secondary_cores(kernel_heaps kh);
 void detect_hypervisor(kernel_heaps kh);
 void detect_devices(kernel_heaps kh, storage_attach sa);
 
-#define SHUTDOWN_COMPLETIONS_SIZE    8
-extern vector shutdown_completions;
 typedef closure_type(shutdown_handler, void, int, merge);
+void add_shutdown_completion(shutdown_handler h);
 extern int shutdown_vector;
 extern boolean shutting_down;
 void wakeup_or_interrupt_cpu_all();

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -361,6 +361,15 @@ static inline int buffer_strchr(buffer b, int c)
     return -1;
 }
 
+static inline int buffer_strrchr(buffer b, int c)
+{
+    for (s64 len = buffer_length(b) - 1; len >= 0; len--) {
+        if (byte(b, len) == c)
+            return len;
+    }
+    return -1;
+}
+
 int buffer_strstr(buffer b, const char *str);
 
 // the ascii subset..utf8 me
@@ -469,3 +478,21 @@ static inline key fnv64(void *z)
 }
 
 void buffer_print(buffer b);
+
+/* modifies the original buffer, buffer must be a string */
+static inline buffer buffer_basename(buffer b)
+{
+    int p;
+
+    if (buffer_length(b) <= 1)
+        return b;
+    if ((p = buffer_strrchr(b, '/')) != -1) {
+        if (p == buffer_length(b) - 1) {
+            b->end--;
+            if ((p = buffer_strrchr(b, '/')) == -1 || buffer_length(b) == 1)
+                return b;
+        }
+        buffer_consume(b, p + 1);
+    }
+    return b;
+}

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -517,7 +517,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     install_fallback_fault_handler((fault_handler)&dummy_thread->fault_handler);
 
     register_special_files(kernel_process);
-    init_syscalls();
+    init_syscalls(kernel_process->process_root);
     register_file_syscalls(linux_syscalls);
 #ifdef NET
     register_net_syscalls(linux_syscalls);
@@ -531,9 +531,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     register_timer_syscalls(linux_syscalls);
     register_other_syscalls(linux_syscalls);
     configure_syscalls(kernel_process);
-    do_syscall_stats = get(kernel_process->process_root, sym(syscall_summary)) != 0;
-    if (do_syscall_stats)
-        vector_push(shutdown_completions, print_syscall_stats);
+
     return kernel_process;
   alloc_fail:
     msg_err("failed to allocate kernel objects\n");

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -737,8 +737,6 @@ static inline void count_syscall_noreturn(thread t)
     t->syscall_time = 0;
     t->last_syscall = -1;
 }
-extern shutdown_handler print_syscall_stats;
-extern boolean do_syscall_stats;
 
 void register_file_syscalls(struct syscall *);
 void register_net_syscalls(struct syscall *);
@@ -837,7 +835,7 @@ static inline u64 iov_total_len(struct iovec *iov, int iovcnt)
 #define resolve_fd_noret(__p, __fd) vector_get(__p->files, __fd)
 #define resolve_fd(__p, __fd) ({void *f ; if (!(f = resolve_fd_noret(__p, __fd))) return set_syscall_error(current, EBADF); f;})
 
-void init_syscalls();
+void init_syscalls(tuple root);
 void init_threads(process p);
 void init_futices(process p);
 

--- a/test/unit/buffer_test.c
+++ b/test/unit/buffer_test.c
@@ -49,7 +49,9 @@ boolean basic_tests(heap h)
     test_assert(buffer_length(b) == 0);
     test_assert(buffer_memcmp(b, test_str, 0) == 0);
     test_assert(buffer_strchr(b, '0') < 0);
+    test_assert(buffer_strrchr(b, '0') < 0);
     test_assert(buffer_strstr(b, test_str) == -1);
+    test_assert(buffer_basename(b) == b);
 
     /* Buffer capacity */
     buffer_write_cstring(b, test_str);
@@ -62,12 +64,23 @@ boolean basic_tests(heap h)
     test_assert(buffer_memcmp(b, test_str, sizeof(test_str)) < 0);
     test_assert(buffer_strchr(b, 't') == 10);
     test_assert(buffer_strchr(b, 'u') < 0);
+    test_assert(buffer_strrchr(b, 'T') == 0);
+    test_assert(buffer_strrchr(b, 'g') == 20);
+    test_assert(buffer_strrchr(b, 'i') == 18);
+    test_assert(buffer_strrchr(b, 'u') == -1);
     test_assert(buffer_strstr(b, "") == 0);
     test_assert(buffer_strstr(b, test_str) == 0);
     test_assert(buffer_strstr(b, "This") == 0);
     test_assert(buffer_strstr(b, "is") == 2);
     test_assert(buffer_strstr(b, "g") == 20);
     test_assert(buffer_strstr(b, "TT") == -1);
+
+    test_assert(buffer_compare_with_cstring(buffer_basename(alloca_wrap_cstring("/usr/lib")), "lib"));
+    test_assert(buffer_compare_with_cstring(buffer_basename(alloca_wrap_cstring("/usr/")), "usr"));
+    test_assert(buffer_compare_with_cstring(buffer_basename(alloca_wrap_cstring("usr")), "usr"));
+    test_assert(buffer_compare_with_cstring(buffer_basename(alloca_wrap_cstring("/")), "/"));
+    test_assert(buffer_compare_with_cstring(buffer_basename(alloca_wrap_cstring(".")), "."));
+    test_assert(buffer_compare_with_cstring(buffer_basename(alloca_wrap_cstring("..")), ".."));
 
     /* Create and then deallocate a wrapped buffer. */
     deallocate_buffer(wrap_buffer_cstring(h, test_str));


### PR DESCRIPTION
A manifest option 'missing_files' has been added that will keep a list of
filenames that are not found by open_internal and then print out the list
when nanos exits. This can be used to help find dynamic libraries or etc
files that need to be included in the filesystem for the application to
run properly. File names only (not path) are added to the list so that if
a file is opened later with a different path it gets removed from the missing
files list. This change also slightly refactors the way shutdown completions
are added as well as adds a couple of new buffer helper functions for fs
path processing.