### PR TITLE
Unix domain sockets: fix setting of filesystem metadata

### DIFF
--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -73,6 +73,7 @@ typedef enum {
     FS_STATUS_IOERR,
     FS_STATUS_NOENT,
     FS_STATUS_EXIST,
+    FS_STATUS_INVAL,
     FS_STATUS_NOTDIR,
     FS_STATUS_NOMEM,
     FS_STATUS_LINKLOOP,
@@ -108,6 +109,10 @@ fs_status filesystem_rename(filesystem fs, tuple oldparent, symbol oldsym,
                        tuple newparent, const char *newname);
 fs_status filesystem_exchange(filesystem fs, tuple parent1, symbol sym1,
                          tuple parent2, symbol sym2);
+
+fs_status filesystem_mk_socket(filesystem *fs, tuple cwd, const char *path, void *s, tuple *t);
+fs_status filesystem_get_socket(filesystem fs, tuple cwd, const char *path, void **s);
+fs_status filesystem_clear_socket(filesystem fs, tuple t);
 
 tuple filesystem_getroot(filesystem fs);
 

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -13,8 +13,12 @@ sysreturn sysreturn_from_fs_status(fs_status s)
         return -ENOENT;
     case FS_STATUS_EXIST:
         return -EEXIST;
+    case FS_STATUS_INVAL:
+        return -EINVAL;
     case FS_STATUS_NOTDIR:
         return -ENOTDIR;
+    case FS_STATUS_NOMEM:
+        return -ENOMEM;
     case FS_STATUS_LINKLOOP:
         return -ELOOP;
     default:
@@ -86,21 +90,6 @@ int resolve_cstring_follow(filesystem *fs, tuple cwd, const char *f, tuple *entr
     if (!f)
         return -EFAULT;
     return sysreturn_from_fs_status(filesystem_resolve_cstring_follow(fs, cwd, f, entry, parent));
-}
-
-int filesystem_add_tuple(const char *path, tuple t)
-{
-    filesystem fs = current->p->cwd_fs;
-    tuple parent;
-    int ret = resolve_cstring(&fs, current->p->cwd, path, 0, &parent);
-    if (ret == 0) {
-        return -EEXIST;
-    }
-    if ((ret != -ENOENT) || !parent) {
-        return ret;
-    }
-    return sysreturn_from_fs_status(do_mkentry(fs, parent,
-        filename_from_path(path), t, true));
 }
 
 void file_readahead(file f, u64 offset, u64 len)

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -32,13 +32,6 @@ int resolve_cstring_follow(filesystem *fs, tuple cwd, const char *f, tuple *entr
 int filesystem_follow_links(filesystem *fs, tuple link, tuple parent,
                             tuple *target);
 
-int filesystem_add_tuple(const char *path, tuple t);
-
-static inline int filesystem_get_tuple(const char *path, tuple *t)
-{
-    return resolve_cstring(0, current->p->cwd, path, t, 0);
-}
-
 /* Perform read-ahead following a userspace read request.
  * offset and len arguments refer to the byte range being read from userspace,
  * not to the range to be read ahead. */


### PR DESCRIPTION
The trick currently being used in unixsock_bind() to prevent the address of a bound socket from being stored in the filesystem log is flawed, because if the filesystem is compacted the newly built log will contain the socket address, which can cause invalid memory accesses if the program tries to connect to the socket after a reboot.
This commit changes the format of the filesystem metadata that encodes the address of a bound socket, using sym(no_encode) to prevent the tuple containing the address from being written to the TFS log.
Direct access to filesystem metadata from the Unix socket code (which will be unsafe when the kernel lock is removed) is replaced by the filesystem_mk_socket(), filesystem_get_socket() and filesystem_clear_socket() functions.

The first commit prevents leaking filesystem metadata if a socket file is unlinked from the filesystem.