### PR TITLE
Check for directory type on open and read syscalls

### DIFF
--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -93,6 +93,7 @@ typedef struct iovec {
 #define O_NOATIME       01000000
 #define O_CLOEXEC       02000000
 #define O_PATH         010000000
+#define O_TMPFILE     (020000000 | O_DIRECTORY)
 
 #define F_LINUX_SPECIFIC_BASE   0x400
 

--- a/src/x86_64/unix_machine.h
+++ b/src/x86_64/unix_machine.h
@@ -28,6 +28,7 @@ struct stat {
 } __attribute__((packed));
 
 #define O_DIRECT        00040000
+#define O_DIRECTORY     00200000
 #define O_NOFOLLOW      00400000
 
 #define MAP_32BIT           0x40

--- a/test/runtime/write.c
+++ b/test/runtime/write.c
@@ -50,7 +50,43 @@ void basic_write_test()
 {
     char buf[BUFLEN];
     ssize_t rv;
-    int fd = open("hello", O_RDWR);
+    int fd = open("/", O_RDWR);
+    if (fd != -1 || errno != EISDIR) {
+        perror("open directory rdwr");
+        exit(EXIT_FAILURE);
+    }
+    fd = open("/", O_WRONLY);
+    if (fd != -1 || errno != EISDIR) {
+        perror("open directory wr");
+        exit(EXIT_FAILURE);
+    }
+    fd = open("/", O_RDONLY | O_DIRECTORY);
+    if (fd < 0) {
+        perror("open directory");
+        exit(EXIT_FAILURE);
+    }
+    close(fd);
+    fd = open("/", O_RDONLY);
+    if (fd < 0) {
+        perror("open directory rd");
+        exit(EXIT_FAILURE);
+    }
+    if (read(fd, buf, BUFLEN) != -1 || errno != EISDIR) {
+        perror("read directory");
+        exit(EXIT_FAILURE);
+    }
+    if (write(fd, buf, BUFLEN) != -1 || errno != EBADF) {
+        perror("write directory");
+        exit(EXIT_FAILURE);
+    }
+    close(fd);
+
+    fd = open("hello", O_RDWR | O_DIRECTORY);
+    if (fd != -1 || errno != ENOTDIR) {
+        perror("open file as directory");
+        exit(EXIT_FAILURE);
+    }
+    fd = open("hello", O_RDWR);
     if (fd < 0) {
         perror("open");
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Linux does not allow normal read or write to directory file descriptors,
so open should return EISDIR for any write access and read should return
EISDIR if the descriptor is a directory. The write runtime test has been
updated to verify this behavior. This change also defines O_DIRECTORY
which should return ENOTDIR if the specified file is not a directory.
See open(2) and read(2) for further description of these behaviors.

Fixes #1533 