### PR TITLE
free_thread(): fix memory leak

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -282,6 +282,7 @@ define_closure_function(1, 0, void, free_thread,
                         thread, t)
 {
     deallocate_bitmap(bound(t)->affinity);
+    deallocate_notify_set(bound(t)->signalfds);
     deallocate(heap_general(get_kernel_heaps()), bound(t), sizeof(struct thread));
 }
 


### PR DESCRIPTION
This function was failing to deallocate the signalfds notify set.