### PR TITLE
support for concurrent pagefaults

### DIFF
--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -160,6 +160,13 @@ static inline void disable_interrupts(void)
     asm volatile("msr daifset, #2");
 }
 
+static inline u64 irq_enable_save(void)
+{
+    register u32 daif;
+    asm volatile("mrs %0, daif; msr daifclr, #2" : "=r"(daif));
+    return daif;
+}
+
 static inline u64 irq_disable_save(void)
 {
     register u32 daif;
@@ -334,6 +341,11 @@ static inline boolean is_div_by_zero(context f)
 static inline void frame_enable_interrupts(context f)
 {
     f[FRAME_ESR_SPSR] &= ~SPSR_I; /* EL0 */
+}
+
+static inline void frame_disable_interrupts(context f)
+{
+    f[FRAME_ESR_SPSR] |= SPSR_I; /* EL0 */
 }
 
 static inline void frame_set_sp(context f, u64 sp)

--- a/src/aarch64/page.h
+++ b/src/aarch64/page.h
@@ -337,7 +337,6 @@ static inline pageflags pageflags_from_pteptr(pteptr pp)
 
 void page_init_mmu(range init_pt, u64 vtarget);
 void page_heap_init(heap locked, id_heap physical);
-void map(u64 virtual, physical p, u64 length, pageflags flags);
 void unmap(u64 virtual, u64 length);
 void unmap_pages_with_handler(u64 virtual, u64 length, range_handler rh);
 void unmap_and_free_phys(u64 virtual, u64 length);
@@ -347,28 +346,41 @@ static inline void unmap_pages(u64 virtual, u64 length)
     unmap_pages_with_handler(virtual, length, 0);
 }
 
-void update_map_flags(u64 vaddr, u64 length, pageflags flags);
+void map_with_complete(u64 virtual, physical p, u64 length, pageflags flags, status_handler complete);
+
+static inline void map(u64 v, physical p, u64 length, pageflags flags)
+{
+    map_with_complete(v, p, length, flags, 0);
+}
+
+void update_map_flags_with_complete(u64 vaddr, u64 length, pageflags flags, status_handler complete);
+
+static inline void update_map_flags(u64 vaddr, u64 length, pageflags flags)
+{
+    update_map_flags_with_complete(vaddr, length, flags, 0);
+}
+
 void zero_mapped_pages(u64 vaddr, u64 length);
 void remap_pages(u64 vaddr_new, u64 vaddr_old, u64 length);
 boolean traverse_ptes(u64 vaddr, u64 length, entry_handler eh);
 
 flush_entry get_page_flush_entry(void);
-void page_invalidate_sync(flush_entry f, thunk completion);
+void page_invalidate_sync(flush_entry f, status_handler completion);
 void page_invalidate(flush_entry f, u64 address);
 void page_invalidate_flush(void);
 
 void dump_ptes(void *vaddr);
 
