### PR TITLE
Revise blockq with locking and other fixes

### DIFF
--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -2,64 +2,37 @@
 
 /* blockq - a facility for queueing up threads waiting for a resource
 
-   Given an action closure, blockq_check() will attempt the action
-   while holding the blockq's lock. If it succeeds (rv >= 0), it will
-   release the lock and return the result of the action to the
-   caller. If rv is negative, an error condition is presumed, the lock
-   is released and rv is returned at once. If rv ==
-   BLOCKQ_BLOCK_REQUIRED, the action gets added to the blockq's
-   waiters queue, an optional timeout is set, the lock is released and
+   Given an action closure, blockq_check() will attempt the action at once. If
+   it either succeeds (rv >= 0) or fails (rv < 0), it will return the result
+   of the action to the caller. If rv == BLOCKQ_BLOCK_REQUIRED, the action
+   gets added to the blockq's waiters queue, an optional timeout is set, and
    the thread is finally blocked.
 
-   blockq_wake_one(), meant to be safe for calling from interrupt context,
-   takes the blockq lock (really a no-op until SMP support) and
-   attempts to apply the action at the head of the waiters queue. If
-   it returns BLOCKQ_BLOCK_REQUIRED, it is left at the head of the
-   queue, the lock is released and waiting resumes, otherwise it
-   causes the action to be removed from the queue, and the lock
-   released. In either case, the call returns to the caller. It is up
-   to the action to apply results to the thread frame and call
-   thread_wakeup() as necessary.
+   blockq_wake_one() attempts to apply the action at the head of the waiters
+   queue. If it returns BLOCKQ_BLOCK_REQUIRED, the waiter is moved to the
+   bottom of the waiters queue and waiting resumes. The waiter is otherwise
+   removed from the queue. It is up to the action to apply results to the
+   thread frame and call thread_wakeup() as necessary.
 
-   The action must adhere to the following:
+   Action invocation only indicates that a wakeup, timeout or nullification
+   occurred for the given blockq. It is up to the action to check status and
+   resource availability as necessary.
 
-   - It must be safe for calling from the syscall handler or interrupt
-     level (including timer expiry).
+   - BLOCKQ_ACTION_BLOCKED will indicate whether the action is being invoked
+     within the syscall handler or after blocking. In the latter case, should
+     the blocked thread resume execution, it is up to the action to call
+     set_syscall_{return,error}() and thread_wakeup().
 
-   - It must be brief, as it will either be called with interrupts
-     disabled or from the interrupt handler itself (though not an
-     issue in the short term with the bifurcated runloop).
+   - BLOCKQ_ACTION_NULLIFY signals that any blocking should be immediately
+     canceled, that the appropriate return code is set for an interrupted
+     blocking operation and that the associated thread is woken (if not
+     terminated). The thread may not continue blocking after this flag has
+     been applied.
 
-   - Action invocation does not presume any particlar condition or
-     state change; a wake up does not guarantee availability of a
-     resource nor indicate the source, e.g. I/O event vs timeout
-     expiry. As such, it's up to the action to check status and
-     resource availability as necessary.
-
-   - A blocked flag will indicate whether the action is being invoked
-     within the syscall handler or after blocking. In the latter case,
-     should the blocked thread resume execution, it is up to the
-     action to call set_syscall_{return,error}() and thread_wakeup().
-
-   - Obviously, it must never call blockq_check() or blockq_wake()
-     itself, for it is called while holding the blockq lock.
-
-   In the existing cases right now, the action return value semantics
-   mirror those of the syscall itself. Of course, the blocking code
-   may interpret this return value as necessary, provided that a value
-   >= 0 represents success (no further blocking required), ==
-   BLOCKQ_BLOCK_REQUIRED indicates blocking required, and < 0 an error
-   condition (and return).
-
-   Note also that this presently serializes requests and handles them
-   in that order alone. The action at the head of the queue must
-   eventually return a non-zero value before any further actions in
-   the queue can be handled (except for blockq_flush, used for
-   exceptions on the resource - e.g. a closed connection). Should it
-   ever become necessary to allow another waiter in the queue to
-   handle the request, we can consider making that an option and
-   moving from the queue to a CAS list for fast removal (similar to
-   the poll notify list). TBD
+   - BLOCKQ_ACTION_TIMEDOUT indicates that a timeout occurred for the
+     respective blocking operation. As with the nullify flag, the thread
+     cannot continue blocking for the associated check, and must either be
+     woken or terminated.
  */
 
 //#define BLOCKQ_DEBUG
