### PR TITLE
Unix special files: add /proc/mounts

### DIFF
--- a/klib/radar.c
+++ b/klib/radar.c
@@ -388,9 +388,9 @@ static void telemetry_boot(void)
     telemetry_retry();
 }
 
-closure_function(2, 3, void, telemetry_vh,
+closure_function(2, 4, void, telemetry_vh,
                  buffer, b, int, count,
-                 u8 *, uuid, const char *, label, filesystem, fs)
+                 u8 *, uuid, const char *, label, filesystem, fs, tuple, mount_point)
 {
     u64 block_size = kfunc(fs_blocksize)(fs);
     buffer b = bound(b);

--- a/src/kernel/storage.c
+++ b/src/kernel/storage.c
@@ -260,12 +260,12 @@ tuple storage_get_mountpoint(tuple root)
 
 void storage_iterate(volume_handler vh)
 {
-    apply(vh, 0, "root", storage.root_fs);
+    apply(vh, 0, "root", storage.root_fs, 0);
     storage_lock();
     list_foreach(&storage.volumes, e) {
         volume v = struct_from_list(e, volume, l);
         if (v->fs)
-            apply(vh, v->uuid, v->label, v->fs);
+            apply(vh, v->uuid, v->label, v->fs, v->mount_dir);
     }
     storage_unlock();
 }

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -24,6 +24,11 @@ static inline void *buffer_ref(buffer b, bytes offset)
     return((void *)b->contents + (b->start + offset));
 }
 
+static inline void *buffer_end(buffer b)
+{
+    return b->contents + b->end;
+}
+
 // out of bounds
 static inline char peek_char(buffer b)
 {
@@ -76,6 +81,11 @@ static inline void buffer_produce(buffer b, bytes s)
 static inline bytes buffer_length(buffer b)
 {
     return b->end - b->start;
+}
+
+static inline bytes buffer_space(buffer b)
+{
+    return b->length - b->end;
 }
 
 static inline boolean buffer_is_wrapped(buffer b)

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -81,5 +81,5 @@ void storage_sync(status_handler sh);
 struct filesystem *storage_get_fs(tuple root);
 tuple storage_get_mountpoint(tuple root);
 
-typedef closure_type(volume_handler, void, u8 *, const char *, struct filesystem *);
+typedef closure_type(volume_handler, void, u8 *, const char *, struct filesystem *, tuple);
 void storage_iterate(volume_handler vh);

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -49,7 +49,7 @@ static tuple lookup_follow_mounts(filesystem *fs, tuple t, symbol a, tuple *p)
         t = get_tuple(m, sym(root));
         if (fs)
             *fs = storage_get_fs(t);
-    } else if ((t == *p) && (a == sym_this(".."))) {
+    } else if ((t == *p) && (a == sym_this("..")) && (t != filesystem_getroot(get_root_fs()))) {
         /* t is the root of its filesystem: look for a mount point for this
          * filesystem, and if found look up the parent of the mount directory.
          */


### PR DESCRIPTION
This file contains the list of currently mounted filesystems, using same syntax as used in the Linux /proc/mounts file.