### PR TITLE
TFS: fix handling of files not linked to the filesystem

### DIFF
--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -664,14 +664,13 @@ closure_function(1, 3, void, pagecache_write_sg,
                 return;
             }
 
-            /* When writing a new page at the end of a node whose length is not block-aligned, zero
-               the remaining portion of the last block. The filesystem will depend on this to properly
+            /* When writing a new page at the end of a node whose length is not page-aligned, zero
+               the remaining portion of the page. The filesystem will depend on this to properly
                implement file holes. */
             range i = range_intersection(byte_range_from_page(pc, pp), q);
-            u64 tail_offset = i.end & MASK(pv->block_order);
-            if (tail_offset) {
-                u64 page_offset = i.end & MASK(pc->page_order);
-                u64 len = U64_FROM_BIT(pv->block_order) - tail_offset;
+            u64 page_offset = i.end & MASK(pc->page_order);
+            if (page_offset) {
+                u64 len = U64_FROM_BIT(pc->page_order) - page_offset;
                 pagecache_debug("   zero unaligned end, i %R, page offset 0x%lx, len 0x%lx\n",
                                 i, page_offset, len);
                 assert(i.end == pn->length);

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -85,9 +85,9 @@ fs_status filesystem_write_eav(filesystem fs, tuple t, symbol a, value v);
 
 typedef closure_type(fs_status_handler, void, fsfile, fs_status);
 
-void filesystem_alloc(filesystem fs, tuple t, long offset, long len,
+void filesystem_alloc(fsfile f, long offset, long len,
         boolean keep_size, fs_status_handler completion);
-void filesystem_dealloc(filesystem fs, tuple t, long offset, long len,
+void filesystem_dealloc(fsfile f, long offset, long len,
         fs_status_handler completion);
 fs_status filesystem_truncate(filesystem fs, fsfile f, u64 len);
 
@@ -100,7 +100,7 @@ fs_status filesystem_mkdirpath(filesystem fs, tuple cwd, const char *fp,
         boolean persistent);
 tuple filesystem_mkdir(filesystem fs, tuple parent, const char *name);
 tuple filesystem_creat(filesystem fs, tuple parent, const char *name);
-tuple filesystem_creat_unnamed(filesystem fs);
+fsfile filesystem_creat_unnamed(filesystem fs);
 tuple filesystem_symlink(filesystem fs, tuple parent, const char *name,
                          const char *target);
 fs_status filesystem_delete(filesystem fs, tuple parent, symbol sym);

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -327,17 +327,15 @@ sysreturn fallocate(int fd, int mode, long offset, long len)
 
     heap h = heap_general(get_kernel_heaps());
     file f = (file) desc;
-    filesystem fs = f->fs;
-    tuple t = fsfile_get_meta(f->fsf);
     switch (mode) {
     case 0:
     case FALLOC_FL_KEEP_SIZE:
-        filesystem_alloc(fs, t, offset, len,
+        filesystem_alloc(f->fsf, offset, len,
                 mode == FALLOC_FL_KEEP_SIZE,
                 closure(h, fs_op_complete, current, f));
         break;
     case FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE:
-        filesystem_dealloc(fs, t, offset, len,
+        filesystem_dealloc(f->fsf, offset, len,
                 closure(h, fs_op_complete, current, f));
         break;
     default:

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -9,7 +9,7 @@
     } else { \
         file f = resolve_fd(current->p, __dirfd); \
         tuple t = file_get_meta(f); \
-        if (!is_dir(t)) return set_syscall_error(current, ENOTDIR); \
+        if (!t || !is_dir(t)) return set_syscall_error(current, ENOTDIR); \
         __fs = f->fs; \
         cwd = t; \
     } \

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -513,7 +513,7 @@ static inline u32 anon_perms(process p)
 static inline u32 file_meta_perms(process p, tuple m)
 {
     if (proc_is_exec_protected(p)) {
-        if (get(m, sym(exec)))
+        if (m && get(m, sym(exec)))
             return (ACCESS_PERM_READ | ACCESS_PERM_EXEC);
         else
             return (ACCESS_PERM_READ | ACCESS_PERM_WRITE);

--- a/test/runtime/fallocate.c
+++ b/test/runtime/fallocate.c
@@ -15,6 +15,24 @@
     } \
 } while (0)
 
+static void test_tmpfile(void)
+{
+    int fd;
+    uint8_t buf[8192];
+
+    fd = open(".", O_RDWR | O_TMPFILE, S_IRWXU);
+    test_assert(fd > 0);
+    test_assert(fallocate(fd, 0, 0, sizeof(buf)) == 0);
+    memset(buf, 0xff, sizeof(buf));
+    test_assert(write(fd, buf, 1) == 1);
+    test_assert(lseek(fd, 0, SEEK_SET) == 0);
+    test_assert(read(fd, buf, sizeof(buf)) == sizeof(buf));
+    test_assert(buf[0] == 0xff);
+    for (int i = 1; i < sizeof(buf); i++)
+        test_assert(buf[i] == 0);
+    test_assert(close(fd) == 0);
+}
+
 int main(int argc, char **argv)
 {
     int fd;
@@ -91,6 +109,8 @@ int main(int argc, char **argv)
     test_assert(lseek(fd, 0, SEEK_END) == file_size);
 
     test_assert(close(fd) == 0);
+
+    test_tmpfile();
 
     printf("fallocate test OK\n");
     return EXIT_SUCCESS;

--- a/test/runtime/write.c
+++ b/test/runtime/write.c
@@ -408,6 +408,29 @@ void truncate_test(const char *prog)
         exit(EXIT_FAILURE);
     }
 
+    /* Test truncation of a file not linked to the filesystem. */
+    fd = open(".", O_TMPFILE | O_RDWR, S_IRUSR | S_IWUSR);
+    if (fd < 0) {
+        perror("open tmpfile");
+        exit(EXIT_FAILURE);
+    }
+    _WRITE(tmp, BUFLEN);
+    _LSEEK(0, SEEK_CUR);
+    if (rv != BUFLEN) {
+        printf("tmpfile lseek returned %ld\n", rv);
+        exit(EXIT_FAILURE);
+    }
+    if (ftruncate(fd, BUFLEN / 2) < 0) {
+        perror("tmpfile truncate failed");
+        exit(EXIT_FAILURE);
+    }
+    _LSEEK(0, SEEK_END);
+    if (rv != BUFLEN / 2) {
+        printf("tmpfile lseek after truncate returned %ld\n", rv);
+        exit(EXIT_FAILURE);
+    }
+    close(fd);
+
     return;
   out_fail:
     close(fd);

--- a/tools/tfs-fuse.c
+++ b/tools/tfs-fuse.c
@@ -590,7 +590,8 @@ static int tfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler, off_
     int rv = 0;
     pthread_rwlock_rdlock(&rwlock);
     file f = resolve_fd(fi->fh);
-    tuple c = children(file_get_meta(f));
+    tuple md = file_get_meta(f);
+    tuple c = md ? children(md) : 0;
     if (c) {
         iterate(c, stack_closure(tfs_readdir_each, buf, f, filler));
     } else {


### PR DESCRIPTION
When a file is not linked to the filesystem (e.g. as a result of an unlink or rename syscall), its metadata and extent tuples can potentially be destroyed at any time when the TFS log is compacted. Thus, they should not be accessed, even if the file may still exist due to open file descriptors.
This PR modifies the code that handles tuples associated to a file so that it accesses these tuples only if the `md` member of struct fsfile is non-zero (which indicates that the file is linked to the filesystem). filesystem_alloc() and filesystem_dealloc() now take an fsfile argument instead of a tuple, because they can be called for files without an associated metadata tuple.
filesystem_creat_unnamed() no longer creates a tuple (because files opened with O_TMPFILE are not linked to the filesystem), and returns an fsfile instead of a tuple.
filesystem_rename() is now fixed so that if a file is being deleted (because it's being overwritten by another file), its reference count is decreased instead of deallocating its extents, because the file could still be referenced by open file descriptors.
When a file is finally deallocated (i.e. when its reference count becomes zero), deallocate_fsfile() is now called instead of file_extents_dealloc() (which was leaking the extent rangemap).
deallocate_fsfile() has been modified to be able to use a generic extent destructor closure.
The fallocate and write runtime tests have been amended to exercise parts of the code that handles files not linked to the filesystem.

The first commit is not specifically related to files not linked to the filesystem, but is a fix for a bug that surfaced when writing test cases to exercise code that handles these files.