### PR TITLE
improve error handling for tfs log; reserve space for log extension in mkfs

### DIFF
--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -75,6 +75,8 @@ boolean filesystem_reserve_log_space(filesystem fs, u64 *next_offset, u64 *offse
 typedef closure_type(buffer_status, buffer, status);
 fsfile allocate_fsfile(filesystem fs, tuple md);
 
+#define filesystem_log_blocks(fs) (TFS_LOG_DEFAULT_EXTENSION_SIZE >> (fs)->blocksize_order)
+
 static inline u64 bytes_from_sectors(filesystem fs, u64 sectors)
 {
     return sectors << fs->blocksize_order;

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -726,7 +726,8 @@ int main(int argc, char **argv)
     }
     if (!img_size)
         img_size = current_size;
-    img_size = pad(img_size - offset, TFS_LOG_DEFAULT_EXTENSION_SIZE) + offset;
+    img_size = pad(img_size - offset + TFS_LOG_DEFAULT_EXTENSION_SIZE,
+                   TFS_LOG_DEFAULT_EXTENSION_SIZE) + offset;
     if (current_size < img_size) {
         if (ftruncate(out, img_size)) {
             halt("could not set image size: %s\n", strerror(errno));


### PR DESCRIPTION
Previously, log_write and log_write_eav would fail if the tuple_staging buffer
reached the log extension size. This could be problematic in transient
situations where a log extension flush completion was backlogged or otherwise
delayed. Instead, only return a failure if an unrecoverable log failure
occurred, such as an inability to reserve space for a log extension. To avoid
endless spooling of encoded log tuples, these functions will also fail if the
tuple_staging buffer reaches TFS_LOG_MAX_TUPLE_STAGING_BYTES.

Another issue in tlog was that a log extension failure could forego the
flushing of the existing log extension, leading to loss of data. This fixes
the issue by flushing a current extension regardless of whether an extension
could be allocated.

Additionally, some unnecessary console output on no-space conditions has been
removed, and mkfs now pads an image size to include space for one log
extension allocation (whereas previously the size would only be aligned to the
extension size).

Resolves #1473 
