### PR TITLE
buffer_extend(): fix handling of consumed buffers

### DIFF
--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -107,7 +107,14 @@ static inline boolean buffer_extend(buffer b, bytes len)
     // xxx - pad to pagesize
     if (b->length < (b->end + len)) {
         bytes new_len = 2 * (b->end - b->start + len);
-        return (buffer_set_capacity(b, new_len) == new_len);
+        if (new_len > b->length) {
+            return (buffer_set_capacity(b, new_len) == new_len);
+        } else {
+            /* no need to resize, move current contents to the beginning of the allocated memory */
+            runtime_memcpy(b->contents, b->contents + b->start, b->end - b->start);
+            b->end -= b->start;
+            b->start = 0;
+        }
     }
     return true;
 }

--- a/test/unit/buffer_test.c
+++ b/test/unit/buffer_test.c
@@ -193,6 +193,14 @@ boolean concat_tests(heap h)
   // end result in a round about way, all of source-buffer has been written to test-buffer
   // validate they match
   test_assert(buffer_compare(b, seed_buffer) == true);
+
+  /* test extension of a consumed buffer */
+  buffer_consume(b, buffer_length(b));
+  size = b->length / 2;
+  test_assert(buffer_extend(b, size) == true);
+  test_assert(buffer_length(b) == 0);
+  buffer_produce(b, size);
+
   failure = false;
   fail:
     if (wb) unwrap_buffer(h, wb);


### PR DESCRIPTION
When less than `len` bytes are available after the end of the current contents, buffer_extend() calculates empirically a new capacity value based on the length of the current contents and the `len` value.
If the buffer has been at least partially consumed from, the calculated capacity value may be less than or equal to the current capacity. If it is equal, then buffer_set_capacity() does not do anything, which leaves the buffer in a state not suitable for appending `len` bytes; if it is less, then the buffer memory area is reallocated with a smaller size, which is not necessary.
This PR fixes the above issues by modifying buffer_extend() so that buffer_set_capacity() is called only if the current capacity value has to be increased, otherwise the current buffer contents are moved to the beginning of the allocated memory to make room for appending new data.
The buffer unit tests have been enhanced with a new test case that would have failed without this fix.