### PR TITLE
Check for null root_fs in get_root_tuple

### DIFF
--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -168,7 +168,7 @@ filesystem get_root_fs(void)
 
 tuple get_root_tuple(void)
 {
-    return filesystem_getroot(root_fs);
+    return root_fs ? filesystem_getroot(root_fs) : 0;
 }
 KLIB_EXPORT(get_root_tuple);
 


### PR DESCRIPTION
If root_fs is null then a call to filesystem_getroot will dereference a
null pointer. This can happen early in booting.