### PR TITLE
Add locking to polling syscalls and notify set

### DIFF
--- a/src/runtime/bitmap.h
+++ b/src/runtime/bitmap.h
@@ -31,7 +31,7 @@ void bitmap_copy(bitmap dest, bitmap src);
          __w &= ~(1ull << (bit)), bit = lsb(__w), i = (offset) + (bit))
 
 #define bitmap_foreach_set(b, i)					\
-    bitmap_foreach_word((b), w, s) bitmap_word_foreach_set(w, __bit, (i), s)
+    bitmap_foreach_word((b), _w, s) bitmap_word_foreach_set(_w, __bit, (i), s)
 
 static inline u64 *bitmap_base(bitmap b)
 {

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -173,7 +173,7 @@ typedef struct io_uring {
     io_completion shutdown_completion;
 } *io_uring;
 
-declare_closure_struct(2, 2, void, iour_poll_notify,
+declare_closure_struct(2, 2, boolean, iour_poll_notify,
                        io_uring, iour, struct iour_poll *, p,
                        u64, events, thread, t);
 
@@ -610,12 +610,13 @@ static void iour_rw(io_uring iour, fdesc f, boolean write, void *addr, u32 len,
     }
 }
 
-define_closure_function(2, 2, void, iour_poll_notify,
+define_closure_function(2, 2, boolean, iour_poll_notify,
                         io_uring, iour, iour_poll, p,
                         u64, events, thread, t)
 {
     if (!events)
-        return;
+        return false;
+    boolean remove = false;
     io_uring iour = bound(iour);
     iour_poll p = bound(p);
     iour_lock(iour);
@@ -627,10 +628,11 @@ define_closure_function(2, 2, void, iour_poll_notify,
     if (found) {
         iour_debug("user_data %ld, events %ld", p->user_data, events);
         iour_complete(iour, p->user_data, events, true, false);
-        notify_remove(p->f->ns, p->ne, false);
+        remove = true;
         fdesc_put(p->f);
         deallocate(iour->h, p, sizeof(*p));
     }
+    return remove;
 }
 
 static void iour_poll_add(io_uring iour, fdesc f, u16 events, u64 user_data)

--- a/src/unix/notify.h
+++ b/src/unix/notify.h
@@ -3,7 +3,7 @@ typedef struct notify_entry *notify_entry;
 
 /* notify handlers receive event changes, including falling edges,
    which are relevant only for waiters on thread t if t is nonzero */
-typedef closure_type(event_handler, void, u64 events, thread t);
+typedef closure_type(event_handler, boolean, u64 events, thread t);
 
 /* NOTIFY_EVENTS_RELEASE is a special value of events to signal to the
    event_handler that a notify_set is being deallocated.

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -292,7 +292,7 @@ void poll_notify(epollfd efd, epoll_blocked w, u64 events);
 void epoll_wait_notify(epollfd efd, epoll_blocked w, u64 report);
 void select_notify(epollfd efd, epoll_blocked w, u64 report);
 
-closure_function(1, 2, void, wait_notify,
+closure_function(1, 2, boolean, wait_notify,
                  epollfd, efd,
                  u64, notify_events, thread, t)
 {
@@ -303,7 +303,7 @@ closure_function(1, 2, void, wait_notify,
         epoll_debug("efd->fd %d unregistered\n", efd->fd);
         efd->registered = false;
         closure_finish();
-        return;
+        return false;
     }
 
     list l = list_get_next(&efd->e->blocked_head);
@@ -317,10 +317,10 @@ closure_function(1, 2, void, wait_notify,
 
     /* XXX need to do some work to properly dole out to multiple epoll_waits (threads)... */
     if (!w || efd->zombie)
-        return;
+        return false;
 
     if (t && t != w->t)
-        return;
+        return false;
 
     switch (efd->e->epoll_type) {
     case EPOLL_TYPE_POLL:
@@ -335,6 +335,7 @@ closure_function(1, 2, void, wait_notify,
     default:
         assert(0);
     }
+    return false;
 }
 
 void epoll_wait_notify(epollfd efd, epoll_blocked w, u64 report)

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -947,7 +947,7 @@ closure_function(1, 2, sysreturn, signalfd_close,
     return io_complete(completion, t, 0);
 }
 
-closure_function(1, 2, void, signalfd_notify,
+closure_function(1, 2, boolean, signalfd_notify,
                  signal_fd, sfd,
                  u64, events,
                  thread, t)
@@ -960,13 +960,14 @@ closure_function(1, 2, void, signalfd_notify,
 
     if ((events & sfd->mask) == 0) {
         sig_debug("%d spurious notify\n", sfd->fd);
-        return;
+        return false;
     }
 
     /* null thread on notify set release (thread dealloc) */
     if (t)
         blockq_wake_one_for_thread(sfd->bq, t);
     notify_dispatch_for_thread(sfd->f.ns, EPOLLIN, t);
+    return false;
 }
 
 static void signalfd_update_siginterest(thread t)

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -579,9 +579,6 @@ void dump_mem_stats(buffer b)
     dump_heap_stats(b, "virtual page", (heap)heap_virtual_page(kh));
     bprintf(b, "Unix heaps:\n");
     dump_heap_stats(b, "file cache", uh->file_cache);
-    dump_heap_stats(b, "epoll cache", uh->epoll_cache);
-    dump_heap_stats(b, "epollfd cache", uh->epollfd_cache);
-    dump_heap_stats(b, "epoll_blocked cache", uh->epoll_blocked_cache);
     dump_heap_stats(b, "pipe cache", uh->pipe_cache);
     dump_heap_stats(b, "socket cache", uh->socket_cache);
 }

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -123,9 +123,6 @@ typedef struct unix_heaps {
 
     /* object caches */
     heap file_cache;
-    heap epoll_cache;
-    heap epollfd_cache;
-    heap epoll_blocked_cache;
     heap pipe_cache;
 #ifdef NET
     heap socket_cache;


### PR DESCRIPTION
This change primarily adds spinlocks to the polling family of syscalls to enable concurrent execution. To make the
change easier, the polling event handlers were consolidated from three separate functions to a single event handler
that calls polling-type specific code for handling event data and the call to notify_dispatch was removed and replaced
by a function that does the same thing without the notify code. The notify code also adds a spinlock to protect the
notify entries list in the set. The notify event handlers are called with this lock held. The event handler signature
is modified to return a boolean to allow the notify code to remove a notify entry from the list when the event handler
returns true which replaces the need to call notify_remove from the event handler which would need to reacquire
the lock.

The polling code may deal with concurrency from multiple sources: simultaneous polling syscalls, asynchronous
events from watched fds (including when the fd is closed independently), and wait time outs, and it needs to protect
multiple fields in multiple structs. The safe interaction of all of these paths requires multiple spinlocks. The epoll
list of waiting threads has a lock, the epoll's bitmap and array of watched fds gets a lock. The watched fd gets
a lock to protect several fields related to its status, and the struct for the waiting thread gets a lock to protect
its data in the union. In some cases, multiple locks may need to be acquired but those should happen in the same
order regardless of path to prevent a deadlock from inversion.

Other small changes include changing the polling object caches to be general locked allocations, converting
tabs to spaces to match the rest of the code and renaming a variable used in a bitmap_foreach macro that can
cause problems if the loop block accidentally used the same name.