### PR TITLE
Allow /proc/mounts to notify pollers of mount change

### DIFF
--- a/klib/tun.c
+++ b/klib/tun.c
@@ -482,7 +482,7 @@ closure_function(0, 1, sysreturn, tun_open,
 int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
 {
     void *(*get_kernel_heaps)(void);
-    boolean (*create_special_file)(const char *path, spec_file_open open);
+    boolean (*create_special_file)(const char *path, spec_file_open open, u64 size);
     tuple (*get_root_tuple)(void);
     if (!(get_kernel_heaps = get_sym("get_kernel_heaps")) ||
             !(create_special_file = get_sym("create_special_file")) ||
@@ -530,7 +530,7 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
     spec_file_open open = closure(tun_heap, tun_open);
     if (open == INVALID_ADDRESS)
         return KLIB_INIT_FAILED;
-    if (create_special_file("/dev/net/tun", open)) {
+    if (create_special_file("/dev/net/tun", open, 0)) {
         return KLIB_INIT_OK;
     } else {
         deallocate_closure(open);

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -85,3 +85,6 @@ typedef closure_type(volume_handler, void, u8 *, const char *, struct filesystem
 void storage_iterate(volume_handler vh);
 
 void storage_detach(block_io r, block_io w, thunk complete);
+typedef closure_type(mount_notification_handler, void, u64);
+void storage_register_mount_notify(mount_notification_handler nh);
+void storage_unregister_mount_notify(mount_notification_handler nh);

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -378,7 +378,10 @@ void file_release(file f)
 {
     release_fdesc(&f->f);
     filesystem_release(f->fs);
-    unix_cache_free(get_unix_heaps(), file, f);
+    if (f->f.type == FDESC_TYPE_SPECIAL)
+        spec_deallocate(f);
+    else
+        unix_cache_free(get_unix_heaps(), file, f);
 }
 KLIB_EXPORT(file_release);
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -857,7 +857,7 @@ sysreturn open_internal(filesystem fs, inode cwd, const char *name, int flags,
         }
     }
 
-    file f = unix_cache_alloc(uh, file);
+    file f = type == FDESC_TYPE_SPECIAL ? spec_allocate(n) : unix_cache_alloc(uh, file);
     if (f == INVALID_ADDRESS) {
         thread_log(current, "failed to allocate struct file");
         ret = -ENOMEM;
@@ -887,7 +887,7 @@ sysreturn open_internal(filesystem fs, inode cwd, const char *name, int flags,
         if (spec_ret != 0) {
             assert(spec_ret < 0);
             thread_log(current, "spec_open failed (%d)\n", spec_ret);
-            unix_cache_free(uh, file, f);
+            spec_deallocate(f);
             ret = spec_ret;
             goto out;
         }

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -962,6 +962,8 @@ typedef closure_type(spec_file_open, sysreturn, file f);
 
 void register_special_files(process p);
 sysreturn spec_open(file f, tuple t);
+file spec_allocate(tuple t);
+void spec_deallocate(file f);
 
 /* Values to pass as first argument to prctl() */
 #define PR_SET_NAME    15               /* Set process name */


### PR DESCRIPTION
The /proc/mounts file has special behavior where a change to the file
from a mount or unmount causes poll to return POLLPRI and POLLERR. This
can be used to monitor the mount status of the system. This change
implements this feature by adding a generation number to track changes
to mounts and calling a list of registered handlers whenever a mount
changes. The /proc/mounts special file registers a handler that checks
to see if the generation number has changed and calls notify_dispatch
to send the event to waiters on the file. In order to track the special
file state, a new pointer field is added to the fdesc struct for holding
arbitrary data.

There are also some small fixes to the mounts_handler that generates
the /proc/mounts contents.