### PR TITLE
brk(): fix deallocation of physical memory

### DIFF
--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -223,6 +223,8 @@ static inline u64 phys_from_linear_backed_virt(u64 virt)
     return virt & ~LINEAR_BACKED_BASE;
 }
 
+void unmap_and_free_phys(u64 virtual, u64 length);
+
 static inline void bhqueue_enqueue_irqsafe(thunk t)
 {
     /* an interrupted enqueue and competing enqueue from int handler could cause a


### PR DESCRIPTION
The process heap may consist of non-contiguous chunks of physical memory, thus when the heap is being shrunk the page table needs to be walked to retrieve the physical pages to be deallocated.