@@ -69,151 +42,116 @@
 #define blockq_debug(x, ...)
 #endif
 
-/* queue of threads waiting for a resource */
-#define BLOCKQ_NAME_MAX 20
-struct blockq {
-    heap h;
-    char name[BLOCKQ_NAME_MAX]; /* for debug */
-    /* XXX: TBD spinlock lock; */
-    struct list waiters_head;   /* of threads and associated timers+actions */
-    io_completion completion;
-    thread completion_thread;
-    sysreturn completion_rv;
-};
-
-declare_closure_struct(2, 1, void, blockq_item_timeout,
-    blockq, bq, struct blockq_item *, bi,
-    u64, overruns);
-
-typedef struct blockq_item {
-    thread t;           /* waiting thread */
-    timer timeout;      /* timer for this item (could be zero) */
-    closure_struct(blockq_item_timeout, timeout_func);
-    blockq_action a;    /* action to test for resource avail. */
-    struct list l;      /* embedding on blockq->waiters_head */
-} *blockq_item;
-
-static inline void free_blockq_item(blockq bq, blockq_item bi)
-{
-    list_delete(&bi->l);
-    deallocate(bq->h, bi, sizeof(struct blockq_item));
-}
-
-static void blockq_item_finish(blockq bq, blockq_item bi)
-{
-    blockq_debug("bq %p (\"%s\") bi %p (tid:%ld) completed\n",
-        bq, blockq_name(bq), bi, bi->t->tid);
-
-    if (bi->timeout)
-        remove_timer(bi->timeout, 0);
-
-    if (bq->completion) {
-        io_completion completion = bq->completion;
-        bq->completion = 0;
-        /* XXX release spinlock */
-        apply(completion, bq->completion_thread, bq->completion_rv);
-        /* XXX acquire spinlock */
-    }
-
-    thread_release(bi->t);
-    free_blockq_item(bq, bi);
-}
-
-/*
- * Apply blockq_item action with lock held
- */
-static void blockq_apply_bi_locked(blockq bq, blockq_item bi, u64 flags)
+/* This applies a blockq action after it has been removed from the
+   waiters list. If the action indicates that waiting should continue,
+   it re-adds the thread to the waiter list and returns false. If the
+   action was terminal, it releases the thread and returns true. */
+static boolean blockq_apply(blockq bq, thread t, u64 bq_flags)
 {
     sysreturn rv;
-
-    blockq_debug("bq %p (\"%s\") bi %p (tid:%ld) %s %s %s\n",
-                 bq, blockq_name(bq), bi, bi->t->tid,
-                 (flags & BLOCKQ_ACTION_BLOCKED) ? "blocked " : "",
-                 (flags & BLOCKQ_ACTION_NULLIFY) ? "nullify " : "",
-                 (flags & BLOCKQ_ACTION_TIMEDOUT) ? "timedout" : "");
+    boolean terminal = false;
+    blockq_debug("bq %p (\"%s\") tid:%ld %s %s %s\n",
+                 bq, blockq_name(bq), t->tid,
+                 (bq_flags & BLOCKQ_ACTION_BLOCKED) ? "blocked " : "",
+                 (bq_flags & BLOCKQ_ACTION_NULLIFY) ? "nullify " : "",
+                 (bq_flags & BLOCKQ_ACTION_TIMEDOUT) ? "timedout" : "");
 
     thread ot = current;
-    thread_resume(bi->t);
-    rv = apply(bi->a, flags);
+    thread_resume(t);
+    rv = apply(t->bq_action, bq_flags);
     blockq_debug("   - returned %ld\n", rv);
 
     /* If the blockq_action returns BLOCKQ_BLOCK_REQUIRED and neither
-       nullify or timeout are set in flags, continue blocking. */
-    if ((flags & (BLOCKQ_ACTION_NULLIFY | BLOCKQ_ACTION_TIMEDOUT)) ||
-        (rv != BLOCKQ_BLOCK_REQUIRED))
-        blockq_item_finish(bq, bi);
+       nullify or timeout are set in bq_flags, continue blocking. */
+    if ((bq_flags & (BLOCKQ_ACTION_NULLIFY | BLOCKQ_ACTION_TIMEDOUT)) ||
+        (rv != BLOCKQ_BLOCK_REQUIRED)) {
+        blockq_debug("   completed\n");
+        u64 saved_flags = spin_lock_irq(&bq->lock);
+        if (t->bq_timeout) {
+            remove_timer(t->bq_timeout, 0);
+            t->bq_timeout = 0;
+        }
+        spin_unlock_irq(&bq->lock, saved_flags);
+
+        io_completion completion = t->bq_completion;
+        if (completion) {
+            t->bq_completion = 0;
+            apply(completion, t, t->bq_completion_rv);
+        }
+        thread_release(t);
+        terminal = true;
+    } else {
+        u64 saved_flags = spin_lock_irq(&bq->lock);
+        list_insert_before(&bq->waiters_head, &t->bq_l);
+        spin_unlock_irq(&bq->lock, saved_flags);
+    }
     if (ot)
         thread_resume(ot);
+    return terminal;
 }
 
