### PR TITLE
Futex: fix race between FUTEX_WAIT and FUTEX_WAKE

### DIFF
--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -249,7 +249,7 @@ void blockq_flush(blockq bq)
     } while (1);
 }
 
-int blockq_transfer_waiters(blockq dest, blockq src, int n)
+int blockq_transfer_waiters(blockq dest, blockq src, int n, blockq_action_handler handler)
 {
     int transferred = 0;
     spin_lock_2(&src->lock, &dest->lock);
@@ -273,6 +273,7 @@ int blockq_transfer_waiters(blockq dest, blockq src, int n)
             }
         }
         list_delete(&t->bq_l);
+        apply(handler, t->bq_action);
         list_insert_before(&dest->waiters_head, &t->bq_l);
         t->blocked_on = dest;
         if (timer_pending && remain > 0) {

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -225,7 +225,6 @@ static void setup_thread_frame(heap h, context frame, thread t)
 void thread_sleep_interruptible(void)
 {
     disable_interrupts();
-    assert(current->blocked_on);
     thread_log(current, "sleep interruptible (on \"%s\")", blockq_name(current->blocked_on));
     ftrace_thread_switch(current, 0);
     count_syscall_save(current);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -143,6 +143,7 @@ typedef struct unix_heaps {
 
 typedef closure_type(io_completion, void, thread t, sysreturn rv);
 typedef closure_type(blockq_action, sysreturn, u64 flags);
+typedef closure_type(blockq_action_handler, void, blockq_action action);
 
 struct blockq;
 typedef struct blockq * blockq;
@@ -196,7 +197,7 @@ void blockq_set_completion(blockq bq, io_completion completion, thread t,
                            sysreturn rv);
 sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_bh, 
                                clock_id id, timestamp timeout, boolean absolute);
-int blockq_transfer_waiters(blockq dest, blockq src, int n);
+int blockq_transfer_waiters(blockq dest, blockq src, int n, blockq_action_handler handler);
 
 static inline sysreturn blockq_check(blockq bq, thread t, blockq_action a, boolean in_bh)
 {


### PR DESCRIPTION
In absence of the global kernel lock, there is a potential race between FUTEX_WAIT and FUTEX_WAKE, which can manifest as in the following example:
- thread 1 calls FUTEX_WAIT, locks the futex, checks that *uaddr == 0, futex_bh() unlocks the futex and returns BLOCKQ_BLOCK_REQUIRED
- thread 2 sets *uaddr = 1, calls FUTEX_WAKE, locks the futex, tries to wake up a blocked thread but does not find any in the futex bq waiter list, unlocks the futex
- in thread 1, blockq_check_timeout() processes the BLOCKQ_BLOCK_REQUIRED return value from futex_bh(), adds the thread to the futex bq waiter list, and goes to sleep, thus missing the FUTEX_WAKE event from thread 2

This PR fixes the above race by adding a `waiters` field to the futex struct, which tracks the number of threads waiting on the futex: when a FUTEX_WAKE operation is requested, if blockq_wake_one() cannot find a thread to wake up but the `waiters` value is non-zero, blockq_wake_one() is called again, on the assumption that a thread is about to be placed in the blockq waiter list.
Since futex_bh() needs to modify the `waiters` value, in order for the correct futex struct to be used by futex_bh() after one or more threads are requeued from one futex to another, a blockq action handler parameter has been added to blockq_transfer_waiters(): this handler is invoked for each action being moved from one blockq to another; the futex code implements this action so that the futex_bh closure member that references the futex is set to the destination futex of the requeue operation.

In addition, the `assert(current->blocked_on)` instruction in thread_sleep_interruptible() has been removed, because without the global kernel lock it is possible for a thread wakeup to be triggered before or during invocation of this function, for example when FUTEX_WAIT and FUTEX_WAKE are done simultaneously by two different CPUs.