### PR TITLE
Thread and process structures: protect against concurrent access

### DIFF
--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -254,8 +254,10 @@ int blockq_transfer_waiters(blockq dest, blockq src, int n)
                                             dest, t));
         }
         list_delete(&t->bq_l);
+        thread_lock(t);
         assert(t->blocked_on == src);
         t->blocked_on = dest;
+        thread_unlock(t);
         list_insert_before(&dest->waiters_head, &t->bq_l);
         transferred++;
     }

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -1,13 +1,16 @@
 #define resolve_dir(__fs, __dirfd, __path) ({ \
     tuple cwd; \
+    process p = current->p; \
     if (*(__path) == '/') { \
-        __fs = current->p->root_fs; \
+        __fs = p->root_fs;              \
         cwd = filesystem_getroot(__fs); \
     } else if (__dirfd == AT_FDCWD) { \
-        __fs = current->p->cwd_fs; \
-        cwd = current->p->cwd; \
+        process_lock(p);              \
+        __fs = p->cwd_fs;             \
+        cwd = p->cwd;                 \
+        process_unlock(p);            \
     } else { \
-        file f = resolve_fd(current->p, __dirfd); \
+        file f = resolve_fd(p, __dirfd);    \
         __fs = f->fs;               \
         tuple t = file_get_meta(f); \
         fdesc_put(&f->f);           \

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -355,6 +355,7 @@ sysreturn get_robust_list(int pid, void *head, u64 *len)
     if (t == INVALID_ADDRESS)
         return -ESRCH;
     *hp = t->robust_list;
+    thread_release(t);
     *len = sizeof(**hp);
     return 0;
 }

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -46,15 +46,7 @@ static struct futex * soft_create_futex(process p, u64 key)
 
 static thread futex_wake_one(struct futex * f)
 {
-    thread w;
-
-    w = blockq_wake_one(f->bq);
-    if (w == INVALID_ADDRESS)
-        return w;
-
-    /* w must be awake */
-    assert(w->blocked_on != f->bq);
-    return w;
+    return blockq_wake_one(f->bq);
 }
 
 /*

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -999,10 +999,13 @@ static sysreturn msync(void *addr, u64 length, int flags)
 
     boolean have_gap = false;
     if (flags & MS_SYNC) {
+        process p = current->p;
         range q = irangel(u64_from_pointer(addr), pad(length, PAGESIZE));
-        rangemap_range_lookup_with_gaps(current->p->vmaps, q,
+        vmap_lock(p);
+        rangemap_range_lookup_with_gaps(p->vmaps, q,
                                         stack_closure(msync_vmap),
                                         stack_closure(msync_gap, &have_gap));
+        vmap_unlock(p);
     }
 
     /* TODO: Linux appears to only use MS_INVALIDATE to test whether a

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -658,12 +658,15 @@ closure_function(3, 1, sysreturn, select_bh,
 
 static inline epoll select_get_epoll(void)
 {
-    epoll e = current->select_epoll;
+    thread t = current;
+    thread_lock(t);
+    epoll e = t->select_epoll;
     if (!e) {
         e = epoll_alloc_internal();
         if (e != INVALID_ADDRESS)
-            current->select_epoll = e;
+            t->select_epoll = e;
     }
+    thread_unlock(t);
     return e;
 }
 

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -329,13 +329,6 @@ thread create_thread(process p)
     init_refcount(&t->refcount, 1, init_closure(&t->free, free_thread, t));
     t->select_epoll = 0;
     runtime_memset((void *)&t->n, 0, sizeof(struct rbnode));
-    spin_lock(&p->threads_lock);
-    do {
-        if (tidcount < 0)
-            tidcount = 1;
-        t->tid = tidcount++;
-    } while (rbtree_lookup(p->threads, &t->n) != INVALID_ADDRESS);
-    spin_unlock(&p->threads_lock);
     t->clear_tid = 0;
     t->name[0] = '\0';
 
@@ -373,6 +366,11 @@ thread create_thread(process p)
     gdb_check_fault_handler(t);
     // XXX sigframe
     spin_lock(&p->threads_lock);
+    do {
+        if (tidcount < 0)
+            tidcount = 1;
+        t->tid = tidcount++;
+    } while (rbtree_lookup(p->threads, &t->n) != INVALID_ADDRESS);
     rbtree_insert_node(p->threads, &t->n);
     spin_unlock(&p->threads_lock);
     return t;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -394,12 +394,8 @@ void exit_thread(thread t)
     /* dequeue signals for thread */
     sigstate_flush_queue(&t->signals);
 
-    /* We don't yet support forcible removal while in an uninterruptible wait. */
-    assert(t->blocked_on != INVALID_ADDRESS);
-
-    /* Kill received during interruptible wait. */
-    if (t->blocked_on)
-        blockq_flush_thread(t->blocked_on, t);
+    /* A thread can only be terminated by itself. */
+    assert(t->blocked_on == 0);
 
     if (t->clear_tid) {
         *t->clear_tid = 0;

--- a/src/unix/unix.h
+++ b/src/unix/unix.h
@@ -5,6 +5,7 @@ typedef struct thread *thread;
 
 process init_unix(kernel_heaps kh, tuple root, filesystem fs);
 process create_process(unix_heaps uh, tuple root, filesystem fs);
+void process_get_cwd(process p, filesystem *cwd_fs, tuple *cwd);
 thread create_thread(process p);
 process exec_elf(buffer ex, process kernel_process);
 


### PR DESCRIPTION
This change adds a spinlock to the thread and process structures, and uses this spinlock to protect structure members against concurrent access.
Also, thread_from_tid() now increments the thread reference count, to prevent a thread from being deallocated while it is being accessed; callers of thread_from_tid() need to call thread_release() when they are done with the thread.
The code that needs to retrieve the current working directory and its filesystem now calls process_get_cwd(), which retrieves this information atomically with respect to the chdir and fchdir syscalls.
For x86_64, the virtual32 heap has been switched from non-locking to locking.