### PR TITLE
lwIP performance optimization

### DIFF
--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -48,6 +48,8 @@
 #define LWIP_NO_LIMITS_H 1
 #define LWIP_NO_CTYPE_H 1
 
+#define LWIP_CHKSUM_ALGORITHM   3
+
 #define LWIP_WND_SCALE 1
 #define TCP_MSS 1460            /* Assuming ethernet; may want to derive this */
 #define TCP_WND 65535
@@ -77,6 +79,8 @@ typedef unsigned long size_t;
 #define LWIP_IPV6   1
 #define LWIP_IPV6_DHCP6 1
 #define IPV6_FRAG_COPYHEADER    1
+
+#define LWIP_STATS  0
 
 typedef unsigned long u64_t;
 typedef unsigned u32_t;
@@ -122,6 +126,9 @@ typedef unsigned long long time;
 extern void lwip_debug(char * format, ...);
 
 #define MEM_LIBC_MALLOC 1
+
+#define lwip_htons(x)   PP_HTONS(x)
+#define lwip_htonl(x)   PP_HTONL(x)
 
 extern u32_t lwip_rand(void);
 #define LWIP_RAND   lwip_rand


### PR DESCRIPTION
This PR changes a few lwIP configuration options, following the hints at https://www.nongnu.org/lwip/2_1_x/optimization.html.
The lwip_htons() and lwip_htonl() macros have been defined so that byte order inversion operations are executed inline instead of as function calls (in #1299, the lwip_htons() function shows up as taking a non-negligible share of CPU time).
Instead of the default checksum algorithm # 2, algorithm # 3 is now being used, because it is faster on 64-bit platforms (checksum calculation on 20-byte data is around 35% faster).