### PR TITLE
TFS log_read_complete(): avoid multiple stack closure allocations

### DIFF
--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -833,9 +833,11 @@ closure_function(4, 1, void, log_read_complete,
     b->start = 0;
     tlog_debug("   log parse finished, end now at %d\n", b->end);
 
+    binding_handler bh = stack_closure(log_read_ingest_extent, 0);
     table_foreach(tl->extents, t, f) {
         assert(is_tuple(t));
-        iterate((tuple)t, stack_closure(log_read_ingest_extent, (fsfile)f));
+        closure_member(log_read_ingest_extent, bh, f) = (fsfile)f;
+        iterate((tuple)t, bh);
     }
     deallocate_table(tl->extents);  /* not needed anymore */
     tl->extents = 0;


### PR DESCRIPTION
Allocating the log_read_ingest_extent closure for each extent found in a given filesystem is not necessary and can lead to a stack
overflow when reading a filesystem with a large number of extents.
This PR moves the closure allocation outside the loop that is executed for each extent, and uses the closure_member() macro inside the loop to update the fsfile closure member.