### PR TITLE
Add tun network interface implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test test-noaccel: image
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws io_uring klibs mkdir mmap netlink netsock pipe readv rename sendfile signal socketpair time unlink thread_test tlbshootdown vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws io_uring klibs mkdir mmap netlink netsock pipe readv rename sendfile signal socketpair time unlink thread_test tlbshootdown tun vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -7,6 +7,7 @@ PROGRAMS= \
 	radar \
 	test \
 	tls \
+	tun \
 
 SRCS-cloud_init= \
 	$(CURDIR)/cloud_azure.c \
@@ -24,6 +25,9 @@ SRCS-test= \
 SRCS-tls= \
 	$(CURDIR)/mbedtls.c \
 	$(SRCS-mbedtls)
+
+SRCS-tun= \
+	$(CURDIR)/tun.c \
 
 SRCS-mbedtls= $(SRCS-mbedtls-crypto) $(SRCS-mbedtls-x509) $(SRCS-mbedtls-tls)
 
@@ -129,6 +133,8 @@ INCLUDES= \
 	-I$(SRCDIR)/kernel \
 	-I$(SRCDIR)/net \
 	-I$(SRCDIR)/runtime \
+	-I$(SRCDIR)/unix \
+	-I$(SRCDIR)/tfs \
 	-I$(PLATFORMDIR)
 
 DEFINES= \

