### PR TITLE
Unix file descriptors: allocate after full initialization

### DIFF
--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -763,6 +763,11 @@ sysreturn netlink_open(int type, int family)
     s->sock.recvfrom = nl_recvfrom;
     s->sock.sendmsg = nl_sendmsg;
     s->sock.recvmsg = nl_recvmsg;
+    s->sock.fd = allocate_fd(current->p, s);
+    if (s->sock.fd == INVALID_PHYSICAL) {
+        apply(s->sock.f.close, 0, io_completion_ignore);
+        return -EMFILE;
+    }
     return s->sock.fd;
   err_queue:
     socket_deinit(&s->sock);

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -815,6 +815,11 @@ static unixsock unixsock_alloc(heap h, int type, u32 flags)
     s->peer = 0;
     init_closure(&s->free, unixsock_free, s);
     init_refcount(&s->refcount, 1, (thunk)&s->free);
+    s->sock.fd = allocate_fd(current->p, s);
+    if (s->sock.fd == INVALID_PHYSICAL) {
+        apply(s->sock.f.close, 0, io_completion_ignore);
+        return 0;
+    }
     return s;
 err_socket:
     deallocate_queue(s->data);

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -82,11 +82,6 @@ static inline int socket_init(process p, heap h, int domain, int type, u32 flags
         struct sock *s)
 {
     runtime_memset((u8 *) s, 0, sizeof(*s));
-    s->fd = allocate_fd(p, s);
-    if (s->fd == INVALID_PHYSICAL) {
-        msg_err("failed to allocate fd\n");
-        goto err_fd;
-    }
     s->rxbq = allocate_blockq(h, "sock receive");
     if (s->rxbq == INVALID_ADDRESS) {
         msg_err("failed to allocate blockq\n");
@@ -102,13 +97,11 @@ static inline int socket_init(process p, heap h, int domain, int type, u32 flags
     s->domain = domain;
     s->type = type;
     s->h = h;
-    return s->fd;
+    return 0;
 
 err_tx:
     deallocate_blockq(s->rxbq);
 err_rx:
-    deallocate_fd(p, s->fd);
-err_fd:
     return -ENOMEM;
 }
 


### PR DESCRIPTION
When allocate_fd() is called, the newly allocated file descriptor number can be accessed by userspace, thus the corresponding kernel structure must be fully initialized to properly handle any syscalls that may be invoked in the file descriptor.
This change makes file descriptor allocation the last step in the initialization sequence of various syscalls, to make it safe in SMP systems without the kernel lock. Most file descriptor allocation errors can now be handled by simply calling the close() function (which will properly clean up the just initialized data structure) and returning -EMFILE.
In the socket code, file descriptor allocation has been removed from socket_init(), and added to its callers after full initialization of socket data.