### PR TITLE
fsfile_open_or_create(): fix handling of file paths

### DIFF
--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -391,11 +391,14 @@ fsfile fsfile_open_or_create(buffer file_path)
     tuple root = filesystem_getroot(fs);
     char *file_str = buffer_to_cstring(file_path);
     int separator = buffer_strrchr(file_path, '/');
-    file_str[separator] = '\0';
-    fs_status s = filesystem_mkdirpath(fs, 0, file_str, true);
-    if ((s != FS_STATUS_OK) && (s != FS_STATUS_EXIST))
-        return 0;
-    file_str[separator] = '/';
+    fs_status s;
+    if (separator > 0) {
+        file_str[separator] = '\0';
+        s = filesystem_mkdirpath(fs, 0, file_str, true);
+        if ((s != FS_STATUS_OK) && (s != FS_STATUS_EXIST))
+            return 0;
+        file_str[separator] = '/';
+    }
     s = filesystem_get_node(&fs, inode_from_tuple(root), file_str, true, true, false, &file, &fsf);
     if (s == FS_STATUS_OK) {
         filesystem_put_node(fs, file);


### PR DESCRIPTION
A file path supplied to fsfile_open_or_create() can consist of a simple file name not prefixed by a directory path; in this case, filesystem_mkdirpath() should not be called.
This PR fixes an issue where fsfile_open_or_create() called with a simple fine name would create a directory with the supplied name, instead of creating a file.