### PR TITLE
TFS: add protection against concurrent execution

### DIFF
--- a/klib/radar.c
+++ b/klib/radar.c
@@ -396,7 +396,7 @@ static void telemetry_boot(void)
 
 closure_function(2, 4, void, telemetry_vh,
                  buffer, b, int, count,
-                 u8 *, uuid, const char *, label, filesystem, fs, tuple, mount_point)
+                 u8 *, uuid, const char *, label, filesystem, fs, inode, mount_point)
 {
     u64 block_size = kfunc(fs_blocksize)(fs);
     buffer b = bound(b);

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -248,7 +248,7 @@ static void __attribute__((noinline)) init_service_new_stack()
     init_debug("in init_service_new_stack");
     init_page_tables((heap)heap_linear_backed(kh));
     init_tuples(allocate_tagged_region(kh, tag_table_tuple));
-    init_symbols(allocate_tagged_region(kh, tag_symbol), heap_general(kh));
+    init_symbols(allocate_tagged_region(kh, tag_symbol), heap_locked(kh));
 
     for_regions(e) {
         if (e->type == REGION_SMBIOS) {

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -247,7 +247,8 @@ static void __attribute__((noinline)) init_service_new_stack()
     kernel_heaps kh = get_kernel_heaps();
     init_debug("in init_service_new_stack");
     init_page_tables((heap)heap_linear_backed(kh));
-    init_tuples(allocate_tagged_region(kh, tag_table_tuple));
+    init_tuples(locking_heap_wrapper(heap_general(kh),
+                allocate_tagged_region(kh, tag_table_tuple)));
     init_symbols(allocate_tagged_region(kh, tag_symbol), heap_locked(kh));
 
     for_regions(e) {

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -226,7 +226,8 @@ static void __attribute__((noinline)) init_service_new_stack(void)
     init_page_tables((heap)heap_linear_backed(kh));
     /* mmu init complete; unmap temporary identity map */
     unmap(PHYSMEM_BASE, INIT_IDENTITY_SIZE);
-    init_tuples(allocate_tagged_region(kh, tag_table_tuple));
+    init_tuples(locking_heap_wrapper(heap_general(kh),
+                allocate_tagged_region(kh, tag_table_tuple)));
     init_symbols(allocate_tagged_region(kh, tag_symbol), heap_locked(kh));
     init_management(allocate_tagged_region(kh, tag_function_tuple), heap_general(kh));
     init_debug("calling runtime init\n");

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -227,7 +227,7 @@ static void __attribute__((noinline)) init_service_new_stack(void)
     /* mmu init complete; unmap temporary identity map */
     unmap(PHYSMEM_BASE, INIT_IDENTITY_SIZE);
     init_tuples(allocate_tagged_region(kh, tag_table_tuple));
-    init_symbols(allocate_tagged_region(kh, tag_symbol), heap_general(kh));
+    init_symbols(allocate_tagged_region(kh, tag_symbol), heap_locked(kh));
     init_management(allocate_tagged_region(kh, tag_function_tuple), heap_general(kh));
     init_debug("calling runtime init\n");
     kernel_runtime_init(kh);

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -79,9 +79,9 @@ void storage_when_ready(status_handler complete);
 void storage_sync(status_handler sh);
 
 struct filesystem *storage_get_fs(tuple root);
-tuple storage_get_mountpoint(tuple root, struct filesystem **fs);
+u64 storage_get_mountpoint(tuple root, struct filesystem **fs);
 
-typedef closure_type(volume_handler, void, u8 *, const char *, struct filesystem *, tuple);
+typedef closure_type(volume_handler, void, u8 *, const char *, struct filesystem *, u64);
 void storage_iterate(volume_handler vh);
 
 void storage_detach(block_io r, block_io w, thunk complete);

--- a/src/runtime/symbol.c
+++ b/src/runtime/symbol.c
@@ -1,8 +1,28 @@
+#ifdef KERNEL
+#include <kernel.h>
+#else
 #include <runtime.h>
+#endif
 
 static table symbols;
 static heap sheap;
 static heap iheap;
+
+#ifdef KERNEL
+
+static struct spinlock slock;
+
+#define sym_lock_init() spin_lock_init(&slock)
+#define sym_lock()      spin_lock(&slock)
+#define sym_unlock()    spin_unlock(&slock)
+
+#else
+
+#define sym_lock_init()
+#define sym_lock()
+#define sym_unlock()
+
+#endif
 
 struct symbol {
     string s;
@@ -20,6 +40,7 @@ KLIB_EXPORT(intern_u64);
 symbol intern(string name)
 {
     symbol s;
+    sym_lock();
     if (!(s = table_find(symbols, name))) {
         // shouldnt really be on transient
         buffer b = allocate_buffer(iheap, buffer_length(name));
@@ -33,6 +54,7 @@ symbol intern(string name)
         s->s = b;
         table_set(symbols, b, s);
     }
+    sym_unlock();
     return s;
   alloc_fail:
     halt("intern: alloc fail\n");
@@ -55,5 +77,6 @@ void init_symbols(heap h, heap init)
     sheap = h;
     iheap = init;    
     symbols = allocate_table(iheap, fnv64, buffer_compare);
+    sym_lock_init();
 }
 

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -1857,6 +1857,8 @@ int filesystem_resolve_cstring(filesystem *fs, tuple cwd, const char *f, tuple *
     }
 
     if (buffer_length(a)) {
+        if (!children(t))
+            return FS_STATUS_NOTDIR;
         t = lookup_follow(fs, t, intern(a), &p);
     }
     err = FS_STATUS_NOENT;

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -195,6 +195,4 @@ int filesystem_resolve_cstring_follow(filesystem *fs, tuple cwd, const char *f, 
 int filesystem_follow_links(filesystem *fs, tuple link, tuple parent,
                             tuple *target);
 
-boolean filepath_is_ancestor(tuple wd1, const char *fp1, tuple wd2, const char *fp2);
-
 int file_get_path(filesystem fs, inode ino, char *buf, u64 len);

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -9,6 +9,20 @@
 
 #define TFS_VERSION 0x00000004
 
+#ifdef KERNEL
+
+#define filesystem_lock_init(fs)    spin_lock_init(&(fs)->lock)
+#define filesystem_lock(fs)         spin_lock(&(fs)->lock)
+#define filesystem_unlock(fs)       spin_unlock(&(fs)->lock)
+
+#else
+
+#define filesystem_lock_init(fs)
+#define filesystem_lock(fs)         ((void)fs)
+#define filesystem_unlock(fs)       ((void)fs)
+
+#endif
+
 typedef struct log *log;
 
 declare_closure_struct(1, 0, void, fs_sync,
@@ -39,6 +53,9 @@ typedef struct filesystem {
     u64 next_extend_log_offset;
     u64 next_new_log_offset;
     tuple root;
+#ifdef KERNEL
+    struct spinlock lock;
+#endif
     struct refcount refcount;
     closure_struct(fs_sync, sync);
     thunk sync_complete;

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -117,6 +117,8 @@ boolean filesystem_reserve_log_space(filesystem fs, u64 *next_offset, u64 *offse
 typedef closure_type(buffer_status, buffer, status);
 fsfile allocate_fsfile(filesystem fs, tuple md);
 
+boolean file_tuple_is_ancestor(tuple t1, tuple t2, tuple p2);
+
 #define filesystem_log_blocks(fs) (TFS_LOG_DEFAULT_EXTENSION_SIZE >> (fs)->blocksize_order)
 
 static inline u64 bytes_from_sectors(filesystem fs, u64 sectors)

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -113,7 +113,7 @@ closure_function(4, 1, void, fs_sync_complete,
 static void filesystem_sync_internal(filesystem fs, pagecache_node pn,
                                      status_handler sh)
 {
-    status_handler sync_complete = closure(heap_general(get_kernel_heaps()),
+    status_handler sync_complete = closure(heap_locked(get_kernel_heaps()),
         fs_sync_complete, fs, pn, sh, false);
     if (sync_complete == INVALID_ADDRESS) {
         apply(sh, timm("result", "cannot allocate closure"));
@@ -309,7 +309,7 @@ sysreturn fallocate(int fd, int mode, long offset, long len)
         goto out;
     }
 
-    heap h = heap_general(get_kernel_heaps());
+    heap h = heap_locked(get_kernel_heaps());
     file f = (file) desc;
     switch (mode) {
     case 0:

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -22,17 +22,6 @@
 sysreturn sysreturn_from_fs_status(fs_status s);
 sysreturn sysreturn_from_fs_status_value(status s);
 
-int resolve_cstring(filesystem *fs, tuple cwd, const char *f, tuple *entry,
-                    tuple *parent);
-
-/* Same as resolve_cstring(), except that if the entry is a symbolic link this
- * function follows the link (recursively). */
-int resolve_cstring_follow(filesystem *fs, tuple cwd, const char *f, tuple *entry,
-        tuple *parent);
-
-int filesystem_follow_links(filesystem *fs, tuple link, tuple parent,
-                            tuple *target);
-
 /* Perform read-ahead following a userspace read request.
  * offset and len arguments refer to the byte range being read from userspace,
  * not to the range to be read ahead. */

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -13,7 +13,6 @@
         filesystem_reserve(__fs);   \
         tuple t = file_get_meta(f); \
         fdesc_put(&f->f);           \
-        if (!t || !is_dir(t)) return set_syscall_error(current, ENOTDIR); \
         cwd = t; \
     } \
     cwd; \

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -1,19 +1,18 @@
 #define resolve_dir(__fs, __dirfd, __path) ({ \
-    tuple cwd; \
+    inode cwd; \
     process p = current->p; \
     if (*(__path) == '/') { \
         __fs = p->root_fs;              \
         filesystem_reserve(__fs);       \
-        cwd = filesystem_getroot(__fs); \
+        cwd = inode_from_tuple(filesystem_getroot(__fs));   \
     } else if (__dirfd == AT_FDCWD) { \
         process_get_cwd(p, &__fs, &cwd);    \
     } else { \
         file f = resolve_fd(p, __dirfd);    \
         __fs = f->fs;               \
         filesystem_reserve(__fs);   \
-        tuple t = file_get_meta(f); \
+        cwd = f->n;                 \
         fdesc_put(&f->f);           \
-        cwd = t; \
     } \
     cwd; \
 })

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -28,7 +28,7 @@ typedef struct unixsock {
     struct sock sock; /* must be first */
     queue data;
     filesystem fs;
-    tuple fs_entry;
+    inode fs_entry;
     struct sockaddr_un local_addr;
     queue conn_q;
     boolean connecting;
@@ -262,9 +262,12 @@ static sysreturn unixsock_write_to(void *src, sg_list sg, u64 length,
 static int lookup_socket(unixsock *s, char *path)
 {
     process p = current->p;
-    fs_status fss = filesystem_get_socket(p->cwd_fs, p->cwd, path, (void **)s);
+    filesystem fs = p->cwd_fs;
+    tuple n;
+    fs_status fss = filesystem_get_socket(&fs, p->cwd, path, &n, (void **)s);
     if (fss == FS_STATUS_INVAL)
         return -ECONNREFUSED;
+    filesystem_put_node(fs, n);
     return sysreturn_from_fs_status(fss);
 }
 

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -41,7 +41,7 @@ static u32 null_events(file f)
 
 closure_function(1, 4, void, mounts_handler,
                  buffer, b,
-                 u8 *, uuid, const char *, label, filesystem, fs, tuple, mount_point)
+                 u8 *, uuid, const char *, label, filesystem, fs, inode, mount_point)
 {
     buffer b = bound(b);
     bytes saved_end = b->end;
@@ -52,7 +52,7 @@ closure_function(1, 4, void, mounts_handler,
     push_u8(b, ' ');
     if (mount_point) {
         while (true) {
-            int rv = file_get_path(mount_point, buffer_end(b), buffer_space(b));
+            int rv = file_get_path(fs, mount_point, buffer_end(b), buffer_space(b));
             if (rv > 0) {
                 buffer_produce(b, rv - 1);  /* drop the string terminator character */
                 break;
@@ -309,8 +309,8 @@ void register_special_files(process p)
 }
 
 sysreturn
-spec_open(file f)
+spec_open(file f, tuple t)
 {
-    spec_file_open open = get(file_get_meta(f), sym(special));
+    spec_file_open open = get(t, sym(special));
     return apply(open, f);
 }

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -281,14 +281,8 @@ void register_special_files(process p)
 {
     heap h = heap_general((kernel_heaps)p->uh);
 
-    tuple proc_self;
-    int ret = resolve_cstring(0, p->cwd, "/proc/self/exe", 0, &proc_self);
-    if (ret == -ENOENT) {
-        if (!proc_self) {
-            filesystem_mkdirpath(p->root_fs, 0, "/proc/self", true);
-            assert(resolve_cstring(0, p->cwd, "/proc/self", &proc_self, 0) == 0);
-        }
-        assert(proc_self);
+    fs_status fss = filesystem_mkdirpath(p->root_fs, 0, "/proc/self", true);
+    if (fss == FS_STATUS_OK) {
         value program = get(p->process_root, sym(program));
         assert(program);
         buffer b = allocate_buffer(h, buffer_length(program) + 2);
@@ -298,7 +292,7 @@ void register_special_files(process p)
             assert(buffer_write_byte(b, '/'));
         assert(push_buffer(b, program));
         assert(buffer_write_byte(b, '\0')); /* append string terminator character */
-        filesystem_symlink(p->root_fs, proc_self, "exe", buffer_ref(b, 0));
+        filesystem_symlink(p->root_fs, 0, "/proc/self/exe", buffer_ref(b, 0));
         deallocate_buffer(b);
     }
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -493,7 +493,8 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     u_heap = uh;
     uh->kh = *kh;
     uh->processes = create_id_heap(h, h, 1, 65535, 1, false);
-    uh->file_cache = allocate_objcache(h, (heap)heap_linear_backed(kh), sizeof(struct file), PAGESIZE);
+    uh->file_cache = locking_heap_wrapper(h,
+        allocate_objcache(h, (heap)heap_linear_backed(kh), sizeof(struct file), PAGESIZE));
     if (uh->file_cache == INVALID_ADDRESS)
 	goto alloc_fail;
     if (!poll_init(uh))

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -353,7 +353,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     }
     filesystem_reserve(fs); /* because it hosts the current working directory */
     p->root_fs = p->cwd_fs = fs;
-    p->cwd = root;
+    p->cwd = inode_from_tuple(root);
     p->process_root = root;
     p->fdallocator = create_id_heap(h, locked, 0, infinity, 1, false);
     p->files = allocate_vector(locked, 64);
@@ -372,7 +372,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     return p;
 }
 
-void process_get_cwd(process p, filesystem *cwd_fs, tuple *cwd)
+void process_get_cwd(process p, filesystem *cwd_fs, inode *cwd)
 {
     process_lock(p);
     *cwd_fs = p->cwd_fs;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -319,6 +319,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
 {
     kernel_heaps kh = (kernel_heaps)uh;
     heap h = heap_general(kh);
+    heap locked = heap_locked(kh);
     process p = allocate(h, sizeof(struct process));
     assert(p != INVALID_ADDRESS); 
     boolean aslr = get(root, sym(noaslr)) == 0;
@@ -354,8 +355,8 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     p->root_fs = p->cwd_fs = fs;
     p->cwd = root;
     p->process_root = root;
-    p->fdallocator = create_id_heap(h, h, 0, infinity, 1, false);
-    p->files = allocate_vector(h, 64);
+    p->fdallocator = create_id_heap(h, locked, 0, infinity, 1, false);
+    p->files = allocate_vector(locked, 64);
     zero(p->files, sizeof(p->files));
     create_stdfiles(uh, p);
     init_threads(p);

--- a/src/unix/unix.h
+++ b/src/unix/unix.h
@@ -5,7 +5,7 @@ typedef struct thread *thread;
 
 process init_unix(kernel_heaps kh, tuple root, filesystem fs);
 process create_process(unix_heaps uh, tuple root, filesystem fs);
-void process_get_cwd(process p, filesystem *cwd_fs, tuple *cwd);
+void process_get_cwd(process p, filesystem *cwd_fs, inode *cwd);
 thread create_thread(process p);
 process exec_elf(buffer ex, process kernel_process);
 

--- a/test/runtime/creat.c
+++ b/test/runtime/creat.c
@@ -48,6 +48,11 @@ void check(const char *path, int expect)
             printf("found file.\n");
             if (expect != 0)
                 exit(EXIT_FAILURE);
+            rc = open(path, O_CREAT | O_EXCL, 0660);
+            if ((rc != -1) || (errno != EEXIST)) {
+                printf("unexpected result from open(): rc %d, errno %d\n", rc, errno);
+                goto fail;
+            }
         }
     }
     return;

--- a/test/runtime/rename.c
+++ b/test/runtime/rename.c
@@ -72,6 +72,7 @@ static void test_renameat2(int olddirfd, int newdirfd)
     int fd = openat(olddirfd, "file", O_CREAT, S_IRWXU);
     test_assert(fd >= 0);
     close(fd);
+    test_assert(syscall(SYS_renameat2, olddirfd, "file", olddirfd, "file", RENAME_EXCHANGE) == 0);
     test_assert((syscall(SYS_renameat2, olddirfd, "file", newdirfd, "dir",
             RENAME_EXCHANGE) < 0) && (errno == ENOENT));
     test_assert(mkdirat(newdirfd, "dir", 0) == 0);
@@ -124,6 +125,8 @@ int main(int argc, char **argv)
     test_assert(fd1 >= 0);
     close(fd1);
     test_assert(mkdir("/my_dir", 0) == 0);
+    test_assert(rename("/my_file", "/my_file") == 0);
+    test_assert(rename("/my_dir", "/my_dir") == 0);
     test_assert((rename("/my_file", "/my_dir") < 0) && (errno == EISDIR));
     test_assert((rename("/my_dir", "/my_file") < 0) && (errno == ENOTDIR));
 

--- a/test/runtime/symlink.c
+++ b/test/runtime/symlink.c
@@ -28,6 +28,7 @@ int main(int argc, char **argv)
     test_assert(errno == ENOENT);
 
     test_assert(symlink("target", "link") == 0);
+    test_assert((symlink("target", "link") == -1) && (errno == EEXIST));
     memset(buf, 0, sizeof(buf));
     test_assert((readlink("link", buf, 1) == 1) && (buf[0] == 't'));
     test_assert((readlinkat(AT_FDCWD, "link", buf, 1) == 1) && (buf[0] == 't'));

--- a/test/runtime/write.c
+++ b/test/runtime/write.c
@@ -389,6 +389,11 @@ void truncate_test(const char *prog)
         exit(EXIT_FAILURE);
     }
 
+    if ((truncate("/dev/null", 0) == 0) || (errno != EINVAL)) {
+        printf("non-regular file truncate test failed\n");
+        exit(EXIT_FAILURE);
+    }
+
     if (mkdir("my_dir", S_IRUSR | S_IWUSR) < 0) {
         perror("mkdir");
         exit(EXIT_FAILURE);


### PR DESCRIPTION
This will allow filesystem-related syscalls and I/O completions to be run without the global kernel lock.
Syscalls that modify the filesystem and take a file path as argument have been changed so that file path resolution and handling of filesystem tuples is done inside the TFS code, where the filesystem is locked; in cases where reading of filesystem metadata is best done at the syscall level, the new filesystem_get_node() function is now called: this function resolves the supplied path to a tuple (possibly creating a new file in the filesystem) and returns that tuple (as well as an fsfile pointer, if applicable), which can be safely accessed from external code until filesystem_put_node() is called.
To correctly handle cases where a filesystem tuple reference held by a file descriptor becomes invalid, most filesystem functions have been modified to take inode numbers instead of tuple pointers, and validate the inode numbers to ensure that they refer to valid filesystem entries; to implement that, all directory entries (not just regular files) are put in the internal TFS file table. Regular files are distinguished from non-regular files by the fact that the latter have a file table entry value set to INVALID_ADDRESS (as opposed to an fsfile pointer). The new filesystem_get_meta() and filesystem_put_meta() functions have been added to allow safe access to filesystem tuples corresponding to inode numbers.