### PR TITLE
Pause thread when scheduling frame

### DIFF
--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -258,7 +258,7 @@ extern void interrupt_exit(void);
 extern char **state_strings;
 
 // static inline void schedule_frame(context f) stupid header deps
-#define schedule_frame(__f)  do { assert((__f)[FRAME_QUEUE] != INVALID_PHYSICAL); assert(enqueue_irqsafe((queue)pointer_from_u64((__f)[FRAME_QUEUE]), pointer_from_u64((__f)[FRAME_RUN]))); } while(0)
+#define schedule_frame(___f)  do { context __f = ___f; assert((__f)[FRAME_QUEUE] != INVALID_PHYSICAL); if ((__f)[FRAME_THREAD]) apply(((nanos_thread)(__f)[FRAME_THREAD])->pause); assert(enqueue_irqsafe((queue)pointer_from_u64((__f)[FRAME_QUEUE]), pointer_from_u64((__f)[FRAME_RUN]))); } while(0)
 
 void kernel_unlock();
 


### PR DESCRIPTION
In an SMP situation, if a thread was running on a cpu and the kernel calls
schedule_frame for that same thread before going back into runloop then
if another cpu grabs and runs that thread then these two cpus will have the
same thread assigned to current. If the new cpu exits and disposes of the
thread then the original cpu has an invalid reference and can crash if it
accesses it. This change calls the pause function on the nanos_thread
associated with the frame during schedule_frame with the idea that if the
thread is being put on the scheduling queue then it should no longer have
a reference on the current cpu. If the cpu's current thread is not the one being
scheduled, then it's a no-op as the pause implementation only performs the
action if the current thread is the one being paused.