--- a/klib/tun.c
+++ b/klib/tun.c
@@ -1,0 +1,349 @@
+#include <unix_internal.h>
+#include <lwip.h>
+#include <socket.h>
+
+/* ioctl requests */
+#define TUNSETIFF   0x400454ca
+#define TUNGETIFF   0x800454d2
+
+/* ifreq flags */
+#define IFF_TUN         0x0001
+#define TUN_TYPE_MASK   0x000f
+#define IFF_NO_PI       0x1000
+
+/* Packet information flags */
+#define TUN_PKT_STRIP   0x0001
+
+#define TUN_QUEUE_LEN   512
+
+typedef struct tun_pi { /* packet information */
+    u16 flags;
+    u16 proto;  /* expressed in network byte order */
+} *tun_pi;
+
+typedef struct tun {
+    file f;
+    queue pq;  /* packet queue */
+    blockq bq;
+    short flags;
+    struct netif *netif;
+} *tun;
+
+static heap tun_heap;
+static struct {
+    sysreturn (*ioctl_generic)(fdesc f, unsigned long request, vlist ap);
+    queue (*allocate_queue)(heap h, u64 size);
+    boolean (*enqueue)(queue q, void *p);
+    void *(*dequeue)(queue q);
+    void (*deallocate_queue)(queue q);
+    blockq (*allocate_blockq)(heap h, char *name);
+    sysreturn (*blockq_check)(blockq bq, thread t, blockq_action a, boolean in_bh);
+    void (*blockq_handle_completion)(blockq bq, u64 bq_flags, io_completion completion, thread t,
+            sysreturn rv);
+    void (*deallocate_blockq)(blockq bq);
+    struct netif *(*netif_add)(struct netif *netif,
+            const ip4_addr_t *ipaddr, const ip4_addr_t *netmask, const ip4_addr_t *gw,
+            void *state, netif_init_fn init, netif_input_fn input);
+    struct netif *(*netif_find)(const char *name);
+    void (*netif_name_cpy)(char *dest, struct netif *netif);
+    err_t (*netif_input)(struct pbuf *p, struct netif *inp);
+    void (*netif_remove)(struct netif *netif);
+    struct pbuf *(*pbuf_alloc)(pbuf_layer layer, u16_t length, pbuf_type type);
+    void (*pbuf_ref)(struct pbuf *p);
+    u16 (*pbuf_copy_partial)(const struct pbuf *buf, void *dataptr, u16 len, u16 offset);
+    u8 (*pbuf_free)(struct pbuf *p);
+    void (*runtime_memcpy)(void *a, const void *b, bytes len);
+    void (*file_release)(file f);
+} kfuncs;
+
+static err_t tun_if_output(struct netif *netif, struct pbuf *p, const ip4_addr_t *ipaddr)
+{
+    tun t = netif->state;
+    if (kfuncs.enqueue(t->pq, p)) {
+        kfuncs.pbuf_ref(p);
+        return ERR_OK;
+    } else {
+        return ERR_WOULDBLOCK;
+    }
+}
+
+static err_t tun_if_init(struct netif *netif)
+{
+    netif->output = tun_if_output;
+    netif->mtu = 32 * KB;
+    netif->flags = NETIF_FLAG_IGMP | NETIF_FLAG_LINK_UP;
+    return ERR_OK;
+}
+
+closure_function(5, 1, sysreturn, tun_read_bh,
+                 tun, tun, void *, dest, u64, len, thread, t, io_completion, completion,
+                 u64, flags)
+{
+    tun tun = bound(tun);
+    sysreturn ret;
+    struct pbuf *p = kfuncs.dequeue(tun->pq);
+    if (p == INVALID_ADDRESS) {
+        if (tun->f->f.flags & O_NONBLOCK) {
+            ret = -EAGAIN;
+            goto out;
+        }
+        return BLOCKQ_BLOCK_REQUIRED;
+    }
+    void * dest = bound(dest);
+    u64 len = bound(len);
+    if (!(tun->flags & IFF_NO_PI)) {
+        struct tun_pi pi;
+        if (len < sizeof(pi)) {
+            ret = -EINVAL;
+            kfuncs.pbuf_free(p);
+            goto out;
+        }
+        if (len < p->tot_len + sizeof(pi))
+            pi.flags = TUN_PKT_STRIP;
+        else
+            pi.flags = 0;
+        int ip_version = IPH_V((struct ip_hdr *)p->payload);
+        switch (ip_version) {
+        case 4:
+            pi.proto = htons(ETHTYPE_IP);
+            break;
+        case 6:
+            pi.proto = htons(ETHTYPE_IPV6);
+            break;
+        }
+        kfuncs.runtime_memcpy(dest, &pi, sizeof(pi));
+        dest += sizeof(pi);
+        len -= sizeof(pi);
+    }
+    ret = MIN(len, p->tot_len);
+    kfuncs.pbuf_copy_partial(p, dest, ret, 0);
+    kfuncs.pbuf_free(p);
+    if (!(tun->flags & IFF_NO_PI))
+        ret += sizeof(struct tun_pi);
+  out:
+    kfuncs.blockq_handle_completion(tun->bq, flags, bound(completion), bound(t), ret);
+    closure_finish();
+    return ret;
+}
+
+closure_function(1, 6, sysreturn, tun_read,
+                 tun, tun,
+                 void *, dest, u64, len, u64, offset_arg, thread, t, boolean, bh, io_completion, completion)
+{
+    tun tun = bound(tun);
+    if (!tun->netif)
+        return io_complete(completion, t, -EBADFD);
+    blockq_action ba = closure(tun_heap, tun_read_bh, bound(tun), dest, len, t, completion);
+    if (ba == INVALID_ADDRESS)
+        return io_complete(completion, t, -ENOMEM);
+    return kfuncs.blockq_check(tun->bq, t, ba, bh);
+}
+
+closure_function(1, 6, sysreturn, tun_write,
+                 tun, tun,
+                 void *, src, u64, len, u64, offset, thread, t, boolean, bh, io_completion, completion)
+{
+    tun tun = bound(tun);
+    if (!tun->netif)
+        return io_complete(completion, t, -EBADFD);
+    if (tun->flags & IFF_NO_PI) {
+        if (len == 0)
+            return io_complete(completion, t, -EINVAL);
+    } else {
+        if (len < sizeof(struct tun_pi))
+            return io_complete(completion, t, -EINVAL);
+        if (len == sizeof(struct tun_pi))
+            return io_complete(completion, t, len);
+
+        /* Discard packet information. */
+        src += sizeof(struct tun_pi);
+        len -= sizeof(struct tun_pi);
+    }
+    struct pbuf *p = kfuncs.pbuf_alloc(PBUF_RAW, len, PBUF_POOL);
+    if (!p)
+        return io_complete(completion, t, -ENOMEM);
+    u64 copied = 0;
+    struct pbuf *q = p;
+    do {
+        kfuncs.runtime_memcpy(q->payload, src + copied, q->len);
+        copied += q->len;
+        q = q->next;
+    } while (q);
+    tun->netif->input(p, tun->netif);
+    if (!(tun->flags & IFF_NO_PI))
+        len += sizeof(struct tun_pi);
+    return len;
+}
+
+closure_function(1, 1, u32, tun_events,
+                 tun, tun,
+                 thread, t)
+{
+    tun tun = bound(tun);
+    if (!tun->netif)
+        return EPOLLERR;
+    u32 events = EPOLLOUT;
+    if (!queue_empty(tun->pq))
+        events += EPOLLIN;
+    return events;
+}
+
+closure_function(1, 2, sysreturn, tun_ioctl,
+                 tun, tun,
+                 unsigned long, request, vlist, ap)
+{
+    tun tun = bound(tun);
+    switch (request) {
+    case TUNSETIFF: {
+        struct ifreq *ifreq = varg(ap, struct ifreq *);
+        if (!validate_user_memory(ifreq, sizeof(struct ifreq), true))
+            return -EFAULT;
+        if (tun->netif || kfuncs.netif_find(ifreq->ifr_name))
+            return -EINVAL;
+        switch (ifreq->ifr.ifr_flags & TUN_TYPE_MASK) {
+        case IFF_TUN:
+            break;
+        default:
+            return -EINVAL;
+        }
+        if ((ifreq->ifr.ifr_flags & ~TUN_TYPE_MASK) & ~IFF_NO_PI)
+            return -EINVAL;
+        tun->flags = ifreq->ifr.ifr_flags;
+        tun->netif = allocate(tun_heap, sizeof(struct netif));
+        if (tun->netif == INVALID_ADDRESS)
+            return -ENOMEM;
+        if (ifreq->ifr_name[0] && ifreq->ifr_name[1]) {
+            tun->netif->name[0] = ifreq->ifr_name[0];
+            tun->netif->name[1] = ifreq->ifr_name[1];
+        } else {    /* assign a default name */
+            tun->netif->name[0] = 't';
+            tun->netif->name[1] = 'u';
+        }
+        tun->netif->state = tun;
+        kfuncs.netif_add(tun->netif, 0, 0, 0, tun, tun_if_init, kfuncs.netif_input);
+        kfuncs.netif_name_cpy(ifreq->ifr_name, tun->netif);
+        break;
+    }
+    case TUNGETIFF: {
+        if (!tun->netif)
+            return -EBADFD;
+        struct ifreq *ifreq = varg(ap, struct ifreq *);
+        if (!validate_user_memory(ifreq, sizeof(struct ifreq), true))
+            return -EFAULT;
+        kfuncs.netif_name_cpy(ifreq->ifr_name, tun->netif);
+        ifreq->ifr.ifr_flags = tun->flags;
+        break;
+    }
+    default:
+        return kfuncs.ioctl_generic(&tun->f->f, request, ap);
+    }
+    return 0;
+}
+
+closure_function(1, 2, sysreturn, tun_close,
+                 tun, tun,
+                 thread, t, io_completion, completion)
+{
+    tun tun = bound(tun);
+    file f = tun->f;
+    if (tun->netif) {
+        kfuncs.netif_remove(tun->netif);
+        deallocate(tun_heap, tun->netif, sizeof(struct netif));
+    }
+    kfuncs.deallocate_blockq(tun->bq);
+    kfuncs.deallocate_queue(tun->pq);
+    deallocate_closure(f->f.read);
+    deallocate_closure(f->f.write);
+    deallocate_closure(f->f.events);
+    deallocate_closure(f->f.ioctl);
+    deallocate_closure(f->f.close);
+    kfuncs.file_release(f);
+    deallocate(tun_heap, tun, sizeof(struct tun));
+    return io_complete(completion, t, 0);
+}
+
+closure_function(0, 1, sysreturn, tun_open,
+                 file, f)
+{
+    tun t = allocate(tun_heap, sizeof(struct tun));
+    if (t == INVALID_ADDRESS)
+        return -ENOMEM;
+    f->f.read = closure(tun_heap, tun_read, t);
+    if (f->f.read == INVALID_ADDRESS)
+        goto no_mem;
+    f->f.write = closure(tun_heap, tun_write, t);
+    if (f->f.write == INVALID_ADDRESS)
+        goto no_mem;
+    f->f.events = closure(tun_heap, tun_events, t);
+    if (f->f.events == INVALID_ADDRESS)
+        goto no_mem;
+    f->f.ioctl = closure(tun_heap, tun_ioctl, t);
+    if (f->f.ioctl == INVALID_ADDRESS)
+        goto no_mem;
+    f->f.close = closure(tun_heap, tun_close, t);
+    if (f->f.close == INVALID_ADDRESS)
+        goto no_mem;
+    t->pq = kfuncs.allocate_queue(tun_heap, TUN_QUEUE_LEN);
+    if (t->pq == INVALID_ADDRESS)
+        goto no_mem;
+    t->bq = kfuncs.allocate_blockq(tun_heap, "tun");
+    if (t->bq == INVALID_ADDRESS) {
+        kfuncs.deallocate_queue(t->pq);
+        goto no_mem;
+    }
+    t->f = f;
+    t->netif = 0;
+    return 0;
+  no_mem:
+    if (f->f.read && (f->f.read != INVALID_ADDRESS))
+        deallocate_closure(f->f.read);
+    if (f->f.write && (f->f.write == INVALID_ADDRESS))
+        deallocate_closure(f->f.write);
+    if (f->f.events && (f->f.events == INVALID_ADDRESS))
+        deallocate_closure(f->f.events);
+    if (f->f.ioctl && (f->f.ioctl == INVALID_ADDRESS))
+        deallocate_closure(f->f.ioctl);
+    if (f->f.close && (f->f.close == INVALID_ADDRESS))
+        deallocate_closure(f->f.close);
+    deallocate(tun_heap, t, sizeof(struct tun));
+    return -ENOMEM;
+}
+
+int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
+{
+    void *(*get_kernel_heaps)(void);
+    boolean (*create_special_file)(const char *path, spec_file_open open);
+    if (!(get_kernel_heaps = get_sym("get_kernel_heaps")) ||
+            !(create_special_file = get_sym("create_special_file")) ||
+            !(kfuncs.ioctl_generic = get_sym("ioctl_generic")) ||
+            !(kfuncs.allocate_queue = get_sym("allocate_queue")) ||
+            !(kfuncs.enqueue = get_sym("enqueue")) ||
+            !(kfuncs.dequeue = get_sym("dequeue")) ||
+            !(kfuncs.deallocate_queue = get_sym("deallocate_queue")) ||
+            !(kfuncs.allocate_blockq = get_sym("allocate_blockq")) ||
+            !(kfuncs.blockq_check = get_sym("blockq_check")) ||
+            !(kfuncs.blockq_handle_completion = get_sym("blockq_handle_completion")) ||
+            !(kfuncs.deallocate_blockq = get_sym("deallocate_blockq")) ||
+            !(kfuncs.netif_add = get_sym("netif_add")) ||
+            !(kfuncs.netif_find = get_sym("netif_find")) ||
+            !(kfuncs.netif_name_cpy = get_sym("netif_name_cpy")) ||
+            !(kfuncs.netif_input = get_sym("netif_input")) ||
+            !(kfuncs.netif_remove = get_sym("netif_remove")) ||
+            !(kfuncs.pbuf_alloc = get_sym("pbuf_alloc")) ||
+            !(kfuncs.pbuf_ref = get_sym("pbuf_ref")) ||
+            !(kfuncs.pbuf_copy_partial = get_sym("pbuf_copy_partial")) ||
+            !(kfuncs.pbuf_free = get_sym("pbuf_free")) ||
+            !(kfuncs.runtime_memcpy = get_sym("runtime_memcpy")) ||
+            !(kfuncs.file_release = get_sym("file_release")))
+        return KLIB_INIT_FAILED;
+    tun_heap = heap_general(get_kernel_heaps());
+    spec_file_open open = closure(tun_heap, tun_open);
+    if (open == INVALID_ADDRESS)
+        return KLIB_INIT_FAILED;
+    if (create_special_file("/dev/net/tun", open)) {
+        return KLIB_INIT_OK;
+    } else {
+        deallocate_closure(open);
+        return KLIB_INIT_FAILED;
+    }
+}

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -160,6 +160,11 @@ kernel_heaps get_kernel_heaps(void)
 }
 KLIB_EXPORT(get_kernel_heaps);
 
