### PR TITLE
Fix miscellaneous event behavior to match Linux

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -170,6 +170,8 @@ closure_function(1, 1, u32, socket_events,
                 (s->info.tcp.lw->state == ESTABLISHED ?
                 (tcp_sndbuf(s->info.tcp.lw) ? EPOLLOUT | EPOLLWRNORM : 0) :
                 EPOLLIN | EPOLLHUP);
+        } else if (s->info.tcp.state == TCP_SOCK_UNDEFINED || s->info.tcp.state == TCP_SOCK_CREATED) {
+            return EPOLLHUP;
         } else {
             return 0;
         }

--- a/src/unix/eventfd.c
+++ b/src/unix/eventfd.c
@@ -15,10 +15,8 @@ closure_function(0, 2, u64, efd_edge_handler,
                 u64, events, u64, lastevents)
 {
     /* A read or a write acts as an edge */
-    if (events & EPOLLIN)
-        lastevents &= ~EPOLLIN;
-    if (events & EPOLLOUT)
-        lastevents &= ~EPOLLOUT;
+    if (events & (EPOLLIN|EPOLLOUT))
+        lastevents &= ~(EPOLLIN|EPOLLOUT);
     return lastevents;
 }
 

--- a/src/unix/eventfd.c
+++ b/src/unix/eventfd.c
@@ -15,8 +15,10 @@ closure_function(0, 2, u64, efd_edge_handler,
                 u64, events, u64, lastevents)
 {
     /* A read or a write acts as an edge */
-    if (events & (EPOLLIN|EPOLLOUT))
-        lastevents &= ~(EPOLLIN|EPOLLOUT);
+    if (events & EPOLLIN)
+        lastevents &= ~EPOLLIN;
+    if (events & EPOLLOUT)
+        lastevents &= ~EPOLLOUT;
     return lastevents;
 }
 
@@ -50,7 +52,7 @@ closure_function(5, 1, sysreturn, efd_read_bh,
         efd->counter = 0;
     }
     blockq_wake_one(efd->write_bq);
-    notify_dispatch(efd->f.ns, EPOLLOUT);
+    fdesc_notify_events(&efd->f);
 out:
     blockq_handle_completion(efd->read_bq, flags, bound(completion), bound(t), rv);
     closure_finish();
@@ -93,7 +95,7 @@ closure_function(5, 1, sysreturn, efd_write_bh,
     }
     efd->counter += counter;
     blockq_wake_one(efd->read_bq);
-    notify_dispatch(efd->f.ns, EPOLLIN);
+    fdesc_notify_events(&efd->f);
 out:
     blockq_handle_completion(efd->write_bq, flags, bound(completion), bound(t), rv);
     closure_finish();

--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -208,7 +208,7 @@ static void nl_enqueue(nlsock s, void *msg, u64 msg_len)
 {
     if (enqueue(s->data, msg)) {
         blockq_wake_one(s->sock.rxbq);
-        notify_dispatch(s->sock.f.ns, EPOLLIN);
+        fdesc_notify_events(&s->sock.f);
     } else {
         msg_err("failed to enqueue message\n");
         deallocate(s->sock.h, msg, msg_len);

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -97,13 +97,13 @@ static void unixsock_dealloc(unixsock s)
 static inline void unixsock_notify_reader(unixsock s)
 {
     blockq_wake_one(s->sock.rxbq);
-    notify_dispatch(s->sock.f.ns, EPOLLIN);
+    fdesc_notify_events(&s->sock.f);
 }
 
 static inline void unixsock_notify_writer(unixsock s)
 {
     blockq_wake_one(s->sock.txbq);
-    notify_dispatch(s->sock.f.ns, EPOLLOUT);
+    fdesc_notify_events(&s->sock.f);
 }
 
 closure_function(8, 1, sysreturn, unixsock_read_bh,
@@ -406,7 +406,7 @@ closure_function(1, 2, sysreturn, unixsock_close,
     if (s->peer) {
         s->peer->peer = 0;
         socket_flush_q(&s->peer->sock);
-        notify_dispatch(s->peer->sock.f.ns, EPOLLHUP);
+        fdesc_notify_events(&s->peer->sock.f);
     }
     if (s->conn_q) {
         /* Notify any connecting sockets that connection is being refused. */

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -630,7 +630,7 @@ struct tms {
 #define EPOLLWRBAND	0x00000200
 #define EPOLLMSG	0x00000400
 #define EPOLLRDHUP	0x00002000
-#define EPOLLEXCLUSIVE	(1u << 29)
+#define EPOLLEXCLUSIVE	(1u << 28)
 #define EPOLLWAKEUP	(1u << 29)
 #define EPOLLONESHOT	(1u << 30)
 #define EPOLLET		(1u << 31)


### PR DESCRIPTION
This fixes some small event notification related bugs: EPOLLEXCLUSIVE was defined incorrectly. eventfd
edge notifications were fixed so that reads or writes are an edge for both reads and writes. Finally, tcp sockets
weren't reporting EPOLLHUP before listen/connect.