### PR TITLE
futex(FUTEX_CMP_REQUEUE): fix return value

### DIFF
--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -197,7 +197,7 @@ sysreturn futex(int *uaddr, int futex_op, int val,
             struct futex * new = soft_create_futex(current->p, u64_from_pointer(uaddr2));
             if (new == INVALID_ADDRESS)
                 return set_syscall_error(current, ENOMEM);
-            int requeued = blockq_transfer_waiters(new->bq, f->bq, val2);
+            requeued = blockq_transfer_waiters(new->bq, f->bq, val2);
             if (futex_verbose)
                 thread_log(current, " awoken: %d, re-queued %d", woken, requeued);
         }

--- a/test/runtime/futex.c
+++ b/test/runtime/futex.c
@@ -215,7 +215,11 @@ static boolean futex_cmp_requeue_test_2()
 
     /* Wake up val threads that are waiting on uaddr and requeue the
     remaining threads to wait on uaddr2 */
-    syscall(SYS_futex, uaddr, FUTEX_CMP_REQUEUE, val, val2, uaddr2, val3);
+    int changed = syscall(SYS_futex, uaddr, FUTEX_CMP_REQUEUE, val, val2, uaddr2, val3);
+    if (changed != num_threads) {
+        printf("Incorrect number of woken up or requeued threads. cmp_requeue test 2: failed.\n");
+        return false;
+    }
 
     /* Wake up remaining threads waiting on uaddr2 
     that haven't been woken up by FUTEX_CMP_REQUEUE */


### PR DESCRIPTION
The existing code is storing the number of requeued threads in a local variable that is out of scope when the syscall return value is calculated.
The futex runtime tests have been amended to check for the return value from futex(FUTEX_CMP_REQUEUE).