+filesystem get_root_fs(void)
+{
+    return root_fs;
+}
+
 tuple get_root_tuple(void)
 {
     return filesystem_getroot(root_fs);

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -247,6 +247,7 @@ void mm_register_balloon_deflater(balloon_deflater deflater);
 
 kernel_heaps get_kernel_heaps(void);
 
+struct filesystem *get_root_fs(void);
 tuple get_root_tuple(void);
 tuple get_environment(void);
 void register_root_notify(symbol s, set_value_notify n);

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -265,4 +265,5 @@ void init_klib(kernel_heaps kh, void *fs, tuple config_root, tuple klib_md)
         load_klib("/klib/radar", closure(h, radar_loaded));
     load_klib("/klib/cloud_init", closure(h, klib_optional_loaded));
     load_klib("/klib/ntp", closure(h, klib_optional_loaded));
+    load_klib("/klib/tun", closure(h, klib_optional_loaded));
 }

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -23,6 +23,7 @@ status direct_connect(heap h, ip_addr_t *addr, u16 port, connection_handler ch);
 struct netif *netif_get_default(void);
 
 u16 ifflags_from_netif(struct netif *netif);
+boolean ifflags_to_netif(struct netif *netif, u16 flags);
 void netif_name_cpy(char *dest, struct netif *netif);
 
 #define netif_is_loopback(netif)    (((netif)->name[0] == 'l') && ((netif)->name[1] == 'o'))

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -169,6 +169,22 @@ u16 ifflags_from_netif(struct netif *netif)
     return flags;
 }
 
