### PR TITLE
x86 IPIs: set ASSERT bit in ICR flags

### DIFF
--- a/src/x86_64/flush.c
+++ b/src/x86_64/flush.c
@@ -187,7 +187,7 @@ void page_invalidate_sync(flush_entry f, thunk completion)
         f->gen = fetch_and_add((word *)&inval_gen, 1) + 1;
         spin_wunlock(&flush_lock);
 
-        apic_ipi(TARGET_EXCLUSIVE_BROADCAST, 0, flush_ipi);
+        apic_ipi(TARGET_EXCLUSIVE_BROADCAST, ICR_ASSERT, flush_ipi);
         _flush_handler();
         irq_restore(flags);
     } else {

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -289,7 +289,7 @@ void common_handler()
     console("\n");
     print_frame(f);
     print_stack(f);
-    apic_ipi(TARGET_EXCLUSIVE_BROADCAST, 0, shutdown_vector);
+    apic_ipi(TARGET_EXCLUSIVE_BROADCAST, ICR_ASSERT, shutdown_vector);
     vm_exit(VM_EXIT_FAULT);
 }
 

--- a/src/x86_64/kernel_machine.c
+++ b/src/x86_64/kernel_machine.c
@@ -4,7 +4,7 @@
 /* stub placeholder, short of a real generic interface */
 void send_ipi(u64 cpu, u8 vector)
 {
-    apic_ipi(cpu, 0, vector);
+    apic_ipi(cpu, ICR_ASSERT, vector);
 }
 
 void interrupt_exit(void)

--- a/src/x86_64/mp.c
+++ b/src/x86_64/mp.c
@@ -128,11 +128,11 @@ void start_cpu(int index) {
     u8 vector = (((u64)apboot) >> 12) & 0xff;
 
     int nproc = total_processors;
-    apic_ipi(index, ICR_TYPE_INIT, 0);
+    apic_ipi(index, ICR_TYPE_INIT | ICR_ASSERT, 0);
     kernel_delay(milliseconds(10));
-    apic_ipi(index, ICR_TYPE_STARTUP, vector);
+    apic_ipi(index, ICR_TYPE_STARTUP | ICR_ASSERT, vector);
     kernel_delay(microseconds(200));
-    apic_ipi(index, ICR_TYPE_STARTUP, vector);
+    apic_ipi(index, ICR_TYPE_STARTUP | ICR_ASSERT, vector);
     for (u64 to = 0; total_processors != nproc + 1 && to < AP_START_TIMEOUT_MS; to++)
         kernel_delay(milliseconds(1));
 }


### PR DESCRIPTION
The Intel software developer's manual (volume 3A, chapter 10 "Advanced Programmable Interrupt Controller", section 10.6.1 "Interrupt Command Register") states that the "Level" field of the ICR must be set to 1 for all IPI delivery modes (except INIT level de-assert).
This commit sets the ICR_ASSERT flag in calls to apic_ipi(), according to the above requirement. This fixes an issue observed on Hyper-V multi-processor instances where the kernel fails to start secondary cores.