### PR TITLE
Network socket recv(): add support for MSG_PEEK flag

### DIFF
--- a/src/net/net_system_structs.h
+++ b/src/net/net_system_structs.h
@@ -37,6 +37,7 @@ enum protocol_type {
 #define ARPHRD_LOOPBACK 772
 
 #define MSG_OOB         0x00000001
+#define MSG_PEEK        0x00000002
 #define MSG_DONTROUTE   0x00000004
 #define MSG_PROBE       0x00000010
 #define MSG_TRUNC       0x00000020

--- a/src/runtime/queue.h
+++ b/src/runtime/queue.h
@@ -136,10 +136,18 @@ static inline boolean queue_full(queue q)
     return q->prod_tail - q->cons_head == _queue_size(q);
 }
 
+static inline void *queue_peek_at(queue q, u32 idx)
+{
+    if (q->prod_tail > q->cons_head + idx)
+        return q->d[_queue_idx(q, q->cons_head + idx)];
+    else
+        return INVALID_ADDRESS;
+}
+
 /* only safe with lock - can we dispose of this? */
 static inline void *queue_peek(queue q)
 {
-    return q->prod_tail > q->cons_head ? q->d[_queue_idx(q, q->cons_head)] : INVALID_ADDRESS;
+    return queue_peek_at(q, 0);
 }
 
 #define queue_data_size(order) ((1ull << (order)) * sizeof(void *))


### PR DESCRIPTION
This flag causes a receive operation to return data from the beginning of the receive queue without removing that data from the queue. Thus, a subsequent receive call will return the same data.

A new test case is being added to the netsock runtime test to exercise this feature.