+boolean ifflags_to_netif(struct netif *netif, u16 flags)
+{
+    u16 diff = ifflags_from_netif(netif) ^ flags;
+    if (diff & ~(IFF_UP | IFF_RUNNING)) /* attempt to modify read-only flags */
+        return false;
+    if (flags & IFF_UP)
+        netif_set_up(netif);
+    else
+        netif_set_down(netif);
+    if (flags & IFF_RUNNING)
+        netif_set_link_up(netif);
+    else
+        netif_set_link_down(netif);
+    return true;
+}
+
 void netif_name_cpy(char *dest, struct netif *netif)
 {
     runtime_memcpy(dest, netif->name, sizeof(netif->name));

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -191,14 +191,21 @@ void netif_name_cpy(char *dest, struct netif *netif)
     dest[sizeof(netif->name)] = '0' + netif->num;
     dest[sizeof(netif->name) + 1] = '\0';
 }
+KLIB_EXPORT(netif_name_cpy);
 
 KLIB_EXPORT(ipaddr_ntoa);
 KLIB_EXPORT(dns_gethostbyname);
 KLIB_EXPORT(pbuf_alloc);
+KLIB_EXPORT(pbuf_ref);
+KLIB_EXPORT(pbuf_copy_partial);
 KLIB_EXPORT(pbuf_free);
 KLIB_EXPORT(udp_new);
 KLIB_EXPORT(udp_sendto);
 KLIB_EXPORT(udp_recv);
+KLIB_EXPORT(netif_add);
+KLIB_EXPORT(netif_find);
+KLIB_EXPORT(netif_input);
+KLIB_EXPORT(netif_remove);
 
 #define MAX_ADDR_LEN 20
 

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -31,8 +31,6 @@
 
 #define MTU_MAX (32 * KB)
 
-#define IFNAMSIZ    16
-
 #define resolve_socket(__p, __fd) ({fdesc f = resolve_fd(__p, __fd); \
     if (f->type != FDESC_TYPE_SOCKET) \
         return set_syscall_error(current, ENOTSOCK); \
