### PR TITLE
add "cwd" manifest option for setting current working directory

### DIFF
--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -27,6 +27,28 @@ static inline void report_sha256(buffer b)
 #define report_sha256(b)
 #endif
 
+const char *string_from_fs_status(fs_status s)
+{
+    switch (s) {
+    case FS_STATUS_NOSPACE:
+        return "no space";
+    case FS_STATUS_IOERR:
+        return "I/O error";
+    case FS_STATUS_NOENT:
+        return "no entry";
+    case FS_STATUS_EXIST:
+        return "file exists";
+    case FS_STATUS_NOTDIR:
+        return "not a directory";
+    case FS_STATUS_NOMEM:
+        return "out of memory";
+    case FS_STATUS_LINKLOOP:
+        return "maximum link hops reached";
+    default:
+        return "unknown error";
+    }
+}
+
 pagecache_volume filesystem_get_pagecache_volume(filesystem fs)
 {
     return fs->pv;

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -76,6 +76,8 @@ typedef enum {
     FS_STATUS_LINKLOOP,
 } fs_status;
 
+const char *string_from_fs_status(fs_status s);
+
 fs_status filesystem_write_tuple(filesystem fs, tuple t);
 fs_status filesystem_write_eav(filesystem fs, tuple t, symbol a, value v);
 

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -126,6 +126,21 @@ void file_readahead(file f, u64 offset, u64 len)
             irangel(offset + len, ra_size));
 }
 
+fs_status filesystem_chdir(process p, const char *path)
+{
+    filesystem fs = p->cwd_fs;
+    fs_status fss;
+    tuple n;
+    fss = filesystem_resolve_cstring_follow(&fs, p->cwd, path, &n, 0);
+    if (fss != FS_STATUS_OK)
+        return fss;
+    if (!is_dir(n))
+        return FS_STATUS_NOENT;
+    p->cwd_fs = fs;
+    p->cwd = n;
+    return FS_STATUS_OK;
+}
+
 closure_function(4, 1, void, fs_sync_complete,
                  filesystem, fs, pagecache_node, pn, status_handler, sh, boolean, fs_flushed,
                  status, s)

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -44,6 +44,8 @@ static inline int filesystem_get_tuple(const char *path, tuple *t)
  * not to the range to be read ahead. */
 void file_readahead(file f, u64 offset, u64 len);
 
+fs_status filesystem_chdir(process p, const char *path);
+
 sysreturn symlink(const char *target, const char *linkpath);
 sysreturn symlinkat(const char *target, int dirfd, const char *linkpath);
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1120,22 +1120,9 @@ sysreturn getdents64(int fd, struct linux_dirent64 *dirp, unsigned int count)
 
 sysreturn chdir(const char *path)
 {
-    int ret;
-    filesystem fs = current->p->cwd_fs;
-    tuple n;
-
     if (!validate_user_string(path))
         return set_syscall_error(current, EFAULT);
-    ret = resolve_cstring_follow(&fs, current->p->cwd, path, &n, 0);
-    if (ret) {
-        return set_syscall_return(current, ret);
-    }
-    if (!is_dir(n)) {
-        return set_syscall_error(current, ENOENT);
-    }
-    current->p->cwd_fs = fs;
-    current->p->cwd = n;
-    return set_syscall_return(current, 0);
+    return sysreturn_from_fs_status(filesystem_chdir(current->p, path));
 }
 
 sysreturn fchdir(int dirfd)

--- a/test/runtime/mkdir.manifest
+++ b/test/runtime/mkdir.manifest
@@ -2,6 +2,7 @@
     children:(
               #user program
 	      mkdir:(contents:(host:output/test/runtime/bin/mkdir))
+              tmp:(children:(mkdir_test:(children:())))
 	      )
     # filesystem path to elf for kernel to run
     program:/mkdir
@@ -9,6 +10,7 @@
 #    debugsyscalls:t
 #    futex_trace:t
 #    fault:t
-    arguments:[webg poppy]
+    arguments:[mkdir /tmp/mkdir_test]
     environment:(USER:bobby PWD:/)
+    cwd:/tmp/mkdir_test
 )


### PR DESCRIPTION
The current working directory for an application may now be set by including a
path string under the "cwd" attribute in the program manifest. A test for this
feature is added to the mkdir runtime test. To allow parity testing with
Linux, the mkdir test has also been updated to use a test directory under
/tmp (rather than the root directory) and create files with legitimate
permissions.

Resolves #1498 
