### PR TITLE
SMP: add support for an arbitrary number of vCPUs

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -138,8 +138,8 @@ void vm_exit(u8 code)
 {
 #ifdef SMP_DUMP_FRAME_RETURN_COUNT
     rprintf("cpu\tframe returns\n");
-    for (int i = 0; i < MAX_CPUS; i++) {
-        cpuinfo ci = cpuinfo_from_id(i);
+    cpuinfo ci;
+    vector_foreach(cpuinfos, ci) {
         if (ci->frcount)
             rprintf("%d\t%ld\n", i, ci->frcount);
     }
@@ -216,8 +216,6 @@ static void count_processors()
         present_processors = 1;
         rprintf("warning: ACPI MADT not found, default to 1 processor");
     }
-    /* config override */
-    present_processors = MIN(present_processors, MAX_CPUS);
 }
 
 void start_secondary_cores(kernel_heaps kh)

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -139,8 +139,8 @@ void vm_exit(u8 code)
 {
 #ifdef SMP_DUMP_FRAME_RETURN_COUNT
     rprintf("cpu\tframe returns\n");
-    for (int i = 0; i < MAX_CPUS; i++) {
-        cpuinfo ci = cpuinfo_from_id(i);
+    cpuinfo ci;
+    vector_foreach(cpuinfos, ci) {
         if (ci->frcount)
             rprintf("%d\t%ld\n", i, ci->frcount);
     }

--- a/src/config.h
+++ b/src/config.h
@@ -21,9 +21,6 @@
 #define RUNLOOP_TIMER_MAX_PERIOD_US     100000
 #define RUNLOOP_TIMER_MIN_PERIOD_US     1000
 
-/* XXX just for initial mp bringup... */
-#define MAX_CPUS 16
-
 /* length of thread scheduling queue */
 #define MAX_THREADS 8192
 

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -303,6 +303,10 @@ void kernel_runtime_init(kernel_heaps kh)
     init_debug("LWIP init");
     init_net(kh);
 
+    init_debug("start_secondary_cores");
+    start_secondary_cores(kh);
+    init_scheduler_cpus(misc);
+
     init_debug("probe fs, register storage drivers");
     init_volumes(locked);
 
@@ -314,9 +318,6 @@ void kernel_runtime_init(kernel_heaps kh)
     init_debug("pci_discover (for other devices)");
     pci_discover();
     init_debug("discover done");
-
-    init_debug("start_secondary_cores");
-    start_secondary_cores(kh);
 
     init_debug("starting runloop");
     runloop();

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -81,48 +81,53 @@ void resume_kernel_context(kernel_context c)
     frame_return(c->frame);
 }
 
-struct cpuinfo cpuinfos[MAX_CPUS];
+vector cpuinfos;
 
-static void init_cpuinfos(heap backed)
+cpuinfo init_cpuinfo(heap backed, int cpu)
 {
-    /* We're stuck with a hard limit of 64 for now due to bitmask... */
-    build_assert(MAX_CPUS <= 64);
-
-    /* We'd like the aps to allocate for themselves, but we don't have
-       per-cpu heaps just yet. */
-    for (int i = 0; i < MAX_CPUS; i++) {
-        cpuinfo ci = cpuinfo_from_id(i);
-        /* state */
-        set_running_frame(ci, 0);
-        ci->id = i;
-        ci->state = cpu_not_present;
-        ci->have_kernel_lock = false;
-        ci->thread_queue = allocate_queue(backed, MAX_THREADS);
-        ci->last_timer_update = 0;
-        ci->frcount = 0;
-
-        init_cpuinfo_machine(ci, backed);
-
-        /* frame and stacks */
-        set_kernel_context(ci, allocate_kernel_context(backed));
+    cpuinfo ci = allocate(backed, sizeof(struct cpuinfo));
+    if (ci == INVALID_ADDRESS)
+        return ci;
+    if (!vector_set(cpuinfos, cpu, ci)) {
+        deallocate(backed, ci, sizeof(struct cpuinfo));
+        return INVALID_ADDRESS;
     }
 
-    cpuinfo ci = cpuinfo_from_id(0);
-    set_running_frame(ci, frame_from_kernel_context(get_kernel_context(ci)));
-    cpu_init(0);
+    /* state */
+    set_running_frame(ci, 0);
+    ci->id = cpu;
+    ci->state = cpu_not_present;
+    ci->have_kernel_lock = false;
+    ci->thread_queue = allocate_queue(backed, MAX_THREADS);
+    assert(ci->thread_queue != INVALID_ADDRESS);
+    ci->last_timer_update = 0;
+    ci->frcount = 0;
+
+    init_cpuinfo_machine(ci, backed);
+
+    /* frame and stacks */
+    set_kernel_context(ci, allocate_kernel_context(backed));
+
+    return ci;
 }
 
 void init_kernel_contexts(heap backed)
 {
     spare_kernel_context = allocate_kernel_context(backed);
     assert(spare_kernel_context != INVALID_ADDRESS);
-    init_cpuinfos(backed);
+    cpuinfos = allocate_vector(backed, 1);
+    assert(cpuinfos != INVALID_ADDRESS);
+    cpuinfo ci = init_cpuinfo(backed, 0);
+    assert(ci != INVALID_ADDRESS);
+    set_running_frame(ci, frame_from_kernel_context(get_kernel_context(ci)));
+    cpu_init(0);
     current_cpu()->state = cpu_kernel;
 }
 
 void install_fallback_fault_handler(fault_handler h)
 {
-    for (int i = 0; i < MAX_CPUS; i++)
-        set_fault_handler(get_kernel_context(cpuinfo_from_id(i)), h);
+    cpuinfo ci;
+    vector_foreach(cpuinfos, ci)
+        set_fault_handler(get_kernel_context(ci), h);
     set_fault_handler(spare_kernel_context, h);
 }

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -35,7 +35,7 @@ typedef struct cpuinfo {
 
 typedef closure_type(fault_handler, context, context);
 
-extern struct cpuinfo cpuinfos[];
+extern vector cpuinfos;
 
 /* subsume with introspection */
 struct mm_stats {
@@ -47,8 +47,7 @@ extern struct mm_stats mm_stats;
 
 static inline cpuinfo cpuinfo_from_id(int cpu)
 {
-    assert(cpu >= 0 && cpu < MAX_CPUS);
-    return &cpuinfos[cpu];
+    return vector_get(cpuinfos, cpu);
 }
 
 static inline boolean is_current_kernel_context(context f)
@@ -142,6 +141,7 @@ context allocate_frame(heap h);
 void deallocate_frame(context);
 void *allocate_stack(heap h, u64 size);
 void deallocate_stack(heap h, u64 size, void *stack);
+cpuinfo init_cpuinfo(heap backed, int cpu);
 kernel_context allocate_kernel_context(heap h);
 void deallocate_kernel_context(kernel_context c);
 void init_kernel_contexts(heap backed);
@@ -266,6 +266,7 @@ void kern_lock(void);
 boolean kern_try_lock(void);
 void kern_unlock(void);
 void init_scheduler(heap);
+void init_scheduler_cpus(heap h);
 void mm_service(void);
 
 typedef closure_type(balloon_deflater, u64, u64);
@@ -288,7 +289,7 @@ extern char **state_strings;
 
 void kernel_unlock();
 
-extern u64 idle_cpu_mask;
+extern bitmap idle_cpu_mask;
 extern u64 total_processors;
 extern u64 present_processors;
 extern void xsave(context f);

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -26,7 +26,7 @@ boolean shutting_down;
 queue runqueue;                 /* kernel space from ?*/
 queue bhqueue;                  /* kernel from interrupt */
 timerheap runloop_timers;
-u64 idle_cpu_mask;              /* xxx - limited to 64 aps. consider merging with bitmask */
+bitmap idle_cpu_mask;
 timestamp last_timer_update;
 
 static timestamp runloop_timer_min;
@@ -115,7 +115,8 @@ NOTRACE void __attribute__((noreturn)) kernel_sleep(void)
     cpuinfo ci = current_cpu();
     sched_debug("sleep\n");
     ci->state = cpu_idle;
-    atomic_set_bit(&idle_cpu_mask, ci->id);
+    if (idle_cpu_mask)
+        bitmap_set_atomic(idle_cpu_mask, ci->id, 1);
 
     while (1) {
         wait_for_interrupt();
@@ -127,7 +128,7 @@ void wakeup_or_interrupt_cpu_all()
     cpuinfo ci = current_cpu();
     for (int i = 0; i < total_processors; i++) {
         if (i != ci->id) {
-            atomic_clear_bit(&idle_cpu_mask, i);
+            bitmap_set_atomic(idle_cpu_mask, i, 0);
             send_ipi(i, wakeup_vector);
         }
     }
@@ -135,16 +136,17 @@ void wakeup_or_interrupt_cpu_all()
 
 static void wakeup_cpu(u64 cpu)
 {
-    if (atomic_test_and_clear_bit(&idle_cpu_mask, cpu)) {
+    if (bitmap_test_and_set_atomic(idle_cpu_mask, cpu, 0)) {
         sched_debug("waking up CPU %d\n", cpu);
         send_ipi(cpu, wakeup_vector);
     }
 }
 
-static thunk migrate_to_self(thunk t, u64 cpu_mask)
+static thunk migrate_to_self(thunk t, u64 first_cpu, u64 ncpus)
 {
-    while (cpu_mask) {
-        u64 cpu = lsb(cpu_mask);
+    u64 cpu;
+    while ((ncpus > 0) &&
+            ((cpu = bitmap_range_get_first(idle_cpu_mask, first_cpu, ncpus)) != INVALID_PHYSICAL)) {
         cpuinfo cpui = cpuinfo_from_id(cpu);
         if (t == INVALID_ADDRESS) {
             t = dequeue(cpui->thread_queue);
@@ -153,15 +155,17 @@ static thunk migrate_to_self(thunk t, u64 cpu_mask)
         }
         if ((t != INVALID_ADDRESS) && !queue_empty(cpui->thread_queue))
             wakeup_cpu(cpu);
-        cpu_mask &= ~U64_FROM_BIT(cpu);
+        ncpus -= cpu - first_cpu + 1;
+        first_cpu = cpu + 1;
     }
     return t;
 }
 
-static void migrate_from_self(cpuinfo ci, u64 cpu_mask)
+static void migrate_from_self(cpuinfo ci, u64 first_cpu, u64 ncpus)
 {
-    while (cpu_mask) {
-        u64 cpu = lsb(cpu_mask);
+    u64 cpu;
+    while ((ncpus > 0) &&
+            ((cpu = bitmap_range_get_first(idle_cpu_mask, first_cpu, ncpus)) != INVALID_PHYSICAL)) {
         cpuinfo cpui = cpuinfo_from_id(cpu);
         thunk t;
         if (!queue_empty(cpui->thread_queue)) {
@@ -171,7 +175,8 @@ static void migrate_from_self(cpuinfo ci, u64 cpu_mask)
             enqueue(cpui->thread_queue, t);
             wakeup_cpu(cpu);
         }
-        cpu_mask &= ~U64_FROM_BIT(cpu);
+        ncpus -= cpu - first_cpu + 1;
+        first_cpu = cpu + 1;
     }
 }
 
@@ -184,9 +189,9 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
 
     sched_thread_pause();
     disable_interrupts();
-    sched_debug("runloop from %s b:%d r:%d t:%d i:%x%s\n", state_strings[ci->state],
+    sched_debug("runloop from %s b:%d r:%d t:%d%s\n", state_strings[ci->state],
                 queue_length(bhqueue), queue_length(runqueue), queue_length(ci->thread_queue),
-                idle_cpu_mask, ci->have_kernel_lock ? " locked" : "");
+                ci->have_kernel_lock ? " locked" : "");
     ci->state = cpu_kernel;
     /* Make sure TLB entries are appropriately flushed before doing any work */
     page_invalidate_flush();
@@ -213,13 +218,13 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
     if (!shutting_down) {
         t = dequeue(ci->thread_queue);
         if (t == INVALID_ADDRESS) {
-            if (idle_cpu_mask) {
-                /* Try to steal a thread from an idle CPU (so that it doesn't
-                 * have to be woken up), and wake up CPUs that have a non-empty
-                 * thread queue). */
-                t = migrate_to_self(t, idle_cpu_mask & ~MASK(ci->id + 1));
-                t = migrate_to_self(t, idle_cpu_mask & MASK(ci->id));
-            }
+            /* Try to steal a thread from an idle CPU (so that it doesn't
+             * have to be woken up), and wake up CPUs that have a non-empty
+             * thread queue). */
+            if (ci->id + 1 < total_processors)
+                t = migrate_to_self(t, ci->id + 1, total_processors - ci->id - 1);
+            if (ci->id > 0)
+                t = migrate_to_self(t, 0, ci->id);
             if (t == INVALID_ADDRESS) {
                 /* No threads found in idle CPUs: try to steal a thread from a
                  * CPU that is currently running another thread. */
@@ -238,11 +243,13 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
                     }
                 }
             }
-        } else if (idle_cpu_mask) {
+        } else {
             /* Wake up idle CPUs that have a non-empty thread queue, and if our
              * thread queue is non-empty, migrate our threads to idle CPUs. */
-            migrate_from_self(ci, idle_cpu_mask & ~MASK(ci->id + 1));
-            migrate_from_self(ci, idle_cpu_mask & MASK(ci->id));
+            if (ci->id + 1 < total_processors)
+                migrate_from_self(ci, ci->id + 1, total_processors - ci->id - 1);
+            if (ci->id > 0)
+                migrate_from_self(ci, 0, ci->id);
         }
         if (t != INVALID_ADDRESS) {
             if (!timer_updated && (total_processors > 1)) {
@@ -284,4 +291,11 @@ void init_scheduler(heap h)
     runloop_timers = allocate_timerheap(h, "runloop");
     assert(runloop_timers != INVALID_ADDRESS);
     shutting_down = false;
+}
+
+void init_scheduler_cpus(heap h)
+{
+    idle_cpu_mask = allocate_bitmap(h, h, total_processors);
+    assert(idle_cpu_mask != INVALID_ADDRESS);
+    bitmap_alloc(idle_cpu_mask, total_processors);
 }

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -1836,8 +1836,8 @@ ftrace_init(unix_heaps uh, filesystem fs)
 
     /* nop tracer */
     current_tracer = &(tracer_list[0]);
-   for (int i = 0; i < MAX_CPUS; i++) {
-        cpuinfo ci = cpuinfo_from_id(i);
+    cpuinfo ci;
+    vector_foreach(cpuinfos, ci) {
         if (ftrace_cpu_init(ci) != 0)
             return -1;
     }
@@ -1847,8 +1847,8 @@ ftrace_init(unix_heaps uh, filesystem fs)
 void
 ftrace_deinit(void)
 {
-    for (int i = 0; i < MAX_CPUS; i++) {
-        cpuinfo ci = cpuinfo_from_id(i);
+    cpuinfo ci;
+    vector_foreach(cpuinfos, ci) {
         ftrace_cpu_deinit(ci);
     }
     deallocate_http_listener(ftrace_heap, ftrace_hl);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2086,28 +2086,31 @@ static thread lookup_thread(int pid)
     return t;
 }
 
-sysreturn sched_setaffinity(int pid, u64 cpusetsize, cpu_set_t *mask)
+sysreturn sched_setaffinity(int pid, u64 cpusetsize, u64 *mask)
 {
-    if (!validate_user_memory(mask, sizeof(mask->mask[0]), false))
+    if (!validate_user_memory(mask, cpusetsize, false))
         return set_syscall_error(current, EFAULT);
     thread t;
-    if (!(t = lookup_thread(pid)) ||
-        (!mask || cpusetsize < sizeof(mask->mask[0])))
+    if (!(t = lookup_thread(pid)))
             return set_syscall_error(current, EINVAL);                
-    runtime_memcpy(&t->affinity, mask, sizeof(mask->mask[0]));
+    u64 cpus = pad(MIN(total_processors, 64 * (cpusetsize / sizeof(u64))), 64);
+    runtime_memcpy(bitmap_base(t->affinity), mask, cpus / 8);
+    if (cpus < total_processors)
+        bitmap_range_check_and_set(t->affinity, cpus, total_processors - cpus, false, false);
     return 0;
 }
 
-sysreturn sched_getaffinity(int pid, u64 cpusetsize, cpu_set_t *mask)
+sysreturn sched_getaffinity(int pid, u64 cpusetsize, u64 *mask)
 {
-    if (!validate_user_memory(mask, sizeof(mask->mask[0]), true))
+    if (!validate_user_memory(mask, cpusetsize, true))
         return set_syscall_error(current, EFAULT);
     thread t;
     if (!(t = lookup_thread(pid)) ||
-        (!mask || cpusetsize < sizeof(mask->mask[0])))
+        (64 * (cpusetsize / sizeof(u64)) < total_processors))
             return set_syscall_error(current, EINVAL);                    
-    runtime_memcpy(mask, &t->affinity, sizeof(mask->mask[0]));        
-    return sizeof(mask->mask[0]);
+    cpusetsize = pad(total_processors, 64) / 8;
+    runtime_memcpy(mask, bitmap_base(t->affinity), cpusetsize);
+    return cpusetsize;
 }
 
 sysreturn capget(cap_user_header_t hdrp, cap_user_data_t datap)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -281,6 +281,7 @@ boolean thread_attempt_interrupt(thread t)
 define_closure_function(1, 0, void, free_thread,
                         thread, t)
 {
+    deallocate_bitmap(bound(t)->affinity);
     deallocate(heap_general(get_kernel_heaps()), bound(t), sizeof(struct thread));
 }
 
@@ -335,8 +336,10 @@ thread create_thread(process p)
     t->sighandler_frame[FRAME_RUN] = u64_from_pointer(init_closure(&t->run_sighandler, run_sighandler, t));
 
     t->thrd.pause = init_closure(&t->pause_thread, pause_thread, t);
-    // xxx another max 64
-    t->affinity.mask[0] = MASK(total_processors);
+    t->affinity = allocate_bitmap(h, h, total_processors);
+    if (t->affinity == INVALID_ADDRESS)
+        goto fail_affinity;
+    bitmap_range_check_and_set(t->affinity, 0, total_processors, false, true);
     t->blocked_on = 0;
     init_sigstate(&t->signals);
     t->dispatch_sigstate = 0;
@@ -354,6 +357,10 @@ thread create_thread(process p)
     rbtree_insert_node(p->threads, &t->n);
     spin_unlock(&p->threads_lock);
     return t;
+  fail_affinity:
+    deallocate_frame(t->sighandler_frame);
+    deallocate_frame(t->default_frame);
+    deallocate_notify_set(t->signalfds);
   fail_sfds:
     deallocate_blockq(t->thread_bq);
   fail_bq:

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -495,8 +495,9 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     runtime_memcpy(dummy_thread->name, "dummy_thread",
         sizeof(dummy_thread->name));
 
-    for (int i = 0; i < MAX_CPUS; i++) {
-        context f = frame_from_kernel_context(get_kernel_context(cpuinfo_from_id(i)));
+    cpuinfo ci;
+    vector_foreach(cpuinfos, ci) {
+        context f = frame_from_kernel_context(get_kernel_context(ci));
         f[FRAME_THREAD] = u64_from_pointer(dummy_thread);
     }
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -106,11 +106,6 @@ struct sysinfo {
                         /* Padding to 64 bytes */
 };
 
-#define CPU_SET_WORDS   (pad(MAX_CPUS, 64) >> 6)
-typedef struct {
-    u64 mask[CPU_SET_WORDS];
-} cpu_set_t;
-
 typedef struct user_cap_header {
     u32 version;
     int pid;
@@ -312,7 +307,7 @@ typedef struct thread {
     u64 signal_stack_length;
 
     closure_struct(resume_syscall, deferred_syscall);
-    cpu_set_t affinity;
+    bitmap affinity;
     struct list l_faultwait;
 } *thread;
 

--- a/src/x86_64/apic.c
+++ b/src/x86_64/apic.c
@@ -228,7 +228,7 @@ void ioapic_register_int(unsigned int gsi, thunk h, const char *name)
         ioapic_set_int(gsi, v);
 }
 
-int cpuid_from_apicid(u8 aid)
+int cpuid_from_apicid(u32 aid)
 {
     for (int i = 0; i < present_processors; i++) {
         if (aid == apic_id_map[i])
@@ -264,7 +264,7 @@ closure_function(2, 2, void, apic_madt_handler,
         /* XXX should eventually deal with online capable */
         if (!(lx2->flags & MADT_LAPIC_ENABLED))
             break;
-        apic_id_map[(*pcnt)++] = lx2->id & 0xff;
+        apic_id_map[(*pcnt)++] = lx2->id;
         if (apic_if)
             break;
         apic_debug("using x2APIC interface\n");

--- a/src/x86_64/apic.h
+++ b/src/x86_64/apic.h
@@ -50,7 +50,7 @@
 /* 64 bit data for x2apic, only 32 used for xapic */
 typedef struct apic_iface {
     const char *name;
-    u8 (*legacy_id)(struct apic_iface *);
+    u32 (*get_id)(struct apic_iface *);
     void (*write)(struct apic_iface *, int reg, u64 val);
     u64 (*read)(struct apic_iface *, int reg);       /* XXX 64 for x2? */
     void (*ipi)(struct apic_iface *, u32 target, u64 flags, u8 vector);
@@ -65,7 +65,7 @@ boolean init_lapic_timer(clock_timer *ct, thunk *per_cpu_init);
 void apic_ipi(u32 target, u64 flags, u8 vector);
 void apic_per_cpu_init(void);
 void apic_enable(void);
-int cpuid_from_apicid(u8 aid);
+int cpuid_from_apicid(u32 aid);
 
 void ioapic_set_int(unsigned int gsi, u64 v);
 boolean ioapic_int_is_free(unsigned int gsi);
@@ -73,8 +73,8 @@ void ioapic_register_int(unsigned int gsi, thunk h, const char *name);
 
 extern apic_iface apic_if;
 
-static inline u8 apic_id(void)
+static inline u32 apic_id(void)
 {
     assert(apic_if);
-    return apic_if->legacy_id(apic_if);
+    return apic_if->get_id(apic_if);
 }

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -214,7 +214,7 @@ void common_handler()
     }
 
     // if we were idle, we are no longer
-    atomic_clear_bit(&idle_cpu_mask, ci->id);
+    bitmap_set_atomic(idle_cpu_mask, ci->id, 0);
 
     int_debug("[%02d] # %d (%s), state %s, frame %p, rip 0x%lx, cr2 0x%lx\n",
               ci->id, i, interrupt_names[i], state_strings[ci->state],
@@ -371,16 +371,13 @@ void register_shirq(int v, thunk t, const char *name)
     list_push_back(shirq_handlers, &handler->l);
 }
 
-#define TSS_SIZE                0x68
-
-extern volatile void * TSS;
-static inline void write_tss_u64(int cpu, int offset, u64 val)
+static inline void write_tss_u64(struct cpuinfo_machine *cpu, int offset, u64 val)
 {
-    u64 * vec = (u64 *)(u64_from_pointer(&TSS) + (TSS_SIZE * cpu) + offset);
+    u64 *vec = (u64 *)(u64_from_pointer(&cpu->tss) + offset);
     *vec = val;
 }
 
-void set_ist(int cpu, int i, u64 sp)
+void set_ist(struct cpuinfo_machine *cpu, int i, u64 sp)
 {
     assert(i > 0 && i <= 7);
     write_tss_u64(cpu, 0x24 + (i - 1) * 8, sp);
@@ -389,7 +386,6 @@ void set_ist(int cpu, int i, u64 sp)
 void init_interrupts(kernel_heaps kh)
 {
     heap general = heap_general(kh);
-    cpuinfo ci = current_cpu();
 
     /* Read ACPI tables for MADT access */
     init_acpi_tables(kh);
@@ -402,13 +398,6 @@ void init_interrupts(kernel_heaps kh)
     assert(interrupt_vector_heap != INVALID_ADDRESS);
 
     int_general = general;
-
-    /* Separate stack to keep exceptions in interrupt handlers from
-       trashing the interrupt stack */
-    set_ist(0, IST_EXCEPTION, u64_from_pointer(ci->m.exception_stack));
-
-    /* External interrupts (> 31) */
-    set_ist(0, IST_INTERRUPT, u64_from_pointer(ci->m.int_stack));
 
     /* IDT setup */
     heap backed = (heap)heap_page_backed(kh);
@@ -434,9 +423,6 @@ void init_interrupts(kernel_heaps kh)
 
     /* APIC initialization */
     init_apic(kh);
-
-    /* GDT64 and TSS for boot cpu */
-    install_gdt64_and_tss(0);
 }
 
 void triple_fault(void)

--- a/src/x86_64/kernel_machine.c
+++ b/src/x86_64/kernel_machine.c
@@ -1,6 +1,23 @@
 #include <kernel.h>
 #include <apic.h>
 
+#define SEG_DESC_G          (1 << 15)   /* Granularity */
+#define SEG_DESC_DB         (1 << 14)   /* Code: default size, Data: big */
+#define SEG_DESC_L          (1 << 13)   /* Code: Long (64-bit) */
+#define SEG_DESC_AVL        (1 << 12)   /* Available */
+#define SEG_DESC_P          (1 << 7)    /* Present */
+#define SEG_DESC_DPL_SHIFT  5           /* Privilege level */
+#define SEG_DESC_S          (1 << 4)    /* Code/data (vs sys) */
+#define SEG_DESC_CODE       (1 << 3)    /* Code descriptor type (vs data) */
+#define SEG_DESC_C          (1 << 2)    /* Conforming */
+#define SEG_DESC_RW         (1 << 1)    /* Code: readable, Data: writable */
+#define SEG_DESC_A          (1 << 0)    /* Accessed */
+
+#define KERN_CODE_SEG_DESC  (SEG_DESC_L | SEG_DESC_P | SEG_DESC_S | SEG_DESC_CODE | SEG_DESC_RW)
+#define KERN_DATA_SEG_DESC  (SEG_DESC_P | SEG_DESC_S | SEG_DESC_RW)
+#define USER_CODE_SEG_DESC  (SEG_DESC_L | SEG_DESC_P | (3 << SEG_DESC_DPL_SHIFT) | SEG_DESC_S | SEG_DESC_CODE | SEG_DESC_RW)
+#define USER_DATA_SEG_DESC  (SEG_DESC_S | (3 << SEG_DESC_DPL_SHIFT) | SEG_DESC_P | SEG_DESC_RW)
+
 /* stub placeholder, short of a real generic interface */
 void send_ipi(u64 cpu, u8 vector)
 {
@@ -39,11 +56,42 @@ void clone_frame_pstate(context dest, context src)
     runtime_memcpy(dest + FRAME_EXTENDED_SAVE, src + FRAME_EXTENDED_SAVE, extended_frame_size);
 }
 
+static void seg_desc_set(seg_desc_t *d, u32 base, u16 limit, u16 flags)
+{
+    d->data[0] = limit & 0xff;
+    d->data[1] = (limit >> 8) & 0xff;
+    d->data[2] = base & 0xff;
+    d->data[3] = (base >> 8) & 0xff;
+    d->data[4] = (base >> 16) & 0xff;
+    d->data[5] = flags & 0xff;
+    d->data[6] = (flags >> 8) & 0xff;
+    d->data[7] = (base >> 24) & 0xff;
+}
+
 void init_cpuinfo_machine(cpuinfo ci, heap backed)
 {
     ci->m.self = &ci->m;
     ci->m.exception_stack = allocate_stack(backed, EXCEPT_STACK_SIZE);
     ci->m.int_stack = allocate_stack(backed, INT_STACK_SIZE);
+
+    /* Separate stack to keep exceptions in interrupt handlers from
+       trashing the interrupt stack */
+    set_ist(&ci->m, IST_EXCEPTION, u64_from_pointer(ci->m.exception_stack));
+
+    /* External interrupts (> 31) */
+    set_ist(&ci->m, IST_INTERRUPT, u64_from_pointer(ci->m.int_stack));
+
+    struct gdt *gdt = &ci->m.gdt;
+    seg_desc_set(&gdt->null, 0, 0, 0);
+    seg_desc_set(&gdt->code, 0, 0, KERN_CODE_SEG_DESC);
+    seg_desc_set(&gdt->data, 0, 0, KERN_DATA_SEG_DESC);
+    seg_desc_set(&gdt->user_code, 0, 0, 0);
+    seg_desc_set(&gdt->user_data, 0, 0, USER_DATA_SEG_DESC);
+    seg_desc_set(&gdt->user_code_64, 0, 0, USER_CODE_SEG_DESC);
+    ci->m.gdt_pointer.limit = sizeof(struct gdt) - 1;
+    u64 gdt_base = u64_from_pointer(gdt);
+    runtime_memcpy(&ci->m.gdt_pointer.base, &gdt_base, sizeof(gdt_base));
+    install_gdt64_and_tss(&ci->m.gdt.tss_desc, &ci->m.tss, gdt, &ci->m.gdt_pointer);
 }
 
 void init_frame(context f)

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -64,6 +64,8 @@
 
 #define TSS_SIZE 0x68
 
+struct cpuinfo_machine;
+
 /* AP boot page */
 extern void * AP_BOOT_PAGE;
 #define AP_BOOT_START u64_from_pointer(&AP_BOOT_PAGE)
@@ -128,8 +130,8 @@ void init_cpu_features();
 #define IST_EXCEPTION 1
 #define IST_INTERRUPT 2
 
-void set_ist(int cpu, int i, u64 sp);
-void install_gdt64_and_tss(u64 cpu);
+void set_ist(struct cpuinfo_machine *cpu, int i, u64 sp);
+void install_gdt64_and_tss(void *tss_desc, void *tss, void *gdt, void *gdt_pointer);
 
 #if defined(KERNEL) || defined(KLIB)
 /* locking constructs */
@@ -224,6 +226,10 @@ typedef struct kernel_context {
     u64 frame[0];
 } *kernel_context;
 
+typedef struct {
+    u8 data[8];
+} seg_desc_t;
+
 struct cpuinfo_machine {
     /*** Fields accessed by low-level entry points. ***/
     /* Don't move these without updating gs-relative accesses in crt0.s ***/
@@ -248,6 +254,21 @@ struct cpuinfo_machine {
 
     /* Stack for interrupts */
     void *int_stack;
+
+    struct gdt {
+        seg_desc_t null;
+        seg_desc_t code;
+        seg_desc_t data;
+        seg_desc_t user_code;
+        seg_desc_t user_data;
+        seg_desc_t user_code_64;
+        u8 tss_desc[0x10];
+    } gdt;
+    struct gdt_pointer {
+        u16 limit;
+        u64 base;
+    } __attribute__((packed)) gdt_pointer;
+    u64 tss[TSS_SIZE / sizeof(u64)];
 
     /* Monotonic clock timestamp when the lapic timer is supposed to fire; used to re-arm the timer
      * when it fires too early (based on what the monotonic clock source says). */

--- a/src/x86_64/lock.h
+++ b/src/x86_64/lock.h
@@ -20,11 +20,14 @@ static inline void spin_unlock(spinlock l) {
 
 static inline void spin_rlock(rw_spinlock l) {
     while (1) {
+        if (l->l.w) {
+            kern_pause();
+            continue;
+        }
         fetch_and_add(&l->readers, 1);
         if (!l->l.w)
             return;
         fetch_and_add(&l->readers, -1);
-        kern_pause();
     }
 }
 

--- a/src/x86_64/x2apic.c
+++ b/src/x86_64/x2apic.c
@@ -37,9 +37,9 @@ static u64 x2apic_read(apic_iface i, int reg)
     return d;
 }
 
-static u8 x2apic_legacy_id(apic_iface i)
+static u32 x2apic_get_id(apic_iface i)
 {
-    return x2apic_read(i, APIC_APICID) & 0xff;
+    return x2apic_read(i, APIC_APICID) & 0xffffffff;
 }
 
 #define XAPIC_READ_TIMEOUT_ITERS 512 /* arbitrary */
@@ -80,7 +80,7 @@ static void per_cpu_init(apic_iface i)
 
 struct apic_iface x2apic_if = {
     "x2apic",
-    x2apic_legacy_id,
+    x2apic_get_id,
     x2apic_write,
     x2apic_read,
     x2apic_ipi,

--- a/src/x86_64/xapic.c
+++ b/src/x86_64/xapic.c
@@ -39,7 +39,7 @@ static u64 xapic_read(apic_iface i, int reg)
     return d;
 }
 
-static u8 xapic_legacy_id(apic_iface i)
+static u32 xapic_get_id(apic_iface i)
 {
     return xapic_read(i, APIC_APICID) >> 24;
 }
@@ -81,7 +81,7 @@ static boolean detect(apic_iface i, kernel_heaps kh)
 
 struct apic_iface xapic_if = {
     "xapic",
-    xapic_legacy_id,
+    xapic_get_id,
     xapic_write,
     xapic_read,
     xapic_ipi,


### PR DESCRIPTION
This PR removes the MAX_CPUS limit and replaces the cpuinfos static array with a dynamically allocated vector.
The 64-bit idle CPU mask in the scheduler is replaced by a bitmap, which is initialized in the newly defined function init_scheduler_cpus(); since the idle CPU mask is accessed by interrupt handlers and runloop code, init_scheduler_cpus() is called before probing any devices (such as disks and network interfaces) which could generate interrupts. The call to init_secondary_cores(), where the total number of CPUs is determined, is being moved to just before the call to init_scheduler_cpus().
init_cpuinfo() is being modified in order to allocate dynamically what previously was in a static array.
The fixed-size cpu_set_t type, used in the thread affinity mask and the sched_getaffinity() and sched_setaffinity() syscalls, is being removed, and the above syscalls now have a u64 * parameter instead, while the thread affinity mask is now a bitmap.
In x86, the per-CPU GDT and TSS memory areas are now part of the struct cpuinfo_machine instead of being statically defined in assembly code, and are initialized in the init_cpuinfo_machine() function.