@@ -60,33 +58,6 @@ struct sockaddr_in6 {
 struct mmsghdr {
     struct msghdr msg_hdr;
     unsigned int msg_len;
-};
-
-struct ifmap {
-    unsigned long mem_start;
-    unsigned long mem_end;
-    unsigned short base_addr;
-    unsigned char irq;
-    unsigned char dma;
-    unsigned char port;
-};
-
-struct ifreq {
-    char ifr_name[IFNAMSIZ];
-    union {
-        struct sockaddr ifr_addr;
-        struct sockaddr ifr_dstaddr;
-        struct sockaddr ifr_broadaddr;
-        struct sockaddr ifr_netmask;
-        struct sockaddr ifr_hwaddr;
-        short ifr_flags;
-        int ifr_ivalue;
-        int ifr_mtu;
-        struct ifmap ifru_map;
-        char ifr_slave[IFNAMSIZ];
-        char ifr_newname[IFNAMSIZ];
-        void *ifr_data;
-    } ifr;
 };
 
 struct ifconf {

--- a/src/runtime/queue.c
+++ b/src/runtime/queue.c
@@ -17,9 +17,23 @@ queue allocate_queue(heap h, u64 size)
     q->h = h;
     return q;
 }
+KLIB_EXPORT(allocate_queue);
+
+boolean kern_enqueue(queue q, void *p)
+{
+    return enqueue(q, p);
+}
+KLIB_EXPORT_RENAME(kern_enqueue, enqueue);
+
+void *kern_dequeue(queue q)
+{
+    return dequeue(q);
+}
+KLIB_EXPORT_RENAME(kern_dequeue, dequeue);
 
 void deallocate_queue(queue q)
 {
     if (q->h)
         deallocate(q->h, q, _queue_alloc_size(q->order));
 }
+KLIB_EXPORT(deallocate_queue);

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -215,6 +215,12 @@ boolean blockq_wake_one_for_thread(blockq bq, thread t)
     return false;
 }
 
+sysreturn kern_blockq_check(blockq bq, thread t, blockq_action a, boolean in_bh)
+{
+    return blockq_check(bq, t, a, in_bh);
+}
+KLIB_EXPORT_RENAME(kern_blockq_check, blockq_check);
+
 sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_bh,
                                clock_id clkid, timestamp timeout, boolean absolute)
 {
@@ -279,6 +285,13 @@ sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_
     thread_sleep_interruptible();  /* no return */
     assert(0);
 }
+
+void kern_blockq_handle_completion(blockq bq, u64 bq_flags, io_completion completion, thread t,
+                                   sysreturn rv)
+{
+    blockq_handle_completion(bq, bq_flags, completion, t, rv);
+}
+KLIB_EXPORT_RENAME(kern_blockq_handle_completion, blockq_handle_completion);
 
 /* XXX This deserves another pass; blockq_item should really just be embedded into thread. */
 boolean blockq_flush_thread(blockq bq, thread t)
@@ -376,6 +389,7 @@ blockq allocate_blockq(heap h, char * name)
 
     return bq;
 }
+KLIB_EXPORT(allocate_blockq);
 
 void deallocate_blockq(blockq bq)
 {
@@ -387,6 +401,7 @@ void deallocate_blockq(blockq bq)
 
     deallocate(bq->h, bq, sizeof(struct blockq));
 }
+KLIB_EXPORT(deallocate_blockq);
 
 const char * blockq_name(blockq bq)
 {

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -370,3 +370,9 @@ sysreturn fadvise64(int fd, s64 off, u64 len, int advice)
     }
     return 0;
 }
+
+void file_release(file f)
+{
+    release_fdesc(&f->f);
+    unix_cache_free(get_unix_heaps(), file, f);
+}

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -376,3 +376,4 @@ void file_release(file f)
     release_fdesc(&f->f);
     unix_cache_free(get_unix_heaps(), file, f);
 }
+KLIB_EXPORT(file_release);

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -56,3 +56,5 @@ sysreturn fstatfs(int fd, struct statfs *buf);
 sysreturn fallocate(int fd, int mode, long offset, long len);
 
 sysreturn fadvise64(int fd, s64 off, u64 len, int advice);
+
+void file_release(file f);

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -20,6 +20,35 @@ struct msghdr {
     int msg_flags;
 };
 
+#define IFNAMSIZ    16
+
+struct ifmap {
+    unsigned long mem_start;
+    unsigned long mem_end;
+    unsigned short base_addr;
+    unsigned char irq;
+    unsigned char dma;
+    unsigned char port;
+};
+
+struct ifreq {
+    char ifr_name[IFNAMSIZ];
+    union {
+        struct sockaddr ifr_addr;
+        struct sockaddr ifr_dstaddr;
+        struct sockaddr ifr_broadaddr;
+        struct sockaddr ifr_netmask;
+        struct sockaddr ifr_hwaddr;
+        short ifr_flags;
+        int ifr_ivalue;
+        int ifr_mtu;
+        struct ifmap ifru_map;
+        char ifr_slave[IFNAMSIZ];
+        char ifr_newname[IFNAMSIZ];
+        void *ifr_data;
+    } ifr;
+};
+
 struct sock {
     struct fdesc f;              /* must be first */
     int fd;

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1969,6 +1969,7 @@ sysreturn ioctl_generic(fdesc f, unsigned long request, vlist ap)
         return -ENOSYS;
     }
 }
