### PR TITLE
Klibs: syslog: send UDP messages from flush timer

### DIFF
--- a/src/net/net.c
+++ b/src/net/net.c
@@ -224,6 +224,8 @@ KLIB_EXPORT(ipaddr_ntoa);
 KLIB_EXPORT(ipaddr_ntoa_r);
 KLIB_EXPORT(dns_gethostbyname);
 KLIB_EXPORT(pbuf_alloc);
+KLIB_EXPORT(pbuf_alloced_custom);
+KLIB_EXPORT(pbuf_remove_header);
 KLIB_EXPORT(pbuf_ref);
 KLIB_EXPORT(pbuf_copy_partial);
 KLIB_EXPORT(pbuf_free);


### PR DESCRIPTION
This change removes sending UDP syslog messages directly from the console write handler, and instead sends them via the flush timer, which has been repurposed to serve buffered data for both file and UDP output.
This allows the syslog klib to send UDP messages output by lwIP callbacks that write to the console, e.g. when a network interface is assigned an IP address. In such cases, the lwIP lock is already held when the console write handler is invoked, thus lwIP functions that need the lock to be acquired cannot be called.