### PR TITLE
Add support for xsave and enable AVX instructions

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -260,6 +260,9 @@ static void __attribute__((noinline)) init_service_new_stack()
     init_debug("init_hwrand");
     init_hwrand();
 
+    init_debug("init cpu features");
+    init_cpu_features();
+
     init_debug("calling kernel_runtime_init");
     kernel_runtime_init(kh);
     while(1);

--- a/src/x86_64/crt0.s
+++ b/src/x86_64/crt0.s
@@ -47,8 +47,6 @@ extern  init_service
 
 extern use_xsave
 
-;; XXX - stick with fx until we can choose according to capabilities -
-;; otherwise existing stuff breaks with ops, etc.
 %macro load_extended_registers 1
         mov al, [use_xsave]
         test al, al

--- a/src/x86_64/crt0.s
+++ b/src/x86_64/crt0.s
@@ -45,19 +45,34 @@ extern  init_service
         wrmsr
 %endmacro
 
+extern use_xsave
 
 ;; XXX - stick with fx until we can choose according to capabilities -
 ;; otherwise existing stuff breaks with ops, etc.
 %macro load_extended_registers 1
-;        mov edx, 0xffffffff
-;        mov eax, edx
+        mov al, [use_xsave]
+        test al, al
+        jnz %%xs
         fxrstor [%1+FRAME_EXTENDED_SAVE*8]
+        jmp %%out
+%%xs:
+        mov edx, 0xffffffff
+        mov eax, edx
+        xrstor [%1+FRAME_EXTENDED_SAVE*8]
+%%out:
 %endmacro
         
 %macro save_extended_registers 1
-;        mov edx, 0xffffffff
-;        mov eax, edx
+        mov al, [use_xsave]
+        test al, al
+        jnz %%xs
         fxsave [%1+FRAME_EXTENDED_SAVE*8]  ; we wouldn't have to do this if we could guarantee no other user thread ran before us
+        jmp %%out
+%%xs:
+        mov edx, 0xffffffff
+        mov eax, edx
+        xsave [%1+FRAME_EXTENDED_SAVE*8]
+%%out:
 %endmacro
 
         

--- a/src/x86_64/kernel_machine.c
+++ b/src/x86_64/kernel_machine.c
@@ -36,7 +36,7 @@ heap allocate_tagged_region(kernel_heaps kh, u64 tag)
 void clone_frame_pstate(context dest, context src)
 {
     runtime_memcpy(dest, src, sizeof(u64) * (FRAME_N_PSTATE + 1));
-    runtime_memcpy(dest + FRAME_EXTENDED_SAVE, src + FRAME_EXTENDED_SAVE, extended_frame_size());
+    runtime_memcpy(dest + FRAME_EXTENDED_SAVE, src + FRAME_EXTENDED_SAVE, extended_frame_size);
 }
 
 void init_cpuinfo_machine(cpuinfo ci, heap backed)

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -110,6 +110,7 @@ void start_cpu(int index);
 void allocate_apboot(heap stackheap, void (*ap_entry)());
 void deallocate_apboot(heap stackheap);
 void install_idt(void);
+void init_cpu_features();
 
 #define IST_EXCEPTION 1
 #define IST_INTERRUPT 2
@@ -249,21 +250,10 @@ static inline cpuinfo current_cpu(void)
     return (cpuinfo)pointer_from_u64(addr);
 }
 
-extern u8 use_xsave;
-
-static inline u64 extended_frame_size(void)
-{
-    if (use_xsave) {
-        u32 v[4];
-        cpuid(0xd, 0, v);
-        return v[1];
-    }
-    return 512;
-}
-
+extern u64 extended_frame_size;
 static inline u64 total_frame_size(void)
 {
-    return FRAME_EXTENDED_SAVE * sizeof(u64) + extended_frame_size();
+    return FRAME_EXTENDED_SAVE * sizeof(u64) + extended_frame_size;
 }
 
 static inline void frame_enable_interrupts(context f)


### PR DESCRIPTION
This change enables AVX instructions in XCR0 if available, which also requires using
xsave for saving the newly enabled registers in context switches. If xsave is not
available then it will continue to use fxsave instead.