+KLIB_EXPORT(ioctl_generic);
 
 sysreturn ioctl(int fd, unsigned long request, ...)
 {

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -67,6 +67,7 @@ typedef struct iovec {
 #define ENOPROTOOPT     42              /* Protocol not available */
 
 #define ETIME           62		/* Timer expired */
+#define EBADFD          77		/* File descriptor in bad state */
 #define EDESTADDRREQ    89		/* Destination address required */
 #define EMSGSIZE        90		/* Message too long */
 #define EOPNOTSUPP      95		/* Operation not supported */

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -872,14 +872,10 @@ sysreturn socketpair(int domain, int type, int protocol, int sv[2]);
 
 int do_eventfd2(unsigned int count, int flags);
 
+typedef closure_type(spec_file_open, sysreturn, file f);
+
 void register_special_files(process p);
 sysreturn spec_open(file f);
-sysreturn spec_close(file f);
-sysreturn spec_read(file f, void *dest, u64 length, u64 offset_arg, thread t,
-        boolean bh, io_completion completion);
-sysreturn spec_write(file f, void *dest, u64 length, u64 offset_arg, thread t,
-        boolean bh, io_completion completion);
-u32 spec_events(file f);
 
 /* Values to pass as first argument to prctl() */
 #define PR_SET_NAME    15               /* Set process name */

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -117,7 +117,7 @@ void install_idt(void);
 void set_ist(int cpu, int i, u64 sp);
 void install_gdt64_and_tss(u64 cpu);
 
-#ifdef KERNEL
+#if defined(KERNEL) || defined(KLIB)
 /* locking constructs */
 #include <lock.h>
 #endif

--- a/src/x86_64/lock.h
+++ b/src/x86_64/lock.h
@@ -1,6 +1,6 @@
 /* struct spinlock defined in machine.h */
 
-#if defined(KERNEL) && defined(SMP_ENABLE)
+#if (defined(KERNEL) || defined(KLIB)) && defined(SMP_ENABLE)
 static inline boolean spin_try(spinlock l) {
     u64 tmp = 1;
     /* Is it worth the compare and branch to skip a pause? */

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -36,6 +36,7 @@ PROGRAMS= \
 	thread_test \
 	time \
 	tlbshootdown \
+	tun \
 	udploop \
 	unixsocket \
 	unlink \
@@ -215,6 +216,11 @@ SRCS-tlbshootdown= \
 	$(RUNTIME)
 LDFLAGS-tlbshootdown=		-static
 LIBS-tlbshootdown=	-lpthread
+
+SRCS-tun= \
+	$(CURDIR)/tun.c \
+	$(SRCDIR)/unix_process/ssp.c
+LDFLAGS-tun=	-static
 
 SRCS-udploop= \
 	$(CURDIR)/udploop.c \

--- a/test/runtime/tun.c
+++ b/test/runtime/tun.c
@@ -1,0 +1,236 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/if_tun.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/udp.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <runtime.h>
+
+#define TUN_ADDR    0x0a0b0c0d
+
+#define TUN_PEER_ADDR   (TUN_ADDR + 1)
+#define TUN_PEER_PORT   1234
+
+#define test_assert(expr) do { \
+    if (!(expr)) { \
+        printf("Error: %s -- failed at %s:%d\n", #expr, __FILE__, __LINE__); \
+        exit(EXIT_FAILURE); \
+    } \
+} while (0)
+
+static int tun_setup(int flags, char *ifname)
+{
+    int tun_fd, sock_fd;
+    struct pollfd pfd;
+    u64 dummy_buf;
+    struct ifreq ifr;
+    struct sockaddr_in addr;
+
+    tun_fd = open("/dev/net/tun", O_RDWR);
+    test_assert(tun_fd > 0);
+
+    /* A file descriptor not attached to a tun interface cannot be read from or written to. */
+    pfd.fd = tun_fd;
+    pfd.events = POLLIN | POLLOUT;
+    test_assert((poll(&pfd, 1, 0) == 1) && (pfd.revents == POLLERR));
+    test_assert((read(tun_fd, &dummy_buf, sizeof(dummy_buf)) == -1) && (errno == EBADFD));
+    test_assert((write(tun_fd, &dummy_buf, sizeof(dummy_buf)) == -1) && (errno == EBADFD));
+
+    test_assert((ioctl(tun_fd, TUNSETIFF, NULL) == -1) && (errno == EFAULT));
+    memset(&ifr, 0, sizeof(ifr));
+    strcpy(ifr.ifr_name, ifname);
+    ifr.ifr_flags = flags;
+    test_assert((ioctl(tun_fd, TUNGETIFF, &ifr) == -1) && (errno == EBADFD));
+    test_assert(ioctl(tun_fd, TUNSETIFF, &ifr) == 0);
+
+    /* Try to re-attach to the interface when already attached. */
+    test_assert((ioctl(tun_fd, TUNSETIFF, &ifr) == -1) && (errno == EINVAL));
+
+    sock_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    test_assert(sock_fd > 0);
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(TUN_ADDR);
+    memcpy(&ifr.ifr_addr, &addr, sizeof(addr));
+    test_assert(ioctl(sock_fd, SIOCSIFADDR, &ifr) == 0);
+    addr.sin_addr.s_addr = htonl(0xffffff00);
+    memcpy(&ifr.ifr_addr, &addr, sizeof(addr));
+    test_assert(ioctl(sock_fd, SIOCSIFNETMASK, &ifr) == 0);
+    test_assert((ioctl(sock_fd, SIOCGIFFLAGS, &ifr) == 0) && !(ifr.ifr_flags & IFF_UP));
+    ifr.ifr_flags |= IFF_UP;
+    test_assert(ioctl(sock_fd, SIOCSIFFLAGS, &ifr) == 0);
+    test_assert(close(sock_fd) == 0);
+    strcpy(ifname, ifr.ifr_name);
+    return tun_fd;
+}
+
+static void tun_test_basic(void)
+{
+    int tun_fd, sock_fd;
+    struct ifreq ifr;
+    struct sockaddr_in addr;
+    socklen_t addr_len;
+    int mtu, hdr_len, pkt_len;
+    struct pollfd pfd;
+    int nbio;
+    uint8_t buf[64 * KB];
+    struct iphdr *ip_hdr = (struct iphdr *)buf;
+    struct udphdr *udp_hdr = (struct udphdr *)(ip_hdr + 1);
+
+    memset(&ifr, 0, sizeof(ifr));
+    ifr.ifr_name[0] = ifr.ifr_name[1] = 't';
+    tun_fd = tun_setup(IFF_TUN | IFF_NO_PI, ifr.ifr_name);
+
+    /* Check that the request for a given interface name is honored. */
+    test_assert((ifr.ifr_name[0] == 't') && (ifr.ifr_name[1] == 't'));
+
+    test_assert((ioctl(tun_fd, TUNGETIFF, NULL) == -1) && (errno == EFAULT));
+    memset(&ifr, 0, sizeof(ifr));
+    test_assert(ioctl(tun_fd, TUNGETIFF, &ifr) == 0);
+    test_assert((ifr.ifr_name[0] == 't') && (ifr.ifr_name[1] == 't'));
+    test_assert(ifr.ifr_flags == (IFF_TUN | IFF_NO_PI));
+
+    /* A newly attached file descriptor can be written to but not read from (until a packet arrives
+     * at the tun interface). */
+    pfd.fd = tun_fd;
+    pfd.events = POLLIN | POLLOUT;
+    test_assert((poll(&pfd, 1, 0) == 1) && (pfd.revents == POLLOUT));
+    nbio = 1;
+    test_assert(ioctl(tun_fd, FIONBIO, &nbio) == 0);
+    test_assert((read(tun_fd, buf, sizeof(buf)) == -1) && (errno == EAGAIN));
+    nbio = 0;
+    test_assert(ioctl(tun_fd, FIONBIO, &nbio) == 0);
+
+    /* Try to send a zero-sized packet. */
+    test_assert((write(tun_fd, buf, 0) == -1) && (errno == EINVAL));
+
+    /* Send an MTU-sized packet. */
+    sock_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    test_assert(sock_fd > 0);
+    test_assert((ioctl(sock_fd, SIOCGIFMTU, &ifr) == 0) && (ifr.ifr_mtu > 1));
+    if (ifr.ifr_mtu >= sizeof(buf)) {
+        ifr.ifr_mtu = sizeof(buf) - 1;
+        test_assert(ioctl(sock_fd, SIOCSIFMTU, &ifr) == 0);
+    }
+    mtu = ifr.ifr_mtu;
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(TUN_PEER_ADDR);
+    addr.sin_port = htons(TUN_PEER_PORT);
+    test_assert(connect(sock_fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    hdr_len = sizeof(struct iphdr) + sizeof(struct udphdr);
+    pkt_len = mtu - hdr_len;
+    for (int i = 0; i < pkt_len; i++)
+        buf[i] = i;
+    test_assert(send(sock_fd, buf, pkt_len, 0) == pkt_len);
+    test_assert((poll(&pfd, 1, 0) == 1) && (pfd.revents == (POLLIN | POLLOUT)));
+    test_assert(read(tun_fd, buf, sizeof(buf)) == mtu);
+    for (int i = 0; i < pkt_len; i++)
+        test_assert(buf[hdr_len + i] == (uint8_t)i);
+
+    /* Swap source and destination, and receive an MTU-sized packet. */
+    ip_hdr->saddr = htonl(TUN_PEER_ADDR);
+    ip_hdr->daddr = htonl(TUN_ADDR);
+    udp_hdr->source = htons(TUN_PEER_PORT);
+    addr_len = sizeof(addr);
+    test_assert(getsockname(sock_fd, (struct sockaddr *)&addr, &addr_len) == 0);
+    udp_hdr->dest = addr.sin_port;
+    test_assert(write(tun_fd, buf, mtu) == mtu);
+    test_assert(recv(sock_fd, buf, sizeof(buf), 0) == pkt_len);
+    for (int i = 0; i < pkt_len; i++)
+        test_assert(buf[i] == (uint8_t)i);
+
+    test_assert(close(tun_fd) == 0);
+
+    /* Check that network interface is removed when file descriptor is closed. */
+    test_assert((ioctl(sock_fd, SIOCGIFMTU, &ifr) == -1) && (errno == ENODEV));
+
+    test_assert(close(sock_fd) == 0);
+}
+
+/* Test packet sending and receiving with packet information enabled in interface options. */
+static void tun_test_pi(void)
+{
+    int tun_fd, sock_fd;
+    struct ifreq ifr;
+    struct sockaddr_in addr;
+    socklen_t addr_len;
+    uint8_t buf[KB];
+    const int pkt_len = sizeof(buf) / 2;
+    const int tot_len =
+            sizeof(struct tun_pi) + sizeof(struct iphdr) + sizeof(struct udphdr) + pkt_len;
+    const struct tun_pi *pi = (struct tun_pi *)buf;
+    struct iphdr *ip_hdr = (struct iphdr *)(buf + sizeof(*pi));
+    struct udphdr *udp_hdr = (struct udphdr *)(ip_hdr + 1);
+
+    memset(&ifr, 0, sizeof(ifr));
+    tun_fd = tun_setup(IFF_TUN, ifr.ifr_name);
+    sock_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    test_assert(sock_fd > 0);
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(TUN_PEER_ADDR);
+    addr.sin_port = htons(TUN_PEER_PORT);
+    test_assert(connect(sock_fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+
+    /* Try to receive a packet with a buffer too small. */
+    test_assert(send(sock_fd, buf, 1, 0) == 1);
+    test_assert((read(tun_fd, buf, sizeof(struct tun_pi) - 1) == -1) && (errno == EINVAL));
+
+    for (int i = 0; i < pkt_len; i++)
+        buf[i] = i;
+    test_assert(send(sock_fd, buf, pkt_len, 0) == pkt_len);
+    test_assert(read(tun_fd, buf, sizeof(buf)) == tot_len);
+    test_assert(pi->proto == htons(ETH_P_IP));
+    test_assert(!(pi->flags & TUN_PKT_STRIP));
+    for (int i = 0; i < pkt_len; i++)
+        test_assert(buf[tot_len - pkt_len + i] == (uint8_t)i);
+
+    /* Receive a packet with a buffer smaller than what is required to hold the entire packet. */
+    for (int i = 0; i < pkt_len; i++)
+        buf[i] = i;
+    test_assert(send(sock_fd, buf, pkt_len, 0) == pkt_len);
+    test_assert(read(tun_fd, buf, tot_len - 1) == tot_len - 1);
+    test_assert(pi->flags & TUN_PKT_STRIP);
+
+    /* Try to send a packet with a buffer too small. */
+    test_assert((write(tun_fd, buf, sizeof(struct tun_pi) - 1) == -1) && (errno == EINVAL));
+
+    /* Send an empty packet. */
+    test_assert(write(tun_fd, buf, sizeof(struct tun_pi)) == sizeof(struct tun_pi));
+
+    /* Swap source and destination, and receive a packet. */
+    ip_hdr->saddr = htonl(TUN_PEER_ADDR);
+    ip_hdr->daddr = htonl(TUN_ADDR);
+    udp_hdr->source = htons(TUN_PEER_PORT);
+    addr_len = sizeof(addr);
+    test_assert(getsockname(sock_fd, (struct sockaddr *)&addr, &addr_len) == 0);
+    udp_hdr->dest = addr.sin_port;
+    test_assert(write(tun_fd, buf, tot_len) == tot_len);
+    test_assert(recv(sock_fd, buf, sizeof(buf), 0) == pkt_len);
+    for (int i = 0; i < pkt_len; i++)
+        test_assert(buf[i] == (uint8_t)i);
+
+    test_assert(close(sock_fd) == 0);
+    test_assert(close(tun_fd) == 0);
+}
+
+int main(int argc, char **argv)
+{
+    /* Wait for tun klib to be loaded. */
+    while (access("/dev/net/tun", O_RDWR) == -1)
+        test_assert(errno == ENOENT);
+
+    tun_test_basic();
+    tun_test_pi();
+    printf("Tun interface tests OK\n");
+    return EXIT_SUCCESS;
+}

--- a/test/runtime/tun.manifest
+++ b/test/runtime/tun.manifest
@@ -1,0 +1,13 @@
+(
+    boot:(
+        children:(
+            klib:(children:(tun:(contents:(host:output/klib/bin/tun))))
+        )
+    )
+    children:(
+        tun:(contents:(host:output/test/runtime/bin/tun))
+    )
+    klibs:bootfs
+    environment:()
+    program:/tun
+)


### PR DESCRIPTION
The tun interface driver is implemented as a klib.
In order to allow adding a new type of special files and implementing blocking I/O on this file, I/O operations on special files have been refactored using custom fdesc closures, instead of relying on the fdesc closures used for regular files.