### PR TITLE
lwIP: add compilation of MD5 hash function

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -147,7 +147,8 @@ SRCS-lwip= \
 	$(LWIPDIR)/src/core/timeouts.c \
 	$(LWIPDIR)/src/core/udp.c \
 	$(LWIPDIR)/src/api/err.c \
-	$(LWIPDIR)/src/netif/ethernet.c
+	$(LWIPDIR)/src/netif/ethernet.c \
+	$(LWIPDIR)/src/netif/ppp/polarssl/md5.c \
 
 INCLUDES=\
 	-I$(SRCDIR) \

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -112,7 +112,8 @@ SRCS-lwip= \
 	$(LWIPDIR)/src/core/timeouts.c \
 	$(LWIPDIR)/src/core/udp.c \
 	$(LWIPDIR)/src/api/err.c \
-	$(LWIPDIR)/src/netif/ethernet.c
+	$(LWIPDIR)/src/netif/ethernet.c \
+	$(LWIPDIR)/src/netif/ppp/polarssl/md5.c \
 
 INCLUDES=\
 	-I$(SRCDIR) \

--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -75,6 +75,7 @@ typedef unsigned long size_t;
 #define LWIP_TIMERS_CUSTOM 1
 #define LWIP_DHCP_BOOTP_FILE 1
 #define LWIP_DNS 1
+#define LWIP_INCLUDED_POLARSSL_MD5  1
 
 #define SO_REUSE 1
 #define LWIP_IPV6   1


### PR DESCRIPTION
This is needed to build the kernel with SYN cookie support implemented in lwIP.