### PR TITLE
Fix various unix socket bugs and behaviors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test test-noaccel: image
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws io_uring klibs mkdir mmap netlink netsock pipe readv rename sendfile signal socketpair time unlink thread_test tlbshootdown tun vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws io_uring klibs mkdir mmap netlink netsock pipe readv rename sendfile signal socketpair time unlink thread_test tlbshootdown tun unixsocket vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -290,8 +290,10 @@ closure_function(8, 1, sysreturn, unixsock_write_bh,
                 rv = -EINVAL;
                 goto out;
             }
-            addr->sun_path[sizeof(addr->sun_path)-1] = 0;
-            rv = lookup_socket(&dest, addr->sun_path);
+            struct sockaddr_un daddr;
+            runtime_memcpy(&daddr, addr, sizeof(daddr));
+            daddr.sun_path[sizeof(daddr.sun_path)-1] = 0;
+            rv = lookup_socket(&dest, daddr.sun_path);
             if (rv != 0)
                 goto out;
         } else if (!dest) {
@@ -645,8 +647,6 @@ sysreturn unixsock_sendto(struct sock *sock, void *buf, u64 len, int flags,
             return -EFAULT;
         if (addrlen < sizeof(struct sockaddr_un))
             return -EINVAL;
-        if (dest_addr && !validate_user_memory(dest_addr, addrlen, true))
-            return -EFAULT;
     }
     return unixsock_write_with_addr(s, buf, len, 0, current, false, syscall_io_complete, (struct sockaddr_un *)dest_addr, addrlen);
 }

--- a/test/runtime/unixsocket.c
+++ b/test/runtime/unixsocket.c
@@ -182,6 +182,7 @@ static void *uds_dgram_server(void *arg)
     test_assert(addr_len > sizeof(addr.sun_family));
     test_assert(addr_len <= sizeof(addr));
     test_assert(addr.sun_family == AF_UNIX);
+    test_assert(!strcmp(addr.sun_path, CLIENT_SOCKET_PATH));
 
     for (int i = 0; i < SMALLBUF_SIZE / 2; i++) {
         test_assert(readBuf[i] == i);

--- a/test/runtime/unixsocket.c
+++ b/test/runtime/unixsocket.c
@@ -10,8 +10,8 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-#define CLIENT_SOCKET_PATH "/client_socket"
-#define SERVER_SOCKET_PATH "/server_socket"
+#define CLIENT_SOCKET_PATH "client_socket"
+#define SERVER_SOCKET_PATH "server_socket"
 
 #define SMALLBUF_SIZE    8
 #define LARGEBUF_SIZE    8192
@@ -35,6 +35,7 @@ static void *uds_stream_server(void *arg)
     struct msghdr msg;
     ssize_t nbytes, total;
 
+    /* on linux, generates SIGPIPE */
     test_assert(accept(fd, (struct sockaddr *) &addr, NULL) == -1);
     test_assert(errno == EFAULT);
     client_fd = accept(fd, (struct sockaddr *) &addr, &addr_len);
@@ -99,9 +100,9 @@ static void uds_stream_test(void)
     test_assert(bind(s1, (struct sockaddr *) &addr, addr_len) == -1);
     test_assert(errno == ENOENT);
     test_assert(connect(s1, (struct sockaddr *) &addr, addr_len) == -1);
-    test_assert(errno == ECONNREFUSED);
+    test_assert(errno == ENOENT);
 
-    strcpy(addr.sun_path, "/unixsocket");
+    strcpy(addr.sun_path, "unixsocket");
     test_assert(bind(s1, (struct sockaddr *) &addr, addr_len) == -1);
     test_assert(errno == EADDRINUSE);
     test_assert(connect(s1, (struct sockaddr *) &addr, addr_len) == -1);
@@ -111,8 +112,8 @@ static void uds_stream_test(void)
     test_assert(bind(s1, (struct sockaddr *) &addr, addr_len) == 0);
     test_assert(stat(SERVER_SOCKET_PATH, &s) == 0);
     test_assert((s.st_mode & S_IFMT) == S_IFSOCK);
-    test_assert((bind(s1, (struct sockaddr *) &addr, addr_len) == -1) &&
-            (errno == EINVAL));
+    test_assert(bind(s1, (struct sockaddr *) &addr, addr_len) == -1);
+    test_assert(errno == EADDRINUSE);
 
     s2 = socket(AF_UNIX, SOCK_STREAM, 0);
     test_assert(s2 >= 0);
@@ -158,6 +159,7 @@ static void uds_stream_test(void)
     test_assert(pthread_join(pt, NULL) == 0);
 
     test_assert(recv(s2, writeBuf, 1, 0) == 0);
+    /* on linux, this generates SIGPIPE instead of returning */
     test_assert((send(s2, writeBuf, 1, 0) == -1) && (errno == EPIPE));
 
     test_assert(close(s1) == 0);
@@ -173,28 +175,23 @@ static void *uds_dgram_server(void *arg)
     int fd = (long) arg;
     struct sockaddr_un addr;
     socklen_t addr_len = sizeof(addr);
-    int client_fd;
     uint8_t readBuf[SMALLBUF_SIZE];
 
-    client_fd = accept(fd, (struct sockaddr *) &addr, &addr_len);
-    test_assert(client_fd >= 0);
+    test_assert(recvfrom(fd, readBuf, SMALLBUF_SIZE / 2, 0, (struct sockaddr *)&addr, &addr_len) ==
+            SMALLBUF_SIZE / 2);
     test_assert(addr_len > sizeof(addr.sun_family));
     test_assert(addr_len <= sizeof(addr));
     test_assert(addr.sun_family == AF_UNIX);
-    test_assert(!strcmp(addr.sun_path, CLIENT_SOCKET_PATH));
 
-    test_assert(recv(client_fd, readBuf, SMALLBUF_SIZE / 2, 0) ==
-            SMALLBUF_SIZE / 2);
     for (int i = 0; i < SMALLBUF_SIZE / 2; i++) {
         test_assert(readBuf[i] == i);
     }
-    test_assert(recv(client_fd, readBuf, SMALLBUF_SIZE, 0) == 1);
+    test_assert(recv(fd, readBuf, SMALLBUF_SIZE, 0) == 1);
     test_assert(readBuf[0] == 0);
 
     /* zero-length datagram */
-    test_assert(recv(client_fd, readBuf, SMALLBUF_SIZE, 0) == 0);
+    test_assert(recv(fd, readBuf, SMALLBUF_SIZE, 0) == 0);
 
-    test_assert(close(client_fd) == 0);
     return NULL;
 }
 
