### PR TITLE
Network send/recv: add support for MSG_DONTWAIT flag

### DIFF
--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -83,6 +83,7 @@ static void netsock_test_basic(int sock_type)
     } else {
         tx_fd = fd;
     }
+    test_assert((recv(tx_fd, tx_buf, sizeof(tx_buf), MSG_DONTWAIT) == -1) && (errno == EAGAIN));
     test_assert(clock_gettime(CLOCK_MONOTONIC, &start) == 0);
     do {
         ret = write(tx_fd, tx_buf, sizeof(tx_buf));


### PR DESCRIPTION
This flag acts like the SOCK_NONBLOCK socket-wide option, but applies only to the send/recv syscalls where it is specified.