-/*
- * A blockq_item timed out.
- *
- * Invoke its action and remove it from the list of waiters,
- * if applicable
- */
-define_closure_function(2, 1, void, blockq_item_timeout,
-                 blockq, bq, blockq_item, bi,
-                 u64, overruns /* ignored */)
+/* A blockq_thread timed out. */
+define_closure_function(2, 1, void, blockq_thread_timeout,
+                        blockq, bq, thread, t,
+                        u64, overruns /* ignored */)
 {
     blockq bq = bound(bq);
-    blockq_item bi = bound(bi);
+    thread t = bound(t);
+    blockq_debug("bq %p (\"%s\") tid %d\n", bq, blockq_name(bq), t->tid);
 
-    blockq_debug("bq %p (\"%s\") bi %p (tid:%ld)\n",
-        bq, blockq_name(bq), bi, bi->t->tid);
-
-    bi->timeout = 0;
-
-    /* XXX take irqsafe spinlock */
-    blockq_apply_bi_locked(bq, bi, BLOCKQ_ACTION_BLOCKED | BLOCKQ_ACTION_TIMEDOUT);
-    /* XXX release lock */
+    /* Take the bq lock here to insure an atomic rmw of t->bq_timeout. */
+    u64 saved_flags = spin_lock_irq(&bq->lock);
+    if (t->bq_timeout) {
+        t->bq_timeout = 0;
+        assert(t->bq_l.next && t->bq_l.prev);
+        list_delete(&t->bq_l);
+        spin_unlock_irq(&bq->lock, saved_flags);
+        blockq_apply(bq, t, BLOCKQ_ACTION_BLOCKED | BLOCKQ_ACTION_TIMEDOUT);
+    } else {
+        spin_unlock_irq(&bq->lock, saved_flags);
+    }
 }
 
-/*
- * Wake a single waiter.
- *
- * Returns thread whose bi action was applied
- * Note that there is no guarantee that the thread is actually awake
- * or the bi completed -- this just means its action was applied
- */
+/* Wake a single waiter, returning the thread whose action was applied
+
+   Note that there is no guarantee that a thread was actually awoken; this
+   just means an action was applied. */
 thread blockq_wake_one(blockq bq)
 {
-    blockq_item bi;
-    list l;
-    thread t;
-
     blockq_debug("%p (\"%s\") \n", bq, blockq_name(bq));
 
-    /* XXX take irqsafe spinlock */
-
-    l = list_get_next(&bq->waiters_head);
-    if (!l)
-        return INVALID_ADDRESS;
-
-    bi = struct_from_list(l, blockq_item, l);
-    t = bi->t;
-    blockq_apply_bi_locked(bq, bi, BLOCKQ_ACTION_BLOCKED);
-
-    /* XXX release lock */
-
-    return t;
+    u64 saved_flags = spin_lock_irq(&bq->lock);
+    list l = list_get_next(&bq->waiters_head);
+    if (l) {
+        thread t = struct_from_list(l, thread, bq_l);
+        list_delete(l);
+        spin_unlock_irq(&bq->lock, saved_flags);
+        return blockq_apply(bq, t, BLOCKQ_ACTION_BLOCKED) ? t : INVALID_ADDRESS;
+    }
+    spin_unlock_irq(&bq->lock, saved_flags);
+    return INVALID_ADDRESS;
 }
 KLIB_EXPORT(blockq_wake_one);
 
