### PR TITLE
Unix: register_special_files(): fix /proc/self/exe symbolic link

### DIFF
--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -292,7 +292,7 @@ void register_special_files(process p)
             assert(buffer_write_byte(b, '/'));
         assert(push_buffer(b, program));
         assert(buffer_write_byte(b, '\0')); /* append string terminator character */
-        filesystem_symlink(p->root_fs, 0, "/proc/self/exe", buffer_ref(b, 0));
+        filesystem_symlink(p->cwd_fs, p->cwd, "/proc/self/exe", buffer_ref(b, 0));
         deallocate_buffer(b);
     }
 

--- a/test/runtime/symlink.c
+++ b/test/runtime/symlink.c
@@ -24,6 +24,8 @@ int main(int argc, char **argv)
 
     setbuf(stdout, NULL);
 
+    test_assert(readlink("/proc/self/exe", buf, sizeof(buf)) > 0);
+
     test_assert(readlink("link", buf, sizeof(buf)) == -1);
     test_assert(errno == ENOENT);
 


### PR DESCRIPTION
Since commit 67a24148e96c7e037f06ae2772f3dcd767e2a94d, filesystem_symlink() must be called with a valid inode number as `cwd` argument. This change fixes a regression introduced in the above commit that is causing the /proc/self/exe symbolic link to not be properly created during the first boot.