-static inline void map_and_zero(u64 v, physical p, u64 length, pageflags flags)
+static inline void map_and_zero(u64 v, physical p, u64 length, pageflags flags, status_handler complete)
 {
     assert((v & MASK(PAGELOG)) == 0);
     assert((p & MASK(PAGELOG)) == 0);
     if (pageflags_is_readonly(flags)) {
         map(v, p, length, pageflags_writable(flags));
         zero(pointer_from_u64(v), length);
-        update_map_flags(v, length, flags);
+        update_map_flags_with_complete(v, length, flags, complete);
     } else {
-        map(v, p, length, flags);
+        map_with_complete(v, p, length, flags, complete);
         zero(pointer_from_u64(v), length);
     }
 }

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -374,7 +374,8 @@ void __attribute__((noreturn)) kernel_shutdown(int status)
                     closure(locked, storage_shutdown));
 
     if (vector_length(shutdown_completions) > 0) {
-        if (this_cpu_has_kernel_lock()) {
+        cpuinfo ci = current_cpu();
+        if (ci->have_kernel_lock) {
             vector_foreach(shutdown_completions, h)
                 apply(h, status, m);
             apply(sh, STATUS_OK);
@@ -385,7 +386,6 @@ void __attribute__((noreturn)) kernel_shutdown(int status)
             vector_foreach(shutdown_completions, h)
                 enqueue_irqsafe(runqueue,
                                 closure(locked, do_shutdown_handler, h, status, m));
-            cpuinfo ci = current_cpu();
             if (ci->state == cpu_interrupt) {
                 interrupt_exit();
                 get_running_frame(ci)[FRAME_FULL] = false;

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -122,8 +122,7 @@ void init_kernel_contexts(heap backed)
 
 void install_fallback_fault_handler(fault_handler h)
 {
-    for (int i = 0; i < MAX_CPUS; i++) {
-        context f = frame_from_kernel_context(get_kernel_context(cpuinfo_from_id(i)));
-        f[FRAME_FAULT_HANDLER] = u64_from_pointer(h);
-    }
+    for (int i = 0; i < MAX_CPUS; i++)
+        set_fault_handler(get_kernel_context(cpuinfo_from_id(i)), h);
+    set_fault_handler(spare_kernel_context, h);
 }

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -58,6 +58,11 @@ void deallocate_kernel_context(kernel_context c)
     deallocate((heap)pointer_from_u64(c->frame[FRAME_HEAP]), c, KERNEL_STACK_SIZE + total_frame_size());
 }
 
+boolean kernel_suspended(void)
+{
+    return spare_kernel_context == 0;
+}
+
 kernel_context suspend_kernel_context(void)
 {
     cpuinfo ci = current_cpu();

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -33,6 +33,8 @@ typedef struct cpuinfo {
 #endif
 } *cpuinfo;
 
+typedef closure_type(fault_handler, context, context);
+
 extern struct cpuinfo cpuinfos[];
 
 /* subsume with introspection */
@@ -94,6 +96,12 @@ static inline __attribute__((always_inline)) context frame_from_kernel_context(k
 static inline __attribute__((always_inline)) void *stack_from_kernel_context(kernel_context c)
 {
     return ((void*)c->stackbase) + KERNEL_STACK_SIZE - STACK_ALIGNMENT;
+}
+
+static inline __attribute__((always_inline)) void set_fault_handler(kernel_context kc, fault_handler h)
+{
+    context f = frame_from_kernel_context(kc);
+    f[FRAME_FAULT_HANDLER] = u64_from_pointer(h);
 }
 
 static inline void count_minor_fault(void)
@@ -209,8 +217,6 @@ heap locking_heap_wrapper(heap meta, heap parent);
 
 void print_stack(context c);
 void print_frame(context f);
-
-typedef closure_type(fault_handler, context, context);
 
 void configure_timer(timestamp rate, thunk t);
 

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -113,6 +113,11 @@ static inline boolean this_cpu_has_kernel_lock(void)
     return current_cpu()->have_kernel_lock;
 }
 
+static inline void this_cpu_release_kernel_lock(void)
+{
+    current_cpu()->have_kernel_lock = false;
+}
+
 NOTRACE static inline __attribute__((always_inline)) __attribute__((noreturn)) void runloop(void)
 {
     cpuinfo ci = current_cpu();

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -108,16 +108,6 @@ static inline void count_major_fault(void)
 
 void runloop_internal() __attribute__((noreturn));
 
-static inline boolean this_cpu_has_kernel_lock(void)
-{
-    return current_cpu()->have_kernel_lock;
-}
-
-static inline void this_cpu_release_kernel_lock(void)
-{
-    current_cpu()->have_kernel_lock = false;
-}
-
 NOTRACE static inline __attribute__((always_inline)) __attribute__((noreturn)) void runloop(void)
 {
     cpuinfo ci = current_cpu();
@@ -147,6 +137,7 @@ void deallocate_stack(heap h, u64 size, void *stack);
 kernel_context allocate_kernel_context(heap h);
 void deallocate_kernel_context(kernel_context c);
 void init_kernel_contexts(heap backed);
+boolean kernel_suspended(void);
 kernel_context suspend_kernel_context(void);
 void resume_kernel_context(kernel_context c);
 void frame_return(context frame) __attribute__((noreturn));

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1107,20 +1107,12 @@ static void map_page(pagecache pc, pagecache_page pp, u64 vaddr, pageflags flags
     map_with_complete(vaddr, pp->phys, cache_pagesize(pc), flags, complete);
 }
 
-closure_function(6, 1, void, map_page_finish,
-                 pagecache, pc, pagecache_page, pp, u64, vaddr, pageflags, flags, boolean, bh, status_handler, complete,
+closure_function(5, 1, void, map_page_finish,
+                 pagecache, pc, pagecache_page, pp, u64, vaddr, pageflags, flags, status_handler, complete,
                  status, s)
 {
     if (is_ok(s)) {
-        status_handler complete;
-        if (bound(bh)) {
-            /* Don't wait for flush on a kernel page fault. */
-            complete = 0;
-            apply(bound(complete), s);
-        } else {
-            complete = bound(complete);
-        }
-        map_page(bound(pc), bound(pp), bound(vaddr), bound(flags), complete);
+        map_page(bound(pc), bound(pp), bound(vaddr), bound(flags), bound(complete));
     } else {
         apply(bound(complete), s);
     }
@@ -1128,7 +1120,7 @@ closure_function(6, 1, void, map_page_finish,
 }
 
 void pagecache_map_page(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags flags,
-                        status_handler complete, boolean bh)
+                        status_handler complete)
 {
     pagecache pc = pn->pv->pc;
     pagecache_lock_node(pn);
@@ -1142,9 +1134,9 @@ void pagecache_map_page(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags
         return;
     }
     merge m = allocate_merge(pc->h, closure(pc->h, map_page_finish,
-                                            pc, pp, vaddr, flags, bh, complete));
+                                            pc, pp, vaddr, flags, complete));
     status_handler k = apply_merge(m);
-    touch_or_fill_page_nodelocked(pn, pp, m, bh);
+    touch_or_fill_page_nodelocked(pn, pp, m, true /* bh */);
     refcount_reserve(&pp->refcount);
     pagecache_unlock_node(pn);
     apply(k, STATUS_OK);

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -875,7 +875,7 @@ static void pagecache_scan_shared_mappings(pagecache pc)
         pagecache_debug("   shared map va %R, node_offset 0x%lx\n", sm->n.r, sm->node_offset);
         pagecache_scan_shared_map(pc, sm, fe);
     }
-    page_invalidate_sync(fe, ignore);
+    page_invalidate_sync(fe, 0);
 }
 
 static void pagecache_scan_node(pagecache_node pn)
@@ -887,7 +887,7 @@ static void pagecache_scan_node(pagecache_node pn)
         pagecache_debug("   shared map va %R, node_offset 0x%lx\n", n->r, sm->node_offset);
         pagecache_scan_shared_map(pn->pv->pc, sm, fe);
     }
-    page_invalidate_sync(fe, ignore);
+    page_invalidate_sync(fe, 0);
 }
 
 closure_function(2, 1, void, pagecache_commit_complete,
@@ -1045,7 +1045,7 @@ void pagecache_node_scan_and_commit_shared_pages(pagecache_node pn, range q /* b
     rangemap_range_lookup(pn->shared_maps, q,
                           stack_closure(scan_shared_pages_intersection, pn->pv->pc, fe));
     pagecache_commit_dirty_pages(pn->pv->pc);
-    page_invalidate_sync(fe, ignore);
+    page_invalidate_sync(fe, 0);
 }
 
 boolean pagecache_node_do_page_cow(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags flags)
@@ -1100,20 +1100,30 @@ void pagecache_node_fetch_pages(pagecache_node pn, range r)
     apply(sh, STATUS_OK);
 }
 
-static void map_page(pagecache pc, pagecache_page pp, u64 vaddr, pageflags flags)
+static void map_page(pagecache pc, pagecache_page pp, u64 vaddr, pageflags flags, status_handler complete)
 {
     assert(pp->refcount.c != 0);
     assert(pp->kvirt != INVALID_ADDRESS);
-    map(vaddr, pp->phys, cache_pagesize(pc), flags);
+    map_with_complete(vaddr, pp->phys, cache_pagesize(pc), flags, complete);
 }
 
-closure_function(5, 1, void, map_page_finish,
-                 pagecache, pc, pagecache_page, pp, u64, vaddr, pageflags, flags, status_handler, complete,
+closure_function(6, 1, void, map_page_finish,
+                 pagecache, pc, pagecache_page, pp, u64, vaddr, pageflags, flags, boolean, bh, status_handler, complete,
                  status, s)
 {
-    if (is_ok(s))
-        map_page(bound(pc), bound(pp), bound(vaddr), bound(flags));
-    apply(bound(complete), s);
+    if (is_ok(s)) {
+        status_handler complete;
+        if (bound(bh)) {
+            /* Don't wait for flush on a kernel page fault. */
+            complete = 0;
+            apply(bound(complete), s);
+        } else {
+            complete = bound(complete);
+        }
+        map_page(bound(pc), bound(pp), bound(vaddr), bound(flags), complete);
+    } else {
+        apply(bound(complete), s);
+    }
     closure_finish();
 }
 
@@ -1132,7 +1142,7 @@ void pagecache_map_page(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags
         return;
     }
     merge m = allocate_merge(pc->h, closure(pc->h, map_page_finish,
-                                            pc, pp, vaddr, flags, complete));
+                                            pc, pp, vaddr, flags, bh, complete));
     status_handler k = apply_merge(m);
     touch_or_fill_page_nodelocked(pn, pp, m, bh);
     refcount_reserve(&pp->refcount);
