### PR TITLE
Add support for SO_REUSEADDR and TCP_NODELAY

### DIFF
--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -76,6 +76,7 @@ typedef unsigned long size_t;
 #define LWIP_DHCP_BOOTP_FILE 1
 #define LWIP_DNS 1
 
+#define SO_REUSE 1
 #define LWIP_IPV6   1
 #define LWIP_IPV6_DHCP6 1
 #define IPV6_FRAG_COPYHEADER    1

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1888,6 +1888,44 @@ sysreturn setsockopt(int sockfd,
             goto unimplemented;
         }
         break;
+    case SOL_SOCKET:
+        switch (optname) {
+        case SO_REUSEADDR:
+            if (optlen != sizeof(int))
+                return -EINVAL;
+            if (s->sock.type == SOCK_STREAM) {
+                if (*((int *)optval))
+                    ip_set_option(s->info.tcp.lw, SOF_REUSEADDR);
+                else
+                    ip_reset_option(s->info.tcp.lw, SOF_REUSEADDR);
+            } else if (s->sock.type == SOCK_DGRAM){
+                if (*((int *)optval))
+                    ip_set_option(s->info.udp.lw, SOF_REUSEADDR);
+                else
+                    ip_reset_option(s->info.udp.lw, SOF_REUSEADDR);
+            } else
+                return -EINVAL;
+            break;
+        default:
+            goto unimplemented;
+        }
+        break;
+    case SOL_TCP:
+        switch (optname) {
+        case TCP_NODELAY:
+            if (optlen != sizeof(int))
+                return -EINVAL;
+            if (s->sock.type != SOCK_STREAM)
+                return -EINVAL;
+            if (*((int *)optval))
+                tcp_nagle_enable(s->info.tcp.lw);
+            else
+                tcp_nagle_disable(s->info.tcp.lw);
+            break;
+        default:
+            goto unimplemented;
+        }
+        break;
     default:
         goto unimplemented;
     }

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -724,6 +724,7 @@ struct io_uring_params {
 
 /* Socket option levels */
 #define SOL_SOCKET      1
+#define SOL_TCP         6
 #define IPPROTO_IPV6    41
 
 /* set/getsockopt optnames */


### PR DESCRIPTION
This implements the setsockopt to set the option or flags for the SO_REUSEADDR
and TCP_NODELAY options on sockets by setting their appropriate flags in
the lwip pcbs and enabling reuse address support in lwipopts.