### PR TITLE
Add locking to heaps

### DIFF
--- a/klib/cloud_init.c
+++ b/klib/cloud_init.c
@@ -503,7 +503,7 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym, status_handler co
         return KLIB_INIT_FAILED;
     }
     init_timer(&retry_timer);
-    cloud_heap = heap_general(get_kernel_heaps());
+    cloud_heap = heap_locked(get_kernel_heaps());
     if (first_boot()) {
         enum cloud c = cloud_detect(get_sym);
         switch (c) {

--- a/klib/mbedtls.c
+++ b/klib/mbedtls.c
@@ -281,7 +281,7 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
         tls.rprintf("TLS init: kernel symbols not found\n");
         return KLIB_INIT_FAILED;
     }
-    tls.h = heap_general(get_kernel_heaps());
+    tls.h = heap_locked(get_kernel_heaps());
     mbedtls_ssl_config_init(&tls.conf);
     mbedtls_ctr_drbg_init(&tls.ctr_drbg);
     mbedtls_entropy_init(&tls.entropy);

--- a/klib/radar.c
+++ b/klib/radar.c
@@ -501,7 +501,7 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
         return KLIB_INIT_FAILED;
     }
     kernel_heaps kh = get_kernel_heaps();
-    telemetry.h = heap_general(kh);
+    telemetry.h = heap_locked(kh);
     telemetry.phys = (heap)heap_physical(kh);
     if (tls_set_cacert(RADAR_CA_CERT, sizeof(RADAR_CA_CERT)) != 0) {
         kfunc(rprintf)("Radar: failed to set CA certificate\n");

--- a/klib/syslog.c
+++ b/klib/syslog.c
@@ -426,7 +426,7 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
         rprintf("syslog: kernel symbols not found\n");
         return KLIB_INIT_FAILED;
     }
-    syslog.h = heap_general(get_kernel_heaps());
+    syslog.h = heap_locked(get_kernel_heaps());
     tuple root = get_root_tuple();
     tuple cfg = get(root, sym(syslog));
     if (!cfg) {

--- a/klib/tun.c
+++ b/klib/tun.c
@@ -518,7 +518,7 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
             !(kfuncs.ip4_addr_netmask_valid = get_sym("ip4_addr_netmask_valid")) ||
             !(kfuncs.intern = get_sym("intern")))
         return KLIB_INIT_FAILED;
-    tun_heap = heap_general(get_kernel_heaps());
+    tun_heap = heap_locked(get_kernel_heaps());
     tuple root = get_root_tuple();
     if (!root)
         return KLIB_INIT_FAILED;

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -146,7 +146,7 @@ void vm_exit(u8 code)
 #endif
 
 #ifdef DUMP_MEM_STATS