@@ -1141,7 +1151,8 @@ void pagecache_map_page(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags
 }
 
 /* no-alloc / no-fill path, meant to be safe outside of kernel lock */
-boolean pagecache_map_page_if_filled(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags flags)
+boolean pagecache_map_page_if_filled(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags flags,
+                                     status_handler complete)
 {
     boolean mapped = false;
     pagecache_lock_node(pn);
@@ -1152,7 +1163,7 @@ boolean pagecache_map_page_if_filled(pagecache_node pn, u64 node_offset, u64 vad
         goto out;
     if (touch_or_fill_page_nodelocked(pn, pp, 0, false /* N/A */)) {
         mapped = true;
-        map_page(pn->pv->pc, pp, vaddr, flags);
+        map_page(pn->pv->pc, pp, vaddr, flags, complete);
     }
     refcount_reserve(&pp->refcount);
   out:
@@ -1196,7 +1207,7 @@ void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node
     traverse_ptes(v.start, range_span(v), stack_closure(pagecache_unmap_page_nodelocked, pn,
                                                         v.start, node_offset, fe));
     pagecache_unlock_node(pn);
-    page_invalidate_sync(fe, ignore);
+    page_invalidate_sync(fe, 0);
 }
 #endif
 

--- a/src/kernel/pagecache.h
+++ b/src/kernel/pagecache.h
@@ -42,7 +42,7 @@ boolean pagecache_node_do_page_cow(pagecache_node pn, u64 node_offset, u64 vaddr
 void pagecache_node_fetch_pages(pagecache_node pn, range r /* bytes */);
 
 void pagecache_map_page(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags flags,
-                        status_handler complete, boolean bh);
+                        status_handler complete);
 
 boolean pagecache_map_page_if_filled(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags flags,
                                      status_handler complete);

--- a/src/kernel/pagecache.h
+++ b/src/kernel/pagecache.h
@@ -44,7 +44,8 @@ void pagecache_node_fetch_pages(pagecache_node pn, range r /* bytes */);
 void pagecache_map_page(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags flags,
                         status_handler complete, boolean bh);
 
-boolean pagecache_map_page_if_filled(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags flags);
+boolean pagecache_map_page_if_filled(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags flags,
+                                     status_handler complete);
 
 void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node_offset);
 #endif

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -348,6 +348,7 @@ closure_function(4, 1, void, filesystem_read_complete,
                  void *, dest, u64, limit, io_status_handler, io_complete, sg_list, sg,
                  status, s)
 {
+    tfs_debug("%s: dest %p, status %v\n", __func__, bound(dest), s);
     u64 count = 0;
     if (is_ok(s)) {
         count = sg_copy_to_buf_and_release(bound(dest), bound(sg), bound(limit));

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -33,7 +33,6 @@ static struct {
     struct list pf_freelist;
 
     kernel_context faulting_kernel_context;
-    boolean kernel_demand_page_completed;
 } mmap_info;
 
 define_closure_function(0, 2, int, pending_fault_compare,
@@ -1261,7 +1260,6 @@ void mmap_process_init(process p, boolean aslr)
                          ivmap(VMAP_FLAG_EXEC, 0, 0, 0)) != INVALID_ADDRESS);
 #endif
 
-    mmap_info.kernel_demand_page_completed = false;
     mmap_info.faulting_kernel_context = 0;
     spin_lock_init(&p->faulting_lock);
     init_rbtree(&p->pending_faults,

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -46,7 +46,7 @@ define_closure_function(0, 2, int, pending_fault_compare,
 define_closure_function(0, 1, boolean, pending_fault_print,
                         rbnode, n)
 {
-    rprintf(" 0x%lx", ((pending_fault)n)->p);
+    rprintf(" 0x%lx", ((pending_fault)n)->addr);
     return true;
 }
 
@@ -108,7 +108,7 @@ define_closure_function(1, 1, void, pending_fault_complete,
     u64 flags = spin_lock_irq(&p->faulting_lock);
     assert(list_empty(&pf->dependents));
     rbtree_remove_node(&pf->p->pending_faults, &pf->n);
-    list_insert_before(&mmap_info.pf_freelist, &pf->l_free);
+    list_insert_after(&mmap_info.pf_freelist, &pf->l_free);
     spin_unlock_irq(&p->faulting_lock, flags);
 }
 

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -16,55 +16,60 @@ typedef struct vmap_heap {
     boolean randomize;
 } *vmap_heap;
 
+declare_closure_function(1, 0, void, kernel_frame_return,
+                         kernel_context, kc);
+declare_closure_function(0, 2, int, pending_fault_compare,
+                         rbnode, a, rbnode, b);
+declare_closure_function(0, 1, boolean, pending_fault_print,
+                         rbnode, n);
+static struct {
+    heap h;
+    id_heap physical;
+
+    closure_struct(kernel_frame_return, do_kernel_frame_return);
+    closure_struct(pending_fault_compare, pf_compare);
+    closure_struct(pending_fault_print, pf_print);
+
+    struct list pf_freelist;
+
+    kernel_context faulting_kernel_context;
+    boolean kernel_demand_page_completed;
+} mmap_info;
+
+define_closure_function(0, 2, int, pending_fault_compare,
+                        rbnode, a, rbnode, b)
+{
+    u64 pa = ((pending_fault)a)->addr;
+    u64 pb = ((pending_fault)b)->addr;
+    return pa == pb ? 0 : (pa < pb ? -1 : 1);
+}
+
+define_closure_function(0, 1, boolean, pending_fault_print,
+                        rbnode, n)
+{
+    rprintf(" 0x%lx", ((pending_fault)n)->p);
+    return true;
+}
+
 /* kernel frame return must happen from runloop, not a bh completion service */
-closure_function(1, 0, void, kernel_frame_return,
-                 kernel_context, kc)
+define_closure_function(1, 0, void, kernel_frame_return,
+                        kernel_context, kc)
 {
     /* kernel lock always held on a valid page fault */
     current_cpu()->have_kernel_lock = true;
     resume_kernel_context(bound(kc));
 }
 
-static closure_struct(kernel_frame_return, do_kernel_frame_return);
-static boolean kernel_demand_page_completed = false;
-static kernel_context faulting_kernel_context;
-
-closure_function(0, 1, void, kernel_demand_pf_complete,
-                 status, s)
+define_closure_function(6, 0, void, thread_demand_file_page,
+                        pending_fault, pf, vmap, vm, u64, node_offset, u64, page_addr, pageflags, flags, boolean, bh)
 {
-    if (!is_ok(s))
-        halt("%s: page fill failed with %v\n", __func__, s);
-
-    if (faulting_kernel_context) {
-        init_closure(&do_kernel_frame_return, kernel_frame_return, faulting_kernel_context);
-        faulting_kernel_context = 0;
-        enqueue_irqsafe(bhqueue, (thunk)&do_kernel_frame_return);
-    }
-    kernel_demand_page_completed = true;
-}
-
-static closure_struct(kernel_demand_pf_complete, do_kernel_demand_pf_complete);
-
-define_closure_function(3, 1, void, thread_demand_file_page_complete,
-                        thread, t, context, frame, u64, vaddr,
-                        status, s)
-{
-    if (!is_ok(s)) {
-        rprintf("%s: page fill failed with %v\n", __func__, s);
-        deliver_fault_signal(SIGBUS, bound(t), bound(vaddr), BUS_ADRERR);
-    }
-    schedule_frame(bound(frame));
-    refcount_release(&bound(t)->refcount);
-}
-
-define_closure_function(5, 0, void, thread_demand_file_page,
-                        thread, t, vmap, vm, u64, node_offset, u64, page_addr, pageflags, flags)
-{
+    pending_fault pf = bound(pf);
     vmap vm = bound(vm);
     pagecache_node pn = vm->cache_node;
-    pagecache_map_page(pn, bound(node_offset), bound(page_addr), bound(flags),
-                       (status_handler)&bound(t)->demand_file_page_complete,
-                       false /* complete on runqueue */);
+    pf_debug("%s: pending_fault %p, node_offset 0x%lx, page_addr 0x%lx\n",
+             __func__, pf, bound(node_offset), pf->addr);
+    pagecache_map_page(pn, bound(node_offset), pf->addr, bound(flags),
+                       (status_handler)&pf->complete, bound(bh));
     range ra = irange(bound(node_offset) + PAGESIZE,
         vm->node_offset + range_span(vm->node.r));
     if (range_valid(ra)) {
@@ -74,10 +79,148 @@ define_closure_function(5, 0, void, thread_demand_file_page,
     }
 }
 
+/* This could be called from either the bh or run queues. */
+define_closure_function(1, 1, void, pending_fault_complete,
+                        pending_fault, pf,
+                        status, s)
+{
+    pending_fault pf = bound(pf);
+    pf_debug("%s: page 0x%lx, kern %d, status %v\n", __func__, pf->addr, pf->kern, s);
+    if (!is_ok(s))
+        rprintf("%s: page fill failed with %v\n", __func__, s);
+    list_foreach(&pf->dependents, l) {
+        thread t = struct_from_list(l, thread, l_faultwait);
+        pf_debug("   wake tid %d\n", t->tid);
+        list_delete(l);
+        if (!is_ok(s))
+            deliver_fault_signal(SIGBUS, t, pf->addr, BUS_ADRERR);
+        schedule_frame(thread_frame(t));
+        refcount_release(&t->refcount);
+    }
+
+    if (pf->kern) {
+        if (mmap_info.faulting_kernel_context) {
+            init_closure(&mmap_info.do_kernel_frame_return, kernel_frame_return, mmap_info.faulting_kernel_context);
+            mmap_info.faulting_kernel_context = 0;
+            enqueue_irqsafe(bhqueue, (thunk)&mmap_info.do_kernel_frame_return);
+        }
+    }
+
+    process p = pf->p;
+    u64 flags = spin_lock_irq(&p->faulting_lock);
+    assert(list_empty(&pf->dependents));
+    rbtree_remove_node(&pf->p->pending_faults, &pf->n);
+    list_insert_before(&mmap_info.pf_freelist, &pf->l_free);
+    spin_unlock_irq(&p->faulting_lock, flags);
+}
+
+static pending_fault new_pending_fault_locked(process p, u64 addr)
+{
+    pending_fault pf;
+    list l;
+    if ((l = list_get_next(&mmap_info.pf_freelist))) {
+        pf = struct_from_list(l, pending_fault, l_free);
+        list_delete(l);
+    } else {
+        pf = allocate(mmap_info.h, sizeof(struct pending_fault));
+        assert(pf != INVALID_ADDRESS);
+    }
+    init_rbnode(&pf->n);
+    pf->addr = addr;
+    pf->p = p;
+    list_init(&pf->dependents);
+    init_closure(&pf->complete, pending_fault_complete, pf);
+    pf->kern = false;
+    assert(rbtree_insert_node(&p->pending_faults, &pf->n));
+    return pf;
+}
+
+static pending_fault find_pending_fault_locked(process p, u64 addr)
+{
+    struct pending_fault k;
+    k.addr = addr;
+    rbnode n = rbtree_lookup(&p->pending_faults, &k.n);
+    if (n == INVALID_ADDRESS)
+        return 0;
+    return (pending_fault)n;
+}
+
+static boolean demand_anonymous_page(pending_fault pf, vmap vm, u64 vaddr)
+{
+    u64 paddr = allocate_u64((heap)mmap_info.physical, PAGESIZE);
+    if (paddr == INVALID_PHYSICAL) {
+        msg_err("cannot get physical page; OOM\n");
+        return false;
+    }
+    pf->kern = false;       /* direct return if kernel fault; no resume */
+    map_and_zero(vaddr & ~MASK(PAGELOG), paddr, PAGESIZE, pageflags_from_vmflags(vm->flags),
+                 (status_handler)&pf->complete);
+    count_minor_fault();
+    return true;
+}
+
+static boolean demand_filebacked_page(thread t, pending_fault pf, vmap vm, u64 vaddr, boolean in_kernel)
+{
+    pageflags flags = pageflags_from_vmflags(vm->flags);
+    u64 page_addr = vaddr & ~PAGEMASK;
+    u64 node_offset = vm->node_offset + (page_addr - vm->node.r.start);
+    boolean shared = (vm->flags & VMAP_FLAG_SHARED) != 0;
+    if (!shared)
+        flags = pageflags_readonly(flags); /* cow */
+
+    pf_debug("   node %p (start 0x%lx), offset 0x%lx\n",
+             vm->cache_node, vm->node.r.start, node_offset);
+
+    u64 padlen = pad(pagecache_get_node_length(vm->cache_node), PAGESIZE);
+    pf_debug("   map length 0x%lx\n", padlen);
+    if (node_offset >= padlen) {
+        pf_debug("   extends past map limit 0x%lx; sending SIGBUS...\n", padlen);
+        if (in_kernel) {
+            /* It would be more graceful to let the kernel fault pass (perhaps using a dummy
+               or zero page) and eventually deliver the SIGBUS to the offending thread. For now,
+               assume this is an unrecoverable error and exit here. */
+            halt("%s: file-backed access in kernel mode outside of map range, "
+                 "node %p (start 0x%lx), offset 0x%lx\n", vm->cache_node,
+                 vm->node.r.start, node_offset);
+        }
+        deliver_fault_signal(SIGBUS, t, vaddr, BUS_ADRERR);
+        return true;
+    }
+
+    pf->kern = false;       /* user, or no kernel context resume if direct return */
+    if (pagecache_map_page_if_filled(vm->cache_node, node_offset, page_addr, flags,
+                                     (status_handler)&pf->complete)) {
+        pf_debug("   immediate completion\n");
+        count_minor_fault();
+        return true;
+    }
+
+    /* page not filled - schedule a page fill for this thread */
+    refcount_reserve(&t->refcount);
+    init_closure(&t->demand_file_page, thread_demand_file_page,
+                 pf, vm, node_offset, page_addr, flags, in_kernel /* bhqueue */);
+    u64 saved_flags = spin_lock_irq(&t->p->faulting_lock);
+    if (in_kernel) {
+        assert(!mmap_info.faulting_kernel_context);
+        assert(this_cpu_has_kernel_lock());
+        mmap_info.faulting_kernel_context = suspend_kernel_context();
+        pf->kern = true;
+        this_cpu_release_kernel_lock();
+    } else {
+        list_insert_before(&pf->dependents, &t->l_faultwait);
+    }
+    spin_unlock_irq(&t->p->faulting_lock, saved_flags);
+    enqueue(bhqueue, &t->demand_file_page);
+    count_major_fault();
+    return false;
+}
+
 boolean do_demand_page(u64 vaddr, vmap vm, context frame)
 {
     cpuinfo ci = current_cpu();
+    u64 page_addr = vaddr & ~PAGEMASK;
     boolean in_kernel = is_current_kernel_context(frame);
+
     if ((vm->flags & VMAP_FLAG_MMAP) == 0) {
         msg_err("vaddr 0x%lx matched vmap with invalid flags (0x%x)\n",
                 vaddr, vm->flags);
@@ -89,88 +232,40 @@ boolean do_demand_page(u64 vaddr, vmap vm, context frame)
              vaddr, vm->flags);
     pf_debug("   vmap %p, frame %p\n", vm, frame);
 
-    int mmap_type = vm->flags & VMAP_MMAP_TYPE_MASK;
-    if (mmap_type == VMAP_MMAP_TYPE_ANONYMOUS) {
-        u64 paddr = allocate_u64((heap)heap_physical(get_kernel_heaps()), PAGESIZE);
-        if (paddr == INVALID_PHYSICAL) {
-            msg_err("cannot get physical page; OOM\n");
-            return false;
-        }
-
-        map_and_zero(vaddr & ~MASK(PAGELOG), paddr, PAGESIZE, pageflags_from_vmflags(vm->flags));
-        count_minor_fault();
-    } else if (mmap_type == VMAP_MMAP_TYPE_FILEBACKED) {
-        u64 page_addr = vaddr & ~PAGEMASK;
-        u64 node_offset = vm->node_offset + (page_addr - vm->node.r.start);
-        boolean shared = (vm->flags & VMAP_FLAG_SHARED) != 0;
-        pageflags flags = pageflags_from_vmflags(vm->flags);
-        if (!shared)
-            flags = pageflags_readonly(flags); /* cow */
-
-        pf_debug("   node %p (start 0x%lx), offset 0x%lx\n",
-                 vm->cache_node, vm->node.r.start, node_offset);
-
-        u64 padlen = pad(pagecache_get_node_length(vm->cache_node), PAGESIZE);
-        pf_debug("   map length 0x%lx\n", padlen);
-        if (node_offset >= padlen) {
-            pf_debug("   extends past map limit 0x%lx; sending SIGBUS...\n", padlen);
-            if (in_kernel) {
-                /* It would be more graceful to let the kernel fault pass (perhaps using a dummy
-                   or zero page) and eventually deliver the SIGBUS to the offending thread. For now,
-                   assume this is an unrecoverable error and exit here. */
-                halt("%s: file-backed access in kernel mode outside of map range, "
-                     "node %p (start 0x%lx), offset 0x%lx\n", vm->cache_node,
-                     vm->node.r.start, node_offset);
-            }
-            deliver_fault_signal(SIGBUS, current, vaddr, BUS_ADRERR);
-            return true;
-        }
-
+    assert(current != dummy_thread);
+    thread t = current;
+    process p = t->p;
+    u64 flags = spin_lock_irq(&p->faulting_lock);
+    pending_fault pf = find_pending_fault_locked(p, page_addr);
+    if (pf) {
+        pf_debug("   found pf %p\n", pf);
         if (in_kernel) {
-            /* Kernel-mode page faults are exclusively for faulting-in user pages within the confines
-               of a syscall (under the kernel lock). As such, we are free to set up an asynchronous page
-               fill, allocate memory, etc. */
-            assert(!faulting_kernel_context);
-            assert(this_cpu_has_kernel_lock());
-            kernel_demand_page_completed = false;
-            pagecache_map_page(vm->cache_node, node_offset, page_addr, flags,
-                               (status_handler)&do_kernel_demand_pf_complete,
-                               true /* complete on bhqueue */);
-            if (kernel_demand_page_completed) {
-                pf_debug("   immediate completion\n");
-                count_minor_fault();
-                return true;
-            }
-            faulting_kernel_context = suspend_kernel_context();
-            ci->have_kernel_lock = false;
+            pf->kern = true;
         } else {
-            /* A user fault can happen outside of the kernel lock. We can try to touch an existing
-               page, but we can't allocate anything, fill a page or start a storage operation. */
-            if (pagecache_map_page_if_filled(vm->cache_node, node_offset, page_addr, flags)) {
-                pf_debug("   immediate completion\n");
-                count_minor_fault();
-                return true;
-            }
-
-            /* schedule a page fill for this thread */
-            thread t = current;
-            refcount_reserve(&t->refcount);
-            init_closure(&t->demand_file_page, thread_demand_file_page, t, vm,
-                         node_offset, page_addr, flags);
-            init_closure(&t->demand_file_page_complete, thread_demand_file_page_complete, t, frame, vaddr);
-            enqueue(runqueue, &t->demand_file_page);
+            refcount_reserve(&t->refcount); /* for fault */
+            list_insert_before(&pf->dependents, &t->l_faultwait);
         }
-        count_major_fault();
-
-        /* suspending */
-        context f = frame_from_kernel_context(get_kernel_context(ci));
-        f[FRAME_FULL] = false;
-        runloop();
+        spin_unlock_irq(&p->faulting_lock, flags);
+        count_minor_fault(); /* XXX not precise...stash pt type in faulting thread? */
     } else {
-        halt("%s: invalid vmap type %d, flags 0x%lx\n", __func__, mmap_type, vm->flags);
-    }
+        pf = new_pending_fault_locked(p, page_addr);
+        spin_unlock_irq(&p->faulting_lock, flags);
 
-    return true;
+        int mmap_type = vm->flags & VMAP_MMAP_TYPE_MASK;
+        switch (mmap_type) {
+        case VMAP_MMAP_TYPE_ANONYMOUS:
+            return demand_anonymous_page(pf, vm, vaddr);
+        case VMAP_MMAP_TYPE_FILEBACKED:
+            if (demand_filebacked_page(t, pf, vm, vaddr, in_kernel))
+                return true;
+            break;
+        default:
+            halt("%s: invalid vmap type %d, flags 0x%lx\n", __func__, mmap_type, vm->flags);
+        }
+    }
+    /* suspend thread or kernel context */
+    frame_from_kernel_context(get_kernel_context(ci))[FRAME_FULL] = false;
+    runloop();
 }
 
 static inline vmap vmap_from_vaddr_locked(process p, u64 vaddr)
@@ -339,7 +434,6 @@ sysreturn mremap(void *old_address, u64 old_size, u64 new_size, int flags, void 
         return -EINVAL;
 
     heap vh = p->virtual;
-    id_heap physical = heap_physical(get_kernel_heaps());
 
     old_size = pad(old_size, vh->pagesize);
     if (new_size <= old_size)
@@ -393,7 +487,7 @@ sysreturn mremap(void *old_address, u64 old_size, u64 new_size, int flags, void 
 
     /* balance of physical allocation */
     u64 dlen = maplen - old_size;
-    u64 dphys = allocate_u64((heap)physical, dlen);
+    u64 dphys = allocate_u64((heap)mmap_info.physical, dlen);
     if (dphys == INVALID_PHYSICAL) {
         msg_err("failed to allocate physical memory, size %ld\n", dlen);
         rv = -ENOMEM;
@@ -627,7 +721,6 @@ sysreturn mprotect(void * addr, u64 len, int prot)
     if (len == 0)
         return 0;
 
-    heap h = heap_general(get_kernel_heaps());
     u64 where = u64_from_pointer(addr);
     u64 padlen = pad(len, PAGESIZE);
     if ((where & MASK(PAGELOG)))
@@ -641,7 +734,7 @@ sysreturn mprotect(void * addr, u64 len, int prot)
 
     process p = current->p;
     vmap_lock(p);
-    sysreturn result = vmap_update_protections(h, p->vmaps, irangel(where, padlen), new_vmflags);
+    sysreturn result = vmap_update_protections(mmap_info.h, p->vmaps, irangel(where, padlen), new_vmflags);
     vmap_unlock(p);
     return result;
 }
@@ -900,8 +993,6 @@ static sysreturn msync(void *addr, u64 length, int flags)
 static sysreturn mmap(void *addr, u64 length, int prot, int flags, int fd, u64 offset)
 {
     process p = current->p;
-    kernel_heaps kh = get_kernel_heaps();
-    heap h = heap_general(kh);
     thread_log(current, "mmap: addr %p, length 0x%lx, prot 0x%x, flags 0x%x, "
                "fd %d, offset 0x%lx", addr, length, prot, flags, fd, offset);
 
@@ -1008,7 +1099,7 @@ static sysreturn mmap(void *addr, u64 length, int prot, int flags, int fd, u64 o
     switch (vmap_mmap_type) {
     case VMAP_MMAP_TYPE_ANONYMOUS:
         thread_log(current, "   anonymous, specified target 0x%lx", where);
-        vmap_paint(h, p, where, len, vmflags, allowed_flags, 0, 0);
+        vmap_paint(mmap_info.h, p, where, len, vmflags, allowed_flags, 0, 0);
         break;
     case VMAP_MMAP_TYPE_IORING:
         thread_log(current, "   fd %d: io_uring", fd);
@@ -1019,7 +1110,7 @@ static sysreturn mmap(void *addr, u64 length, int prot, int flags, int fd, u64 o
             ret = io_uring_mmap(desc, len, pageflags_from_vmflags(vmflags), offset);
             thread_log(current, "   io_uring_mmap returned 0x%lx", ret);
             if (ret > 0)
-               vmap_paint(h, p, (u64)ret, len, vmflags, allowed_flags, 0, 0);
+               vmap_paint(mmap_info.h, p, (u64)ret, len, vmflags, allowed_flags, 0, 0);
         }
         break;
     case VMAP_MMAP_TYPE_FILEBACKED:
@@ -1033,7 +1124,7 @@ static sysreturn mmap(void *addr, u64 length, int prot, int flags, int fd, u64 o
             thread_log(current, "   associated with cache node %p @ offset 0x%lx", node, offset);
             if (vmflags & VMAP_FLAG_SHARED)
                 pagecache_node_add_shared_map(node, irangel(where, len), offset);
-            vmap_paint(h, p, where, len, vmflags, allowed_flags, node, offset);
+            vmap_paint(mmap_info.h, p, where, len, vmflags, allowed_flags, node, offset);
         }
         break;
     default:
@@ -1061,7 +1152,7 @@ extern void * START;
 
 static void add_varea(process p, u64 start, u64 end, id_heap vheap, boolean allow_fixed)
 {
-    assert(allocate_varea(heap_general((kernel_heaps)p->uh), p->vareas, irange(start, end),
+    assert(allocate_varea(mmap_info.h, p->vareas, irange(start, end),
                           vheap, allow_fixed) != INVALID_ADDRESS);
 
     /* reserve area by marking as allocated */
@@ -1116,7 +1207,9 @@ bytes vmh_total(struct heap *h)
 void mmap_process_init(process p, boolean aslr)
 {
     kernel_heaps kh = &p->uh->kh;
-    heap h = heap_general(kh);
+    heap h = heap_locked(kh);
+    mmap_info.h = h;
+    mmap_info.physical = heap_physical(kh);
     spin_lock_init(&p->vmap_lock);
     p->vareas = allocate_rangemap(h);
     p->vmaps = allocate_rangemap(h);
@@ -1164,7 +1257,13 @@ void mmap_process_init(process p, boolean aslr)
                          ivmap(VMAP_FLAG_EXEC, 0, 0, 0)) != INVALID_ADDRESS);
 #endif
 
-    init_closure(&do_kernel_demand_pf_complete, kernel_demand_pf_complete);
+    mmap_info.kernel_demand_page_completed = false;
+    mmap_info.faulting_kernel_context = 0;
+    spin_lock_init(&p->faulting_lock);
+    init_rbtree(&p->pending_faults,
+                init_closure(&mmap_info.pf_compare, pending_fault_compare),
+                init_closure(&mmap_info.pf_print, pending_fault_print));
+    list_init(&mmap_info.pf_freelist);
 }
 
 void register_mmap_syscalls(struct syscall *map)

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2454,14 +2454,18 @@ static boolean syscall_defer;
 static void syscall_schedule(context f)
 {
     /* kernel context set on syscall entry */
+    current_cpu()->state = cpu_kernel;
+#if 0
+    // XXX temp disable until workaround found for spinlock / flush issue
     if (!syscall_defer && !kernel_suspended())
         kern_lock();
-    else if (!kern_try_lock()) {
+    else
+#endif
+    if (!kern_try_lock()) {
         enqueue_irqsafe(runqueue, &current->deferred_syscall);
         thread_pause(current);
         runloop();
     }
-    current_cpu()->state = cpu_kernel;
     syscall_debug(f);
 }
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1626,7 +1626,7 @@ static sysreturn brk(void *addr)
             goto out;
         }
         pageflags flags = pageflags_writable(pageflags_noexec(pageflags_user(pageflags_memory())));
-        map_and_zero(old_end, phys, alloc, flags);
+        map_and_zero(old_end, phys, alloc, flags, 0);
     }
     p->brk = addr;
   out:

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2454,7 +2454,7 @@ static boolean syscall_defer;
 static void syscall_schedule(context f)
 {
     /* kernel context set on syscall entry */
-    if (!syscall_defer)
+    if (!syscall_defer && !kernel_suspended())
         kern_lock();
     else if (!kern_try_lock()) {
         enqueue_irqsafe(runqueue, &current->deferred_syscall);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2455,13 +2455,9 @@ static void syscall_schedule(context f)
 {
     /* kernel context set on syscall entry */
     current_cpu()->state = cpu_kernel;
-#if 0
-    // XXX temp disable until workaround found for spinlock / flush issue
     if (!syscall_defer && !kernel_suspended())
         kern_lock();
-    else
-#endif
-    if (!kern_try_lock()) {
+    else if (!kern_try_lock()) {
         enqueue_irqsafe(runqueue, &current->deferred_syscall);
         thread_pause(current);
         runloop();

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -347,6 +347,8 @@ thread create_thread(process p)
     t->start_time = now(CLOCK_ID_MONOTONIC_RAW);
     t->last_syscall = -1;
 
+    list_init(&t->l_faultwait);
+
     // XXX sigframe
     spin_lock(&p->threads_lock);
     rbtree_insert_node(p->threads, &t->n);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -210,6 +210,23 @@ struct ftrace_graph_entry;
 
 #include <notify.h>
 
+struct pending_fault;
+declare_closure_struct(1, 1, void, pending_fault_complete,
+                       struct pending_fault *, pf,
+                       status, s);
+
+typedef struct pending_fault {
+    struct rbnode n;            /* must be first */
+    u64 addr;
+    process p;
+    union {
+        struct list dependents;
+        struct list l_free;
+    };
+    closure_struct(pending_fault_complete, complete);
+    boolean kern;
+} *pending_fault;
+
 declare_closure_struct(1, 0, void, free_thread,
                        thread, t);
 declare_closure_struct(1, 0, void, resume_syscall,
@@ -223,10 +240,10 @@ declare_closure_struct(1, 0, void, run_sighandler,
 declare_closure_struct(1, 1, context, default_fault_handler,
                        thread, t,
                        context, frame);
-declare_closure_struct(5, 0, void, thread_demand_file_page,
-                       thread, t, struct vmap *, vm, u64, node_offset, u64, page_addr, pageflags, flags);
-declare_closure_struct(3, 1, void, thread_demand_file_page_complete,
-                       thread, t, context, frame, u64, vaddr,
+declare_closure_struct(6, 0, void, thread_demand_file_page,
+                       pending_fault, pf, struct vmap *, vm, u64, node_offset, u64, page_addr, pageflags, flags, boolean, bh);
+declare_closure_struct(2, 1, void, thread_demand_page_complete,
+                       thread, t, u64, vaddr,
                        status, s);
 
 /* XXX probably should bite bullet and allocate these... */
@@ -260,7 +277,7 @@ typedef struct thread {
     closure_struct(run_sighandler, run_sighandler);
     closure_struct(default_fault_handler, fault_handler);
     closure_struct(thread_demand_file_page, demand_file_page);
-    closure_struct(thread_demand_file_page_complete, demand_file_page_complete);
+    closure_struct(thread_demand_page_complete, demand_page_complete);
 
     epoll select_epoll;
     int *clear_tid;
@@ -295,7 +312,8 @@ typedef struct thread {
     u64 signal_stack_length;
 
     closure_struct(resume_syscall, deferred_syscall);
-    cpu_set_t affinity;    
+    cpu_set_t affinity;
+    struct list l_faultwait;
 } *thread;
 
 typedef closure_type(file_io, sysreturn, void *buf, u64 length, u64 offset, thread t,
@@ -429,6 +447,8 @@ typedef struct process {
     rangemap          vmaps;    /* process mappings */
     vmap              stack_map;
     vmap              heap_map;
+    struct rbtree     pending_faults; /* pending_faults in progress */
+    struct spinlock   faulting_lock;
     struct sigstate   signals;
     struct sigaction  sigactions[NSIG];
     id_heap           posix_timer_ids;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -240,8 +240,8 @@ declare_closure_struct(1, 0, void, run_sighandler,
 declare_closure_struct(1, 1, context, default_fault_handler,
                        thread, t,
                        context, frame);
-declare_closure_struct(6, 0, void, thread_demand_file_page,
-                       pending_fault, pf, struct vmap *, vm, u64, node_offset, u64, page_addr, pageflags, flags, boolean, bh);
+declare_closure_struct(5, 0, void, thread_demand_file_page,
+                       pending_fault, pf, struct vmap *, vm, u64, node_offset, u64, page_addr, pageflags, flags);
 declare_closure_struct(2, 1, void, thread_demand_page_complete,
                        thread, t, u64, vaddr,
                        status, s);

--- a/src/x86_64/flush.c
+++ b/src/x86_64/flush.c
@@ -135,9 +135,8 @@ closure_function(0, 0, void, do_flush_service)
         u64 flags = spin_wlock_irq(&flush_lock);
         service_list(false);
         spin_wunlock_irq(&flush_lock, flags);
-        while ((c = dequeue(flush_completion_queue)) != INVALID_ADDRESS) {
+        while ((c = dequeue(flush_completion_queue)) != INVALID_ADDRESS)
             apply(c, STATUS_OK);
-        }
     }
 }
 
@@ -145,7 +144,7 @@ static void queue_flush_service(void)
 {
     if (!service_scheduled) {
         service_scheduled = true;
-        assert(enqueue(runqueue, flush_service));
+        assert(enqueue_irqsafe(bhqueue, flush_service));
     }
 }
 

--- a/src/x86_64/flush.c
+++ b/src/x86_64/flush.c
@@ -128,7 +128,7 @@ static void service_list(boolean trydefer)
 
 closure_function(0, 0, void, do_flush_service)
 {
-    thunk c;
+    status_handler c;
 
     while (service_scheduled) {
         service_scheduled = false;
@@ -136,7 +136,7 @@ closure_function(0, 0, void, do_flush_service)
         service_list(false);
         spin_wunlock_irq(&flush_lock, flags);
         while ((c = dequeue(flush_completion_queue)) != INVALID_ADDRESS) {
-            apply(c);
+            apply(c, STATUS_OK);
         }
     }
 }

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -252,6 +252,8 @@ void common_handler()
     }
     f[FRAME_FULL] = true;
 
+    boolean kern_return = ci->state == cpu_kernel;
+
     /* invoke handler if available, else general fault handler */
     if (handlers[i]) {
         ci->state = cpu_interrupt;
@@ -276,8 +278,13 @@ void common_handler()
             goto exit_fault;
         }
     }
-    if (is_current_kernel_context(f))
+    if (is_current_kernel_context(f)) {
+        if (kern_return) {
+            ci->state = cpu_kernel;
+            frame_return(f);
+        }
         f[FRAME_FULL] = false;      /* no longer saving frame for anything */
+    }
     runloop();
   exit_fault:
     console("cpu ");

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -199,7 +199,6 @@ static void write_pte(u64 target, physical to, u64 flags, boolean * invalidate)
 #endif
 	return;
     }
-    assert(!pte_is_present(*pteptr));
     /* Unconditionally invalidate in case this cpu's TLB is not up-to-date. The
      * TLB can be outdated in SMP situations where another cpu has marked the
      * PTE as not present but this cpu hasn't processed the shootdown yet. */

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -199,6 +199,7 @@ static void write_pte(u64 target, physical to, u64 flags, boolean * invalidate)
 #endif
 	return;
     }
+    assert(!pte_is_present(*pteptr));
     /* Unconditionally invalidate in case this cpu's TLB is not up-to-date. The
      * TLB can be outdated in SMP situations where another cpu has marked the
      * PTE as not present but this cpu hasn't processed the shootdown yet. */

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -140,6 +140,7 @@ SRCS-mmap= \
 	$(SRCDIR)/unix_process/unix_process_runtime.c \
 	$(RUNTIME)
 LDFLAGS-mmap=		-static
+LIBS-mmap=		-lpthread
 
 SRCS-mkdir= \
 	$(CURDIR)/mkdir.c \

--- a/test/runtime/mmap.manifest
+++ b/test/runtime/mmap.manifest
@@ -3,6 +3,7 @@
         mmap:(contents:(host:output/test/runtime/bin/mmap))
 	infile:(contents:(host:test/runtime/read_contents/hello))
 	mapfile:(contents:(host:test/runtime/read_contents/mapfile))
+	mapfile2:(contents:(host:test/runtime/read_contents/mapfile))
 	unmapme:(contents:(host:test/runtime/read_contents/unmapme))
     )
     # filesystem path to elf for kernel to run


### PR DESCRIPTION
The existing demand paging fault mechanism was not properly handling the case when a fault for a page occurred while another fault for the same page was being processed. The effects of such races were being masked by the fact that the x86 page table code tacitly allows mappings to be overwritten (this is fixed in #1507). As a result, a mapping set up by one page fault could be displaced by a new mapping set up by a subsequent fault. To remedy this, a "pending_fault" entry is now created for each virtual page address of a demand page fault. When a pending_fault exists for a page that caused a fault, the faulting thread (or kernel context) is added to the pending_fault as a dependent waiter. On completion of the page table flush (tlb shootdown) associated with the mapping created, any threads (and/or kernel context) that faulted on the page are resumed. To enable such completions, the functions map_with_complete and update_map_flags_with_complete have been added. Internally, flush completions are now status_handlers rather than thunks.

This also fixes a bug that would occur if the suspended kernel context wound up being recycled and maintained as one of the per-cpu kernel contexts - a normal occurrence if the kernel was suspended while running on one cpu and later resumed on a different cpu. Since this spare context didn't have its FRAME_HANDLER field initialized - probably an oversight as it was assumed the context would only be used while the kernel is blocked (during which time no legitimate page fault can happen in the kernel) - the system would crash on the next page fault taken on the core that continued using the spare kernel context as its active one. The fix is simply to install the frame handler for spare_kernel_context in install_fallback_fault_handler.

Note: The usage of flush completions exposed an issue with flush IPIs not being handled on cores that are spin waiting, in particular with the call to kern_lock from syscall_schedule. If a core is spinning on a lock with interrupts off, it has no way to handle flush IPI events in the meantime, and flush completions cannot take place until the lock is taken and execution proceeds through to the runloop and either kernel_sleep or a unix thread return, whereupon interrupts are re-enabled. But if a running kernel context is suspended on a page fault, keeping the kernel lock held until the page is filled and context resumed, another core calling kern_lock may result in a deadlocked situation. Even prior to this change and the use of flush completions, a call to kern_lock on cpu 0 could prevent I/O interrupts from being dispatched, also possibly leading to a deadlock on a kernel page fault.

~~At the moment, the call to kern_lock in syscall_schedule has been disabled while a solution is sought. While this should be safer, not calling kern_lock can have a deleterious effect on performance (see #1317), so it is not recommended to merge this fix as-is (or without acknowledgement and tracking of the likely performance regression).~~

Edit: see commit https://github.com/nanovms/nanos/pull/1538/commits/6fa2d17a9a4f257bad1d5773317b96f21344c2b3 for the proposed fix.
