### PR TITLE
Unix file descriptors: implement proper reference counting

### DIFF
--- a/klib/tun.c
+++ b/klib/tun.c
@@ -246,7 +246,7 @@ closure_function(1, 6, sysreturn, tun_write,
     tun->netif.input(p, &tun->netif);
     if (!(tun->flags & IFF_NO_PI))
         len += sizeof(struct tun_pi);
-    return len;
+    return io_complete(completion, t, len);
 }
 
 closure_function(1, 1, u32, tun_events,

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -8,9 +8,10 @@
         cwd = current->p->cwd; \
     } else { \
         file f = resolve_fd(current->p, __dirfd); \
+        __fs = f->fs;               \
         tuple t = file_get_meta(f); \
+        fdesc_put(&f->f);           \
         if (!t || !is_dir(t)) return set_syscall_error(current, ENOTDIR); \
-        __fs = f->fs; \
         cwd = t; \
     } \
     cwd; \

--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -567,21 +567,27 @@ closure_function(1, 2, sysreturn, nl_close,
 static sysreturn nl_bind(struct sock *sock, struct sockaddr *addr, socklen_t addrlen)
 {
     nlsock s = (nlsock)sock;
+    sysreturn rv;
     struct sockaddr_nl *nl_addr = (struct sockaddr_nl *)addr;
-    if ((addrlen != sizeof(*nl_addr)) || (nl_addr->nl_family != AF_NETLINK))
-        return -EINVAL;
+    if ((addrlen != sizeof(*nl_addr)) || (nl_addr->nl_family != AF_NETLINK)) {
+        rv = -EINVAL;
+        goto out;
+    }
     nl_debug("bind to pid %d, multicast 0x%x", nl_addr->nl_pid, nl_addr->nl_groups);
     if (s->addr.nl_pid != 0) {  /* already bound */
         if (nl_addr->nl_pid == s->addr.nl_pid)
-            return 0;
+            rv = 0;
         else
-            return -EINVAL;
+            rv = -EINVAL;
+        goto out;
     }
     runtime_memcpy(&s->addr, nl_addr, addrlen);
     if (nl_addr->nl_pid == 0) {
         u64 pid = allocate_u64((heap)netlink.pids, 1);
-        if (pid == INVALID_PHYSICAL)
-            return -ENOMEM;
+        if (pid == INVALID_PHYSICAL) {
+            rv = -ENOMEM;
+            goto out;
+        }
         nl_debug(" allocated pid %d", pid);
         s->addr.nl_pid = pid;
     } else {
@@ -589,10 +595,14 @@ static sysreturn nl_bind(struct sock *sock, struct sockaddr *addr, socklen_t add
         if (pid != nl_addr->nl_pid) {
             deallocate_u64((heap)netlink.pids, pid, 1);
             s->addr.nl_pid = 0;
-            return -EADDRINUSE;
+            rv = -EADDRINUSE;
+            goto out;
         }
     }
-    return 0;
+    rv = 0;
+  out:
+    socket_release(sock);
+    return rv;
 }
 
 static sysreturn nl_getsockname(struct sock *sock, struct sockaddr *addr, socklen_t *addrlen)
@@ -600,6 +610,7 @@ static sysreturn nl_getsockname(struct sock *sock, struct sockaddr *addr, sockle
     nlsock s = (nlsock)sock;
     runtime_memcpy(addr, &s->addr, MIN(sizeof(s->addr), *addrlen));
     *addrlen = sizeof(s->addr);
+    socket_release(sock);
     return 0;
 }
 
@@ -608,9 +619,11 @@ static sysreturn nl_sendto(struct sock *sock, void *buf, u64 len, int flags,
 {
     nl_debug("sendto: len %ld, flags 0x%x", len, flags);
     sysreturn rv = nl_check_dest(dest_addr, addrlen);
-    if (rv)
+    if (rv) {
+        socket_release(sock);
         return rv;
-    return apply(sock->f.write, buf, len, 0, current, false, syscall_io_complete);
+    }
+    return apply(sock->f.write, buf, len, 0, current, false, (io_completion)&sock->f.io_complete);
 }
 
 static sysreturn nl_recvfrom(struct sock *sock, void *buf, u64 len, int flags,
@@ -619,9 +632,11 @@ static sysreturn nl_recvfrom(struct sock *sock, void *buf, u64 len, int flags,
     nl_debug("recvfrom: len %ld, flags 0x%x", len, flags);
     nlsock s = (nlsock)sock;
     blockq_action ba = closure(s->sock.h, nl_read_bh, s, current, buf, len, 0, flags,
-        syscall_io_complete);
-    if (ba == INVALID_ADDRESS)
+        (io_completion)&sock->f.io_complete);
+    if (ba == INVALID_ADDRESS) {
+        socket_release(sock);
         return -ENOMEM;
+    }
     if (addrlen) {
         if (src_addr && (*addrlen >= sizeof(struct sockaddr_nl))) {
             struct sockaddr_nl *addr = (struct sockaddr_nl *)src_addr;
@@ -641,7 +656,7 @@ static sysreturn nl_sendmsg(struct sock *sock, const struct msghdr *msg, int fla
     nlsock s = (nlsock)sock;
     sysreturn rv = nl_check_dest(msg->msg_name, msg->msg_namelen);
     if (rv)
-        return rv;
+        goto out;
     u64 written = 0;
     for (u64 i = 0; i < msg->msg_iovlen; i++) {
         rv = nl_write_internal(s, msg->msg_iov[i].iov_base, msg->msg_iov[i].iov_len);
@@ -650,7 +665,10 @@ static sysreturn nl_sendmsg(struct sock *sock, const struct msghdr *msg, int fla
         else
             break;
     }
-    return (written > 0) ? written : rv;
+    rv = (written > 0) ? written : rv;
+  out:
+    socket_release(sock);
+    return rv;
 }
 
 static sysreturn nl_recvmsg(struct sock *sock, struct msghdr *msg, int flags)
@@ -658,9 +676,11 @@ static sysreturn nl_recvmsg(struct sock *sock, struct msghdr *msg, int flags)
     nl_debug("recvmsg: iovlen %ld, flags 0x%x", msg->msg_iovlen, flags);
     nlsock s = (nlsock)sock;
     blockq_action ba = closure(s->sock.h, nl_read_bh, s, current, 0, 0, msg, flags,
-        syscall_io_complete);
-    if (ba == INVALID_ADDRESS)
+        (io_completion)&sock->f.io_complete);
+    if (ba == INVALID_ADDRESS) {
+        socket_release(sock);
         return -ENOMEM;
+    }
     if (msg->msg_name && (msg->msg_namelen >= sizeof(struct sockaddr_nl))) {
         struct sockaddr_nl *addr = msg->msg_name;
         addr->nl_family = AF_NETLINK;

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -81,10 +81,7 @@ static void pipe_file_release(pipe_file pf)
     release_fdesc(&(pf->f));
 
     if (pf->fd > 0) {
-        /* sys_close could have deallocated fds already */
-        if (resolve_fd_noret(pf->pipe->proc, pf->fd))
-            deallocate_fd(pf->pipe->proc, pf->fd);
-
+        deallocate_fd(pf->pipe->proc, pf->fd);
         pf->fd = -1;
     }
 
@@ -111,6 +108,7 @@ static void pipe_release(pipe p)
 static inline void pipe_dealloc_end(pipe p, pipe_file pf)
 {
     if (pf->fd != -1) {
+        pf->fd = -1;    /* fd has already been deallocated by the close() syscall */
         if (&p->files[PIPE_READ] == pf) {
             pipe_notify_writer(pf, EPOLLHUP);
             pipe_debug("%s(%p): writer notified\n", __func__, p);

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -1010,13 +1010,16 @@ sysreturn signalfd4(int fd, const u64 *mask, u64 sigsetsize, int flags)
         return allocate_signalfd(mask, flags);
 
     signal_fd sfd = resolve_fd(current->p, fd); /* macro, may return EBADF */
-    if (fdesc_type(&sfd->f) != FDESC_TYPE_SIGNALFD)
+    if (fdesc_type(&sfd->f) != FDESC_TYPE_SIGNALFD) {
+        fdesc_put(&sfd->f);
         return -EINVAL;
+    }
 
     /* update mask */
     sfd->mask = *mask;
     notify_entry_update_eventmask(sfd->n, sfd->mask);
     signalfd_update_siginterest(current);
+    fdesc_put(&sfd->f);
     return fd;
 }
 

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -76,6 +76,8 @@ struct sock {
     sysreturn (*shutdown)(struct sock *sock, int how);
 };
 
+#define socket_release(s) fdesc_put(&(s)->f)
+
 static inline int socket_init(process p, heap h, int domain, int type, u32 flags,
         struct sock *s)
 {

--- a/test/runtime/epoll.c
+++ b/test/runtime/epoll.c
@@ -1,3 +1,4 @@
+#include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
@@ -25,6 +26,14 @@ void test_ctl()
         printf("Cannot create epoll\n");
         goto fail;
     }
+
+    event.events = 0;
+    test_assert((epoll_ctl(efd, EPOLL_CTL_ADD, -1, &event) == -1) && (errno == EBADF));
+
+    int dirfd = open(".", O_RDONLY);
+    test_assert(dirfd >= 0);
+    test_assert((epoll_ctl(efd, EPOLL_CTL_ADD, dirfd, &event) == -1) && (errno == EPERM));
+    close(dirfd);
 
     int fd = socket(AF_INET, SOCK_STREAM, 0);
     event.data.fd = fd;

--- a/test/runtime/mkdir.c
+++ b/test/runtime/mkdir.c
@@ -366,5 +366,14 @@ int main(int argc, char **argv)
     _fchdir(fd);
     close(fd);
     listdir("test", ".");
+
+    fd = OPEN("subdir/test_newfile", O_RDONLY, 0);
+    _fchdir(fd);
+    if (errno != ENOTDIR) {
+        printf("fchdir(): expecting errno %d, found %d (%s)\n", ENOTDIR, errno, strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+    close(fd);
+
     exit(EXIT_SUCCESS);
 }

--- a/test/runtime/sendfile.c
+++ b/test/runtime/sendfile.c
@@ -79,6 +79,11 @@ int main(int argc, char *argv[])
     if (fd_out == -1) 
         sf_err_goto(err_fdout, "error %d opeing sendfile_test_out\n", errno);
 
+    ret = sendfile(-1, fd_in, NULL, BUF_LEN);
+    if ((ret != -1) || (errno != EBADF))
+        sf_err_goto(err_fop, "sendfile returned %d (errno %d) with invalid output fd\n",
+            ret, errno);
+
     sf_dbg("IN fd %d OUT fd %d\n", fd_in, fd_out);
     memset(buf, 0, sizeof(buf));
     lseek(fd_out, 0, SEEK_SET);

--- a/test/runtime/signal.c
+++ b/test/runtime/signal.c
@@ -943,6 +943,18 @@ static void * test_signalfd_child(void *arg)
     if (nfds != 0)
         fail_error("epoll_wait test with no signal events failed (rv = %d)\n", nfds);
 
+    rv = close(fd2);
+    if (rv < 0)
+        fail_perror("close fd2");
+    rv = close(fd);
+    if (rv < 0)
+        fail_perror("close fd");
+
+    rv = signalfd(0, &ss, 0);
+    if ((rv != -1) || (errno != EINVAL))
+        fail_error("signalfd() with invalid fd returned %d, errno %d (%s)\n", rv, errno,
+            strerror(errno));
+
     sigtest_debug("success; child exiting\n");
     return (void *)EXIT_SUCCESS;
 }

--- a/test/runtime/unixsocket.c
+++ b/test/runtime/unixsocket.c
@@ -130,8 +130,16 @@ static void uds_stream_test(void)
     test_assert(pthread_create(&pt, NULL, uds_stream_server, (void *)(long) s1)
             == 0);
 
+    test_assert(sendto(s2, writeBuf, sizeof(writeBuf), 0, (struct sockaddr *)&addr,
+        addr_len) == -1);
+    test_assert(errno == EOPNOTSUPP);
+
     test_assert(connect(s2, (struct sockaddr *) &addr, addr_len) == 0);
     test_assert(connect(s2, (struct sockaddr *) &addr, addr_len) == -1);
+    test_assert(errno == EISCONN);
+
+    test_assert(sendto(s2, writeBuf, sizeof(writeBuf), 0, (struct sockaddr *)&addr,
+        addr_len) == -1);
     test_assert(errno == EISCONN);
 
     for (int i = 0; i < LARGEBUF_SIZE; i++) {
@@ -212,6 +220,8 @@ static void uds_dgram_test(void)
     strcpy(server_addr.sun_path, SERVER_SOCKET_PATH);
     test_assert(bind(s1, (struct sockaddr *) &server_addr, addr_len) == 0);
     test_assert(listen(s1, 1) == -1 && errno == EOPNOTSUPP);
+    test_assert(accept(s1, (struct sockaddr *) &server_addr, &addr_len) == -1);
+    test_assert(errno == EOPNOTSUPP);
 
     s2 = socket(AF_UNIX, SOCK_DGRAM, 0);
     test_assert(s2 >= 0);

--- a/test/runtime/write.c
+++ b/test/runtime/write.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #define _GNU_SOURCE
 #define __USE_GNU
 #include <fcntl.h>
@@ -12,6 +11,7 @@
 #include <sys/time.h>
 #include <sys/eventfd.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 //#define WRITETEST_DEBUG
 #ifdef WRITETEST_DEBUG
@@ -137,7 +137,18 @@ void basic_write_test()
         goto out_fail;
     }
 
+    rv = syncfs(fd);
+    if (rv < 0) {
+        perror("syncfs");
+        goto out_fail;
+    }
     close(fd);
+    rv = syncfs(fd);
+    if ((rv != -1) || (errno != EBADF)) {
+        printf("syncfs(): expected rv -1 (errno %d), found rv %ld (errno %d)\n", EBADF, rv, errno);
+        goto out_fail;
+    }
+
     writetest_debug("basic write test passed\n");
     return;
   out_fail:


### PR DESCRIPTION
Whenever an fdesc structure is retrieved from the list of open file descriptors, its reference count needs to be bumped until the structure is no longer used. This is to avoid accessing invalid memory if a file descriptor is closed while the underlying fdesc structure is still used (e.g. in the middle of a read or write).
This PR changes all file descriptor accesses to use fdesc_get() and fdesc_put(), which update the fdesc reference count appropriately. For all socket callbacks (e.g. sendto, recvfrom, etc.), the onus of calling fdesc_put() is on each implementation of a callback (because it may block and thus not return to the caller).
A couple of error return codes from syscalls have been fixed in the process, in order to match Linux kernel behavior. Some test cases have been added to the runtime tests to exercise parts of the code that has been changed.
Even though updating the fdesc reference count is currently necessary only for syscalls that block, it is being done also in syscalls that don't block, because this will become necessary when the global kernel lock is removed.
The first commit is a fix to the tun klib that was failing to properly decrement the fdesc reference count after a write.
The second commit is an optimization of the poll.c source to remove calls to the resolve_fd_noret() macro, which is being removed.
The third commit implements file descriptor reference counting.