+
+static inline boolean blockq_wake_thread_internal(blockq bq, thread t, u64 bq_flags)
+{
+    blockq_debug("%p (\"%s\"), tid %d\n", bq, blockq_name(bq), t->tid);
+    assert(t->bq_l.next && t->bq_l.prev);
+    u64 saved_flags = spin_lock_irq(&bq->lock);
+    list_delete(&t->bq_l);
+    spin_unlock_irq(&bq->lock, saved_flags);
+    return blockq_apply(bq, t, bq_flags);
+}
+
 boolean blockq_wake_one_for_thread(blockq bq, thread t)
 {
-    blockq_debug("%p (\"%s\") \n", bq, blockq_name(bq));
+    return blockq_wake_thread_internal(bq, t, BLOCKQ_ACTION_BLOCKED);
+}
 
-    /* XXX take irqsafe spinlock */
-    list_foreach(&bq->waiters_head, l) {
-        blockq_item bi = struct_from_list(l, blockq_item, l);
-        if (bi->t != t)
-            continue;
-        blockq_apply_bi_locked(bq, bi, BLOCKQ_ACTION_BLOCKED);
-        return true;
-    }
-    /* XXX release lock */
-    return false;
+boolean blockq_flush_thread(blockq bq, thread t)
+{
+    return blockq_wake_thread_internal(bq, t, BLOCKQ_ACTION_BLOCKED | BLOCKQ_ACTION_NULLIFY);
 }
 
 sysreturn kern_blockq_check(blockq bq, thread t, blockq_action a, boolean in_bh)
@@ -232,54 +170,35 @@ sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_
     blockq_debug("%p \"%s\", tid %ld, action %p, timeout %ld, clock_id %d\n",
                  bq, blockq_name(bq), t->tid, a, timeout, clkid);
 
-    /* XXX irqsafe mutex/spinlock
-
-       We're actually not irq safe here at the moment, and any blockq
-       actions "should" only happen in the bhqueue.
-
-       Before we switch on another CPU thread, insert IRQ-safe
-       spinlock.
-    */
     sysreturn rv = apply(a, 0);
     if (rv != BLOCKQ_BLOCK_REQUIRED) {
-        /* XXX release spinlock */
         blockq_debug(" - direct return: %ld\n", rv);
         return rv;
     }
 
