### PR TITLE
Add syslog klib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test test-noaccel: image
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws io_uring klibs mkdir mmap netlink netsock pipe readv rename sendfile signal socketpair time unlink thread_test tlbshootdown tun vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws io_uring klibs mkdir mmap netlink netsock pipe readv rename sendfile signal socketpair syslog time unlink thread_test tlbshootdown tun vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -5,6 +5,7 @@ PROGRAMS= \
 	cloud_init \
 	ntp \
 	radar \
+	syslog \
 	test \
 	tls \
 	tun \
@@ -18,6 +19,9 @@ SRCS-ntp= \
 
 SRCS-radar= \
 	$(CURDIR)/radar.c \
+
+SRCS-syslog= \
+	$(CURDIR)/syslog.c \
 
 SRCS-test= \
 	$(CURDIR)/test.c

--- a/klib/syslog.c
+++ b/klib/syslog.c
@@ -1,0 +1,460 @@
+#include <unix_internal.h>
+#include <drivers/console.h>
+#include <filesystem.h>
+#include <lwip.h>
+#include <mktime.h>
+
+#define __STRING(x)     #x
+#define __XSTRING(x)    __STRING(x)
+
+#define SYSLOG_BUF_LEN  (8 * KB)
+
+#define SYSLOG_FLUSH_INTERVAL   seconds(1)
+
+#define SYSLOG_FILE_MAXSIZE_DEFAULT (8 * MB)
+
+#define SYSLOG_FILE_ROTATE_DEFAULT  1
+#define SYSLOG_FILE_ROTATE_MAX      9
+
+/* facility: 1 (user-level messages)
+ * severity: 6 (informational messages)
+ * priority = facility * 8 + severity
+ */
+#define SYSLOG_PRIORITY 14
+
+#define SYSLOG_VERSION  "1"
+
+#define SYSLOG_UDP_PORT_DEFAULT 514
+
+declare_closure_struct(0, 1, void, syslog_timer_func,
+    u64, overruns);
+
+#define syslog_lock()   u64 _irqflags = spin_lock_irq(&syslog.lock)
+#define syslog_unlock() spin_unlock_irq(&syslog.lock, _irqflags)
+
+static struct {
+    struct console_driver driver;
+    heap h;
+    buffer file_path;
+    u64 file_max_size;
+    u64 file_rotate;
+    fsfile fsf;
+    sg_io fs_write;
+    u64 file_offset;
+    sg_list file_sg;
+    sg_buf file_sgb;
+    timer file_flush_timer;
+    closure_struct(syslog_timer_func, file_flush);
+    buffer program;
+    char *server;
+    boolean dns_in_progress;
+    timestamp dns_backoff;
+    timestamp dns_req_next;
+    ip_addr_t server_ip;
+    u16 server_port;
+    struct udp_pcb *udp_pcb;
+    char local_ip[40];
+    bytes hdr_len;
+    struct spinlock lock;
+} syslog;
+
+static struct {
+    fsfile (*fsfile_open_or_create)(buffer file_path);
+    sg_io (*fsfile_get_writer)(fsfile f);
+    fs_status (*fsfile_truncate)(fsfile f, u64 len);
+    sg_list (*allocate_sg_list)(void);
+    sg_buf (*sg_list_tail_add)(sg_list sg, word length);
+    void (*deallocate_sg_list)(sg_list sg);
+    void (*runtime_memcpy)(void *a, const void *b, bytes len);
+    timer (*register_timer)(clock_id id, timestamp val, boolean absolute, timestamp interval,
+            timer_handler n);
+    void (*timm_dealloc)(tuple t);
+    sysreturn (*fs_rename)(buffer oldpath, buffer newpath);
+    err_t (*dns_gethostbyname)(const char *hostname, ip_addr_t *addr,
+            dns_found_callback found, void *callback_arg);
+    struct netif *(*netif_get_default)(void);
+    char *(*ipaddr_ntoa_r)(const ip_addr_t *addr, char *buf, int buflen);
+    struct pbuf *(*pbuf_alloc)(pbuf_layer layer, u16_t length, pbuf_type type);
+    u8 (*pbuf_free)(struct pbuf *p);
+    timestamp (*now)(clock_id id);
+    struct tm *(*gmtime_r)(u64 *timep, struct tm *result);
+    int (*rsnprintf)(char *str, u64 size, const char *fmt, ...);
+    err_t(*udp_sendto)(struct udp_pcb *pcb, struct pbuf *p,
+            const ip_addr_t *dst_ip, u16_t dst_port);
+} kfuncs;
+
+static void syslog_file_rotate(void)
+{
+    bytes path_len = buffer_length(syslog.file_path);
+    buffer old_file = alloca_wrap_buffer(stack_allocate(path_len + 2), path_len + 2);
+    buffer new_file = alloca_wrap_buffer(stack_allocate(path_len + 2), path_len + 2);
+    kfuncs.runtime_memcpy(buffer_ref(old_file, 0), buffer_ref(syslog.file_path, 0), path_len);
+    kfuncs.runtime_memcpy(buffer_ref(new_file, 0), buffer_ref(syslog.file_path, 0), path_len);
+    byte(old_file, path_len) = byte(new_file, path_len) = '.';
+
+    /* Rename rotated log files by replacing the ".<n-1>" name extension with ".<n>". */
+    for (u64 i = syslog.file_rotate; i > 1; i--) {
+        byte(new_file, path_len + 1) = '0' + i - 1;
+        byte(old_file, path_len + 1) = '0' + i;
+        kfuncs.fs_rename(new_file, old_file);
+    }
+
+    /* Rename the current log file by adding a ".1" extension to the file name. */
+    byte(old_file, path_len + 1) = '1';
+    sysreturn ret = kfuncs.fs_rename(syslog.file_path, old_file);
+
+    if (ret == 0) {
+        /* Continue logging on a new file. */
+        fsfile file = kfuncs.fsfile_open_or_create(syslog.file_path);
+        syslog.file_offset = 0;
+        syslog.fs_write = kfuncs.fsfile_get_writer(file);
+    } else {
+        syslog.fs_write = 0;    /* stop logging */
+    }
+}
+
+closure_function(3, 1, void, syslog_file_write_complete,
+                 void *, buf, u64, len, sg_list, sg,
+                 status, s)
+{
+    if (is_ok(s)) {
+        fetch_and_add(&syslog.file_offset, bound(len));
+        if (syslog.file_offset >= syslog.file_max_size) {
+            /* Avoid deadlock in case a write completion occurs synchronously. */
+            boolean unlock = spin_try(&syslog.lock);
+
+            if (syslog.file_rotate > 0) {
+                syslog_file_rotate();
+            } else {
+                /* Delete old logs instead of rotating. */
+                if (kfuncs.fsfile_truncate(syslog.fsf, 0) == FS_STATUS_OK)
+                    syslog.file_offset = 0;
+                else
+                    syslog.fs_write = 0;    /* stop logging */
+            }
+            if (unlock)
+                spin_unlock(&syslog.lock);
+        }
+    } else {
+        kfuncs.timm_dealloc(s);
+    }
+    deallocate(syslog.h, bound(buf), SYSLOG_BUF_LEN);
+    kfuncs.deallocate_sg_list(bound(sg));
+    closure_finish();
+}
+
+static void syslog_file_flush(void)
+{
+    syslog_lock();
+    sg_list sg = syslog.file_sg;
+    if (sg) {
+        syslog.file_sg = 0;
+        u64 len = syslog.file_sgb->offset;
+        status_handler sh =
+                closure(syslog.h, syslog_file_write_complete, syslog.file_sgb->buf, len, sg);
+        if (sh != INVALID_ADDRESS) {
+            syslog.file_sgb->offset = 0;
+            apply(syslog.fs_write, sg, irangel(syslog.file_offset, len), sh);
+        } else {
+            /* Discard logged data. */
+            deallocate(syslog.h, syslog.file_sgb->buf, SYSLOG_BUF_LEN);
+            kfuncs.deallocate_sg_list(sg);
+        }
+    }
+    syslog_unlock();
+}
+
+define_closure_function(0, 1, void, syslog_timer_func,
+                        u64, overruns)
+{
+    syslog.file_flush_timer = INVALID_ADDRESS;
+    syslog_file_flush();
+}
+
+static void syslog_file_write(const char *s, bytes count)
+{
+    if (!syslog.fs_write || (count > SYSLOG_BUF_LEN))
+        return;
+    if (!syslog.file_sg) {
+        syslog.file_sg = kfuncs.allocate_sg_list();
+        if (syslog.file_sg == INVALID_ADDRESS)
+            return;
+        syslog.file_sgb = kfuncs.sg_list_tail_add(syslog.file_sg, SYSLOG_BUF_LEN);
+        if (!syslog.file_sgb) {
+            kfuncs.deallocate_sg_list(syslog.file_sg);
+            syslog.file_sg = 0;
+            return;
+        }
+        syslog.file_sgb->buf = allocate(syslog.h, SYSLOG_BUF_LEN);
+        if (syslog.file_sgb->buf == INVALID_ADDRESS) {
+            kfuncs.deallocate_sg_list(syslog.file_sg);
+            syslog.file_sg = 0;
+            return;
+        }
+        syslog.file_sgb->size = SYSLOG_BUF_LEN;
+        syslog.file_sgb->offset = 0;
+        syslog.file_sgb->refcount = 0;
+    }
+    if (syslog.file_sgb->offset + count <= SYSLOG_BUF_LEN) {
+        kfuncs.runtime_memcpy(syslog.file_sgb->buf + syslog.file_sgb->offset, s, count);
+        syslog.file_sgb->offset += count;
+        if (syslog.file_flush_timer == INVALID_ADDRESS) {
+            syslog.file_flush_timer = kfuncs.register_timer(CLOCK_ID_MONOTONIC,
+                SYSLOG_FLUSH_INTERVAL, false, 0, (timer_handler)&syslog.file_flush.__apply);
+        }
+    } else {
+        syslog_file_flush();
+        syslog_file_write(s, count);
+    }
+}
+
+static void syslog_dns_failure(void)
+{
+    if (syslog.dns_backoff == 0)
+        syslog.dns_backoff = seconds(1);
+    else
+        syslog.dns_backoff *= 2;
+    syslog.dns_req_next = kfuncs.now(CLOCK_ID_MONOTONIC) + syslog.dns_backoff;
+}
+
+static void syslog_dns_cb(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
+{
+    if (ipaddr)
+        syslog.server_ip = *ipaddr;
+    else
+        syslog_dns_failure();
+    syslog.dns_in_progress = false;
+}
+
+static void syslog_server_resolve(void)
+{
+    if (syslog.dns_in_progress || (kfuncs.now(CLOCK_ID_MONOTONIC) < syslog.dns_req_next))
+        return;
+    err_t err = kfuncs.dns_gethostbyname(syslog.server, &syslog.server_ip, syslog_dns_cb, 0);
+    switch (err) {
+    case ERR_OK:
+        break;
+    case ERR_INPROGRESS:
+        syslog.dns_in_progress = true;
+        break;
+    default:
+        syslog_dns_failure();
+        break;
+    }
+}
+
+static void syslog_set_hdr_len(void)
+{
+    struct netif *n = kfuncs.netif_get_default();
+    if (!n)
+        return;
+    kfuncs.ipaddr_ntoa_r(&n->ip_addr, syslog.local_ip, sizeof(syslog.local_ip));
+    syslog.hdr_len = 1 + sizeof(__XSTRING(SYSLOG_PRIORITY)) + sizeof(SYSLOG_VERSION) +
+            sizeof("YYYY-MM-ddThh:mm:ss.uuuuuuZ") + runtime_strlen(syslog.local_ip) + 1 +
+            buffer_length(syslog.program) + 7;
+}
+
+static void syslog_udp_write(const char *s, bytes count)
+{
+    if (ip_addr_isany_val(syslog.server_ip)) {
+        syslog_server_resolve();
+        return;
+    }
+    if (!syslog.hdr_len) {
+        syslog_set_hdr_len();
+        if (!syslog.hdr_len)
+            return;
+    }
+    struct pbuf *pb = kfuncs.pbuf_alloc(PBUF_TRANSPORT, syslog.hdr_len + count, PBUF_RAM);
+    if (!pb)
+        return;
+    timestamp t = kfuncs.now(CLOCK_ID_REALTIME);
+    u64 seconds = sec_from_timestamp(t);
+    struct tm tm;
+    kfuncs.gmtime_r(&seconds, &tm);
+    kfuncs.rsnprintf(pb->payload, syslog.hdr_len + 1, "<" __XSTRING(SYSLOG_PRIORITY) ">"
+        SYSLOG_VERSION " %d-%02d-%02dT%02d:%02d:%02d.%06dZ %s %b - - - ",
+        1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec,
+        usec_from_timestamp(t) - seconds * MILLION, syslog.local_ip, syslog.program);
+    kfuncs.runtime_memcpy(pb->payload + syslog.hdr_len, s, count);
+    kfuncs.udp_sendto(syslog.udp_pcb, pb, &syslog.server_ip, syslog.server_port);
+    kfuncs.pbuf_free(pb);
+}
+
+static void syslog_write(void *d, const char *s, bytes count)
+{
+    if (syslog.file_path)
+        syslog_file_write(s, count);
+    if (syslog.server)
+        syslog_udp_write(s, count);
+}
+
+closure_function(2, 2, boolean, syslog_cfg,
+                 void *, intern, void *, rprintf,
+                 value, s, value, v)
+{
+    symbol (*intern)(string name) = bound(intern);
+    void (*rprintf)(const char *format, ...) = bound(rprintf);
+    if (s == sym(file)) {
+        if (!is_string(v)) {
+            rprintf("invalid syslog file\n");
+            return false;
+        }
+        syslog.file_path = v;
+    } else if (s == sym(file_max_size)) {
+        if (!is_string(v)) {
+            rprintf("invalid syslog file max size\n");
+            return false;
+        }
+        buffer b = alloca_wrap(v);
+        if (!parse_int(b, 10, &syslog.file_max_size)) {
+            rprintf("invalid syslog file max size\n");
+            return false;
+        }
+        if (buffer_length(b) == 1) {
+            char suffix = *(char *)buffer_ref(b, 0);
+            u64 size;
+            switch (suffix) {
+            case 'k':
+            case 'K':
+                size = syslog.file_max_size * KB;
+                break;
+            case 'm':
+            case 'M':
+                size = syslog.file_max_size * MB;
+                break;
+            case 'g':
+            case 'G':
+                size = syslog.file_max_size * GB;
+                break;
+            default:
+                rprintf("invalid syslog file max size suffix '%c'\n", suffix);
+                return false;
+            }
+            if (size < syslog.file_max_size) {
+                /* Size value cannot be represented in 64 bits. */
+                rprintf("invalid syslog file max size\n");
+                return false;
+            }
+            syslog.file_max_size = size;
+        } else if (buffer_length(b) > 1) {
+            rprintf("invalid syslog file max size\n");
+            return false;
+        }
+    } else if (s == sym(file_rotate)) {
+        if (!is_string(v) || !u64_from_value(v, &syslog.file_rotate)) {
+            rprintf("invalid syslog file rotate count\n");
+            return false;
+        } else if (syslog.file_rotate > SYSLOG_FILE_ROTATE_MAX) {
+            rprintf("syslog file rotate count greater than %d not supported\n",
+                SYSLOG_FILE_ROTATE_MAX);
+            return false;
+        }
+    } else if (s == sym(server)) {
+        if (!is_string(v)) {
+            rprintf("invalid syslog server\n");
+            return false;
+        }
+        bytes len = buffer_length(v);
+        syslog.server = allocate(syslog.h, len + 1);
+        if (syslog.server == INVALID_ADDRESS) {
+            rprintf("unable to allocate memory for syslog server\n");
+            return false;
+        }
+        kfuncs.runtime_memcpy(syslog.server, buffer_ref(v, 0), len);
+        syslog.server[len] = '\0';
+    } else if (s == sym(server_port)) {
+        u64 port;
+        if (!is_string(v) || !u64_from_value(v, &port) || (port > U16_MAX)) {
+            rprintf("invalid syslog port\n");
+            return false;
+        }
+        syslog.server_port = port;
+    } else {
+        rprintf("invalid syslog option '%v'\n", s);
+        return false;
+    }
+    return true;
+}
+
+int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
+{
+    void (*rprintf)(const char *format, ...);
+    if (!(rprintf = get_sym("rprintf")))
+        return KLIB_INIT_FAILED;
+    tuple (*get_root_tuple)(void) = get_sym("get_root_tuple");
+    symbol (*intern)(string name) = get_sym("intern");
+    value (*get)(value e, symbol a) = get_sym("get");
+    boolean (*iterate)(value e, binding_handler h) = get_sym("iterate");
+    u64 (*fsfile_get_length)(fsfile f) = get_sym("fsfile_get_length");
+    void *(*get_kernel_heaps)(void) = get_sym("get_kernel_heaps");
+    struct udp_pcb *(*udp_new)(void) = get_sym("udp_new");
+    void (*attach_console_driver)(struct console_driver *driver) =
+            get_sym("attach_console_driver");
+    if (!get_root_tuple || !intern || !get || !iterate || !fsfile_get_length || !get_kernel_heaps ||
+            !udp_new || !attach_console_driver ||
+            !(kfuncs.fsfile_open_or_create = get_sym("fsfile_open_or_create")) ||
+            !(kfuncs.fsfile_get_writer = get_sym("fsfile_get_writer")) ||
+            !(kfuncs.fsfile_truncate = get_sym("fsfile_truncate")) ||
+            !(kfuncs.allocate_sg_list = get_sym("allocate_sg_list")) ||
+            !(kfuncs.sg_list_tail_add = get_sym("sg_list_tail_add")) ||
+            !(kfuncs.deallocate_sg_list = get_sym("deallocate_sg_list")) ||
+            !(kfuncs.runtime_memcpy = get_sym("runtime_memcpy")) ||
+            !(kfuncs.register_timer = get_sym("kern_register_timer")) ||
+            !(kfuncs.timm_dealloc = get_sym("timm_dealloc")) ||
+            !(kfuncs.fs_rename = get_sym("fs_rename")) ||
+            !(kfuncs.dns_gethostbyname = get_sym("dns_gethostbyname")) ||
+            !(kfuncs.netif_get_default = get_sym("netif_get_default")) ||
+            !(kfuncs.ipaddr_ntoa_r = get_sym("ipaddr_ntoa_r")) ||
+            !(kfuncs.pbuf_alloc = get_sym("pbuf_alloc")) ||
+            !(kfuncs.pbuf_free = get_sym("pbuf_free")) ||
+            !(kfuncs.now = get_sym("now")) ||
+            !(kfuncs.gmtime_r = get_sym("gmtime_r")) ||
+            !(kfuncs.rsnprintf = get_sym("rsnprintf")) ||
+            !(kfuncs.udp_sendto = get_sym("udp_sendto"))) {
+        rprintf("syslog: kernel symbols not found\n");
+        return KLIB_INIT_FAILED;
+    }
+    syslog.h = heap_general(get_kernel_heaps());
+    tuple root = get_root_tuple();
+    tuple cfg = get(root, sym(syslog));
+    if (!cfg) {
+        rprintf("syslog configuration not specified\n");
+        return KLIB_INIT_FAILED;
+    }
+
+    /* Default configuration option values */
+    syslog.file_max_size = SYSLOG_FILE_MAXSIZE_DEFAULT;
+    syslog.file_rotate = SYSLOG_FILE_ROTATE_DEFAULT;
+    syslog.server_port = SYSLOG_UDP_PORT_DEFAULT;
+
+    if (!is_tuple(cfg) || !iterate(cfg, stack_closure(syslog_cfg, intern, rprintf))) {
+        rprintf("invalid syslog configuration\n");
+        return KLIB_INIT_FAILED;
+    }
+    if (syslog.file_path) {
+        syslog.fsf = kfuncs.fsfile_open_or_create(syslog.file_path);
+        if (!syslog.fsf) {
+            rprintf("cannot create syslog output file\n");
+            return KLIB_INIT_FAILED;
+        }
+        syslog.fs_write = kfuncs.fsfile_get_writer(syslog.fsf);
+        syslog.file_offset = fsfile_get_length(syslog.fsf); /* append to existing contents */
+        syslog.file_flush_timer = INVALID_ADDRESS;
+        init_closure(&syslog.file_flush, syslog_timer_func);
+    }
+    if (syslog.server) {
+        syslog_server_resolve();
+        syslog.program = get(root, sym(program));
+        syslog.udp_pcb = udp_new();
+        if (!syslog.udp_pcb) {
+            rprintf("syslog: unable to create UDP PCB\n");
+            return KLIB_INIT_FAILED;
+        }
+    }
+    syslog.driver.write = syslog_write;
+    syslog.driver.name = "syslog";
+    syslog.driver.disabled = false;
+    attach_console_driver(&syslog.driver);
+    return KLIB_INIT_OK;
+}

--- a/src/drivers/console.c
+++ b/src/drivers/console.c
@@ -20,6 +20,15 @@ static struct list console_drivers;
 
 static struct spinlock write_lock;
 
+void attach_console_driver(struct console_driver *driver)
+{
+    spin_lock(&write_lock);
+    list_insert_before(driver->disabled ? list_end(&console_drivers) : list_begin(&console_drivers),
+            &driver->l);
+    spin_unlock(&write_lock);
+}
+KLIB_EXPORT(attach_console_driver);
+
 void console_write(const char *s, bytes count)
 {
     spin_lock(&write_lock);
@@ -35,8 +44,7 @@ void console_write(const char *s, bytes count)
 closure_function(0, 1, void, attach_console,
                  struct console_driver *, d)
 {
-    list_insert_before(d->disabled ? list_end(&console_drivers) : list_begin(&console_drivers),
-            &d->l);
+    attach_console_driver(d);
 }
 
 void init_console(kernel_heaps kh)

--- a/src/drivers/console.h
+++ b/src/drivers/console.h
@@ -1,4 +1,5 @@
 struct console_driver {
+    struct list l;
     void (*write)(void *d, const char *s, bytes count);
     void (*config)(void *d, tuple r);
     char *name;

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -265,5 +265,6 @@ void init_klib(kernel_heaps kh, void *fs, tuple config_root, tuple klib_md)
         load_klib("/klib/radar", closure(h, radar_loaded));
     load_klib("/klib/cloud_init", closure(h, klib_optional_loaded));
     load_klib("/klib/ntp", closure(h, klib_optional_loaded));
+    load_klib("/klib/syslog", closure(h, klib_optional_loaded));
     load_klib("/klib/tun", closure(h, klib_optional_loaded));
 }

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -194,6 +194,7 @@ void netif_name_cpy(char *dest, struct netif *netif)
 KLIB_EXPORT(netif_name_cpy);
 
 KLIB_EXPORT(ipaddr_ntoa);
+KLIB_EXPORT(ipaddr_ntoa_r);
 KLIB_EXPORT(dns_gethostbyname);
 KLIB_EXPORT(pbuf_alloc);
 KLIB_EXPORT(pbuf_ref);

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -46,6 +46,14 @@ static inline char peek_char(buffer b)
 
 #define byte(__b, __i) *(u8 *)((__b)->contents + (__b)->start + (__i))
 
+#define buffer_to_cstring(__b) ({                           \
+            bytes len = buffer_length(__b);                 \
+            char *str = stack_allocate(len + 1);            \
+            runtime_memcpy(str, buffer_ref(__b, 0), len);   \
+            str[len] = '\0';                                \
+            str;                                            \
+        })
+
 static inline void buffer_clear(buffer b)
 {
     b->start = b->end = 0;

--- a/src/runtime/sg.c
+++ b/src/runtime/sg.c
@@ -150,6 +150,7 @@ sg_list allocate_sg_list(void)
     sg->count = 0;
     return sg;
 }
