### PR TITLE
futex.c: make code safe to run without kernel lock

### DIFF
--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -192,6 +192,19 @@ _IRQSAFE_1(boolean, queue_full, queue);
 _IRQSAFE_1(void *, queue_peek, queue);
 #undef _IRQSAFE_1
 #undef _IRQSAFE_2
+
+/* Acquires 2 locks, guarding against potential deadlock resulting from a concurrent thread trying
+ * to acquire the same locks. */
+static inline void spin_lock_2(spinlock l1, spinlock l2)
+{
+    spin_lock(l1);
+    while (!spin_try(l2)) {
+        spin_unlock(l1);
+        kern_pause();
+        spin_lock(l1);
+    }
+}
+
 #endif
 
 typedef struct queue *queue;


### PR DESCRIPTION
This will allow futex syscalls to be executed in parallel threads without the global kernel lock.