-    // XXX make cache
-    blockq_item bi = allocate(bq->h, sizeof(struct blockq_item));
-    if (bi == INVALID_ADDRESS) {
-        msg_err("unable to allocate blockq_item\n");
-        return -EAGAIN;
-    }
-
-    bi->a = a;
-    bi->t = t;
+    t->bq_action = a;
     thread_reserve(t);
 
     if (timeout > 0) {
-        bi->timeout = register_timer(runloop_timers, clkid, timeout, absolute, 0,
-            init_closure(&bi->timeout_func, blockq_item_timeout, bq, bi));
-        if (bi->timeout == INVALID_ADDRESS) {
+        assert(!t->bq_timeout);
+        t->bq_timeout = register_timer(runloop_timers, clkid, timeout, absolute, 0,
+                                       init_closure(&t->bq_timeout_func, blockq_thread_timeout, bq, t));
+        if (t->bq_timeout == INVALID_ADDRESS) {
             msg_err("failed to allocate blockq timer\n");
-            deallocate(bq->h, bi, sizeof(struct blockq_item));
             return -EAGAIN;
         }
     } else {
-        bi->timeout = 0;
+        t->bq_timeout = 0;
     }
 
-    blockq_debug("queuing bi %p, a %p, tid %d\n", bi, bi->a, bi->t->tid);
-    list_insert_before(&bq->waiters_head, &bi->l);
+    blockq_debug("queuing action %p, tid %d\n", t->bq_action, t->tid);
+    u64 saved_flags = spin_lock_irq(&bq->lock);
+    list_insert_before(&bq->waiters_head, &t->bq_l);
+    spin_unlock_irq(&bq->lock, saved_flags);
     if (!in_bh)
         t->blocked_on = bq;
 
-    /* XXX release spinlock */
-
-    /* if we're either in bh or a non-current thread is invoking this,
-     * return now
-     */
+    /* if we're either in bh or a non-current thread is invoking this, return now */
     if (in_bh || (current != t))
         return BLOCKQ_BLOCK_REQUIRED;
 
@@ -294,80 +213,81 @@ void kern_blockq_handle_completion(blockq bq, u64 bq_flags, io_completion comple
 }
 KLIB_EXPORT_RENAME(kern_blockq_handle_completion, blockq_handle_completion);
 
-/* XXX This deserves another pass; blockq_item should really just be embedded into thread. */
-boolean blockq_flush_thread(blockq bq, thread t)
-{
-    boolean unblocked = false;
-    blockq_debug("bq %p, name %p\n", bq, blockq_name(bq));
-
-    /* XXX take irqsafe spinlock */
-
-    list_foreach(&bq->waiters_head, l) {
-        blockq_item bi = struct_from_list(l, blockq_item, l);
-        if (bi->t != t)
-            continue;
-
-        blockq_apply_bi_locked(bq, bi, BLOCKQ_ACTION_BLOCKED | BLOCKQ_ACTION_NULLIFY);
-        unblocked = true;
-    }
-
-    /* XXX release lock */
-    return unblocked;
-}
-
 /* Wake all waiters and empty queue, typically for error conditions,
    closed pipe/connections, etc. Actions are called with nullify set,
    indicating the last time that the action will be used by the
    blockq, regardless of what the action returns.
 */
-
 void blockq_flush(blockq bq)
 {
     blockq_debug("bq %p - \"%s\"\n", bq, blockq_name(bq));
-
-    /* XXX take irqsafe spinlock */
-    list_foreach(&bq->waiters_head, l) {
-        blockq_item bi = struct_from_list(l, blockq_item, l);
-        blockq_apply_bi_locked(bq, bi, BLOCKQ_ACTION_BLOCKED | BLOCKQ_ACTION_NULLIFY);
-    }
-    /* XXX release lock */
+    do {
+        u64 saved_flags = spin_lock_irq(&bq->lock);
+        list l = list_get_next(&bq->waiters_head);
+        if (!l) {
+            spin_unlock_irq(&bq->lock, saved_flags);
+            return;
+        }
+        list_delete(l);
+        spin_unlock_irq(&bq->lock, saved_flags);
+        blockq_apply(bq, struct_from_list(l, thread, bq_l),
+                     BLOCKQ_ACTION_BLOCKED | BLOCKQ_ACTION_NULLIFY);
+    } while (1);
 }
 
 int blockq_transfer_waiters(blockq dest, blockq src, int n)
 {
     int transferred = 0;
-
-    /* XXX locks for dest and src */
+    u64 saved_flags = spin_lock_irq(&src->lock);
+    spin_lock(&dest->lock);
     list_foreach(&src->waiters_head, l) {
         if (transferred >= n)
             break;
-        blockq_item bi = struct_from_list(l, blockq_item, l);
-        if (bi->timeout) {
+        thread t = struct_from_list(l, thread, bq_l);
+        if (t->bq_timeout) {
             timestamp remain;
-            timer_handler t = bi->timeout->t;
-            clock_id id = bi->timeout->id;
-            remove_timer(bi->timeout, &remain);
-            bi->timeout = remain == 0 ? 0 :
+            clock_id id = t->bq_timeout->id;
+            remove_timer(t->bq_timeout, &remain);
+            t->bq_timeout = remain == 0 ? 0 :
                 register_timer(runloop_timers, id, remain, false, 0,
-                    init_closure(&bi->timeout_func, blockq_item_timeout, dest,
-                        bi));
-            assert(t);
-            deallocate_closure(t);
+                               init_closure(&t->bq_timeout_func, blockq_thread_timeout,
+                                            dest, t));
         }
-        list_delete(&bi->l);
-        assert(bi->t->blocked_on == src);
-        bi->t->blocked_on = dest;
-        list_insert_before(&dest->waiters_head, &bi->l);
+        list_delete(&t->bq_l);
+        assert(t->blocked_on == src);
+        t->blocked_on = dest;
+        list_insert_before(&dest->waiters_head, &t->bq_l);
         transferred++;
     }
+    spin_unlock(&dest->lock);
+    spin_unlock_irq(&src->lock, saved_flags);
     return transferred;
 }
 
 void blockq_set_completion(blockq bq, io_completion completion, thread t, sysreturn rv)
 {
-    bq->completion = completion;
-    bq->completion_thread = t;
-    bq->completion_rv = rv;
+    assert(!t->bq_completion);
+    assert(bq == t->blocked_on);
+    t->bq_completion = completion;
+    t->bq_completion_rv = rv;
+}
+
+void blockq_thread_init(thread t)
+{
+    t->bq_timeout = 0;
+    t->bq_action = 0;
+    t->bq_l.prev = t->bq_l.next = 0;
+    t->bq_completion = 0;
+    t->bq_completion_rv = 0;
+}
+
+define_closure_function(1, 0, void, free_blockq,
+                        blockq, bq)
+{
+    blockq bq = bound(bq);
+    blockq_debug("for \"%s\"\n", blockq_name(bq));
+    assert(list_empty(&bq->waiters_head));
+    deallocate(bq->h, bq, sizeof(struct blockq));
 }
 
 blockq allocate_blockq(heap h, char * name)
@@ -377,34 +297,24 @@ blockq allocate_blockq(heap h, char * name)
     if (bq == INVALID_ADDRESS)
         return bq;
 
-    if (name) {
-        runtime_memcpy(bq->name, name, MIN(runtime_strlen(name) + 1, BLOCKQ_NAME_MAX - 1));
-        bq->name[BLOCKQ_NAME_MAX - 1] = '\0';
-    }
-
     bq->h = h;
-    bq->completion = 0;
-    bq->completion_thread = 0;
-    bq->completion_rv = 0;
+    u64 len;
+    if (name) {
+        len = MIN(runtime_strlen(name), BLOCKQ_NAME_MAX - 1);
+        runtime_memcpy(bq->name, name, len);
+    } else {
+        len = 0;
+    }
+    bq->name[len] = '\0';
+    spin_lock_init(&bq->lock);
     list_init(&bq->waiters_head);
-
+    init_refcount(&bq->refcount, 1, init_closure(&bq->free, free_blockq, bq));
     return bq;
 }
 KLIB_EXPORT(allocate_blockq);
 
 void deallocate_blockq(blockq bq)
 {
-    blockq_debug("for \"%s\"\n", blockq_name(bq));
-
-    /* XXX what's the right behavior if we have waiters? */
-    /* for now err out */
-    assert(list_empty(&bq->waiters_head));
-
-    deallocate(bq->h, bq, sizeof(struct blockq));
+    blockq_release(bq);
 }
 KLIB_EXPORT(deallocate_blockq);
