### PR TITLE
Unix sockets: fix behavior of connect() before server accept()

### DIFF
--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -70,6 +70,7 @@ typedef struct iovec {
 #define EBADFD          77		/* File descriptor in bad state */
 #define EDESTADDRREQ    89		/* Destination address required */
 #define EMSGSIZE        90		/* Message too long */
+#define EPROTOTYPE      91		/* Wrong protocol type for socket */
 #define EOPNOTSUPP      95		/* Operation not supported */
 #define EISCONN         106
 #define ENOTCONN        107


### PR DESCRIPTION
When a server socket is in listening state, client connections should succeed without blocking (unless the server backlog is full), even if accept() has not been called on the server socket. This commit fixes unixsock_connect() and unixsock_accept() to implement the above behavior.
In addition, the EPROTOTYPE error code is returned instead of ECONNREFUSED when trying to connect a given socket to a socket of a different type, to match the Linux kernel behavior.