### PR TITLE
Klibs: fix handling of lwIP lock

### DIFF
--- a/klib/cloud_init.c
+++ b/klib/cloud_init.c
@@ -379,15 +379,11 @@ static status cloud_download_connect(ip_addr_t *addr, connection_handler ch)
 
 static void cloud_download_dns_cb(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
 {
+    if (ipaddr)
+        return;
     connection_handler ch = (connection_handler)callback_arg;
-    status s;
-    if (ipaddr) {
-        s = cloud_download_connect((ip_addr_t *)ipaddr, ch);
-        if (is_ok(s))
-            return;
-    } else {
-        s = kfuncs.timm_alloc("result", "cloud_init: failed to resolve server hostname '%s'", name);
-    }
+    status s = kfuncs.timm_alloc("result", "cloud_init: failed to resolve server hostname '%s'",
+                                 name);
     cloud_download_cfg cfg = closure_member(cloud_download_ch, ch, cfg);
     status_handler sh = (status_handler)&cfg->complete;
     apply(sh, s);
@@ -414,7 +410,6 @@ static void cloud_download(connection_handler ch)
             goto error;
         break;
     case ERR_INPROGRESS:
-        break;
     case ERR_VAL:
         if (!cloud_download_retry(ch)) {
             s = kfuncs.timm_alloc("result", "cloud_init: failed to schedule download retry");

--- a/klib/radar.c
+++ b/klib/radar.c
@@ -109,16 +109,8 @@ static void telemetry_stats_send(void);
 
 static void telemetry_dns_cb(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
 {
-    connection_handler ch = (connection_handler)callback_arg;
-    if (ipaddr) {
-        if (telemetry.tls_connect((ip_addr_t *)ipaddr, RADAR_PORT, ch) == 0)
-            return;
-        else
-            kfunc(rprintf)("Radar: failed to connect to server\n");
-    } else {
+    if (!ipaddr)
         kfunc(rprintf)("Radar: failed to look up server hostname\n");
-    }
-    deallocate_closure(ch);
 }
 
 define_closure_function(0, 1, void, retry_timer_func,
@@ -132,7 +124,6 @@ define_closure_function(0, 1, void, retry_timer_func,
 
 static void telemetry_retry(void)
 {
-    kfunc(rprintf)("retry\n");
     kfunc(register_timer)(CLOCK_ID_MONOTONIC, telemetry.retry_backoff, false, 0,
             init_closure(&telemetry.retry_func, retry_timer_func));
     if (telemetry.retry_backoff < seconds(600))
@@ -232,22 +223,22 @@ closure_function(3, 1, buffer_handler, telemetry_ch,
 
 boolean telemetry_send(const char *url, buffer data, value_handler vh)
 {
-    connection_handler ch = closure(telemetry.h, telemetry_ch, url, data, vh);
-    if (ch == INVALID_ADDRESS)
-        return false;
+    connection_handler ch;
     ip_addr_t radar_addr;
     telemetry.lwip_lock();
-    err_t err = kfunc(dns_gethostbyname)(RADAR_HOSTNAME, &radar_addr, telemetry_dns_cb, ch);
+    err_t err = kfunc(dns_gethostbyname)(RADAR_HOSTNAME, &radar_addr, telemetry_dns_cb, 0);
     telemetry.lwip_unlock();
     switch (err) {
     case ERR_OK:
+        ch = closure(telemetry.h, telemetry_ch, url, data, vh);
+        if (ch == INVALID_ADDRESS)
+            break;
         if (telemetry.tls_connect(&radar_addr, RADAR_PORT, ch) == 0)
             return true;
+        else
+            deallocate_closure(ch);
         break;
-    case ERR_INPROGRESS:
-        return true;
     }
-    deallocate_closure(ch);
     return false;
 }
 

--- a/src/net/direct.c
+++ b/src/net/direct.c
@@ -66,6 +66,7 @@ define_closure_function(1, 0, void, direct_receive_service,
                 s = apply(dc->receive_bh, alloca_wrap_buffer(p->payload, p->len));
                 lwip_lock();
                 tcp_recved(dc->p, p->len);
+                pbuf_free(p);
                 lwip_unlock();
             } else {
                 lwip_lock();


### PR DESCRIPTION
A few changes have been made in net/direct.c to allow TCP clients implemented in the klibs to operate correctly:
- connection establishment and shutdown events are processed by the receive service routine instead of being processed directly by the respective lwIP callbacks
- the receive service routine dequeues all pbufs found in a given queue, instead of just the first one
- direct_conn structures created as a result of a client connection being accepted are added to the connection list of the direct structure, so that they are properly serviced
In addition, a missing call to pbuf_free() in the receive service routine has been added.

The radar, ntp  and cloud_init klibs have been fixed to avoid calling lwip_lock() from within the DNS callback, where the lock is already held.