### PR TITLE
Use allocate_zero for newly allocated cpuinfo struct

### DIFF
--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -85,7 +85,7 @@ vector cpuinfos;
 
 cpuinfo init_cpuinfo(heap backed, int cpu)
 {
-    cpuinfo ci = allocate(backed, sizeof(struct cpuinfo));
+    cpuinfo ci = allocate_zero(backed, sizeof(struct cpuinfo));
     if (ci == INVALID_ADDRESS)
         return ci;
     if (!vector_set(cpuinfos, cpu, ci)) {


### PR DESCRIPTION
The cpuinfo structs were located in bss before the move to heap allocated
and thus were already zeroed. The initialization code assumes this struct
is zeroed so if a heap allocation provides non-zeroed memory for the cpuinfo
then the vm would not start up and hang or crash.