### PR TITLE
Bring gdb stub up-to-date for user programs

### DIFF
--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -20,6 +20,9 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/aarch64/unix_machine.c \
 	$(SRCDIR)/drivers/console.c \
 	$(SRCDIR)/drivers/netconsole.c \
+	$(SRCDIR)/gdb/gdbstub.c \
+	$(SRCDIR)/gdb/gdbtcp.c \
+	$(SRCDIR)/gdb/gdbutil.c \
 	$(SRCDIR)/kernel/elf.c \
 	$(SRCDIR)/kernel/clock.c \
 	$(SRCDIR)/kernel/init.c \

--- a/src/aarch64/gdb_machine.h
+++ b/src/aarch64/gdb_machine.h
@@ -33,3 +33,13 @@ static inline void read_registers(buffer b, thread t)
 static inline void write_registers(buffer b, thread t)
 {
 }
+
+boolean breakpoint_insert(heap h, u64 a, u8 type, u8 log_length, thunk completion)
+{
+    return false;
+}
+
+boolean breakpoint_remove(heap h, u32 a, thunk completion)
+{
+    return false;
+}

--- a/src/aarch64/gdb_machine.h
+++ b/src/aarch64/gdb_machine.h
@@ -1,0 +1,35 @@
+
+static inline int computeSignal (context frame)
+{
+    return 0;
+}
+
+static inline void clear_thread_stepping(thread t)
+{
+}
+
+static inline void set_thread_stepping(thread t)
+{
+}
+
+static inline int get_register(u64 num, void *buf, context c)
+{
+    return -1;
+}
+
+static boolean set_thread_register(thread t, int regno, u64 val)
+{
+    return false;
+}
+
+static inline void set_thread_pc(thread t, u64 addr)
+{
+}
+
+static inline void read_registers(buffer b, thread t)
+{
+}
+
+static inline void write_registers(buffer b, thread t)
+{
+}

--- a/src/aarch64/gdb_machine.h
+++ b/src/aarch64/gdb_machine.h
@@ -34,6 +34,10 @@ static inline void write_registers(buffer b, thread t)
 {
 }
 
