### PR TITLE
x86 init_cpu_features(): enable SSE state in XCR0 when using XSAVE

### DIFF
--- a/src/x86_64/mp.c
+++ b/src/x86_64/mp.c
@@ -48,11 +48,11 @@ void init_cpu_features()
     cr &= ~C0_EM;
     mov_to_cr("cr0", cr);
     if (use_xsave) {
-        if (v[2] & CPUID_AVX) {
-            xgetbv(0, &v[0], &v[1]);
-            v[0] |= XCR0_SSE | XCR0_AVX;
-            xsetbv(0, v[0], v[1]);
-        }
+        xgetbv(0, &v[0], &v[1]);
+        v[0] |= XCR0_SSE;
+        if (v[2] & CPUID_AVX)
+            v[0] |= XCR0_AVX;
+        xsetbv(0, v[0], v[1]);
         cpuid(0xd, 0, v);
         extended_frame_size = v[1];
     }


### PR DESCRIPTION
The FXSAVE and FXRSTOR instructions manage both the x87 state and the SSE state; in order to provide equivalent functionality when using XSAVE/XRSTOR, bit 1 of XCR0 must be set to 1, otherwise the SSE state is not managed.
As noted in the Intel Architecture SDM (volume 1, chapter 13 "Managing state using the xsave feature set", section 13.2 "Enabling the xsave feature set and xsave-enabled features"), every processor that supports the XSAVE feature set allows software to set XCR0[1].
This fixes unwanted SEGV signals being triggered by multi-threaded programs using SSE instructions on CPUs that support the xsave features but not the AVX instructions.
Example output when running `ops pkg load node_v14.2.0 -a hi.js`:
```
en1: assigned 10.0.2.15
en1: assigned FE80::CCDC:27FF:FEF2:9DB3
signal 11 received by tid 1, errno 0, code 1
   fault address 0x40008
   core dump (unimplemented)
```

Closes #1528.