### PR TITLE
Xen: add support for attaching and detaching volumes in a running instance

### DIFF
--- a/src/kernel/pagecache_internal.h
+++ b/src/kernel/pagecache_internal.h
@@ -12,6 +12,12 @@ struct pagecache_completion_queue;
 declare_closure_struct(2, 0, void, pagecache_service_completions,
                        struct pagecache *, pc, struct pagecache_completion_queue *, cq);
 
+declare_closure_struct(0, 2, int, pagecache_page_compare,
+                       rbnode, a, rbnode, b);
+declare_closure_struct(1, 1, boolean, pagecache_page_print_key,
+                       struct pagecache *, pc,
+                       rbnode, n);
+
 typedef struct page_completion {
     struct list l;
     union {
@@ -55,6 +61,8 @@ typedef struct pagecache {
     boolean scan_in_progress;
     timer scan_timer;
     closure_struct(pagecache_scan_timer, do_scan_timer);
+    closure_struct(pagecache_page_compare, page_compare);
+    closure_struct(pagecache_page_print_key, page_print_key);
 } *pagecache;
 
 typedef struct pagecache_volume {

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -79,7 +79,7 @@ void storage_when_ready(status_handler complete);
 void storage_sync(status_handler sh);
 
 struct filesystem *storage_get_fs(tuple root);
-tuple storage_get_mountpoint(tuple root);
+tuple storage_get_mountpoint(tuple root, struct filesystem **fs);
 
 typedef closure_type(volume_handler, void, u8 *, const char *, struct filesystem *, tuple);
 void storage_iterate(volume_handler vh);

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -83,3 +83,5 @@ tuple storage_get_mountpoint(tuple root, struct filesystem **fs);
 
 typedef closure_type(volume_handler, void, u8 *, const char *, struct filesystem *, tuple);
 void storage_iterate(volume_handler vh);
+
+void storage_detach(block_io r, block_io w, thunk complete);

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -114,6 +114,8 @@ fs_status filesystem_mk_socket(filesystem *fs, tuple cwd, const char *path, void
 fs_status filesystem_get_socket(filesystem fs, tuple cwd, const char *path, void **s);
 fs_status filesystem_clear_socket(filesystem fs, tuple t);
 
+fs_status filesystem_mount(filesystem parent, tuple mount_dir, filesystem child);
+
 tuple filesystem_getroot(filesystem fs);
 
 u64 fs_blocksize(filesystem fs);
@@ -167,7 +169,7 @@ symbol lookup_sym(tuple parent, tuple t);
 /* Expects an empty buffer, and never resizes the buffer. */
 boolean dirname_from_path(buffer dest, const char *path);
 
-void fs_set_path_helper(filesystem (*get_root_fs)(), tuple (*lookup_follow)(filesystem *, tuple, symbol, tuple *));
+void fs_set_path_helper(filesystem (*get_root_fs)(), tuple (*get_mountpoint)(tuple, filesystem *));
 
 int filesystem_resolve_cstring(filesystem *fs, tuple cwd, const char *f, tuple *entry,
                     tuple *parent);

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -4,6 +4,7 @@ typedef closure_type(filesystem_complete, void, filesystem, status);
 
 typedef struct fsfile *fsfile;
 
+filesystem fsfile_get_fs(fsfile f);
 pagecache_volume filesystem_get_pagecache_volume(filesystem fs);
 
 u64 fsfile_get_length(fsfile f);
@@ -45,6 +46,9 @@ void filesystem_read_linear(fsfile f, void *dest, range q, io_status_handler com
 void filesystem_write_linear(fsfile f, void *src, range q, io_status_handler completion);
 
 void filesystem_flush(filesystem fs, status_handler completion);
+
+void filesystem_reserve(filesystem fs);
+void filesystem_release(filesystem fs);
 
 timestamp filesystem_get_atime(filesystem fs, tuple t);
 timestamp filesystem_get_mtime(filesystem fs, tuple t);
@@ -115,6 +119,7 @@ fs_status filesystem_get_socket(filesystem fs, tuple cwd, const char *path, void
 fs_status filesystem_clear_socket(filesystem fs, tuple t);
 
 fs_status filesystem_mount(filesystem parent, tuple mount_dir, filesystem child);
+void filesystem_unmount(filesystem parent, tuple mount_dir, filesystem child, thunk complete);
 
 tuple filesystem_getroot(filesystem fs);
 

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -11,6 +11,12 @@
 
 typedef struct log *log;
 
+declare_closure_struct(1, 0, void, fs_sync,
+                       struct filesystem *, fs);
+declare_closure_struct(1, 1, void, fs_free,
+                       struct filesystem *, fs,
+                       status, s);
+
 typedef struct filesystem {
     id_heap storage;
     u64 size;
@@ -33,6 +39,10 @@ typedef struct filesystem {
     u64 next_extend_log_offset;
     u64 next_new_log_offset;
     tuple root;
+    struct refcount refcount;
+    closure_struct(fs_sync, sync);
+    thunk sync_complete;
+    closure_struct(fs_free, free);
 } *filesystem;
 
 declare_closure_struct(1, 1, void, fsf_sync_complete,

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -35,6 +35,10 @@ typedef struct filesystem {
     tuple root;
 } *filesystem;
 
+declare_closure_struct(1, 1, void, fsf_sync_complete,
+                       struct fsfile *, f,
+                       status, s);
+
 typedef struct fsfile {
     rangemap extentmap;
     filesystem fs;
@@ -44,6 +48,7 @@ typedef struct fsfile {
     sg_io read;
     sg_io write;
     struct refcount refcount;
+    closure_struct(fsf_sync_complete, sync_complete);
 } *fsfile;
 
 typedef struct uninited_queued_op {

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -41,34 +41,6 @@ sysreturn sysreturn_from_fs_status_value(status s)
     return rv;
 }
 
-static tuple lookup_follow_mounts(filesystem *fs, tuple t, symbol a, tuple *p)
-{
-    tuple m = get_tuple(t, sym(mount));
-
-    if (m) {
-        t = get_tuple(m, sym(root));
-        if (fs)
-            *fs = storage_get_fs(t);
-    } else if ((t == *p) && (a == sym_this("..")) && (t != filesystem_getroot(get_root_fs()))) {
-        /* t is the root of its filesystem: look for a mount point for this
-         * filesystem, and if found look up the parent of the mount directory.
-         */
-        tuple mp = storage_get_mountpoint(t);
-        if (mp) {
-            *p = mp;
-            t = lookup(mp, a);
-            if (fs)
-                *fs = current->p->root_fs;
-        }
-    }
-    return t;
-}
-
-void init_fs_path_helper()
-{
-    fs_set_path_helper(get_root_fs, lookup_follow_mounts);
-}
-
 /* If the file path being resolved crosses a filesystem boundary (i.e. a mount
  * point), the 'fs' argument (if non-null) is updated to point to the new
  * filesystem. */

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -23,8 +23,6 @@
 sysreturn sysreturn_from_fs_status(fs_status s);
 sysreturn sysreturn_from_fs_status_value(status s);
 
-void init_fs_path_helper();
-
 int resolve_cstring(filesystem *fs, tuple cwd, const char *f, tuple *entry,
                     tuple *parent);
 

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -3,15 +3,14 @@
     process p = current->p; \
     if (*(__path) == '/') { \
         __fs = p->root_fs;              \
+        filesystem_reserve(__fs);       \
         cwd = filesystem_getroot(__fs); \
     } else if (__dirfd == AT_FDCWD) { \
-        process_lock(p);              \
-        __fs = p->cwd_fs;             \
-        cwd = p->cwd;                 \
-        process_unlock(p);            \
+        process_get_cwd(p, &__fs, &cwd);    \
     } else { \
         file f = resolve_fd(p, __dirfd);    \
         __fs = f->fs;               \
+        filesystem_reserve(__fs);   \
         tuple t = file_get_meta(f); \
         fdesc_put(&f->f);           \
         if (!t || !is_dir(t)) return set_syscall_error(current, ENOTDIR); \

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -358,6 +358,7 @@ vmap allocate_vmap(rangemap rm, range q, struct vmap k)
         return INVALID_ADDRESS;
     }
     if (vm->fsf) {
+        filesystem_reserve(fsfile_get_fs(vm->fsf));
         fsfile_reserve(vm->fsf);
     }
     return vm;
@@ -368,6 +369,7 @@ void deallocate_vmap(rangemap rm, vmap vm)
 {
     if (vm->fsf) {
         fsfile_release(vm->fsf);
+        filesystem_release(fsfile_get_fs(vm->fsf));
     }
     deallocate(rm->h, vm, sizeof(struct vmap));
 }

--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -514,7 +514,7 @@ closure_function(1, 6, sysreturn, nl_read,
     blockq_action ba = closure(s->sock.h, nl_read_bh, s, current, dest, length, 0, 0,
         completion);
     if (ba == INVALID_ADDRESS)
-        return -ENOMEM;
+        return io_complete(completion, t, -ENOMEM);
     return blockq_check(s->sock.rxbq, current, ba, false);
 }
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -517,7 +517,7 @@ closure_function(2, 6, sysreturn, file_read,
 {
     file f = bound(f);
     if (fdesc_type(&f->f) == FDESC_TYPE_DIRECTORY)
-        return -EISDIR;
+        return io_complete(completion, t, -EISDIR);
     boolean is_file_offset = offset_arg == infinity;
     u64 offset = is_file_offset ? f->offset : offset_arg;
     thread_log(t, "%s: f %p, dest %p, offset %ld (%s), length %ld, file length %ld",
@@ -531,7 +531,7 @@ closure_function(2, 6, sysreturn, file_read,
     sg_list sg = allocate_sg_list();
     if (sg == INVALID_ADDRESS) {
         thread_log(t, "   unable to allocate sg list");
-        return -ENOMEM;
+        return io_complete(completion, t, -ENOMEM);
     }
     begin_file_read(t, f);
     apply(f->fs_read, sg, irangel(offset, length), closure(h, file_read_complete, t, sg, dest, length,
@@ -636,7 +636,7 @@ closure_function(2, 6, sysreturn, file_write,
     sg_list sg = allocate_sg_list();
     if (sg == INVALID_ADDRESS) {
         thread_log(t, "   unable to allocate sg list");
-        return -ENOMEM;
+        return io_complete(completion, t, -ENOMEM);
     }
     sg_buf sgb = sg_list_tail_add(sg, length);
     sgb->buf = src;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -350,6 +350,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
         p->virtual = 0;
         p->vareas = p->vmaps = INVALID_ADDRESS;
     }
+    filesystem_reserve(fs); /* because it hosts the current working directory */
     p->root_fs = p->cwd_fs = fs;
     p->cwd = root;
     p->process_root = root;
@@ -374,6 +375,7 @@ void process_get_cwd(process p, filesystem *cwd_fs, tuple *cwd)
 {
     process_lock(p);
     *cwd_fs = p->cwd_fs;
+    filesystem_reserve(*cwd_fs);
     *cwd = p->cwd;
     process_unlock(p);
 }

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -505,7 +505,6 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     if (!netsyscall_init(uh))
         goto alloc_fail;
 #endif
-    init_fs_path_helper();
     process kernel_process = create_process(uh, root, fs);
     dummy_thread = create_thread(kernel_process);
     runtime_memcpy(dummy_thread->name, "dummy_thread",

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -424,6 +424,7 @@ typedef struct vmap {
     u32 allowed_flags;
     pagecache_node cache_node;
     u64 node_offset;
+    fsfile fsf;
 } *vmap;
 
 typedef struct varea {
@@ -432,11 +433,12 @@ typedef struct varea {
     boolean allow_fixed;
 } *varea;
 
-#define ivmap(__f, __af, __o, __c) (struct vmap) {  \
+#define ivmap(__f, __af, __o, __fsf) (struct vmap) {        \
     .flags = __f,                                   \
     .allowed_flags = __f | __af,                    \
     .node_offset = __o,                             \
-    .cache_node = __c,                              \
+    .cache_node = __fsf ? fsfile_get_cachenode(__fsf) : 0,  \
+    .fsf = __fsf,                                   \
 }
 typedef closure_type(vmap_handler, void, vmap);
 

--- a/src/xen/xen.c
+++ b/src/xen/xen.c
@@ -702,7 +702,8 @@ status xenbus_get_state(buffer path, XenbusState *state)
     status s = xenstore_read_u64(0, path, "state", &val);
     if (!is_ok(s))
         *state = XenbusStateUnknown;
-    *state = val;
+    else
+        *state = val;
     return s;
 }
 

--- a/src/xen/xen_internal.h
+++ b/src/xen/xen_internal.h
@@ -39,6 +39,7 @@ status xen_allocate_evtchn(domid_t other_id, evtchn_port_t *evtchn);
 void xen_register_evtchn_handler(evtchn_port_t evtchn, thunk handler);
 int xen_notify_evtchn(evtchn_port_t evtchn);
 int xen_unmask_evtchn(evtchn_port_t evtchn);
+int xen_close_evtchn(evtchn_port_t evtchn);
 
 grant_ref_t xen_grant_page_access(u16 domid, u64 phys, boolean readonly);
 void xen_revoke_page_access(grant_ref_t ref);
@@ -47,6 +48,7 @@ typedef closure_type(xenstore_watch_handler, void, const char *);
 
 status xenbus_get_state(buffer path, XenbusState *state);
 status xenbus_set_state(u32 tx_id, buffer path, XenbusState newstate);
+status xenbus_watch_state(buffer path, xenstore_watch_handler handler, boolean watch);
 
 status xenstore_read_u64(u32 tx_id, buffer path, const char *node, u64 *result);
 status xenstore_sync_request(u32 tx_id, enum xsd_sockmsg_type type, buffer request, buffer response);
@@ -55,6 +57,8 @@ status xenstore_transaction_start(u32 *tx_id);
 status xenstore_transaction_end(u32 tx_id, boolean abort);
 
 status xendev_attach(xen_dev xd, int id, buffer frontend, tuple meta);
+
+void xen_driver_unbind(tuple meta);
 
 typedef closure_type(xen_device_probe, boolean, int, buffer, tuple);
 void register_xen_driver(const char * name, xen_device_probe probe);

--- a/src/xen/xen_internal.h
+++ b/src/xen/xen_internal.h
@@ -43,6 +43,8 @@ int xen_unmask_evtchn(evtchn_port_t evtchn);
 grant_ref_t xen_grant_page_access(u16 domid, u64 phys, boolean readonly);
 void xen_revoke_page_access(grant_ref_t ref);
 
+typedef closure_type(xenstore_watch_handler, void, const char *);
+
 status xenbus_get_state(buffer path, XenbusState *state);
 status xenbus_set_state(u32 tx_id, buffer path, XenbusState newstate);
 

--- a/test/runtime/mmap.c
+++ b/test/runtime/mmap.c
@@ -1013,6 +1013,20 @@ static void filebacked_test(heap h)
     if (close(fd) < 0)
         handle_err("close read-only file");
 
+    printf("** testing mmap with closed file descriptor\n");
+    fd = open(".", O_TMPFILE | O_RDWR, S_IRUSR | S_IWUSR);
+    if (fd < 0)
+        handle_err("open tmpfile");
+    rv = ftruncate(fd, PAGESIZE);
+    if (rv < 0)
+        handle_err("ftruncate for tmpfile");
+    p = mmap(NULL, PAGESIZE, PROT_WRITE, MAP_PRIVATE, fd, 0);
+    if (p == (void *)-1ull)
+        handle_err("mmap tmpfile");
+    close(fd);
+    *(uint64_t *)p = 0; /* random access to file-backed memory */
+    __munmap(p, PAGESIZE);
+
     printf("** all file-backed tests passed\n");
 }
 

--- a/test/runtime/unlink.c
+++ b/test/runtime/unlink.c
@@ -88,6 +88,7 @@ static void test_tmpfile()
         exit(EXIT_FAILURE);
     }
     close(fd);
+    usleep(8);  /* Give some time to the kernel to deallocate storage space asynchronously. */
     statfs("/", &statbuf);
     if (statbuf.f_bfree <= fsfree) {
         printf("bfree check grow\n");


### PR DESCRIPTION
The xen code now supports "watching" xenstore paths, which is the mechanism by which the hypervisor notifies to the guest events such has attachment and detachment of volumes in a running instance.

When a new volume is attached to an instance, the xen driver triggers a rescan of all attached devices, and invokes the probe closure of the xenblk driver: this allows a volume to be automatically mounted by the kernel when attached to a running instance.

The xenblk driver is now notified when a volume detach has been requested. When such notification arrives, the block device is removed from the list of volumes, and if there is a mounted filesystem, the filesystem is unmounted and its reference count is decremented, so that when any open files are closed and any file-backed memory mappings are unmapped, the filesystem is deallocated and the block device is released (effectively marking the volume detach operation as complete).

A change partially related to this feature consists of adjusting the reference count of memory-mapped files (to allow safe access to file-backed memory after a file has been closed and possibly deleted from the filesystem) and of their filesystem (to prevent a volume from being detached while there are file-backed memory mappings).

Proper deallocation of page cache nodes (which is required to avoid leaking memory when a filesystem is unmounted) is now implemented.