### PR TITLE
virtIO SCSI: remove maximum queue size setting for GCP

### DIFF
--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -109,8 +109,6 @@ status virtqueue_alloc(vtdev dev,
                        thunk *t,
                        queue sched_queue);
 
-void virtqueue_set_max_queued(virtqueue, int);
-
 /* The Host uses this in used->flags to advise the Guest: don't kick me
  * when you add a buffer.  It's unreliable, so it's simply an
  * optimization.  Guest will still kick if it's out of buffers. */


### PR DESCRIPTION
The maximum number of pending virtIO SCSI requests was set to 1 for Google Cloud Platform because otherwise the SCSI device would return an "Overlapped commands attempted" error. This error was caused by the fact that the virtIO SCSI driver was failing to set the command identifier (corresponding to the "task tag" in the SCSI standard) in its requests.
The SCSI standard (SAM-3, section 5.9.3) states that "an overlapped command occurs when a task manager detects the use of a duplicate tag in a command before a task holding that tag completes its task lifetime. A task manager that detects an overlapped command shall abort all tasks for the faulted initiator port in the task set and the device server shall return CHECK CONDITION status for that command. The sense key shall be set to ABORTED COMMAND and the additional sense code shall be set to OVERLAPPED COMMANDS ATTEMPTED".
This commit adds setting of the command identifier to a unique value in virtio_scsi_alloc_request (similarly to what Linux does,
the identifier is set to the address of the SCSI request structure), and removes the maximum queue size setting, thereby
allowing multiple requests to be enqueued at the same time. Since the maximum queue size setting is now unused, this functionality is being removed from the virtqueue code.
With this change, the write runtime test shows a tenfold increase in performance for the filesystem stress test and a speed increase by a factor of 5.5 for the bulk write test.
Example test run before this change:
```
fs stress test
   write   1.659341256s
   delete   0.020281360s
   total   1.679622616s
bulk write test, size 20480 KB:
   write   0.039089554s
   fsync   8.994906062s
    read   0.022408186s
   total   9.056403802s (2261 KB/s)
```
Example test run after this change:
```
fs stress test
   write   0.139564050s
   delete   0.014996136s
   total   0.154560186s
bulk write test, size 20480 KB:
   write   0.042244509s
   fsync   1.608039334s
    read   0.021905470s
   total   1.672189313s (12247 KB/s)
```
Closes #649.