### PR TITLE
halt(): fix setting up of string format buffer

### DIFF
--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -171,13 +171,9 @@ void halt(char *format, ...)
 {
     vlist a;
     buffer b = little_stack_buffer(512);
-    struct buffer f;
-    f.start = 0;
-    f.contents = format;
-    f.end = runtime_strlen(format);
 
     vstart(a, format);
-    vbprintf(b, &f, &a);
+    vbprintf(b, alloca_wrap_cstring(format), &a);
     buffer_print(b);
     kernel_shutdown(VM_EXIT_HALT);
 }

--- a/src/kernel/kvm_platform.c
+++ b/src/kernel/kvm_platform.c
@@ -22,13 +22,9 @@ void halt(char *format, ...)
 {
     vlist a;
     buffer b = little_stack_buffer(512);
-    struct buffer f;
-    f.start = 0;
-    f.contents = format;
-    f.end = runtime_strlen(format);
 
     vstart(a, format);
-    vbprintf(b, &f, &a);
+    vbprintf(b, alloca_wrap_cstring(format), &a);
     buffer_print(b);
     kernel_shutdown(VM_EXIT_HALT);
 }


### PR DESCRIPTION
The existing code was failing to set the buffer length, which could cause a `(b->start + offset <= b->length)` assertion failure when printing the string to the console.