### PR TITLE
Unix signals: make code safe to run without the kernel lock 

### DIFF
--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -902,6 +902,7 @@ closure_function(5, 1, sysreturn, signalfd_read_bh,
         }
         sig_debug("   sig %d, errno %d, code %d\n", qs->si.si_signo, qs->si.si_errno, qs->si.si_code);
         signalfd_siginfo_fill(info, qs);
+        free_queued_signal(qs);
         info++;
         ninfos++;
     }

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -752,8 +752,10 @@ static inline void sigstate_thread_restore(thread t)
     sigstate ss = t->dispatch_sigstate;
     if (ss) {
         t->dispatch_sigstate = 0;
+        spin_lock(&ss->ss_lock);
         ss->mask = ss->saved;
         ss->saved = 0;
+        spin_unlock(&ss->ss_lock);
     }
 }
 


### PR DESCRIPTION
In an SMP system, without the kernel lock multiple cores can call dequeue_signal() concurrently; since this function accesses the process signal state, it can happen that a signal initially selected among the pending signals cannot be dequeued because it has been dequeued by another core; in this case, instead of triggering an assertion failure, another attempt should be made at finding a signal to be dequeued; if a signal is successfully dequeued, the corresponding sigstate struct should be kept locked until no longer accessed.
In deliver_signal(), the sigstate struct should be kept locked during the entire sequence of instructions that access it; if the sigstate is unlocked after determining that a signal should be delivered but before setting the signal as pending, it could happen for example that another core sets the same signal as pending, causing the signal to be enqueued twice.
In sigstate_thread_restore(), the sigstate being restored should be locked, because it could be the process-wide sigstate.
Use of the general heap is being removed in favor of the locked heap.

The second commit fixes a memory leak in signalfd_read_bh().