### PR TITLE
fix race condition when setting up new user pages

### DIFF
--- a/src/aarch64/page_machine.h
+++ b/src/aarch64/page_machine.h
@@ -404,18 +404,4 @@ static inline pageflags pageflags_from_pteptr(pteptr pp)
     return (pageflags){.w = PAGE_FLAGS_MASK & *pp};
 }
 
-static inline void map_and_zero(u64 v, physical p, u64 length, pageflags flags, status_handler complete)
-{
-    assert((v & MASK(PAGELOG)) == 0);
-    assert((p & MASK(PAGELOG)) == 0);
-    if (pageflags_is_readonly(flags)) {
-        map(v, p, length, pageflags_writable(flags));
-        zero(pointer_from_u64(v), length);
-        update_map_flags_with_complete(v, length, flags, complete);
-    } else {
-        map_with_complete(v, p, length, flags, complete);
-        zero(pointer_from_u64(v), length);
-    }
-}
-
 void init_mmu(range init_pt, u64 vtarget);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1634,13 +1634,11 @@ static sysreturn brk(void *addr)
         if (!validate_user_memory(pointer_from_u64(old_end), alloc, true) ||
             !adjust_process_heap(p, irange(p->heap_base, new_end)))
             goto out;
-        u64 phys = allocate_u64((heap)physical, alloc);
-        if (phys == INVALID_PHYSICAL) {
+        pageflags flags = pageflags_writable(pageflags_noexec(pageflags_user(pageflags_memory())));
+        if (new_zeroed_pages(old_end, alloc, flags, 0) == INVALID_PHYSICAL) {
             adjust_process_heap(p, irange(p->heap_base, old_end));
             goto out;
         }
-        pageflags flags = pageflags_writable(pageflags_noexec(pageflags_user(pageflags_memory())));
-        map_and_zero(old_end, phys, alloc, flags, 0);
     }
     p->brk = addr;
   out:

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -773,6 +773,7 @@ boolean unix_timers_init(unix_heaps uh);
 #define sysreturn_from_pointer(__x) ((s64)u64_from_pointer(__x));
 
 extern sysreturn syscall_ignore();
+u64 new_zeroed_pages(u64 v, u64 length, pageflags flags, status_handler complete);
 boolean do_demand_page(u64 vaddr, vmap vm, context frame);
 vmap vmap_from_vaddr(process p, u64 vaddr);
 void vmap_iterator(process p, vmap_handler vmh);

--- a/src/x86_64/page_machine.h
+++ b/src/x86_64/page_machine.h
@@ -262,20 +262,6 @@ physical physical_from_virtual(void *x);
 
 typedef struct flush_entry *flush_entry;
 
-static inline void map_and_zero(u64 v, physical p, u64 length, pageflags flags, status_handler complete)
-{
-    assert((v & MASK(PAGELOG)) == 0);
-    assert((p & MASK(PAGELOG)) == 0);
-    if (pageflags_is_readonly(flags)) {
-        map(v, p, length, pageflags_writable(flags));
-        zero(pointer_from_u64(v), length);
-        update_map_flags_with_complete(v, length, flags, complete);
-    } else {
-        map_with_complete(v, p, length, flags, complete);
-        zero(pointer_from_u64(v), length);
-    }
-}
-
 void flush_tlb();
 void *bootstrap_page_tables(heap initial);
 #ifdef KERNEL


### PR DESCRIPTION
The map_and_zero function, used by both demand_anonymous_page and brk to set up new user mappings with zeroed contents, allowed for a race condition whereby a mapping could be set up on one processor (typically as a result of a page fault, not an mmap itself) and then be used by a thread running on another processor before the function had completed zeroing the memory. With webg running in an SMP configuration and a large number of concurrent connections, a range of errors could occur as a result of some memory being zeroed after having been written to. In one such failure mode within the go runtime, a queueing function that used cas would loop indefinitely as the target value, having been zeroed, would never reach the expected value.

This solution takes advantage of the new linear_backed_heap by making allocations for physical memory through it, allowing the memory to be zeroed prior to setting up the desired user mapping. It also obviates the need to first map read-only memory as writable and then update the flags to read-only, thus simplifying the operation.