+KLIB_EXPORT(allocate_sg_list);
 
 void deallocate_sg_list(sg_list sg)
 {
@@ -159,6 +160,13 @@ void deallocate_sg_list(sg_list sg)
     list_insert_after(&free_sg_lists, &sg->l);
     sg_unlock();
 }
+KLIB_EXPORT(deallocate_sg_list);
+
+sg_buf kern_sg_list_tail_add(sg_list sg, word length)
+{
+    return sg_list_tail_add(sg, length);
+}
+KLIB_EXPORT_RENAME(kern_sg_list_tail_add, sg_list_tail_add);
 
 closure_function(4, 0, void, sg_wrapped_buf_release,
                  refcount, refcount, heap, backed, void *, buf, bytes, padlen)

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -58,6 +58,7 @@ u64 fsfile_get_length(fsfile f)
 {
     return f->length;
 }
+KLIB_EXPORT(fsfile_get_length);
 
 void fsfile_set_length(fsfile f, u64 length)
 {
@@ -88,6 +89,7 @@ sg_io fsfile_get_writer(fsfile f)
 {
     return f->write;
 }
+KLIB_EXPORT(fsfile_get_writer);
 
 pagecache_node fsfile_get_cachenode(fsfile f)
 {

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -60,14 +60,9 @@ static tuple lookup_follow_mounts(filesystem *fs, tuple t, symbol a, tuple *p)
     return t;
 }
 
-static filesystem get_root(void)
-{
-    return current->p->root_fs;
-}
-
 void init_fs_path_helper()
 {
-    fs_set_path_helper(get_root, lookup_follow_mounts);
+    fs_set_path_helper(get_root_fs, lookup_follow_mounts);
 }
 
 /* If the file path being resolved crosses a filesystem boundary (i.e. a mount

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -60,3 +60,5 @@ sysreturn fallocate(int fd, int mode, long offset, long len);
 sysreturn fadvise64(int fd, s64 off, u64 len, int advice);
 
 void file_release(file f);
+
+fsfile fsfile_open_or_create(buffer file_path);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1857,6 +1857,16 @@ sysreturn renameat2(int olddirfd, const char *oldpath, int newdirfd,
     }
 }
 
+/* File paths are treated as absolute paths. */
+sysreturn fs_rename(buffer oldpath, buffer newpath)
+{
+    filesystem fs = get_root_fs();
+    tuple root = filesystem_getroot(fs);
+    return rename_internal(fs, root, buffer_to_cstring(oldpath),
+        fs, root, buffer_to_cstring(newpath));
+}
+KLIB_EXPORT(fs_rename);
+
 sysreturn close(int fd)
 {
     thread_log(current, "close: fd %d", fd);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1738,40 +1738,40 @@ static sysreturn rename_internal(filesystem oldfs, tuple oldwd,
                                  tuple newwd, const char *newpath)
 {
     if (!oldpath[0] || !newpath[0]) {
-        return set_syscall_error(current, ENOENT);
+        return -ENOENT;
     }
     int ret;
     tuple old;
     tuple oldparent;
     ret = resolve_cstring(&oldfs, oldwd, oldpath, &old, &oldparent);
     if (ret) {
-        return set_syscall_return(current, ret);
+        return ret;
     }
     tuple new, newparent;
     ret = resolve_cstring(&newfs, newwd, newpath, &new, &newparent);
     if (ret && (ret != -ENOENT)) {
-        return set_syscall_return(current, ret);
+        return ret;
     }
     if (!newparent) {
-        return set_syscall_error(current, ENOENT);
+        return -ENOENT;
     }
     if (oldfs != newfs)
         return -EXDEV;
     if (!ret && is_dir(new)) {
         if (!is_dir(old)) {
-            return set_syscall_error(current, EISDIR);
+            return -EISDIR;
         }
         tuple c = children(new);
         boolean notempty = false;
         iterate(c, stack_closure(check_notempty_each, &notempty));
         if (notempty)
-            return set_syscall_error(current, ENOTEMPTY);
+            return -ENOTEMPTY;
     }
     if (new && !is_dir(new) && is_dir(old)) {
-        return set_syscall_error(current, ENOTDIR);
+        return -ENOTDIR;
     }
     if (filepath_is_ancestor(oldwd, oldpath, newwd, newpath)) {
-        return set_syscall_error(current, EINVAL);
+        return -EINVAL;
     }
     if ((newparent == oldparent) && (new == old))
         return 0;

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -33,6 +33,7 @@ PROGRAMS= \
 	signal \
 	socketpair \
 	symlink \
+	syslog \
 	thread_test \
 	time \
 	tlbshootdown \
@@ -197,6 +198,11 @@ SRCS-symlink= \
 	$(CURDIR)/symlink.c \
 	$(SRCDIR)/unix_process/ssp.c
 LDFLAGS-symlink=	-static
+
+SRCS-syslog= \
+	$(CURDIR)/syslog.c \
+	$(SRCDIR)/unix_process/ssp.c
+LDFLAGS-syslog=	-static
 
 SRCS-thread_test= \
 	$(SRCDIR)/unix_process/ssp.c\

--- a/test/runtime/syslog.c
+++ b/test/runtime/syslog.c
@@ -1,0 +1,53 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <runtime.h>
+
+#define SYSLOG_FILE_PATH    "var/log/syslog"
+
+#define test_assert(expr) do { \
+    if (!(expr)) { \
+        printf("Error: %s -- failed at %s:%d\n", #expr, __FILE__, __LINE__); \
+        exit(EXIT_FAILURE); \
+    } \
+} while (0)
+
+static void syslog_test_basic(void)
+{
+    const int total = 64 * KB;
+    struct stat s;
+    int fd;
+    char buf[64];
+
+    do {
+        printf("01234567890123456789012345678901234567890123456789012345678901234567890123456789");
+        test_assert(stat(SYSLOG_FILE_PATH, &s) == 0);
+    } while (s.st_size < total);
+
+    /* Look for the pattern output via printf() in the syslog file (which will contain kernel trace
+     * messages interspersed with the printf output). */
+    fd = open(SYSLOG_FILE_PATH, O_RDONLY);
+    test_assert(fd > 0);
+    buf[sizeof(buf) - 1] = '\0';
+    while (1) {
+        test_assert(read(fd, buf, sizeof(buf) - 1) == sizeof(buf) - 1);
+        if (strstr(buf, "0123456789"))
+            break;
+    }
+}
+
+int main(int argc, char **argv)
+{
+    /* Wait for syslog klib to be loaded. */
+    while (access(SYSLOG_FILE_PATH, O_RDONLY) == -1)
+        test_assert(errno == ENOENT);
+
+    syslog_test_basic();
+    return EXIT_SUCCESS;
+}

--- a/test/runtime/syslog.manifest
+++ b/test/runtime/syslog.manifest
@@ -1,0 +1,19 @@
+(
+    boot:(
+        children:(
+            klib:(children:(syslog:(contents:(host:output/klib/bin/syslog))))
+        )
+    )
+    children:(
+        syslog:(contents:(host:output/test/runtime/bin/syslog))
+    )
+    klibs:bootfs
+    syslog:(
+        file:var/log/syslog
+    )
+    consoles:[-serial -vga]
+    trace:t
+    debugsyscalls:t
+    environment:()
+    program:syslog
+)


### PR DESCRIPTION
This klib implements a console driver, which can be configured via the manifest to output console messages to a file (with a simple log rotation algorithm) and/or to an UDP syslog server.
The `syslog` manifest tuple is used to configure syslog behavior.
Supported configuration options:
- file: if present, syslog output is written to a file (whose path is indicated by the value of this option)
- file_max_size: file size at which log rotation occurs (default value: 8 MB); its value contains a byte count, optionally followed by a multiplier suffix ('k' or 'K' for KB, 'm' or 'M' for MB, 'g or 'G' for GB)
- file_rotate: number of rotated files to keep in the filesystem (default value: 1); if 0, old logs are deleted instead of being rotated
- server: if present, syslog output is sent to an UDP server (whose hostname or IP address is indicated by the value of this option)
- server port: UDP port number (default value: 514) at which syslog output is sent

Example manifest contents for file output:
```
syslog:(
  file:var/log/syslog
)
```
Example manifest contents for UDP output:
```
syslog:(
  server:example.com
)
```

To make log rotation actually useful, the filesystem_rename() function has been fixed to deallocate the extents associated to a file being overwritten, otherwise the storage space occupied by an overwritten file is leaked.

The console_write() function has been made slightly more efficient by sorting the attached console drivers based on their enabled status.