### PR TITLE
poll(): properly initialize revents field for all pollfd structures

### DIFF
--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -958,11 +958,11 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
     bitmap remove_efds = bitmap_clone(e->fds); /* efds to remove */
     for (int i = 0; i < nfds; i++) {
         struct pollfd *pfd = fds + i;
+        pfd->revents = 0;
         epollfd efd;
 
         /* skip ignored events */
         if (pfd->fd < 0) {
-            pfd->revents = 0;
             continue;
         }
 


### PR DESCRIPTION
When poll() is invoked, the kernel should initialize to 0 the revents field for all the structs supplied in the syscall, not only for those to be ignored, otherwise there may be spurious values in this field when the syscall returns.
This PR fixes the above issue and adds to the pipe runtime test a test case that would have failed without this fix.
Closes #833.