@@ -212,7 +209,7 @@ static void uds_dgram_test(void)
     strcpy(client_addr.sun_path, CLIENT_SOCKET_PATH);
     strcpy(server_addr.sun_path, SERVER_SOCKET_PATH);
     test_assert(bind(s1, (struct sockaddr *) &server_addr, addr_len) == 0);
-    test_assert(listen(s1, 1) == 0);
+    test_assert(listen(s1, 1) == -1 && errno == EOPNOTSUPP);
 
     s2 = socket(AF_UNIX, SOCK_DGRAM, 0);
     test_assert(s2 >= 0);
@@ -277,17 +274,16 @@ static void uds_nonblocking_test(void)
 
     s2 = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
     test_assert(s2 >= 0);
+    int rv = connect(s2, (struct sockaddr *) &addr, addr_len);
+    test_assert(rv == 0 || (rv == -1 && errno == EINPROGRESS));
     test_assert(connect(s2, (struct sockaddr *) &addr, addr_len) == -1);
-    test_assert(errno == EINPROGRESS);
-    test_assert(connect(s2, (struct sockaddr *) &addr, addr_len) == -1);
-    test_assert(errno == EALREADY);
+    test_assert(errno == EALREADY || errno == EISCONN);
 
     test_assert(pthread_create(&pt, NULL, uds_nonblocking_server,
             (void *)(long) s1) == 0);
     fds.fd = s2;
-    fds.events = POLLIN | POLLOUT;
+    fds.events = POLLIN | POLLOUT | POLLHUP;
     test_assert((poll(&fds, 1, -1) == 1) && (fds.revents == POLLOUT));
-    test_assert(connect(s2, (struct sockaddr *) &addr, addr_len) == 0);
     test_assert(pthread_join(pt, NULL) == 0);
     test_assert(close(s2) == 0);
 
@@ -301,7 +297,7 @@ static void uds_nonblocking_test(void)
 
     test_assert(close(s1) == 0);
     fds.fd = s2;
-    test_assert((poll(&fds, 1, -1) == 1) && (fds.revents == POLLHUP));
+    test_assert((poll(&fds, 1, -1) == 1) && (fds.revents & POLLHUP));
     test_assert(close(s2) == 0);
     test_assert(unlink(SERVER_SOCKET_PATH) == 0);
 }


### PR DESCRIPTION
This change fixes a number of bugs in the AF_UNIX family of sockets and in
general brings unix socket behavior more in lin with Linux behavior. The
biggest part of the change fixes the handling of SOCK_DGRAM unix
sockets: the source address is now carried in the sharedbuf struct so
that sendto and recvfrom could be implemented, listen/accept were updated
to not support datagrams, connect was updated to only stash the destination
and return for datagram type, and a SOCK_DGRAM socket can now have
datagrams from multiple other sockets. Other fixes include matching event
notifications to more closely imitate Linux, update some errno returns
to more closely imitate Linux, no overwriting existing flags on accept
and check valid flags on accept, and fix the handling of the connecting
state which caused some socket functions to erroneously return errors.

This change also updates the existing unixsocket runtime test to allow it
to run on Linux and reflect Linux behaviors in places. It also adds the
unixsocket test to the set of default runtime tests.