-    buffer b = allocate_buffer(heap_general(get_kernel_heaps()), 512);
+    buffer b = allocate_buffer(heap_locked(get_kernel_heaps()), 512);
     if (b != INVALID_ADDRESS) {
         dump_mem_stats(b);
         buffer_print(b);

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -147,7 +147,7 @@ void vm_exit(u8 code)
 #endif
 
 #ifdef DUMP_MEM_STATS
-    buffer b = allocate_buffer(heap_general(get_kernel_heaps()), 512);
+    buffer b = allocate_buffer(heap_locked(get_kernel_heaps()), 512);
     if (b != INVALID_ADDRESS) {
         dump_mem_stats(b);
         buffer_print(b);

--- a/src/aws/ena/ena.c
+++ b/src/aws/ena/ena.c
@@ -2235,6 +2235,6 @@ static struct ena_aenq_handlers aenq_handlers = {
 
 void init_aws_ena(kernel_heaps kh)
 {
-    heap h = heap_general(kh);
+    heap h = heap_locked(kh);
     register_pci_driver(closure(h, ena_probe, h, (heap)heap_linear_backed(kh)));
 }

--- a/src/hyperv/netvsc/netvsc.c
+++ b/src/hyperv/netvsc/netvsc.c
@@ -251,7 +251,7 @@ netvsc_attach(kernel_heaps kh, hv_device* device)
     hn_softc_t *hn = allocate(h, sizeof(hn_softc_t));
     assert(hn != INVALID_ADDRESS);
 
-    hn->general = heap_general(kh);
+    hn->general = heap_locked(kh);
     hn->contiguous = (heap)heap_linear_backed(kh);
 
     hn->hn_dev_obj = device;

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -275,7 +275,7 @@ void kernel_runtime_init(kernel_heaps kh)
     init_symtab(kh);
     read_kernel_syms();
     reclaim_regions();          /* for pc: no accessing regions after this point */
-    shutdown_completions = allocate_vector(misc, SHUTDOWN_COMPLETIONS_SIZE);
+    shutdown_completions = allocate_vector(locked, SHUTDOWN_COMPLETIONS_SIZE);
     init_debug("pci_discover (for VGA)");
     pci_discover(); // early PCI discover to configure VGA console
     init_debug("clock");

--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -126,7 +126,7 @@ closure_function(6, 0, void, startup,
     }
     status_handler start = bound(start);
     closure_member(program_start, start, kp) = kp;
-    heap general = heap_general(kh);
+    heap general = heap_locked(kh);
     buffer_handler pg = closure(general, read_program_complete, general, root,
         bound(m), start, bound(completion));
 
@@ -157,7 +157,7 @@ closure_function(6, 0, void, startup,
 
 thunk create_init(kernel_heaps kh, tuple root, filesystem fs, merge *m)
 {
-    heap h = heap_general(kh);
+    heap h = heap_locked(kh);
     status_handler start = closure(h, program_start, 0, 0);
     *m = allocate_merge(h, start);
     return closure(h, startup, kh, root, fs, *m, start, apply_merge(*m));
@@ -191,7 +191,7 @@ closure_function(4, 2, void, bootfs_complete,
         if (v) {
             kernel_heaps kh = bound(kh);
             filesystem_read_entire(fs, v, (heap)heap_page_backed(kh),
-                                   closure(heap_general(kh),
+                                   closure(heap_locked(kh),
                                            kernel_read_complete, fs, !klibs_complete),
                                    ignore_status);
         }
@@ -203,6 +203,6 @@ filesystem_complete bootfs_handler(kernel_heaps kh, tuple root,
                                    status_handler klibs_complete,
                                    boolean ingest_kernel_syms)
 {
-    return closure(heap_general(kh), bootfs_complete,
+    return closure(heap_locked(kh), bootfs_complete,
                    kh, root, klibs_complete, ingest_kernel_syms);
 }

--- a/src/kernel/symtab.c
+++ b/src/kernel/symtab.c
@@ -100,6 +100,6 @@ void print_u64_with_sym(u64 a)
 
 void init_symtab(kernel_heaps kh)
 {
-    general = heap_general(kh);
-    elf_symtable = allocate_rangemap(general);
+    general = heap_locked(kh);
+    elf_symtable = allocate_rangemap(heap_general(kh));
 }

--- a/src/runtime/runtime_init.c
+++ b/src/runtime/runtime_init.c
@@ -119,7 +119,7 @@ heap transient;
 void init_runtime(heap general, heap safe)
 {
     // environment specific
-    transient = general;
+    transient = safe;
     register_format('p', format_pointer, 0);
     register_format('x', format_number, 1);
     register_format('d', format_number, 1);

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -231,7 +231,7 @@ process exec_elf(buffer ex, process kp)
     foreach_phdr(e, p) {
         if (p->p_type == PT_INTERP) {
             char *n = (void *)e + p->p_offset;
-            interp = resolve_path(root, split(heap_general(kh), alloca_wrap_buffer(n, runtime_strlen(n)), '/'));
+            interp = resolve_path(root, split(heap_locked(kh), alloca_wrap_buffer(n, runtime_strlen(n)), '/'));
             if (!interp) 
                 halt("couldn't find program interpreter %s\n", n);
         } else if (p->p_type == PT_LOAD) {
@@ -290,13 +290,13 @@ process exec_elf(buffer ex, process kp)
         exec_debug("...done\n");
     }
 
-    register_root_notify(sym(trace), closure(heap_general(kh), trace_notify, proc));
+    register_root_notify(sym(trace), closure(heap_locked(kh), trace_notify, proc));
 
     if (interp) {
         exec_debug("reading interp...\n");
         filesystem_read_entire(fs, interp, (heap)heap_page_backed(kh),
-                               closure(heap_general(kh), load_interp_complete, t, kh),
-                               closure(heap_general(kh), load_interp_fail));
+                               closure(heap_locked(kh), load_interp_complete, t, kh),
+                               closure(heap_locked(kh), load_interp_fail));
         return proc;
     }
 

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -1824,7 +1824,7 @@ ftrace_init(unix_heaps uh, filesystem fs)
 {
     int ret;
 
-    ftrace_heap = heap_general(&(uh->kh));
+    ftrace_heap = heap_locked(&(uh->kh));
     rbuf_heap = (heap)heap_linear_backed(&(uh->kh));
 
     /* init http listener */

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -109,7 +109,7 @@ closure_function(1, 1, void, maps_handler,
 
 static sysreturn maps_read(file f, void *dest, u64 length, u64 offset)
 {
-    heap h = heap_general(get_kernel_heaps());
+    heap h = heap_locked(get_kernel_heaps());
     buffer b = allocate_buffer(h, 512);
     if (b == INVALID_ADDRESS) {
         return -ENOMEM;
@@ -226,7 +226,7 @@ closure_function(1, 1, sysreturn, special_open,
                  file, f)
 {
     special_file *sf = bound(sf);
-    heap h = heap_general(get_kernel_heaps());
+    heap h = heap_locked(get_kernel_heaps());
     sysreturn ret;
 
     thread_log(current, "spec_open: %s", sf->path);
@@ -279,7 +279,7 @@ KLIB_EXPORT(create_special_file);
 
 void register_special_files(process p)
 {
-    heap h = heap_general((kernel_heaps)p->uh);
+    heap h = heap_locked((kernel_heaps)p->uh);
 
     fs_status fss = filesystem_mkdirpath(p->root_fs, 0, "/proc/self", true);
     if (fss == FS_STATUS_OK) {

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -298,7 +298,7 @@ define_closure_function(1, 0, void, free_thread,
 {
     deallocate_bitmap(bound(t)->affinity);
     deallocate_notify_set(bound(t)->signalfds);
-    deallocate(heap_general(get_kernel_heaps()), bound(t), sizeof(struct thread));
+    deallocate(heap_locked(get_kernel_heaps()), bound(t), sizeof(struct thread));
 }
 
 define_closure_function(1, 0, void, resume_syscall, thread, t)
@@ -310,7 +310,7 @@ define_closure_function(1, 0, void, resume_syscall, thread, t)
 thread create_thread(process p)
 {
     static int tidcount = 0;
-    heap h = heap_general((kernel_heaps)p->uh);
+    heap h = heap_locked((kernel_heaps)p->uh);
 
     thread t = allocate(h, sizeof(struct thread));
     if (t == INVALID_ADDRESS)
@@ -468,7 +468,7 @@ void threads_to_vector(process p, vector v)
 
 void init_threads(process p)
 {
-    heap h = heap_general((kernel_heaps)p->uh);
+    heap h = heap_locked((kernel_heaps)p->uh);
     p->threads = allocate_rbtree(h, closure(h, thread_tid_compare), closure(h, tid_print_key));
     spin_lock_init(&p->threads_lock);
     init_futices(p);

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -393,8 +393,8 @@ void init_interrupts(kernel_heaps kh)
     /* Exception handlers */
     handlers = allocate_zero(general, n_interrupt_vectors * sizeof(thunk));
     assert(handlers != INVALID_ADDRESS);
-    interrupt_vector_heap = create_id_heap(general, general, INTERRUPT_VECTOR_START,
-                                           n_interrupt_vectors - INTERRUPT_VECTOR_START, 1, false);
+    interrupt_vector_heap = create_id_heap(general, heap_locked(kh), INTERRUPT_VECTOR_START,
+                                           n_interrupt_vectors - INTERRUPT_VECTOR_START, 1, true);
     assert(interrupt_vector_heap != INVALID_ADDRESS);
 
     int_general = general;

--- a/src/xen/xennet.c
+++ b/src/xen/xennet.c
@@ -759,7 +759,7 @@ static status xennet_attach(kernel_heaps kh, int id, buffer frontend, tuple meta
     xd = allocate(h, sizeof(struct xennet_dev));
     assert(xd != INVALID_ADDRESS);
 
-    xd->h = heap_general(kh);
+    xd->h = heap_locked(kh);
     xd->contiguous = (heap)heap_linear_backed(kh);
 
     xd->netif = allocate(h, sizeof(struct netif));


### PR DESCRIPTION
All heaps used after boot should be accessed with some form of locking. This change makes heap usage safe without the global kernel lock.