+static inline void set_write_protect(boolean enable)
+{
+}
+
 boolean breakpoint_insert(heap h, u64 a, u8 type, u8 log_length, thunk completion)
 {
     return false;

--- a/src/gdb/gdb.h
+++ b/src/gdb/gdb.h
@@ -2,4 +2,4 @@
 
 // thunk service?
 void init_tcp_gdb(heap h, process p, u16 port);
-void gdb_install_fault_handler(thread t);
+void gdb_check_fault_handler(thread t);

--- a/src/gdb/gdb.h
+++ b/src/gdb/gdb.h
@@ -2,5 +2,4 @@
 
 // thunk service?
 void init_tcp_gdb(heap h, process p, u16 port);
-
-    
+void gdb_install_fault_handler(thread t);

--- a/src/gdb/gdb_internal.h
+++ b/src/gdb/gdb_internal.h
@@ -11,6 +11,9 @@ typedef struct gdb {
     buffer_handler output_handler;
     thread t; // we can really get several 
     process p;
+    u64 fault_handler;
+    boolean multiprocess;
+    int ctid; // thread id for vcont/continues
 } *gdb;
 
 typedef struct handler {

--- a/src/gdb/gdb_internal.h
+++ b/src/gdb/gdb_internal.h
@@ -2,6 +2,7 @@
 #include <lwip.h>
 
 typedef struct gdb {
+    struct spinlock send_lock;
     string output;
     string send_buffer;
     string out;
@@ -13,6 +14,7 @@ typedef struct gdb {
     process p;
     u64 fault_handler;
     boolean multiprocess;
+    boolean sending;
     int ctid; // thread id for vcont/continues
 } *gdb;
 
@@ -51,6 +53,7 @@ boolean parse_hex_pair(buffer in, u64 *first, u64 *second);
 boolean mem2hex (string b, void *mem, int count);
 boolean hex2mem (buffer b, void *mem, int count);
 void putpacket(gdb, string b);
+void putpacket_deferred(gdb, string b);
 boolean handle_query(gdb g, buffer b, string out, handler h);
 
 buffer_handler init_gdb(heap h,

--- a/src/gdb/gdbstub.c
+++ b/src/gdb/gdbstub.c
@@ -1,5 +1,4 @@
 #include <gdb_internal.h>
-#include <kvm_platform.h>
 #include <gdb_machine.h>
 
 // #define GDB_DEBUG

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -99,6 +99,7 @@ cpuinfo init_cpuinfo(heap backed, int cpu)
     ci->state = cpu_not_present;
     ci->have_kernel_lock = false;
     ci->thread_queue = allocate_queue(backed, MAX_THREADS);
+    ci->cpu_queue = allocate_queue(backed, 8); // XXX This is an arbitrary size
     assert(ci->thread_queue != INVALID_ADDRESS);
     ci->last_timer_update = 0;
     ci->frcount = 0;

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -26,7 +26,7 @@ typedef struct cpuinfo {
     timestamp last_timer_update;
     u64 frcount;
     u64 inval_gen; /* Generation number for invalidates */
-
+    queue cpu_queue;
 #ifdef CONFIG_FTRACE
     int graph_idx;
     struct ftrace_graph_entry * graph_stack;
@@ -134,8 +134,8 @@ void kernel_runtime_init(kernel_heaps kh);
 void read_kernel_syms(void);
 void reclaim_regions(void);
 
-boolean breakpoint_insert(u64 a, u8 type, u8 length);
-boolean breakpoint_remove(u32 a);
+boolean breakpoint_insert(heap h, u64 a, u8 type, u8 length, thunk completion);
+boolean breakpoint_remove(heap h, u32 a, thunk completion);
 
 context allocate_frame(heap h);
 void deallocate_frame(context);

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -196,6 +196,9 @@ NOTRACE void __attribute__((noreturn)) runloop_internal()
     /* Make sure TLB entries are appropriately flushed before doing any work */
     page_invalidate_flush();
 
+    /* queue for cpu specific operations */
+    while ((t = dequeue(ci->cpu_queue)) != INVALID_ADDRESS)
+        run_thunk(t);
     /* bhqueue is for operations outside the realm of the kernel lock,
        e.g. storage I/O completions */
     while ((t = dequeue(bhqueue)) != INVALID_ADDRESS)

--- a/src/runtime/text.h
+++ b/src/runtime/text.h
@@ -169,6 +169,21 @@ static inline boolean parse_int(buffer b, u32 base, u64 *result)
   return st;
 }
 
+static inline boolean parse_signed_int(buffer b, u32 base, s64 *result)
+{
+  int sign = 1;
+
+  if (*(u8 *)buffer_ref(b, 0) == '-') {
+    sign = -1;
+    pop_u8(b);
+  }
+
+  if (!parse_int(b, base, (u64 *)result) || *result < 0)
+    return false;
+  *result *= sign;
+  return true;
+}
+
 static inline const u8 *utf8_find(const u8 *x, character c)
 {
     int nbytes;

--- a/src/runtime/text.h
+++ b/src/runtime/text.h
@@ -173,7 +173,7 @@ static inline boolean parse_signed_int(buffer b, u32 base, s64 *result)
 {
   int sign = 1;
 
-  if (*(u8 *)buffer_ref(b, 0) == '-') {
+  if (buffer_length(b) > 0 && *(u8 *)buffer_ref(b, 0) == '-') {
     sign = -1;
     pop_u8(b);
   }

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -142,8 +142,8 @@ void start_process(thread t, void *start)
 {
     t->default_frame[SYSCALL_FRAME_PC] = u64_from_pointer(start);
     if (get(t->p->process_root, sym(gdb))) {
-        rputs("TODO: in-kernel gdb needs revisiting\n");
-//        init_tcp_gdb(heap_general(get_kernel_heaps()), t->p, 9090);
+        rputs("NOTE: in-kernel gdb is a work in progress\n");
+        init_tcp_gdb(heap_general(get_kernel_heaps()), t->p, 9090);
     } else {
         schedule_frame(t->default_frame);
     }

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -143,7 +143,7 @@ void start_process(thread t, void *start)
     t->default_frame[SYSCALL_FRAME_PC] = u64_from_pointer(start);
     if (get(t->p->process_root, sym(gdb))) {
         rputs("NOTE: in-kernel gdb is a work in progress\n");
-        init_tcp_gdb(heap_general(get_kernel_heaps()), t->p, 9090);
+        init_tcp_gdb(heap_locked(get_kernel_heaps()), t->p, 9090);
     } else {
         schedule_frame(t->default_frame);
     }

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -355,7 +355,8 @@ thread create_thread(process p)
 
     list_init(&t->l_faultwait);
 
-    gdb_install_fault_handler(t);
+    /* install gdb fault handler if gdb is inited */
+    gdb_check_fault_handler(t);
     // XXX sigframe
     spin_lock(&p->threads_lock);
     rbtree_insert_node(p->threads, &t->n);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -1,5 +1,6 @@
 #include <unix_internal.h>
 #include <ftrace.h>
+#include <gdb.h>
 
 thread dummy_thread;
 
@@ -185,6 +186,8 @@ define_closure_function(1, 0, void, run_thread,
                         thread, t)
 {
     thread t = bound(t);
+    if (t->p->trap)
+        runloop();
     dispatch_signals(t);
     current_cpu()->state = cpu_user;
     run_thread_frame(t);
@@ -352,6 +355,7 @@ thread create_thread(process p)
 
     list_init(&t->l_faultwait);
 
+    gdb_install_fault_handler(t);
     // XXX sigframe
     spin_lock(&p->threads_lock);
     rbtree_insert_node(p->threads, &t->n);

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -224,7 +224,7 @@ define_closure_function(1, 1, context, default_fault_handler,
 
     if (p && get(p->process_root, sym(fault))) {
         rputs("TODO: in-kernel gdb needs revisiting\n");
-//        init_tcp_gdb(heap_general(get_kernel_heaps()), p, 9090);
+//        init_tcp_gdb(heap_locked(get_kernel_heaps()), p, 9090);
 //        thread_sleep_uninterruptible();
     }
     /* XXX need a safe, polling storage driver to try to save crash dump here */

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -452,6 +452,7 @@ typedef struct process {
     id_heap           aio_ids;
     vector            aio;
     boolean           trace;
+    boolean           trap;         /* do not run threads when set */
 } *process;
 
 typedef struct sigaction *sigaction;

--- a/src/x86_64/frame.h
+++ b/src/x86_64/frame.h
@@ -17,8 +17,8 @@
 
 #define FRAME_RIP 16
 #define FRAME_FLAGS 17
-#define FRAME_SS 18
-#define FRAME_CS 19
+#define FRAME_CS 18
+#define FRAME_SS 19
 #define FRAME_DS 20
 #define FRAME_ES 21
 #define FRAME_FSBASE 22

--- a/src/x86_64/gdb_machine.h
+++ b/src/x86_64/gdb_machine.h
@@ -65,3 +65,8 @@ static inline void write_registers(buffer b, thread t)
 {
     hex2mem (b, thread_frame(t), sizeof(u64)*17);
 }
+
+static inline void set_write_protect(boolean enable)
+{
+    set_page_write_protect(enable);
+}

--- a/src/x86_64/gdb_machine.h
+++ b/src/x86_64/gdb_machine.h
@@ -1,0 +1,67 @@
+int signalmap[]={8, 5, 0, 5, 8, 10, 4, 8, 7, 10, 11, 11, 11, 11, 0, 0, 8, 10, 10, 8, 10};
+static inline int computeSignal (context frame)
+{
+    u64 exceptionVector = frame[FRAME_VECTOR];
+    if (exceptionVector > (sizeof(signalmap)/sizeof(int)))
+        return(7);
+    return(signalmap[exceptionVector]);
+}
+
+static inline void clear_thread_stepping(thread t)
+{
+    thread_frame(t)[FRAME_FLAGS] &= ~U64_FROM_BIT(FLAG_TRAP);
+    thread_frame(t)[FRAME_FLAGS] |= U64_FROM_BIT(FLAG_RESUME);
+}
+
+static inline void set_thread_stepping(thread t)
+{
+    thread_frame(t)[FRAME_FLAGS] &= ~U64_FROM_BIT(FLAG_RESUME);
+    thread_frame(t)[FRAME_FLAGS] |= U64_FROM_BIT(FLAG_TRAP);
+}
+
+/* XXX This is a hack. The numbering of the registers is based on
+ * xml files describing the registers. For reference, see
+ * https://github.com/bminor/binutils-gdb/tree/master/gdb/features/i386
+ * The register numbers can change based on which register groups
+ * gdb is using. I think the qSupported xmlRegisters option can allow
+ * the stub to define which registers are which number, which is the
+ * real solution. */
+static inline int get_register(u64 num, void *buf, context c)
+{
+    /* gp registers plus rip */
+    if (num >= 0 && num < 17) {
+        *(u64 *)buf = c[num];
+        return sizeof(u64);
+    } else if (num >= 17 && num < 24) {
+        *(u32 *)buf = (u32)c[num];
+        return sizeof(u32);
+    } else if (num == 57 || num == 58) {
+        *(u64 *)buf = c[num-35];
+        return sizeof(u64);
+    } else
+        return -1;
+}
+
+static boolean set_thread_register(thread t, int regno, u64 val)
+{
+    if (regno < 22) {
+        thread_frame(t)[regno] = val;
+        return true;
+    }
+    return false;
+}
+
+static inline void set_thread_pc(thread t, u64 addr)
+{
+    set_thread_register(t, FRAME_RIP, addr);
+}
+
+static inline void read_registers(buffer b, thread t)
+{
+    mem2hex (b, thread_frame(t), sizeof(u64)*17);
+}
+
+static inline void write_registers(buffer b, thread t)
+{
+    hex2mem (b, thread_frame(t), sizeof(u64)*17);
+}

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -60,7 +60,9 @@
 #define CR4_OSXMMEXCPT  (1 << 10)
 #define CR4_OSXSAVE     (1 << 18)
 
+#define FLAG_TRAP 8
 #define FLAG_INTERRUPT 9
+#define FLAG_RESUME 16
 
 #define TSS_SIZE 0x68
 
@@ -198,7 +200,7 @@ static inline void set_syscall_handler(void *syscall_entry)
     write_msr(LSTAR_MSR, u64_from_pointer(syscall_entry));
     u32 selectors = ((USER_CODE32_SELECTOR | 0x3) << 16) | KERNEL_CODE_SELECTOR;
     write_msr(STAR_MSR, (u64)selectors << 32);
-    write_msr(SFMASK_MSR, U64_FROM_BIT(FLAG_INTERRUPT));
+    write_msr(SFMASK_MSR, U64_FROM_BIT(FLAG_INTERRUPT) | U64_FROM_BIT(FLAG_TRAP));
     write_msr(EFER_MSR, read_msr(EFER_MSR) | EFER_SCE);
 }
 


### PR DESCRIPTION
This change updates the in-kernel gdb stub to work again with multi-threaded
user programs running on multiple cpus. It breaks out the architecture
specific parts to allow for future ARM debugging support. This adds support
for thread commands, status, and id. The gdb exception handler was updated
to pass through certain exceptions like page faults, and the handler is
now installed for all frames of all threads on the user process.

Breakpoint handling has been updated allowing hardware breakpoints
to be installed on all cpus, and using the correct code of hardware
breakpoints. This allows the use of software breakpoints which are much
less limiting for line-by-line debugging. Software breaks are not
implemented directly, but deferred to gdb so it will manually insert
trap instructions. Text pages are force updated with write permission
to allow traps to be inserted, although it's not a long term solution.

A new queue is added to the cpuinfo struct to allow thunks to be run
for that specific cpu. This is necessary for hardware breakpoints to
be modified on every cpu. This should also be temporary until thunks
can be scheduled per cpu.

There is further work to be done on the stub so this should be
considered a work-in-progress update with expected limits and gaps
in stub functionality.