### PR TITLE
Network sockets: fix syscall handling for shut down TCP sockets

### DIFF
--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -212,6 +212,7 @@ static void netsock_test_connclosed(void)
 {
     int fd, conn_fd;
     struct sockaddr_in addr;
+    socklen_t addr_len;
     const int port = 1234;
     pthread_t pt;
     uint8_t buf[8];
@@ -260,6 +261,12 @@ static void netsock_test_connclosed(void)
     msg.msg_iovlen = 1;
     test_assert(recvmsg(conn_fd, &msg, 0) == 0);
     test_assert(pthread_join(pt, NULL) == 0);
+    test_assert((listen(conn_fd, 1) == -1) && (errno == EINVAL));
+    addr_len = sizeof(addr);
+    test_assert(getsockname(conn_fd, (struct sockaddr *)&addr, &addr_len) == 0);
+    test_assert(addr_len == sizeof(addr));
+    test_assert(getpeername(conn_fd, (struct sockaddr *)&addr, &addr_len) == -1);
+    test_assert(errno == ENOTCONN);
     test_assert(close(conn_fd) == 0);
 
     test_assert(close(fd) == 0);


### PR DESCRIPTION
When both TX and RX directions of a TCP socket are shut down, the `info.tcp.lw` netsock struct member is set to NULL, because the lwIP PCB structure can be deallocated at any time and should not be referenced anymore. If other syscalls are invoked on a shut down socket, they should deal properly with this state and avoid accessing a NULL pointer.
A few more test cases have been added to the netsock runtime tests to exercise handling of sockets after shutdown.