### PR TITLE
virtio: vqmsg_push(): fix length value passed to buffer_extend()

### DIFF
--- a/src/virtio/virtqueue.c
+++ b/src/virtio/virtqueue.c
@@ -135,7 +135,7 @@ void deallocate_vqmsg(virtqueue vq, vqmsg m)
 
 void vqmsg_push(virtqueue vq, vqmsg m, u64 phys_addr, u32 len, boolean write)
 {
-    assert(buffer_extend(m->descv, (m->count + 1) * sizeof(struct vring_desc)));
+    assert(buffer_extend(m->descv, sizeof(struct vring_desc)));
     struct vring_desc * d = buffer_ref(m->descv, m->count * sizeof(struct vring_desc));
     d->busaddr = phys_addr;
     d->len = len;


### PR DESCRIPTION
buffer_extend() takes as length value the number of bytes that the caller wants to append to the buffer, not the number of total bytes in the buffer after appending.
This fix prevents an unnecessary buffer extension in all cases where VQMSG_DEFAULT_SIZE (currently 3) descriptors are associated to a virtqueue message, which happens at each I/O request made by virtio-block and virtio-scsi drivers.