-
-const char * blockq_name(blockq bq)
-{
-    return bq->name;
-}

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -944,7 +944,10 @@ closure_function(1, 2, void, signalfd_notify,
         sig_debug("%d spurious notify\n", sfd->fd);
         return;
     }
-    blockq_wake_one_for_thread(sfd->bq, t);
+
+    /* null thread on notify set release (thread dealloc) */
+    if (t)
+        blockq_wake_one_for_thread(sfd->bq, t);
     notify_dispatch_for_thread(sfd->f.ns, EPOLLIN, t);
 }
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -342,6 +342,7 @@ thread create_thread(process p)
         goto fail_affinity;
     bitmap_range_check_and_set(t->affinity, 0, total_processors, false, true);
     t->blocked_on = 0;
+    blockq_thread_init(t);
     init_sigstate(&t->signals);
     t->dispatch_sigstate = 0;
     t->active_signo = 0;


### PR DESCRIPTION
To support syscall execution outside of the domain of the kernel lock, the
blockq code is revised to allow operations on a blockq to occur safely on
multiple processors. This essentially amounts to protecting the list of
waiting threads per blockq with a spinlock. Other improvements that have been
made include the embedding of the previous "blockq_item" struct directly into
the thread struct, which obviates the need to (de)allocate items on each
block, adding blockq_reserve() and blockq_release() calls to support safe
implementation of thread_attempt_interrupt(), and associating any
io_completions for a given blocking operation with each waiting thread instead
of with the blockq, thus allowing multiple waiting threads to have their own
io_completions, rather than only a single I/O completion for a given
resource (blockq).

The comments at the head of blockq.c were very outdated and have been updated
to reflect the current behavior and usage.