### PR TITLE
Volumes: fix filesystem leak on error condition

### DIFF
--- a/src/kernel/storage.c
+++ b/src/kernel/storage.c
@@ -111,6 +111,8 @@ closure_function(2, 2, void, volume_link,
         msg_err("cannot mount filesystem: %v\n", s);
     }
     v->mounting = false;
+    if (!v->fs)
+        filesystem_release(fs);
     closure_finish();
     timm_dealloc(s);
     if (!storage.mounting)


### PR DESCRIPTION
The fist commit fixes a deadlock that would happen if a filesystem creation completion is invoked synchronously (e.g. if an error is encountered).
The second commit fixes a memory leak when a filesystem associated to a volume cannot be mounted.