### PR TITLE
Improve ftrace smp performance and accuracy

### DIFF
--- a/src/x86_64/ftrace.s
+++ b/src/x86_64/ftrace.s
@@ -20,6 +20,7 @@ extern __ftrace_graph_entry_fn
 extern __ftrace_graph_return_fn
 extern prepare_ftrace_return
 extern ftrace_return_to_handler
+extern tracing_on
 
 ;; After this is called, the following registers contain:
 ;;  %rdi - holds IP of tracee (address of function being traced)
@@ -96,6 +97,14 @@ global mcount
 global return_to_handler
 
 mcount:
+    ;; check if globally enabled
+    test byte [tracing_on], 1
+    jz ftrace_stub
+
+    ;; check if enabled on this cpu
+    test qword [gs:32], 1
+    jnz ftrace_stub
+
     cmp qword [__ftrace_function_fn], ftrace_stub
     jnz do_trace
 

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -249,6 +249,10 @@ struct cpuinfo_machine {
     /* One temporary for syscall enter to use so that we don't need to touch the user stack. +24 */
     u64 tmp;
 
+#ifdef CONFIG_FTRACE
+    /* Used by mcount to determine if to enter ftrace code. Should be the last to not mess with crt0.s +32 */
+    u64 ftrace_disable_cnt;
+#endif
     /*** End of fields touched by kernel entries ***/
 
     /* Stack for exceptions (which may occur in interrupt handlers) */


### PR DESCRIPTION
Ftrace was tracking events in a global rbuf struct where every function
entry and exit on each cpu required synchronized access to the global
array. This change converts the global array to a per-cpu set of arrays,
where the total configured array memory is divided evenly among cpus.
This eliminates contention between cpus to potentially improve tracing
performance and fixes a bug in smp ftrace where other cpus would not
record data when one cpu is recording information into the rbuf array.
Trace data is outputted for each cpu sequentially and not interleaved by
time on the assumption that the data will be summarized before use.
An additional quality-of-life improvement is added that leaves tracing
disabled at ftrace_init to avoid consuming trace buffer space from startup
and adds two new temporary uris to turn tracing on and off during runtime
with a get request until put support is available.

Testing reveals that the the user program is slightly slower with this change
than the original when running with multiple cpus.  This is because the
original code toggled off the mcount on rbuf_disable, which disables it for all
cores, not just the one needing it and a good amount of work gets done
by the user program in this disabled period. There was also significant
unreported call time missing with multiple cpus because of this bug.