### PR TITLE
Network socket listen(): allow call on already listening socket

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1864,7 +1864,12 @@ static sysreturn netsock_listen(struct sock *sock, int backlog)
         goto unlock_out;
     }
     if (s->info.tcp.state != TCP_SOCK_CREATED) {
-        rv = -EINVAL;
+        if (s->info.tcp.state == TCP_SOCK_LISTENING) {
+            tcp_backlog_set(s->info.tcp.lw, backlog);
+            rv = 0;
+        } else {
+            rv = -EINVAL;
+        }
         goto unlock_out;
     }
     struct tcp_pcb * lw = tcp_listen_with_backlog(s->info.tcp.lw, backlog);

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -80,6 +80,7 @@ static void netsock_test_basic(int sock_type)
         socklen_t len = sizeof(val);
         test_assert(getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &val, &len) == 0 && val == 0);
         test_assert(listen(fd, 1) == 0);
+        test_assert(listen(fd, 1) == 0);    /* test listen() call on already listening socket */
         test_assert(getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &val, &len) == 0 && val == 1);
         ret = pthread_create(&pt, NULL, netsock_test_basic_thread, (void *)(long)sock_type);
         test_assert(ret == 0);


### PR DESCRIPTION
It is allowed to call listen() on a socket that is already listening, and this can be used to change the backlog value.
This PR resolves an "[alert] 2#0: listen() to 0.0.0.0:8084, backlog 511 failed, ignored (22: Invalid argument)" error message output by Nginx.
In addition, truncation of the user-supplied backlog value to SOCK_QUEUE_LEN is being fixed.