### PR TITLE
klibs: implement dynamic linking to kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ image: $(THIRD_PARTY) tools
 
 release: $(THIRD_PARTY) tools
 	$(Q) $(MAKE) -C $(PLATFORMDIR) boot
-	$(Q) $(MAKE) -C $(PLATFORMDIR) kernel
 	$(Q) $(MAKE) -C klib
+	$(Q) $(MAKE) -C $(PLATFORMDIR) kernel
 	$(Q) $(RM) -r release
 	$(Q) $(MKDIR) release
 	$(CP) $(MKFS) release

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -155,8 +155,6 @@ endif
 
 CFLAGS+=	$(KERNCFLAGS) -O3 $(INCLUDES) -fPIC $(DEFINES)
 
-# TODO should add stack protection to klibs...
-CFLAGS+=	-fno-stack-protector
 LDFLAGS+=	-shared -Bsymbolic -nostdlib -T$(ARCHDIR)/klib.lds
 
 CLEANFILES+=	$(KLIB_SYMS)

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -116,6 +116,8 @@ SRCS-mbedtls-tls= \
 
 all: $(PROGRAMS)
 
+KLIB_SYMS= $(OBJDIR)/klib-syms.lds
+
 include ../rules.mk
 
 ifeq ($(UNAME_s),Darwin)
@@ -155,6 +157,7 @@ CFLAGS+=	$(KERNCFLAGS) -O3 $(INCLUDES) -fPIC $(DEFINES)
 
 # TODO should add stack protection to klibs...
 CFLAGS+=	-fno-stack-protector
-LDFLAGS+=	-pie -nostdlib -T$(ARCHDIR)/klib.lds
+LDFLAGS+=	-shared -Bsymbolic -nostdlib -T$(ARCHDIR)/klib.lds
 
+CLEANFILES+=	$(KLIB_SYMS)
 CLEANDIRS+=	$(OUTDIR)/klib/vendor $(OUTDIR)/klib/vendor/mbedtls

--- a/klib/cloud_init.c
+++ b/klib/cloud_init.c
@@ -1,8 +1,10 @@
 #include <unix_internal.h>
 #include <cloud_init.h>
 #include <drivers/dmi.h>
+#include <filesystem.h>
 #include <http.h>
 #include <lwip.h>
+#include <tls.h>
 
 #define AZURE_CHASSIS   "7783-7084-3265-9085-8269-3286-77"
 
@@ -29,48 +31,8 @@ typedef struct cloud_download_cfg {
 
 static heap cloud_heap;
 
-static struct {
-    void (*rprintf)(const char *format, ...);
-    void (*runtime_memcpy)(void *a, const void *b, bytes len);
-    int (*runtime_memcmp)(const void *a, const void *b, bytes len);
-    void *(*get_klib_sym)(const char *sym_name);
-    buffer (*allocate_buffer)(heap h, bytes s);
-    merge (*allocate_merge)(heap h, status_handler completion);
-    status_handler (*apply_merge)(merge m);
-    u64 (*fsfile_get_length)(fsfile f);
-    fs_status (*fsfile_truncate)(fsfile f, u64 len);
-    fsfile (*fsfile_open_or_create)(buffer file_path);
-    void (*filesystem_write_linear)(fsfile f, void *src, range q, io_status_handler io_complete);
-    void (*lwip_lock)(void);
-    void (*lwip_unlock)(void);
-    err_t (*dns_gethostbyname)(const char *hostname, ip_addr_t *addr,
-            dns_found_callback found, void *callback_arg);
-    status (*direct_connect)(heap h, ip_addr_t *addr, u16 port, connection_handler ch);
-    int (*tls_connect)(ip_addr_t *addr, u16 port, connection_handler ch);
-    status (*http_request)(heap h, buffer_handler bh, http_method method,
-            tuple headers, buffer body);
-    buffer_handler (*allocate_http_parser)(heap h, value_handler each);
-    symbol (*intern)(string name);
-    tuple (*allocate_tuple)(void);
-    value (*get)(value e, symbol a);
-    void (*set)(value z, void *c, void *v);
-    void (*deallocate_value)(tuple t);
-    void (*destruct_tuple)(tuple t, boolean recursive);
-    tuple (*timm_alloc)(char *name, ...);
-    void (*timm_dealloc)(tuple t);
-    void (*register_timer)(timer t, clock_id id, timestamp val, boolean absolute,
-            timestamp interval, timer_handler n);
-} kfuncs;
-
-#undef sym
-#define sym(name)   sym_intern(name, kfuncs.intern)
-
-static enum cloud cloud_detect(klib_get_sym get_sym)
+static enum cloud cloud_detect(void)
 {
-    const char *(*dmi_get_string)(enum dmi_field) = get_sym("dmi_get_string");
-    int (*runtime_strcmp)(const char *, const char *) = get_sym("runtime_strcmp");
-    if (!dmi_get_string || !runtime_strcmp)
-        return CLOUD_ERROR;
     const char *chassis_asset_tag = dmi_get_string(DMI_CHASSIS_ASSET_TAG);
     if (!chassis_asset_tag)
         return CLOUD_UNKNOWN;
@@ -81,30 +43,25 @@ static enum cloud cloud_detect(klib_get_sym get_sym)
 
 static int cloud_download_parse(tuple config, cloud_download_cfg parsed_cfg)
 {
-    buffer src = kfuncs.get(config, sym(src));
+    buffer src = get(config, sym(src));
     if (!src) {
-        kfuncs.rprintf("cloud_init: missing download source in %v\n", config);
+        rprintf("cloud_init: missing download source in %v\n", config);
         return KLIB_INIT_FAILED;
     }
     if (!is_string(src) || (buffer_length(src) < 8)) {
-        kfuncs.rprintf("cloud_init: invalid download source %v\n", src);
+        rprintf("cloud_init: invalid download source %v\n", src);
         return KLIB_INIT_FAILED;
     }
-    if (!kfuncs.runtime_memcmp(buffer_ref(src, 0), "http://", 7)) {
+    if (!runtime_memcmp(buffer_ref(src, 0), "http://", 7)) {
         parsed_cfg->server_host.start = 7;
         parsed_cfg->server_port = 80;
         parsed_cfg->tls = false;
-    } else if (!kfuncs.runtime_memcmp(buffer_ref(src, 0), "https://", 8)) {
-        if (!kfuncs.tls_connect &&
-                ((kfuncs.tls_connect = kfuncs.get_klib_sym("tls_connect")) == INVALID_ADDRESS)) {
-            kfuncs.tls_connect = 0;
-            return KLIB_MISSING_DEP;
-        }
+    } else if (!runtime_memcmp(buffer_ref(src, 0), "https://", 8)) {
         parsed_cfg->server_host.start = 8;
         parsed_cfg->server_port = 443;
         parsed_cfg->tls = true;
     } else {
-        kfuncs.rprintf("cloud_init: invalid download source %b\n", src);
+        rprintf("cloud_init: invalid download source %b\n", src);
         return KLIB_INIT_FAILED;
     }
     parsed_cfg->server_host.contents = buffer_ref(src, 0);
@@ -124,38 +81,38 @@ static int cloud_download_parse(tuple config, cloud_download_cfg parsed_cfg)
     host_end = buffer_strchr(&parsed_cfg->server_host, ':');
     if (host_end >= 0) {
         if (host_end == buffer_length(&parsed_cfg->server_host) - 1) {
-            kfuncs.rprintf("cloud_init: invalid download source %b\n", src);
+            rprintf("cloud_init: invalid download source %b\n", src);
             return KLIB_INIT_FAILED;
         }
         buffer b = alloca_wrap_buffer(buffer_ref(&parsed_cfg->server_host, host_end + 1),
             buffer_length(&parsed_cfg->server_host) - host_end - 1);
         u64 port;
         if (!u64_from_value(b, &port) || (port > U16_MAX)) {
-            kfuncs.rprintf("invalid server port in download source %b\n", src);
+            rprintf("invalid server port in download source %b\n", src);
             return KLIB_INIT_FAILED;
         }
         parsed_cfg->server_port = port;
         parsed_cfg->server_host.end = parsed_cfg->server_host.start + host_end;
     }
     parsed_cfg->server_host.wrapped = true;
-    parsed_cfg->file_path = kfuncs.get(config, sym(dest));
+    parsed_cfg->file_path = get(config, sym(dest));
     if (!parsed_cfg->file_path) {
-        kfuncs.rprintf("cloud_init: missing download destination in %v\n", config);
+        rprintf("cloud_init: missing download destination in %v\n", config);
         return KLIB_INIT_FAILED;
     }
     if (!is_string(parsed_cfg->file_path)) {
-        kfuncs.rprintf("cloud_init: invalid download destination %v\n", parsed_cfg->file_path);
+        rprintf("cloud_init: invalid download destination %v\n", parsed_cfg->file_path);
         return KLIB_INIT_FAILED;
     }
     parsed_cfg->optional = parsed_cfg->done = false;
-    fsfile f = kfuncs.fsfile_open_or_create(parsed_cfg->file_path);
+    fsfile f = fsfile_open_or_create(parsed_cfg->file_path);
     if (!f) {
-        kfuncs.rprintf("cloud_init: download destination file '%b' cannot be created\n",
+        rprintf("cloud_init: download destination file '%b' cannot be created\n",
             parsed_cfg->file_path);
         return KLIB_INIT_FAILED;
     }
-    if (kfuncs.fsfile_get_length(f) > 0) {
-        if (kfuncs.get(config, sym(overwrite)))
+    if (fsfile_get_length(f) > 0) {
+        if (get(config, sym(overwrite)))
             parsed_cfg->optional = true;
         else
             parsed_cfg->done = true;
@@ -169,7 +126,7 @@ define_closure_function(2, 1, void, cloud_download_done,
 {
     cloud_download_cfg cfg = bound(cfg);
     if (!is_ok(s) && cfg->optional) {
-        kfuncs.timm_dealloc(s);
+        timm_dealloc(s);
         s = STATUS_OK;
     }
     deallocate(cloud_heap, cfg, sizeof(struct cloud_download_cfg));
@@ -182,7 +139,7 @@ closure_function(3, 2, void, cloud_download_save_complete,
 {
     value v = bound(v);
     if (v)
-        kfuncs.destruct_tuple(v, true);
+        destruct_tuple(v, true);
     else
         deallocate_buffer(bound(content));
     apply(bound(sh), s);
@@ -198,29 +155,27 @@ closure_function(5, 1, void, cloud_download_save,
     buffer content;
     if (v) {
         /* This is the beginning of the HTTP response from the server, parsed by the HTTP parser. */
-        tuple start_line = kfuncs.get(v, sym(start_line));
-        buffer status_code = kfuncs.get(start_line, sym(1));
+        tuple start_line = get_tuple(v, sym(start_line));
+        buffer status_code = get(start_line, sym(1));
         if (!status_code || (buffer_length(status_code) < 1) || (byte(status_code, 0) != '2')) {
             /* HTTP status code 2xx not found. */
-            s = kfuncs.timm_alloc("result", "%s: unexpected server response %v",
-                __func__, start_line);
+            s = timm("result", "%s: unexpected server response %v", __func__, start_line);
             goto error;
         }
-        buffer b = kfuncs.get(v, sym(Content-Length));
+        buffer b = get(v, sym(Content-Length));
         if (b) {
             if (!parse_int(b, 10, bound(content_len))) {
-                s = kfuncs.timm_alloc("result", "%s: failed to parse content length '%b'",
-                    __func__, b);
+                s = timm("result", "%s: failed to parse content length '%b'", __func__, b);
                 goto error;
             }
         }
-        content = kfuncs.get(v, sym(content));
+        content = get(v, sym(content));
     } else {
         /* This is a chunk of the body of the HTTP response from the server. */
         bytes len = buffer_length(bound(content));
-        content = kfuncs.allocate_buffer(cloud_heap, len);
+        content = allocate_buffer(cloud_heap, len);
         if (content != INVALID_ADDRESS) {
-            kfuncs.runtime_memcpy(buffer_ref(content, 0), buffer_ref(bound(content), 0), len);
+            runtime_memcpy(buffer_ref(content, 0), buffer_ref(bound(content), 0), len);
             buffer_produce(content, len);
         } else {
             content = 0;
@@ -229,23 +184,23 @@ closure_function(5, 1, void, cloud_download_save,
     if (content) {
         io_status_handler io_sh = closure(cloud_heap, cloud_download_save_complete, v, content, sh);
         if (io_sh == INVALID_ADDRESS) {
-            s = kfuncs.timm_alloc("result", "%s: failed to allocate I/O status handler", __func__);
+            s = timm("result", "%s: failed to allocate I/O status handler", __func__);
             if (!v)
                 deallocate_buffer(content);
             goto error;
         }
         bytes len = buffer_length(content);
-        kfuncs.filesystem_write_linear(bound(f), buffer_ref(content, 0),
+        filesystem_write_linear(bound(f), buffer_ref(content, 0),
             irangel(*bound(received), len), io_sh);
         *bound(received) += len;
         return;
     } else {
-        s = kfuncs.timm_alloc("result", "%s: no HTTP content", __func__);
+        s = timm("result", "%s: no HTTP content", __func__);
     }
   error:
     *bound(content_len) = (bytes)-1;    /* special value that indicates error */
     if (v)
-        kfuncs.destruct_tuple(v, true);
+        destruct_tuple(v, true);
     apply(sh, s);
 }
 
@@ -258,14 +213,14 @@ closure_function(7, 1, status, cloud_download_recv,
     if (data) {
         if (!bound(m)) {
             /* This is the first chunk of data received after connection establishment. */
-            fsfile f = kfuncs.fsfile_open_or_create(cfg->file_path);
+            fsfile f = fsfile_open_or_create(cfg->file_path);
             if (!f) {
-                kfuncs.rprintf("%s: failed to open file '%b'\n", __func__, cfg->file_path);
+                rprintf("%s: failed to open file '%b'\n", __func__, cfg->file_path);
                 goto error;
             }
-            fs_status fss = kfuncs.fsfile_truncate(f, 0);
+            fs_status fss = fsfile_truncate(f, 0);
             if (fss != FS_STATUS_OK) {
-                kfuncs.rprintf("%s: failed to truncate file '%b' (%d)\n",
+                rprintf("%s: failed to truncate file '%b' (%d)\n",
                     __func__, cfg->file_path, fss);
                 goto error;
             }
@@ -273,29 +228,29 @@ closure_function(7, 1, status, cloud_download_recv,
             /* Now that the file has been truncated, any download/save error will be fatal. */
             cfg->optional = false;
 
-            bound(m) = kfuncs.allocate_merge(cloud_heap, sh);
-            sh = bound(sh) = kfuncs.apply_merge(bound(m));
+            bound(m) = allocate_merge(cloud_heap, sh);
+            sh = bound(sh) = apply_merge(bound(m));
             bound(vh) = closure(cloud_heap, cloud_download_save, 0, &bound(content_len), f,
-                &bound(received), kfuncs.apply_merge(bound(m)));
+                &bound(received), apply_merge(bound(m)));
             if (bound(vh) == INVALID_ADDRESS) {
-                kfuncs.rprintf("%s: failed to allocate value handler\n", __func__);
+                rprintf("%s: failed to allocate value handler\n", __func__);
                 goto error;
             }
-            buffer_handler parser = kfuncs.allocate_http_parser(cloud_heap, bound(vh));
+            buffer_handler parser = allocate_http_parser(cloud_heap, bound(vh));
             if (parser != INVALID_ADDRESS) {
                 status s = apply(parser, data);
                 if (!is_ok(s)) {
-                    kfuncs.rprintf("%s: failed to parse HTTP response %v\n", __func__, s);
-                    kfuncs.timm_dealloc(s);
+                    rprintf("%s: failed to parse HTTP response %v\n", __func__, s);
+                    timm_dealloc(s);
                     goto error;
                 }
             } else {
-                kfuncs.rprintf("%s: failed to allocate HTTP parser\n", __func__);
+                rprintf("%s: failed to allocate HTTP parser\n", __func__);
                 goto error;
             }
         } else {
             closure_member(cloud_download_save, bound(vh), content) = data;
-            kfuncs.apply_merge(bound(m));
+            apply_merge(bound(m));
             apply(bound(vh), 0);
         }
         bytes content_len = bound(content_len);
@@ -307,9 +262,9 @@ closure_function(7, 1, status, cloud_download_recv,
         if (content_len == (bytes)-1)
             s = STATUS_OK;  /* error status has been set by cloud_download_save() */
         else if (bound(received) == 0)
-            s = kfuncs.timm_alloc("result", "empty file %b", cfg->file_path);
+            s = timm("result", "empty file %b", cfg->file_path);
         else if (bound(received) < content_len)
-            s = kfuncs.timm_alloc("result", "incomplete file %b (%ld/%ld)", cfg->file_path,
+            s = timm("result", "incomplete file %b (%ld/%ld)", cfg->file_path,
                 bound(received), content_len);
         else
             s = STATUS_OK;
@@ -335,26 +290,25 @@ closure_function(1, 1, buffer_handler, cloud_download_ch,
     buffer_handler in = 0;
     if (!out) {
         if (!cloud_download_retry((connection_handler)closure_self())) {
-            apply(sh, kfuncs.timm_alloc("result", "%s: failed to schedule retry", __func__));
+            apply(sh, timm("result", "%s: failed to schedule retry", __func__));
             goto done;
         }
         return in;
     }
-    tuple req = kfuncs.allocate_tuple();
+    tuple req = allocate_tuple();
     if (req == INVALID_ADDRESS) {
-        apply(sh, kfuncs.timm_alloc("result", "%s: failed to allocate tuple", __func__));
+        apply(sh, timm("result", "%s: failed to allocate tuple", __func__));
         goto done;
     }
-    kfuncs.set(req, sym(url), &cfg->server_path);
-    kfuncs.set(req, sym(Host), &cfg->server_host);
-    kfuncs.set(req, sym(Connection), alloca_wrap_cstring("close"));
-    status s = kfuncs.http_request(cloud_heap, out, HTTP_REQUEST_METHOD_GET, req, 0);
-    kfuncs.deallocate_value(req);
+    set(req, sym(url), &cfg->server_path);
+    set(req, sym(Host), &cfg->server_host);
+    set(req, sym(Connection), alloca_wrap_cstring("close"));
+    status s = http_request(cloud_heap, out, HTTP_REQUEST_METHOD_GET, req, 0);
+    deallocate_value(req);
     if (is_ok(s)) {
         in = closure(cloud_heap, cloud_download_recv, cfg, out, INVALID_ADDRESS, 0, 0, sh, 0);
         if (in == INVALID_ADDRESS)
-            apply(sh, kfuncs.timm_alloc("result", "%s: failed to allocate buffer handler",
-                __func__));
+            apply(sh, timm("result", "%s: failed to allocate buffer handler", __func__));
     } else {
         apply(sh, s);
     }
@@ -367,13 +321,13 @@ static status cloud_download_connect(ip_addr_t *addr, connection_handler ch)
 {
     cloud_download_cfg cfg = closure_member(cloud_download_ch, ch, cfg);
     if (cfg->tls) {
-        if (kfuncs.tls_connect(addr, cfg->server_port, ch) == 0)
+        if (tls_connect(addr, cfg->server_port, ch) == 0)
             return STATUS_OK;
-        return kfuncs.timm_alloc("result",
+        return timm("result",
             "cloud_init: failed to establish TLS connection with download server %b",
             &cfg->server_host);
     } else {
-        return kfuncs.direct_connect(cloud_heap, addr, cfg->server_port, ch);
+        return direct_connect(cloud_heap, addr, cfg->server_port, ch);
     }
 }
 
@@ -382,8 +336,7 @@ static void cloud_download_dns_cb(const char *name, const ip_addr_t *ipaddr, voi
     if (ipaddr)
         return;
     connection_handler ch = (connection_handler)callback_arg;
-    status s = kfuncs.timm_alloc("result", "cloud_init: failed to resolve server hostname '%s'",
-                                 name);
+    status s = timm("result", "cloud_init: failed to resolve server hostname '%s'", name);
     cloud_download_cfg cfg = closure_member(cloud_download_ch, ch, cfg);
     status_handler sh = (status_handler)&cfg->complete;
     apply(sh, s);
@@ -397,12 +350,12 @@ static void cloud_download(connection_handler ch)
     status s;
     bytes host_len = buffer_length(&cfg->server_host);
     char host[host_len + 1];
-    kfuncs.runtime_memcpy(host, buffer_ref(&cfg->server_host, 0), host_len);
+    runtime_memcpy(host, buffer_ref(&cfg->server_host, 0), host_len);
     host[host_len] = '\0';                                \
     ip_addr_t addr;
-    kfuncs.lwip_lock();
-    err_t err = kfuncs.dns_gethostbyname(host, &addr, cloud_download_dns_cb, ch);
-    kfuncs.lwip_unlock();
+    lwip_lock();
+    err_t err = dns_gethostbyname(host, &addr, cloud_download_dns_cb, ch);
+    lwip_unlock();
     switch (err) {
     case ERR_OK:
         s = cloud_download_connect(&addr, ch);
@@ -412,13 +365,12 @@ static void cloud_download(connection_handler ch)
     case ERR_INPROGRESS:
     case ERR_VAL:
         if (!cloud_download_retry(ch)) {
-            s = kfuncs.timm_alloc("result", "cloud_init: failed to schedule download retry");
+            s = timm("result", "cloud_init: failed to schedule download retry");
             goto error;
         }
         break;
     default:
-        s = kfuncs.timm_alloc("result", "cloud_init: failed to resolve server hostname '%s' (%d)",
-            host, err);
+        s = timm("result", "cloud_init: failed to resolve server hostname '%s' (%d)", host, err);
         goto error;
     }
     return;
@@ -443,7 +395,7 @@ static boolean cloud_download_retry(connection_handler ch)
     timer_handler th = closure(cloud_heap, cloud_download_retry_func, retry_timer, ch);
     if (th == INVALID_ADDRESS)
         return false;
-    kfuncs.register_timer(&closure_member(cloud_download_retry_func, th, timer),
+    register_timer(kernel_timers, &closure_member(cloud_download_retry_func, th, timer),
                    CLOCK_ID_MONOTONIC, seconds(1), false, 0, th);
     return true;
 }
@@ -452,103 +404,68 @@ static void cloud_download_start(cloud_download_cfg cfg, status_handler sh)
 {
     cloud_download_cfg cfg_copy = allocate(cloud_heap, sizeof(*cfg_copy));
     if (cfg_copy == INVALID_ADDRESS) {
-        apply(sh, kfuncs.timm_alloc("result", "%s: failed to allocate configuration", __func__));
+        apply(sh, timm("result", "%s: failed to allocate configuration", __func__));
         return;
     }
-    kfuncs.runtime_memcpy(cfg_copy, cfg, sizeof(*cfg_copy));
+    runtime_memcpy(cfg_copy, cfg, sizeof(*cfg_copy));
     init_closure(&cfg_copy->complete, cloud_download_done, cfg_copy, sh);
     connection_handler ch = closure(cloud_heap, cloud_download_ch, cfg_copy);
     if (ch == INVALID_ADDRESS) {
         deallocate(cloud_heap, cfg_copy, sizeof(*cfg_copy));
-        apply(sh, kfuncs.timm_alloc("result", "%s: failed to allocate connection handler",
-            __func__));
+        apply(sh, timm("result", "%s: failed to allocate connection handler", __func__));
         return;
     }
     cloud_download(ch);
 }
 
-int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym, status_handler complete)
+int init(status_handler complete)
 {
-    if (!(kfuncs.rprintf = get_sym("rprintf")))
-        return KLIB_INIT_FAILED;
-    void *(*get_kernel_heaps)(void) = get_sym("get_kernel_heaps");
-    boolean (*first_boot)(void) = get_sym("first_boot");
-    tuple (*get_root_tuple)(void) = get_sym("get_root_tuple");
-    symbol (*intern_u64)(u64 u) = get_sym("intern_u64");
-    if (!get_kernel_heaps || !first_boot || !get_root_tuple || !intern_u64 ||
-            !(kfuncs.runtime_memcpy = get_sym("runtime_memcpy")) ||
-            !(kfuncs.runtime_memcmp = get_sym("runtime_memcmp")) ||
-            !(kfuncs.get_klib_sym = get_sym("get_klib_sym")) ||
-            !(kfuncs.allocate_buffer = get_sym("allocate_buffer")) ||
-            !(kfuncs.allocate_merge = get_sym("allocate_merge")) ||
-            !(kfuncs.apply_merge = get_sym("apply_merge")) ||
-            !(kfuncs.fsfile_get_length = get_sym("fsfile_get_length")) ||
-            !(kfuncs.fsfile_truncate = get_sym("fsfile_truncate")) ||
-            !(kfuncs.fsfile_open_or_create = get_sym("fsfile_open_or_create")) ||
-            !(kfuncs.filesystem_write_linear = get_sym("filesystem_write_linear")) ||
-            !(kfuncs.lwip_lock = get_sym("lwip_lock")) ||
-            !(kfuncs.lwip_unlock = get_sym("lwip_unlock")) ||
-            !(kfuncs.dns_gethostbyname = get_sym("dns_gethostbyname")) ||
-            !(kfuncs.direct_connect = get_sym("direct_connect")) ||
-            !(kfuncs.http_request = get_sym("http_request")) ||
-            !(kfuncs.allocate_http_parser = get_sym("allocate_http_parser")) ||
-            !(kfuncs.intern = get_sym("intern")) ||
-            !(kfuncs.allocate_tuple = get_sym("allocate_tuple")) ||
-            !(kfuncs.get = get_sym("get")) || !(kfuncs.set = get_sym("set")) ||
-            !(kfuncs.deallocate_value = get_sym("deallocate_value")) ||
-            !(kfuncs.destruct_tuple = get_sym("destruct_tuple")) ||
-            !(kfuncs.timm_alloc = get_sym("timm")) ||
-            !(kfuncs.timm_dealloc = get_sym("timm_dealloc")) ||
-            !(kfuncs.register_timer = get_sym("kern_register_timer"))) {
-        kfuncs.rprintf("cloud_init: kernel symbols not found\n");
-        return KLIB_INIT_FAILED;
-    }
     cloud_heap = heap_locked(get_kernel_heaps());
     if (first_boot()) {
-        enum cloud c = cloud_detect(get_sym);
+        enum cloud c = cloud_detect();
         switch (c) {
         case CLOUD_ERROR:
             return KLIB_INIT_FAILED;
         case CLOUD_AZURE:
-            if (!azure_cloud_init(cloud_heap, get_sym))
+            if (!azure_cloud_init(cloud_heap))
                 return KLIB_INIT_FAILED;
             break;
         default:
             break;
         }
     }
-    tuple config = kfuncs.get(get_root_tuple(), sym(cloud_init));
+    tuple config = get(get_root_tuple(), sym(cloud_init));
     if (!config)
         return KLIB_INIT_OK;
     if (!is_tuple(config)) {
-        kfuncs.rprintf("invalid cloud_init configuration\n");
+        rprintf("invalid cloud_init configuration\n");
         return KLIB_INIT_FAILED;
     }
-    tuple download = kfuncs.get(config, sym(download));
+    tuple download = get(config, sym(download));
     if (download) {
         if (!is_tuple(download)) {
-            kfuncs.rprintf("invalid cloud_init download configuration\n");
+            rprintf("invalid cloud_init download configuration\n");
             return KLIB_INIT_FAILED;
         }
         int num_entries;
-        for (num_entries = 0; kfuncs.get(download, intern_u64(num_entries)); num_entries++)
+        for (num_entries = 0; get(download, intern_u64(num_entries)); num_entries++)
             ;
         struct cloud_download_cfg cfg[num_entries];
         for (int i = 0; i < num_entries; i++) {
-            value d = kfuncs.get(download, intern_u64(i));
+            value d = get(download, intern_u64(i));
             if (!is_tuple(d)) {
-                kfuncs.rprintf("invalid cloud_init download configuration\n");
+                rprintf("invalid cloud_init download configuration\n");
                 return KLIB_INIT_FAILED;
             }
             int ret = cloud_download_parse(d, &cfg[i]);
             if (ret != KLIB_INIT_OK)
                 return ret;
         }
-        merge m = kfuncs.allocate_merge(cloud_heap, complete);
-        complete = kfuncs.apply_merge(m);
+        merge m = allocate_merge(cloud_heap, complete);
+        complete = apply_merge(m);
         for (int i = 0; i < num_entries; i++)
             if (!cfg[i].done)
-                cloud_download_start(&cfg[i], kfuncs.apply_merge(m));
+                cloud_download_start(&cfg[i], apply_merge(m));
         apply(complete, STATUS_OK);
         return KLIB_INIT_IN_PROGRESS;
     }

--- a/klib/cloud_init.h
+++ b/klib/cloud_init.h
@@ -1,1 +1,1 @@
-boolean azure_cloud_init(heap h, klib_get_sym get_sym);
+boolean azure_cloud_init(heap h);

--- a/klib/klib.h
+++ b/klib/klib.h
@@ -5,7 +5,3 @@ enum {
     KLIB_INIT_IN_PROGRESS,
     KLIB_INIT_FAILED
 };
-
-typedef void *(*klib_get_sym)(const char *name);
-
-typedef void (*klib_add_sym)(void *e, const char *a, void *v);

--- a/klib/mbedtls_conf.h
+++ b/klib/mbedtls_conf.h
@@ -1,6 +1,7 @@
 #ifndef _RUNTIME_H_
 #include <runtime.h>
 #endif
+#include <mktime.h>
 
 #define NULL    ((void *)0)
 
@@ -22,52 +23,33 @@ typedef unsigned long uint64_t;
 typedef unsigned long size_t;
 typedef unsigned long uintptr_t;
 
-struct tm {
-    int tm_year;
-    uint8_t tm_mon;
-    uint8_t tm_mday;
-    uint8_t tm_hour;
-    uint8_t tm_min;
-    uint8_t tm_sec;
-};
-
-extern struct kern_funcs {
-    void (*memset)(void *a, unsigned char b, unsigned long len);
-    void (*memcopy)(void *a, const void *b, unsigned long len);
-    int (*memcmp)(const void *a, const void *b, unsigned long len);
-    int (*strcmp_f)(const char *string1, const char *string2);
-    char *(*strstr_f)(const char *haystack, const char *needle);
-    long (*time_f)(long *result);
-    int (*rsnprintf)(char *str, u64 size, const char *fmt, ...);
-} kern_funcs;
-
 #define MBEDTLS_PLATFORM_CALLOC_MACRO       mbedtls_calloc
 #define MBEDTLS_PLATFORM_FREE_MACRO         mbedtls_free
-#define MBEDTLS_PLATFORM_TIME_MACRO         kern_funcs.time_f
+#define MBEDTLS_PLATFORM_TIME_MACRO         rtime
 #define MBEDTLS_PLATFORM_TIME_TYPE_MACRO    long
-#define MBEDTLS_PLATFORM_SNPRINTF_MACRO     kern_funcs.rsnprintf
+#define MBEDTLS_PLATFORM_SNPRINTF_MACRO     rsnprintf
 
 void *mbedtls_calloc(size_t n, size_t s);
 void mbedtls_free(void *ptr);
 
 #ifndef memset
-#define memset  kern_funcs.memset
+#define memset(block, c, size)  runtime_memset((void *)(block), c, size)
 #endif
 #ifndef memcpy
-#define memcpy  kern_funcs.memcopy
+#define memcpy  runtime_memcpy
 #endif
 #ifndef memmove
-#define memmove kern_funcs.memcopy
+#define memmove runtime_memcpy
 #endif
 #ifndef memcmp
-#define memcmp  kern_funcs.memcmp
+#define memcmp  runtime_memcmp
 #endif
 #ifndef strlen
 #define strlen  runtime_strlen
 #endif
 #ifndef strcmp
-#define strcmp  kern_funcs.strcmp_f
+#define strcmp  runtime_strcmp
 #endif
 #ifndef strstr
-#define strstr  kern_funcs.strstr_f
+#define strstr  runtime_strstr
 #endif

--- a/klib/radar.c
+++ b/klib/radar.c
@@ -5,6 +5,7 @@
 #include <pagecache.h>
 #include <storage.h>
 #include <tfs/tfs.h>
+#include <tls.h>
 
 #define RADAR_HOSTNAME  "radar.relayered.net"
 #define RADAR_PORT      443
@@ -62,48 +63,10 @@ static struct telemetry {
     closure_struct(telemetry_stats, stats_func);
     u64 stats_mem_used[RADAR_STATS_BATCH_SIZE];
     int stats_count;
-    void (*rprintf)(const char *format, ...);
-    tuple (*allocate_tuple)(void);
-    void (*set)(value z, void *c, void *v);
-    void *(*get)(value z, void *c);
-    void (*deallocate_value)(tuple t);
-    void (*destruct_tuple)(tuple t, boolean recursive);
-    void (*timm_dealloc)(tuple t);
-    symbol (*intern)(string name);
-    symbol (*intern_u64)(u64 u);
-    void (*klog_load)(klog_dump dest, status_handler sh);
-    void (*klog_dump_clear)(void);
-    void (*klog_set_boot_id)(u64 id);
-    buffer (*allocate_buffer)(heap h, bytes s);
-    void (*buffer_write)(buffer b, const void *source, bytes length);
-    int (*buffer_strstr)(buffer b, const char *str);
-    void (*bprintf)(buffer b, const char *fmt, ...);
-    void (*print_uuid)(buffer b, u8 *uuid);
-    void (*storage_iterate)(volume_handler vh);
-    u64 (*fs_blocksize)(filesystem fs);
-    u64 (*fs_totalblocks)(filesystem fs);
-    u64 (*fs_usedblocks)(filesystem fs);
-    void (*register_timer)(timer t, clock_id id, timestamp val, boolean absolute,
-            timestamp interval, timer_handler n);
-    void (*lwip_lock)(void);
-    void (*lwip_unlock)(void);
-    struct netif *(*netif_get_default)(void);
-    char *(*ipaddr_ntoa)(const ip_addr_t *addr);
-    err_t (*dns_gethostbyname)(const char *hostname, ip_addr_t *addr,
-            dns_found_callback found, void *callback_arg);
-    buffer_handler (*allocate_http_parser)(heap h, value_handler each);
-    status (*http_request)(heap h, buffer_handler bh, http_method method,
-            tuple headers, buffer body);
-    int (*tls_connect)(ip_addr_t *addr, u16 port, connection_handler ch);
 } telemetry;
 
-#undef sym
-#define sym(name)   sym_intern(name, telemetry.intern)
-
-#define kfunc(name) telemetry.name
-
 /* To be used with literal strings only */
-#define buffer_write_cstring(b, s)  kfunc(buffer_write)(b, s, sizeof(s) - 1)
+#define buffer_write_cstring(b, s)  buffer_write(b, s, sizeof(s) - 1)
 
 static void telemetry_crash_report(void);
 static void telemetry_boot(void);
@@ -112,7 +75,7 @@ static void telemetry_stats_send(void);
 static void telemetry_dns_cb(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
 {
     if (!ipaddr)
-        kfunc(rprintf)("Radar: failed to look up server hostname\n");
+        rprintf("Radar: failed to look up server hostname\n");
 }
 
 define_closure_function(0, 2, void, retry_timer_func,
@@ -128,7 +91,7 @@ define_closure_function(0, 2, void, retry_timer_func,
 
 static void telemetry_retry(void)
 {
-    kfunc(register_timer)(&telemetry.retry_timer, CLOCK_ID_MONOTONIC, telemetry.retry_backoff, false, 0,
+    register_timer(kernel_timers, &telemetry.retry_timer, CLOCK_ID_MONOTONIC, telemetry.retry_backoff, false, 0,
             init_closure(&telemetry.retry_func, retry_timer_func));
     if (telemetry.retry_backoff < seconds(600))
         telemetry.retry_backoff <<= 1;
@@ -136,19 +99,19 @@ static void telemetry_retry(void)
 
 static boolean telemetry_req(const char *url, buffer data, buffer_handler bh)
 {
-    tuple req = kfunc(allocate_tuple)();
+    tuple req = allocate_tuple();
     if (req == INVALID_ADDRESS)
         return false;
-    kfunc(set)(req, sym(url), alloca_wrap_cstring(url));
-    kfunc(set)(req, sym(Host), alloca_wrap_cstring(RADAR_HOSTNAME));
-    kfunc(set)(req, sym(RADAR-KEY), telemetry.auth_header);
-    kfunc(set)(req, sym(Content-Type), alloca_wrap_cstring("application/json"));
-    status s = kfunc(http_request)(telemetry.h, bh, HTTP_REQUEST_METHOD_POST, req, data);
-    kfunc(deallocate_value)(req);
+    set(req, sym(url), alloca_wrap_cstring(url));
+    set(req, sym(Host), alloca_wrap_cstring(RADAR_HOSTNAME));
+    set(req, sym(RADAR-KEY), telemetry.auth_header);
+    set(req, sym(Content-Type), alloca_wrap_cstring("application/json"));
+    status s = http_request(telemetry.h, bh, HTTP_REQUEST_METHOD_POST, req, data);
+    deallocate_value(req);
     if (is_ok(s)) {
         return true;
     } else {
-        kfunc(timm_dealloc)(s);
+        timm_dealloc(s);
         return false;
     }
 }
@@ -160,15 +123,15 @@ closure_function(2, 1, status, telemetry_recv,
     if (data) {
         value_handler vh = bound(vh);
         if (vh) {
-            buffer_handler parser = kfunc(allocate_http_parser)(telemetry.h, vh);
+            buffer_handler parser = allocate_http_parser(telemetry.h, vh);
             if (parser != INVALID_ADDRESS) {
                 status s = apply(parser, data);
                 if (!is_ok(s)) {
-                    kfunc(rprintf)("Radar: failed to parse HTTP response: %v\n", s);
-                    kfunc(timm_dealloc)(s);
+                    rprintf("Radar: failed to parse HTTP response: %v\n", s);
+                    timm_dealloc(s);
                 }
             } else {
-                kfunc(rprintf)("Radar: failed to allocate HTTP parser\n");
+                rprintf("Radar: failed to allocate HTTP parser\n");
                 apply(vh, 0);
             }
         }
@@ -179,7 +142,7 @@ closure_function(2, 1, status, telemetry_recv,
             if (telemetry.dump_done) {
                 /* We just sent a crash report: clear the log dump (so that it's not
                  * sent again at the next boot), then send a boot event. */
-                kfunc(klog_dump_clear)();
+                klog_dump_clear();
                 deallocate(telemetry.h, telemetry.dump, sizeof(*telemetry.dump));
                 telemetry.dump = 0;
                 telemetry_boot();
@@ -193,7 +156,7 @@ closure_function(2, 1, status, telemetry_recv,
                     telemetry.stats_mem_used[count] = heap_allocated(telemetry.phys);
                 telemetry_stats_send();
                 telemetry.stats_count = 0;
-                kfunc(register_timer)(&telemetry.stats_timer, CLOCK_ID_MONOTONIC, RADAR_STATS_INTERVAL, false,
+                register_timer(kernel_timers, &telemetry.stats_timer, CLOCK_ID_MONOTONIC, RADAR_STATS_INTERVAL, false,
                         RADAR_STATS_INTERVAL, (timer_handler)&telemetry.stats_func);
                 telemetry.running = true;
             } else {
@@ -229,15 +192,15 @@ boolean telemetry_send(const char *url, buffer data, value_handler vh)
 {
     connection_handler ch;
     ip_addr_t radar_addr;
-    telemetry.lwip_lock();
-    err_t err = kfunc(dns_gethostbyname)(RADAR_HOSTNAME, &radar_addr, telemetry_dns_cb, 0);
-    telemetry.lwip_unlock();
+    lwip_lock();
+    err_t err = dns_gethostbyname(RADAR_HOSTNAME, &radar_addr, telemetry_dns_cb, 0);
+    lwip_unlock();
     switch (err) {
     case ERR_OK:
         ch = closure(telemetry.h, telemetry_ch, url, data, vh);
         if (ch == INVALID_ADDRESS)
             break;
-        if (telemetry.tls_connect(&radar_addr, RADAR_PORT, ch) == 0)
+        if (tls_connect(&radar_addr, RADAR_PORT, ch) == 0)
             return true;
         else
             deallocate_closure(ch);
@@ -250,45 +213,45 @@ static void telemetry_print_env(buffer b)
 {
     /* Assumes that the buffer already contains at least one JSON attribute
      * (hence the initial comma in the strings below). */
-    buffer nanos_ver = kfunc(get)(telemetry.env, sym(NANOS_VERSION));
+    buffer nanos_ver = get(telemetry.env, sym(NANOS_VERSION));
     if (nanos_ver)
-        kfunc(bprintf)(b, ",\"nanosVersion\":\"%b\"", nanos_ver);
-    buffer ops_ver = kfunc(get)(telemetry.env, sym(OPS_VERSION));
+        bprintf(b, ",\"nanosVersion\":\"%b\"", nanos_ver);
+    buffer ops_ver = get(telemetry.env, sym(OPS_VERSION));
     if (ops_ver)
-        kfunc(bprintf)(b, ",\"opsVersion\":\"%b\"", ops_ver);
-    buffer image_name = kfunc(get)(telemetry.env, sym(RADAR_IMAGE_NAME));
+        bprintf(b, ",\"opsVersion\":\"%b\"", ops_ver);
+    buffer image_name = get(telemetry.env, sym(RADAR_IMAGE_NAME));
     if (image_name)
-        kfunc(bprintf)(b, ",\"imageName\":\"%b\"", image_name);
+        bprintf(b, ",\"imageName\":\"%b\"", image_name);
 }
 
 closure_function(0, 1, void, telemetry_crash_recv,
                  value, v)
 {
     if (v) {
-        tuple resp = kfunc(get)(v, sym(start_line));
+        tuple resp = get(v, sym(start_line));
         if (resp && is_tuple(resp)) {
             buffer word;
-            for (u64 i = 0; (word = kfunc(get)(resp, kfunc(intern_u64)(i))); i++)
-                if (kfunc(buffer_strstr)(word, "OK") == 0) {
+            for (u64 i = 0; (word = get(resp, intern_u64(i))); i++)
+                if (buffer_strstr(word, "OK") == 0) {
                     telemetry.dump_done = true;
                     break;
                 }
         }
-        kfunc(destruct_tuple)(v, true);
+        destruct_tuple(v, true);
     }
     closure_finish();
 }
 
 static void telemetry_crash_report(void)
 {
-    buffer b = kfunc(allocate_buffer)(telemetry.h, PAGESIZE);
+    buffer b = allocate_buffer(telemetry.h, PAGESIZE);
     if (b == INVALID_ADDRESS)
         goto error;
     value_handler vh = closure(telemetry.h, telemetry_crash_recv);
     if (vh == INVALID_ADDRESS) {
         goto err_free_buf;
     }
-    kfunc(bprintf)(b, "{\"bootID\":%ld", telemetry.dump->boot_id);
+    bprintf(b, "{\"bootID\":%ld", telemetry.dump->boot_id);
     telemetry_print_env(b);
     buffer_write_cstring(b, ",\"dump\":\"");
     for (int i = 0; (i < sizeof(telemetry.dump->msgs)) && telemetry.dump->msgs[i]; i++) {
@@ -320,7 +283,7 @@ static void telemetry_crash_report(void)
             buffer_write_cstring(b, "\\f");
             break;
         default:
-            kfunc(buffer_write)(b, &c, 1);
+            buffer_write(b, &c, 1);
         }
     }
     buffer_write_cstring(b, "\"}\r\n");
@@ -340,9 +303,9 @@ closure_function(0, 1, void, telemetry_boot_recv,
     telemetry.boot_id = 0;
     if (!v) /* couldn't allocate HTTP parser */
         return;
-    buffer content = kfunc(get)(v, sym(content));
+    buffer content = get(v, sym(content));
     if (content) {
-        int index = kfunc(buffer_strstr)(content, "\"id\"");
+        int index = buffer_strstr(content, "\"id\"");
         if (index < 0)
             goto exit;
         buffer_consume(content, index);
@@ -354,28 +317,28 @@ closure_function(0, 1, void, telemetry_boot_recv,
                 goto exit;
         }
         parse_int(alloca_wrap_buffer(buffer_ref(content, 0), index), 10, &telemetry.boot_id);
-        kfunc(klog_set_boot_id)(telemetry.boot_id);
+        klog_set_boot_id(telemetry.boot_id);
     }
   exit:
-    kfunc(destruct_tuple)(v, true);
+    destruct_tuple(v, true);
     closure_finish();
 }
 
 static void telemetry_boot(void)
 {
-    struct netif *netif = kfunc(netif_get_default)();
+    struct netif *netif = netif_get_default();
     if (!netif)
         goto error;
-    buffer b = kfunc(allocate_buffer)(telemetry.h, 64);
+    buffer b = allocate_buffer(telemetry.h, 64);
     if (b == INVALID_ADDRESS)
         goto error;
     value_handler vh = closure(telemetry.h, telemetry_boot_recv);
     if (vh == INVALID_ADDRESS) {
         goto err_free_buf;
     }
-    telemetry.lwip_lock();      /* ipaddr_ntoa is not reentrant */
-    kfunc(bprintf)(b, "{\"privateIP\":\"%s\"", kfunc(ipaddr_ntoa)(&netif->ip_addr));
-    telemetry.lwip_unlock();
+    lwip_lock();      /* ipaddr_ntoa is not reentrant */
+    bprintf(b, "{\"privateIP\":\"%s\"", ipaddr_ntoa(&netif->ip_addr));
+    lwip_unlock();
     telemetry_print_env(b);
     buffer_write_cstring(b, "}\r\n");
     if (!telemetry_send("/api/v1/boots", b, vh)) {
@@ -393,34 +356,34 @@ closure_function(2, 4, void, telemetry_vh,
                  buffer, b, int, count,
                  u8 *, uuid, const char *, label, filesystem, fs, inode, mount_point)
 {
-    u64 block_size = kfunc(fs_blocksize)(fs);
+    u64 block_size = fs_blocksize(fs);
     buffer b = bound(b);
-    kfunc(bprintf)(b, "%s{\"volume\":\"", (bound(count) == 0) ? "" : ",");
+    bprintf(b, "%s{\"volume\":\"", (bound(count) == 0) ? "" : ",");
     if (label[0])
-        kfunc(bprintf)(b, "%s", label);
+        bprintf(b, "%s", label);
     else
-        kfunc(print_uuid)(b, uuid);
-    kfunc(bprintf)(b, "\",\"used\":%ld,\"total\":%ld}", kfunc(fs_usedblocks)(fs) * block_size,
-            kfunc(fs_totalblocks)(fs) * block_size);
+        print_uuid(b, uuid);
+    bprintf(b, "\",\"used\":%ld,\"total\":%ld}", fs_usedblocks(fs) * block_size,
+            fs_totalblocks(fs) * block_size);
     bound(count)++;
 }
 
 static void telemetry_stats_send(void)
 {
-    buffer b = kfunc(allocate_buffer)(telemetry.h, 128);
+    buffer b = allocate_buffer(telemetry.h, 128);
     if (b == INVALID_ADDRESS) {
-        kfunc(rprintf)("%s: failed to allocate buffer\n", __func__);
+        rprintf("%s: failed to allocate buffer\n", __func__);
         return;
     }
-    kfunc(bprintf)(b, "{\"bootID\":%ld,\"memUsed\":[", telemetry.boot_id);
+    bprintf(b, "{\"bootID\":%ld,\"memUsed\":[", telemetry.boot_id);
     for (int i = 0; i < RADAR_STATS_BATCH_SIZE; i++)
-        kfunc(bprintf)(b, "%ld%s", telemetry.stats_mem_used[i],
+        bprintf(b, "%ld%s", telemetry.stats_mem_used[i],
                 (i < RADAR_STATS_BATCH_SIZE - 1) ? "," : "");
     buffer_write_cstring(b, "],\"diskUsage\":[");
-    kfunc(storage_iterate)(stack_closure(telemetry_vh, b, 0));
+    storage_iterate(stack_closure(telemetry_vh, b, 0));
     buffer_write_cstring(b, "]}\r\n");
     if (!telemetry_send("/api/v1/machine-stats", b, 0)) {
-        kfunc(rprintf)("%s: failed to send stats\n", __func__);
+        rprintf("%s: failed to send stats\n", __func__);
         deallocate_buffer(b);
     }
 }
@@ -449,66 +412,21 @@ closure_function(0, 1, void, klog_dump_loaded,
             telemetry_boot();
         }
     } else
-        kfunc(timm_dealloc)(s);
+        timm_dealloc(s);
     closure_finish();
 }
 
-int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
+int init(status_handler complete)
 {
-    void *(*get_klib_sym)(const char *name) = get_sym("get_klib_sym");
-    if (!get_klib_sym)
-        return KLIB_INIT_FAILED;
-    int (*tls_set_cacert)(void *cert, u64 len) = get_klib_sym("tls_set_cacert");
-    if ((tls_set_cacert == INVALID_ADDRESS) ||
-            ((telemetry.tls_connect = get_klib_sym("tls_connect")) == INVALID_ADDRESS))
-        return KLIB_MISSING_DEP;
-    telemetry.rprintf = get_sym("rprintf");
-    if (!telemetry.rprintf)
-        return KLIB_INIT_FAILED;
-    void *(*get_kernel_heaps)(void) = get_sym("get_kernel_heaps");
-    void *(*get_environment)(void) = get_sym("get_environment");
-    u64 (*random_u64)(void) = get_sym("random_u64");
-    if (!get_kernel_heaps || !get_environment || !random_u64 ||
-            !(telemetry.allocate_tuple = get_sym("allocate_tuple")) ||
-            !(telemetry.set = get_sym("set")) ||
-            !(telemetry.get = get_sym("get")) ||
-            !(telemetry.deallocate_value = get_sym("deallocate_value")) ||
-            !(telemetry.destruct_tuple = get_sym("destruct_tuple")) ||
-            !(telemetry.timm_dealloc = get_sym("timm_dealloc")) ||
-            !(telemetry.intern = get_sym("intern")) ||
-            !(telemetry.intern_u64 = get_sym("intern_u64")) ||
-            !(telemetry.klog_load = get_sym("klog_load")) ||
-            !(telemetry.klog_dump_clear = get_sym("klog_dump_clear")) ||
-            !(telemetry.klog_set_boot_id = get_sym("klog_set_boot_id")) ||
-            !(telemetry.allocate_buffer = get_sym("allocate_buffer")) ||
-            !(telemetry.buffer_write = get_sym("buffer_write")) ||
-            !(telemetry.buffer_strstr = get_sym("buffer_strstr")) ||
-            !(telemetry.bprintf = get_sym("bprintf")) ||
-            !(telemetry.print_uuid = get_sym("print_uuid")) ||
-            !(telemetry.storage_iterate = get_sym("storage_iterate")) ||
-            !(telemetry.fs_blocksize = get_sym("fs_blocksize")) ||
-            !(telemetry.fs_totalblocks = get_sym("fs_totalblocks")) ||
-            !(telemetry.fs_usedblocks = get_sym("fs_usedblocks")) ||
-            !(telemetry.register_timer = get_sym("kern_register_timer")) ||
-            !(telemetry.lwip_lock = get_sym("lwip_lock")) ||
-            !(telemetry.lwip_unlock = get_sym("lwip_unlock")) ||
-            !(telemetry.netif_get_default = get_sym("netif_get_default")) ||
-            !(telemetry.ipaddr_ntoa = get_sym("ipaddr_ntoa")) ||
-            !(telemetry.dns_gethostbyname = get_sym("dns_gethostbyname")) ||
-            !(telemetry.allocate_http_parser = get_sym("allocate_http_parser")) ||
-            !(telemetry.http_request = get_sym("http_request"))) {
-        kfunc(rprintf)("Radar: kernel symbols not found\n");
-        return KLIB_INIT_FAILED;
-    }
     kernel_heaps kh = get_kernel_heaps();
     telemetry.h = heap_locked(kh);
     telemetry.phys = (heap)heap_physical(kh);
     if (tls_set_cacert(RADAR_CA_CERT, sizeof(RADAR_CA_CERT)) != 0) {
-        kfunc(rprintf)("Radar: failed to set CA certificate\n");
+        rprintf("Radar: failed to set CA certificate\n");
         return KLIB_INIT_FAILED;
     }
     telemetry.env = get_environment();
-    telemetry.auth_header = kfunc(get)(telemetry.env, sym(RADAR_KEY));
+    telemetry.auth_header = get(telemetry.env, sym(RADAR_KEY));
     telemetry.retry_backoff = seconds(1);
     init_timer(&telemetry.retry_timer);
     telemetry.running = false;
@@ -516,15 +434,15 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
     init_closure(&telemetry.stats_func, telemetry_stats);
     telemetry.dump = allocate(telemetry.h, sizeof(*telemetry.dump));
     if (telemetry.dump == INVALID_ADDRESS) {
-        kfunc(rprintf)("Radar: failed to allocate log dump\n");
+        rprintf("Radar: failed to allocate log dump\n");
         return KLIB_INIT_FAILED;
     }
     status_handler sh = closure(telemetry.h, klog_dump_loaded);
     if (sh == INVALID_ADDRESS) {
-        kfunc(rprintf)("Radar: failed to allocate log dump load handler\n");
+        rprintf("Radar: failed to allocate log dump load handler\n");
         deallocate(telemetry.h, telemetry.dump, sizeof(*telemetry.dump));
         return KLIB_INIT_FAILED;
     }
-    kfunc(klog_load)(telemetry.dump, sh);
+    klog_load(telemetry.dump, sh);
     return KLIB_INIT_OK;
 }

--- a/klib/syslog.c
+++ b/klib/syslog.c
@@ -71,60 +71,31 @@ static struct {
     struct spinlock lock;
 } syslog;
 
-static struct {
-    fsfile (*fsfile_open_or_create)(buffer file_path);
-    sg_io (*fsfile_get_writer)(fsfile f);
-    fs_status (*fsfile_truncate)(fsfile f, u64 len);
-    sg_list (*allocate_sg_list)(void);
-    sg_buf (*sg_list_tail_add)(sg_list sg, word length);
-    void (*deallocate_sg_list)(sg_list sg);
-    void (*runtime_memcpy)(void *a, const void *b, bytes len);
-    void (*register_timer)(timer t, clock_id id, timestamp val, boolean absolute, timestamp interval,
-            timer_handler n);
-    void (*timm_dealloc)(tuple t);
-    sysreturn (*fs_rename)(buffer oldpath, buffer newpath);
-    void (*lwip_lock)(void);
-    void (*lwip_unlock)(void);
-    err_t (*dns_gethostbyname)(const char *hostname, ip_addr_t *addr,
-            dns_found_callback found, void *callback_arg);
-    struct netif *(*netif_get_default)(void);
-    char *(*ipaddr_ntoa_r)(const ip_addr_t *addr, char *buf, int buflen);
-    struct pbuf *(*pbuf_alloced_custom)(pbuf_layer l, u16_t length, pbuf_type type,
-            struct pbuf_custom *p, void *payload_mem, u16_t payload_mem_len);
-    u8_t (*pbuf_remove_header)(struct pbuf *p, size_t header_size);
-    u8 (*pbuf_free)(struct pbuf *p);
-    timestamp (*now)(clock_id id);
-    struct tm *(*gmtime_r)(u64 *timep, struct tm *result);
-    int (*rsnprintf)(char *str, u64 size, const char *fmt, ...);
-    err_t(*udp_sendto)(struct udp_pcb *pcb, struct pbuf *p,
-            const ip_addr_t *dst_ip, u16_t dst_port);
-} kfuncs;
-
 static void syslog_file_rotate(void)
 {
     bytes path_len = buffer_length(syslog.file_path);
     buffer old_file = alloca_wrap_buffer(stack_allocate(path_len + 2), path_len + 2);
     buffer new_file = alloca_wrap_buffer(stack_allocate(path_len + 2), path_len + 2);
-    kfuncs.runtime_memcpy(buffer_ref(old_file, 0), buffer_ref(syslog.file_path, 0), path_len);
-    kfuncs.runtime_memcpy(buffer_ref(new_file, 0), buffer_ref(syslog.file_path, 0), path_len);
+    runtime_memcpy(buffer_ref(old_file, 0), buffer_ref(syslog.file_path, 0), path_len);
+    runtime_memcpy(buffer_ref(new_file, 0), buffer_ref(syslog.file_path, 0), path_len);
     byte(old_file, path_len) = byte(new_file, path_len) = '.';
 
     /* Rename rotated log files by replacing the ".<n-1>" name extension with ".<n>". */
     for (u64 i = syslog.file_rotate; i > 1; i--) {
         byte(new_file, path_len + 1) = '0' + i - 1;
         byte(old_file, path_len + 1) = '0' + i;
-        kfuncs.fs_rename(new_file, old_file);
+        fs_rename(new_file, old_file);
     }
 
     /* Rename the current log file by adding a ".1" extension to the file name. */
     byte(old_file, path_len + 1) = '1';
-    sysreturn ret = kfuncs.fs_rename(syslog.file_path, old_file);
+    sysreturn ret = fs_rename(syslog.file_path, old_file);
 
     if (ret == 0) {
         /* Continue logging on a new file. */
-        fsfile file = kfuncs.fsfile_open_or_create(syslog.file_path);
+        fsfile file = fsfile_open_or_create(syslog.file_path);
         syslog.file_offset = 0;
-        syslog.fs_write = kfuncs.fsfile_get_writer(file);
+        syslog.fs_write = fsfile_get_writer(file);
     } else {
         syslog.fs_write = 0;    /* stop logging */
     }
@@ -144,7 +115,7 @@ closure_function(3, 1, void, syslog_file_write_complete,
                 syslog_file_rotate();
             } else {
                 /* Delete old logs instead of rotating. */
-                if (kfuncs.fsfile_truncate(syslog.fsf, 0) == FS_STATUS_OK)
+                if (fsfile_truncate(syslog.fsf, 0) == FS_STATUS_OK)
                     syslog.file_offset = 0;
                 else
                     syslog.fs_write = 0;    /* stop logging */
@@ -153,10 +124,10 @@ closure_function(3, 1, void, syslog_file_write_complete,
                 spin_unlock(&syslog.lock);
         }
     } else {
-        kfuncs.timm_dealloc(s);
+        timm_dealloc(s);
     }
     deallocate(syslog.h, bound(buf), SYSLOG_BUF_LEN);
-    kfuncs.deallocate_sg_list(bound(sg));
+    deallocate_sg_list(bound(sg));
     closure_finish();
 }
 
@@ -175,7 +146,7 @@ static void syslog_file_flush(void)
         } else {
             /* Discard logged data. */
             deallocate(syslog.h, syslog.file_sgb->buf, SYSLOG_BUF_LEN);
-            kfuncs.deallocate_sg_list(sg);
+            deallocate_sg_list(sg);
         }
     }
     syslog_unlock();
@@ -186,18 +157,18 @@ static void syslog_file_write(const char *s, bytes count)
     if (!syslog.fs_write || (count > SYSLOG_BUF_LEN))
         return;
     if (!syslog.file_sg) {
-        syslog.file_sg = kfuncs.allocate_sg_list();
+        syslog.file_sg = allocate_sg_list();
         if (syslog.file_sg == INVALID_ADDRESS)
             return;
-        syslog.file_sgb = kfuncs.sg_list_tail_add(syslog.file_sg, SYSLOG_BUF_LEN);
+        syslog.file_sgb = sg_list_tail_add(syslog.file_sg, SYSLOG_BUF_LEN);
         if (!syslog.file_sgb) {
-            kfuncs.deallocate_sg_list(syslog.file_sg);
+            deallocate_sg_list(syslog.file_sg);
             syslog.file_sg = 0;
             return;
         }
         syslog.file_sgb->buf = allocate(syslog.h, SYSLOG_BUF_LEN);
         if (syslog.file_sgb->buf == INVALID_ADDRESS) {
-            kfuncs.deallocate_sg_list(syslog.file_sg);
+            deallocate_sg_list(syslog.file_sg);
             syslog.file_sg = 0;
             return;
         }
@@ -206,10 +177,10 @@ static void syslog_file_write(const char *s, bytes count)
         syslog.file_sgb->refcount = 0;
     }
     if (syslog.file_sgb->offset + count <= SYSLOG_BUF_LEN) {
-        kfuncs.runtime_memcpy(syslog.file_sgb->buf + syslog.file_sgb->offset, s, count);
+        runtime_memcpy(syslog.file_sgb->buf + syslog.file_sgb->offset, s, count);
         syslog.file_sgb->offset += count;
         if (!timer_is_active(&syslog.flush_timer)) {
-            kfuncs.register_timer(&syslog.flush_timer, CLOCK_ID_MONOTONIC,
+            register_timer(kernel_timers, &syslog.flush_timer, CLOCK_ID_MONOTONIC,
                                   SYSLOG_FLUSH_INTERVAL, false, 0,
                                   (timer_handler)&syslog.flush);
         }
@@ -225,7 +196,7 @@ static void syslog_dns_failure(void)
         syslog.dns_backoff = seconds(1);
     else
         syslog.dns_backoff *= 2;
-    syslog.dns_req_next = kfuncs.now(CLOCK_ID_MONOTONIC) + syslog.dns_backoff;
+    syslog.dns_req_next = kern_now(CLOCK_ID_MONOTONIC) + syslog.dns_backoff;
 }
 
 static void syslog_dns_cb(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
@@ -239,11 +210,11 @@ static void syslog_dns_cb(const char *name, const ip_addr_t *ipaddr, void *callb
 
 static void syslog_server_resolve(void)
 {
-    if (syslog.dns_in_progress || (kfuncs.now(CLOCK_ID_MONOTONIC) < syslog.dns_req_next))
+    if (syslog.dns_in_progress || (kern_now(CLOCK_ID_MONOTONIC) < syslog.dns_req_next))
         return;
-    kfuncs.lwip_lock();
-    err_t err = kfuncs.dns_gethostbyname(syslog.server, &syslog.server_ip, syslog_dns_cb, 0);
-    kfuncs.lwip_unlock();
+    lwip_lock();
+    err_t err = dns_gethostbyname(syslog.server, &syslog.server_ip, syslog_dns_cb, 0);
+    lwip_unlock();
     switch (err) {
     case ERR_OK:
         break;
@@ -258,10 +229,10 @@ static void syslog_server_resolve(void)
 
 static void syslog_set_hdr_len(void)
 {
-    struct netif *n = kfuncs.netif_get_default();
+    struct netif *n = netif_get_default();
     if (!n)
         return;
-    kfuncs.ipaddr_ntoa_r(&n->ip_addr, syslog.local_ip, sizeof(syslog.local_ip));
+    ipaddr_ntoa_r(&n->ip_addr, syslog.local_ip, sizeof(syslog.local_ip));
     syslog.hdr_len = syslog.max_hdr_len - sizeof(syslog.local_ip) +
             runtime_strlen(syslog.local_ip) + 1;
 }
@@ -284,10 +255,10 @@ static void syslog_udp_flush(void)
         syslog.udp_msg_count--;
         u64 seconds = sec_from_timestamp(msg->t);
         struct tm tm;
-        kfuncs.gmtime_r(&seconds, &tm);
+        gmtime_r(&seconds, &tm);
         struct pbuf *pbuf = &msg->p.pbuf;
-        kfuncs.pbuf_remove_header(pbuf, syslog.max_hdr_len - syslog.hdr_len);
-        kfuncs.rsnprintf(pbuf->payload, syslog.hdr_len,
+        pbuf_remove_header(pbuf, syslog.max_hdr_len - syslog.hdr_len);
+        rsnprintf(pbuf->payload, syslog.hdr_len,
             "<" __XSTRING(SYSLOG_PRIORITY) ">" SYSLOG_VERSION
             " %d-%02d-%02dT%02d:%02d:%02d.%06dZ %s %b - - -",
             1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec,
@@ -297,10 +268,10 @@ static void syslog_udp_flush(void)
          * header. */
         *(char *)(pbuf->payload + syslog.hdr_len - 1) = ' ';
 
-        kfuncs.lwip_lock();
-        kfuncs.udp_sendto(syslog.udp_pcb, pbuf, &syslog.server_ip, syslog.server_port);
-        kfuncs.pbuf_free(pbuf);
-        kfuncs.lwip_unlock();
+        lwip_lock();
+        udp_sendto(syslog.udp_pcb, pbuf, &syslog.server_ip, syslog.server_port);
+        pbuf_free(pbuf);
+        lwip_unlock();
     }
     syslog_unlock();
 }
@@ -319,17 +290,17 @@ static void syslog_udp_write(const char *s, bytes count)
     if (msg == INVALID_ADDRESS)
         return;
     msg->len = syslog.max_hdr_len + count;
-    msg->t = kfuncs.now(CLOCK_ID_REALTIME);
+    msg->t = kern_now(CLOCK_ID_REALTIME);
     msg->p.custom_free_function = syslog_udp_free;
-    kfuncs.pbuf_alloced_custom(PBUF_TRANSPORT, msg->len, PBUF_RAM, &msg->p, msg->buf,
+    pbuf_alloced_custom(PBUF_TRANSPORT, msg->len, PBUF_RAM, &msg->p, msg->buf,
                                PBUF_TRANSPORT + msg->len);
-    kfuncs.runtime_memcpy(msg->buf + PBUF_TRANSPORT + syslog.max_hdr_len, s, count);
+    runtime_memcpy(msg->buf + PBUF_TRANSPORT + syslog.max_hdr_len, s, count);
     syslog_lock();
     list_push_back(&syslog.udp_msgs, &msg->l);
     syslog.udp_msg_count++;
     if (!timer_is_active(&syslog.flush_timer)) {
-        kfuncs.register_timer(&syslog.flush_timer, CLOCK_ID_MONOTONIC, SYSLOG_FLUSH_INTERVAL, false,
-                              0, (timer_handler)&syslog.flush);
+        register_timer(kernel_timers, &syslog.flush_timer, CLOCK_ID_MONOTONIC,
+                       SYSLOG_FLUSH_INTERVAL, false, 0, (timer_handler)&syslog.flush);
     }
     syslog_unlock();
 }
@@ -423,7 +394,7 @@ closure_function(2, 2, boolean, syslog_cfg,
             rprintf("unable to allocate memory for syslog server\n");
             return false;
         }
-        kfuncs.runtime_memcpy(syslog.server, buffer_ref(v, 0), len);
+        runtime_memcpy(syslog.server, buffer_ref(v, 0), len);
         syslog.server[len] = '\0';
     } else if (s == sym(server_port)) {
         u64 port;
@@ -439,47 +410,8 @@ closure_function(2, 2, boolean, syslog_cfg,
     return true;
 }
 
-int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
+int init(status_handler complete)
 {
-    void (*rprintf)(const char *format, ...);
-    if (!(rprintf = get_sym("rprintf")))
-        return KLIB_INIT_FAILED;
-    tuple (*get_root_tuple)(void) = get_sym("get_root_tuple");
-    symbol (*intern)(string name) = get_sym("intern");
-    value (*get)(value e, symbol a) = get_sym("get");
-    boolean (*iterate)(value e, binding_handler h) = get_sym("iterate");
-    u64 (*fsfile_get_length)(fsfile f) = get_sym("fsfile_get_length");
-    void *(*get_kernel_heaps)(void) = get_sym("get_kernel_heaps");
-    struct udp_pcb *(*udp_new)(void) = get_sym("udp_new");
-    void (*attach_console_driver)(struct console_driver *driver) =
-            get_sym("attach_console_driver");
-    if (!get_root_tuple || !intern || !get || !iterate || !fsfile_get_length || !get_kernel_heaps ||
-            !udp_new || !attach_console_driver ||
-            !(kfuncs.fsfile_open_or_create = get_sym("fsfile_open_or_create")) ||
-            !(kfuncs.fsfile_get_writer = get_sym("fsfile_get_writer")) ||
-            !(kfuncs.fsfile_truncate = get_sym("fsfile_truncate")) ||
-            !(kfuncs.allocate_sg_list = get_sym("allocate_sg_list")) ||
-            !(kfuncs.sg_list_tail_add = get_sym("sg_list_tail_add")) ||
-            !(kfuncs.deallocate_sg_list = get_sym("deallocate_sg_list")) ||
-            !(kfuncs.runtime_memcpy = get_sym("runtime_memcpy")) ||
-            !(kfuncs.register_timer = get_sym("kern_register_timer")) ||
-            !(kfuncs.timm_dealloc = get_sym("timm_dealloc")) ||
-            !(kfuncs.fs_rename = get_sym("fs_rename")) ||
-            !(kfuncs.lwip_lock = get_sym("lwip_lock")) ||
-            !(kfuncs.lwip_unlock = get_sym("lwip_unlock")) ||
-            !(kfuncs.dns_gethostbyname = get_sym("dns_gethostbyname")) ||
-            !(kfuncs.netif_get_default = get_sym("netif_get_default")) ||
-            !(kfuncs.ipaddr_ntoa_r = get_sym("ipaddr_ntoa_r")) ||
-            !(kfuncs.pbuf_alloced_custom = get_sym("pbuf_alloced_custom")) ||
-            !(kfuncs.pbuf_remove_header = get_sym("pbuf_remove_header")) ||
-            !(kfuncs.pbuf_free = get_sym("pbuf_free")) ||
-            !(kfuncs.now = get_sym("now")) ||
-            !(kfuncs.gmtime_r = get_sym("gmtime_r")) ||
-            !(kfuncs.rsnprintf = get_sym("rsnprintf")) ||
-            !(kfuncs.udp_sendto = get_sym("udp_sendto"))) {
-        rprintf("syslog: kernel symbols not found\n");
-        return KLIB_INIT_FAILED;
-    }
     syslog.h = heap_locked(get_kernel_heaps());
     tuple root = get_root_tuple();
     tuple cfg = get(root, sym(syslog));
@@ -498,12 +430,12 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
         return KLIB_INIT_FAILED;
     }
     if (syslog.file_path) {
-        syslog.fsf = kfuncs.fsfile_open_or_create(syslog.file_path);
+        syslog.fsf = fsfile_open_or_create(syslog.file_path);
         if (!syslog.fsf) {
             rprintf("cannot create syslog output file\n");
             return KLIB_INIT_FAILED;
         }
-        syslog.fs_write = kfuncs.fsfile_get_writer(syslog.fsf);
+        syslog.fs_write = fsfile_get_writer(syslog.fsf);
         syslog.file_offset = fsfile_get_length(syslog.fsf); /* append to existing contents */
     }
     if (syslog.server) {
@@ -512,9 +444,9 @@ int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
         syslog.max_hdr_len = 1 + sizeof(__XSTRING(SYSLOG_PRIORITY)) + sizeof(SYSLOG_VERSION) +
                 sizeof("YYYY-MM-ddThh:mm:ss.uuuuuuZ") + sizeof(syslog.local_ip) +
                 buffer_length(syslog.program) + 7;
-        kfuncs.lwip_lock();
+        lwip_lock();
         syslog.udp_pcb = udp_new();
-        kfuncs.lwip_unlock();
+        lwip_unlock();
         if (!syslog.udp_pcb) {
             rprintf("syslog: unable to create UDP PCB\n");
             return KLIB_INIT_FAILED;

--- a/klib/test.c
+++ b/klib/test.c
@@ -1,33 +1,25 @@
 #include <klib.h>
+#include <runtime.h>
 
 #define Z_LEN 1024
 
 int y = 123;
 unsigned long z[Z_LEN];
 
-static int foo(int x)
+int foo(int x)
 {
     z[0] = x; /* bss write */
     return z[0] + y; /* test data */
 }
 
-void (*memset)(void *a, unsigned char b, unsigned long len);
-
-int init(void *md, klib_get_sym get_sym, klib_add_sym add_sym)
+int init(status_handler complete)
 {
     /* test that bss is clear */
     for (int i = 0; i < Z_LEN; i++)
         if (z[i] != 0)
             return KLIB_INIT_FAILED;
 
-    add_sym(md, "foo", foo);
-    add_sym(md, "bar", (void*)0);
-
-    memset = get_sym("runtime_memset");
-    if (!memset)
-        return KLIB_INIT_FAILED;
-
     unsigned long a = -1ull;
-    memset(&a, 0, sizeof(unsigned long));
+    runtime_memset((void *)&a, 0, sizeof(unsigned long));
     return a == 0 ? KLIB_INIT_OK : KLIB_INIT_FAILED;
 }

--- a/klib/tls.h
+++ b/klib/tls.h
@@ -1,0 +1,2 @@
+int tls_set_cacert(void *cert, u64 len);
+int tls_connect(ip_addr_t *addr, u16 port, connection_handler ch);

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -297,7 +297,7 @@ $(VDSO_OBJDIR)/vdso.so: $(VDSO_OBJS)
 $(VDSO_OBJDIR)/vdso-image.c: $(VDSOGEN) $(VDSO_OBJDIR)/vdso.so
 	$(call cmd,vdsogen)
 
-$(PROG-kernel.elf): linker_script $(VDSO_OBJDIR)/vdso-image.c
+$(PROG-kernel.elf): linker_script $(OUTDIR)/klib/klib-syms.lds $(VDSO_OBJDIR)/vdso-image.c
 
 $(KERNEL): $(PROG-kernel.elf)
 	$(call cmd,strip)

--- a/platform/pc/linker_script
+++ b/platform/pc/linker_script
@@ -2,6 +2,7 @@ OUTPUT_FORMAT("elf64-x86-64")
 
 ENTRY(_phys_start)
 
+INCLUDE klib-syms.lds
 
 PHDRS
 {
@@ -49,14 +50,6 @@ SECTIONS
     {
         *(.rodata)
         *(.rodata.*)
-    } :rodata
-
-    .klib_symtab ALIGN(16): AT(ADDR(.klib_symtab) - LOAD_OFFSET)
-    {
-        klib_syms_start = .;
-        KEEP(*(.klib_symtab.syms))
-        klib_syms_end = .;
-        KEEP(*(.klib_symtab.strs))
     } :rodata
 
     READONLY_END = .;

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -263,7 +263,7 @@ $(VDSO_OBJDIR)/vdso-offset.h: $(VDSO_OBJDIR)/vdso.so
 
 $(OBJDIR)/src/$(ARCH)/unix_machine.o: $(VDSO_OBJDIR)/vdso-offset.h
 
-$(PROG-kernel.elf): linker_script $(VDSO_OBJDIR)/vdso-image.c
+$(PROG-kernel.elf): linker_script $(OUTDIR)/klib/klib-syms.lds $(VDSO_OBJDIR)/vdso-image.c
 
 $(KERNEL): $(PROG-kernel.elf)
 	$(call cmd,strip)

--- a/platform/virt/linker_script
+++ b/platform/virt/linker_script
@@ -2,6 +2,8 @@ OUTPUT_FORMAT("elf64-littleaarch64")
 
 ENTRY(_phys_start)
 
+INCLUDE klib-syms.lds
+
 SECTIONS
 {
         KERNEL_PHYSADDR = 0x40400000;
@@ -42,14 +44,6 @@ SECTIONS
         {
             *(.rodata)
             *(.rodata.*)
-        }
-
-        .klib_symtab ALIGN(16): AT(ADDR(.klib_symtab) - LOAD_OFFSET)
-        {
-            klib_syms_start = .;
-            KEEP(*(.klib_symtab.syms))
-            klib_syms_end = .;
-            KEEP(*(.klib_symtab.strs))
         }
 
         . = ALIGN(4096);

--- a/src/aarch64/elf64.c
+++ b/src/aarch64/elf64.c
@@ -1,6 +1,8 @@
 #include <kernel.h>
 #include <elf64.h>
 
+#define R_AARCH64_GLOB_DAT   1025
+#define R_AARCH64_JUMP_SLOT  1026
 #define R_AARCH64_RELATIVE   1027
 
 void elf_apply_relocate_add(buffer elf, Elf64_Shdr *s, u64 offset)
@@ -14,4 +16,19 @@ void elf_apply_relocate_add(buffer elf, Elf64_Shdr *s, u64 offset)
             break;
         }
     }
+}
+
+boolean elf_apply_relocate_syms(buffer elf, Elf64_Shdr *s, elf_sym_relocator relocator)
+{
+    Elf64_Rela *rel = buffer_ref(elf, s->sh_addr);
+    for (int i = 0; i < s->sh_size / sizeof(*rel); i++) {
+        switch (ELF64_R_TYPE(rel[i].r_info)) {
+        case R_AARCH64_GLOB_DAT:
+        case R_AARCH64_JUMP_SLOT:
+            if (!apply(relocator, &rel[i]))
+                return false;
+            break;
+        }
+    }
+    return true;
 }

--- a/src/drivers/console.c
+++ b/src/drivers/console.c
@@ -27,7 +27,6 @@ void attach_console_driver(struct console_driver *driver)
             &driver->l);
     spin_unlock(&write_lock);
 }
-KLIB_EXPORT(attach_console_driver);
 
 void console_write(const char *s, bytes count)
 {

--- a/src/drivers/console.h
+++ b/src/drivers/console.h
@@ -10,3 +10,4 @@ typedef closure_type(console_attach, void, struct console_driver *);
 
 void init_console(kernel_heaps kh);
 void config_console(tuple root);
+void attach_console_driver(struct console_driver *driver);

--- a/src/drivers/dmi.c
+++ b/src/drivers/dmi.c
@@ -128,4 +128,3 @@ const char *dmi_get_string(enum dmi_field field)
     }
     return 0;
 }
-KLIB_EXPORT(dmi_get_string);

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -63,7 +63,6 @@ status http_request(heap h, buffer_handler bh, http_method method, tuple headers
         s = apply(bh, body);
     return s;
 }
-KLIB_EXPORT(http_request);
 
 static status send_http_headers(buffer_handler out, tuple t)
 {
@@ -270,7 +269,6 @@ buffer_handler allocate_http_parser(heap h, value_handler each)
     reset_parser(p);
     return closure(h, http_recv, p);
 }
-KLIB_EXPORT(allocate_http_parser);
 
 const char *http_request_methods[] = {
     [HTTP_REQUEST_METHOD_GET] = "GET",

--- a/src/kernel/clock.c
+++ b/src/kernel/clock.c
@@ -18,7 +18,6 @@ timestamp kern_now(clock_id id)
 {
     return now(id);
 }
-KLIB_EXPORT_RENAME(kern_now, now);
 
 void clock_adjust(timestamp wallclock_now, s64 temp_cal, timestamp sync_complete, s64 cal)
 {
@@ -34,7 +33,6 @@ void clock_adjust(timestamp wallclock_now, s64 temp_cal, timestamp sync_complete
     timer_reorder(kernel_timers);
     rtc_settimeofday(sec_from_timestamp(wallclock_now));
 }
-KLIB_EXPORT(clock_adjust);
 
 closure_function(1, 1, boolean, timer_adjust_handler,
                 s64, amt,
@@ -63,4 +61,3 @@ void clock_reset_rtc(timestamp wallclock_now)
     timer_reorder(kernel_timers);
     reset_clock_vdso_dat();
 }
-KLIB_EXPORT(clock_reset_rtc);

--- a/src/kernel/elf64.h
+++ b/src/kernel/elf64.h
@@ -202,6 +202,8 @@ typedef struct {
 #define SHT_SYMTAB 2/* symbol table section */
 #define SHT_STRTAB 3/* string table section */
 #define SHT_RELA   4
+#define SHT_DYNAMIC 6
+#define SHT_DYNSYM  11
 
 #define foreach_phdr(__e, __p)\
     for (int __i = 0; __i< __e->e_phnum; __i++)\
@@ -214,12 +216,16 @@ typedef struct {
 /* returns virtual address to access map (e.g. vaddr or identity in stage2) */
 typedef closure_type(elf_map_handler, u64, u64 /* vaddr */, u64 /* paddr, -1ull if bss */, u64 /* size */, pageflags /* flags */);
 typedef closure_type(elf_sym_handler, void, char *, u64, u64, u8);
+typedef closure_type(elf_sym_resolver, void *, const char *);
 void elf_symbols(buffer elf, elf_sym_handler each);
+boolean elf_dyn_link(buffer elf, void *load_addr, elf_sym_resolver resolver);
 void walk_elf(buffer elf, range_handler rh);
 void *load_elf(buffer elf, u64 load_offset, elf_map_handler mapper);
 
 /* Architecture-specific */
+typedef closure_type(elf_sym_relocator, boolean, Elf64_Rela *);
 void elf_apply_relocate_add(buffer elf, Elf64_Shdr *s, u64 offset);
+boolean elf_apply_relocate_syms(buffer elf, Elf64_Shdr *s, elf_sym_relocator relocator);
 
 static inline void elf_apply_relocs(buffer elf, u64 offset)
 {

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -273,6 +273,7 @@ void configure_timer(timestamp rate, thunk t);
 
 void kernel_sleep();
 void kernel_delay(timestamp delta);
+timestamp kern_now(clock_id id);    /* klibs must use this instead of now() */
 
 void init_clock(void);
 

--- a/src/kernel/klib.h
+++ b/src/kernel/klib.h
@@ -8,12 +8,10 @@ typedef struct klib_mapping {
     pageflags flags;
 } *klib_mapping;
 
-typedef int (*klib_init)(void *md, klib_get_sym get_sym, klib_add_sym add_sym,
-        status_handler complete);
+typedef int (*klib_init)(status_handler complete);
 
 typedef struct klib {
     char name[KLIB_MAX_NAME];
-    table syms;
     range load_range;
     rangemap mappings;
     buffer elf;
@@ -22,12 +20,9 @@ typedef struct klib {
 
 typedef closure_type(klib_handler, void, klib, int);
 
-void *klib_sym(klib kl, symbol s);
-void *get_klib_sym(const char *name);
-
 void load_klib(const char *name, klib_handler complete, status_handler sh);
 
 /* The caller must assure no references to klib remain before unloading. */
 void unload_klib(klib kl);
 
-void init_klib(kernel_heaps kh, void *fs, tuple root, tuple klib_md, status_handler complete);
+void init_klib(kernel_heaps kh, void *fs, tuple root, status_handler complete);

--- a/src/kernel/log.c
+++ b/src/kernel/log.c
@@ -52,7 +52,6 @@ void klog_set_boot_id(u64 id)
 {
     klog.dump.boot_id = id;
 }
-KLIB_EXPORT(klog_set_boot_id);
 
 define_closure_function(2, 1, void, klog_load_sh,
                         klog_dump, dest, status_handler, sh,
@@ -74,7 +73,6 @@ void klog_load(klog_dump dest, status_handler sh)
               irangel(klog.disk_offset >> SECTOR_OFFSET, KLOG_DUMP_SIZE >> SECTOR_OFFSET),
               init_closure(&klog.load_sh, klog_load_sh, dest, sh));
 }
-KLIB_EXPORT(klog_load);
 
 void klog_save(int exit_code, status_handler sh)
 {
@@ -109,4 +107,3 @@ void klog_dump_clear(void)
     apply(klog.disk_write, &klog.dump,
         irangel(klog.disk_offset >> SECTOR_OFFSET, 1), ignore_status);
 }
-KLIB_EXPORT(klog_dump_clear);

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -65,13 +65,6 @@ void kern_unlock()
     spin_unlock(&kernel_lock);
 }
 
-void kern_register_timer(timer t, clock_id id, timestamp val, boolean absolute,
-                         timestamp interval, timer_handler n)
-{
-    return register_timer(kernel_timers, t, id, val, absolute, interval, n);
-}
-KLIB_EXPORT(kern_register_timer);
-
 static void run_thunk(thunk t)
 {
     sched_debug(" run: %F state: %s\n", t, state_strings[current_cpu()->state]);

--- a/src/kernel/storage.c
+++ b/src/kernel/storage.c
@@ -303,7 +303,6 @@ void storage_iterate(volume_handler vh)
     }
     storage_unlock();
 }
-KLIB_EXPORT(storage_iterate);
 
 void storage_detach(block_io r, block_io w, thunk complete)
 {

--- a/src/kernel/symtab.h
+++ b/src/kernel/symtab.h
@@ -1,4 +1,7 @@
 void init_symtab(kernel_heaps kh);
+boolean symtab_is_empty(void);
+void *symtab_get_addr(const char *sym_name);
+void symtab_remove_addrs(range r);
 void add_elf_syms(buffer b, u64 load_offset);
 char * find_elf_sym(u64 a, u64 *offset, u64 *len);
 void print_u64_with_sym(u64 a);

--- a/src/net/direct.c
+++ b/src/net/direct.c
@@ -385,4 +385,3 @@ status direct_connect(heap h, ip_addr_t *addr, u16 port, connection_handler ch)
     lwip_unlock();
     return s;
 }
-KLIB_EXPORT(direct_connect);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -158,19 +158,6 @@ struct netif *netif_get_default(void)
 {
     return netif_default;
 }
-KLIB_EXPORT(netif_get_default);
-
-void kern_lwip_lock(void)
-{
-    lwip_lock();
-}
-KLIB_EXPORT_RENAME(kern_lwip_lock, lwip_lock);
-
-void kern_lwip_unlock(void)
-{
-    lwip_unlock();
-}
-KLIB_EXPORT_RENAME(kern_lwip_unlock, lwip_unlock);
 
 u16 ifflags_from_netif(struct netif *netif)
 {
@@ -217,27 +204,6 @@ void netif_name_cpy(char *dest, struct netif *netif)
     dest[sizeof(netif->name)] = '0' + netif->num;
     dest[sizeof(netif->name) + 1] = '\0';
 }
-KLIB_EXPORT(netif_name_cpy);
-
-KLIB_EXPORT(ip4addr_aton);
-KLIB_EXPORT(ipaddr_ntoa);
-KLIB_EXPORT(ipaddr_ntoa_r);
-KLIB_EXPORT(dns_gethostbyname);
-KLIB_EXPORT(pbuf_alloc);
-KLIB_EXPORT(pbuf_alloced_custom);
-KLIB_EXPORT(pbuf_remove_header);
-KLIB_EXPORT(pbuf_ref);
-KLIB_EXPORT(pbuf_copy_partial);
-KLIB_EXPORT(pbuf_free);
-KLIB_EXPORT(udp_new);
-KLIB_EXPORT(udp_sendto);
-KLIB_EXPORT(udp_recv);
-KLIB_EXPORT(netif_add);
-KLIB_EXPORT(netif_find);
-KLIB_EXPORT(netif_input);
-KLIB_EXPORT(netif_remove);
-KLIB_EXPORT(netif_set_up);
-KLIB_EXPORT(ip4_addr_netmask_valid);
 
 #define MAX_ADDR_LEN 20
 

--- a/src/runtime/buffer.c
+++ b/src/runtime/buffer.c
@@ -18,19 +18,6 @@ buffer allocate_buffer(heap h, bytes s)
     }
     return b;
 }
-KLIB_EXPORT(allocate_buffer);
-
-boolean kern_buffer_write(buffer b, const void *source, bytes length)
-{
-    return buffer_write(b, source, length);
-}
-KLIB_EXPORT_RENAME(kern_buffer_write, buffer_write);
-
-boolean kern_buffer_read(buffer b, void *dest, bytes length)
-{
-    return buffer_read(b, dest, length);
-}
-KLIB_EXPORT_RENAME(kern_buffer_read, buffer_read);
 
 boolean buffer_append(buffer b,
                      const void *body,
@@ -49,7 +36,6 @@ int buffer_strstr(buffer b, const char *str) {
     }
     return -1;
 }
-KLIB_EXPORT(buffer_strstr);
 
 void buffer_print(buffer b)
 {

--- a/src/runtime/extra_prints.c
+++ b/src/runtime/extra_prints.c
@@ -43,7 +43,6 @@ void print_uuid(buffer b, u8 *uuid)
     for (int i = 10; i < 16; i++)
         bprintf(b, "%02x", uuid[i]);
 }
-KLIB_EXPORT(print_uuid);
 
 /* just a little tool for debugging */
 void print_csum_buffer(buffer s, buffer b)

--- a/src/runtime/format.c
+++ b/src/runtime/format.c
@@ -141,7 +141,6 @@ void bprintf(buffer b, const char *fmt, ...)
     vbprintf(b, f, &ap);
     vend(ap);
 }
-KLIB_EXPORT(bprintf);
 
 int rsnprintf(char *str, u64 size, const char *fmt, ...)
 {
@@ -167,7 +166,6 @@ int rsnprintf(char *str, u64 size, const char *fmt, ...)
     deallocate_buffer(b);
     return n;
 }
-KLIB_EXPORT(rsnprintf);
 
 void rprintf(const char *format, ...)
 {
@@ -179,4 +177,3 @@ void rprintf(const char *format, ...)
     vbprintf(b, f, &a);
     buffer_print(b);
 }
-KLIB_EXPORT(rprintf);

--- a/src/runtime/management.c
+++ b/src/runtime/management.c
@@ -194,7 +194,6 @@ void management_reset(void)
     }
 #endif
 }
-KLIB_EXPORT(management_reset);
 
 parser management_parser(buffer_handler out)
 {
@@ -202,7 +201,6 @@ parser management_parser(buffer_handler out)
     return tuple_parser(h, closure(h, mgmt_tuple_parsed, out),
                         closure(h, mgmt_tuple_parse_error, out));
 }
-KLIB_EXPORT(management_parser);
 
 tuple allocate_function_tuple(tuple_get g, tuple_set s, tuple_iterate i)
 {
@@ -214,7 +212,6 @@ tuple allocate_function_tuple(tuple_get g, tuple_set s, tuple_iterate i)
     f->i = i;
     return (tuple)f;
 }
-KLIB_EXPORT(allocate_function_tuple);
 
 typedef struct tuple_notifier {
     struct function_tuple f;

--- a/src/runtime/memops.c
+++ b/src/runtime/memops.c
@@ -123,7 +123,6 @@ void runtime_memcpy(void *a, const void *b, bytes len)
         memcpyb_8(a, b, end_len);
     }
 }
-KLIB_EXPORT(runtime_memcpy);
 
 void runtime_memset(u8 *a, u8 b, bytes len)
 {
@@ -151,7 +150,6 @@ void runtime_memset(u8 *a, u8 b, bytes len)
     }
     memset_8(dest, b, end_len);
 }
-KLIB_EXPORT(runtime_memset);
 
 
 int runtime_memcmp(const void *a, const void *b, bytes len)
@@ -206,4 +204,3 @@ int runtime_memcmp(const void *a, const void *b, bytes len)
     }
     return memcmp_8(a + len - end_len, p_long_b, end_len);
 }
-KLIB_EXPORT(runtime_memcmp);

--- a/src/runtime/merge.c
+++ b/src/runtime/merge.c
@@ -45,10 +45,8 @@ merge allocate_merge(heap h, status_handler completion)
     m->last_status = STATUS_OK;
     return m;
 }
-KLIB_EXPORT(allocate_merge);
 
 status_handler apply_merge(merge m)
 {
     return apply(m->apply);
 }
-KLIB_EXPORT(apply_merge);

--- a/src/runtime/queue.c
+++ b/src/runtime/queue.c
@@ -17,23 +17,9 @@ queue allocate_queue(heap h, u64 size)
     q->h = h;
     return q;
 }
-KLIB_EXPORT(allocate_queue);
-
-boolean kern_enqueue(queue q, void *p)
-{
-    return enqueue(q, p);
-}
-KLIB_EXPORT_RENAME(kern_enqueue, enqueue);
-
-void *kern_dequeue(queue q)
-{
-    return dequeue(q);
-}
-KLIB_EXPORT_RENAME(kern_dequeue, dequeue);
 
 void deallocate_queue(queue q)
 {
     if (q->h)
         deallocate(q->h, q, _queue_alloc_size(q->order));
 }
-KLIB_EXPORT(deallocate_queue);

--- a/src/runtime/random.c
+++ b/src/runtime/random.c
@@ -114,11 +114,9 @@ u64 random_u64()
     arc4rand(&retval, sizeof(retval));
     return retval;
 }
-KLIB_EXPORT(random_u64);
 
 u64 random_buffer(buffer b)
 {
     arc4rand(buffer_ref(b, 0), buffer_length(b));
     return buffer_length(b);
 }
-KLIB_EXPORT(random_buffer);

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -255,20 +255,3 @@ void __stack_chk_guard_init();
 #define _countof(a) (sizeof(a) / sizeof(*(a)))
 
 #define struct_from_field(l, s, f) ((s)pointer_from_u64(u64_from_pointer(l) - offsetof(s, f)))
-
-#ifdef KERNEL
-typedef struct export_sym {
-    const char *name;
-    void *v;
-} *export_sym;
-
-#define KLIB_EXPORT_RENAME(sym, name)                                      \
-    static const char * __attribute__((section(".klib_symtab.strs")))      \
-        __attribute__((used)) _klib_sym_str_ ##sym = #name;                \
-    static struct export_sym __attribute__((section(".klib_symtab.syms"))) \
-        __attribute__((used)) _klib_export_sym_ ##sym = (struct export_sym){#name, (sym)};
-#define KLIB_EXPORT(sym)    KLIB_EXPORT_RENAME(sym, sym)
-#else
-#define KLIB_EXPORT(x)
-#define KLIB_EXPORT_RENAME(x, y)
-#endif

--- a/src/runtime/sg.c
+++ b/src/runtime/sg.c
@@ -150,7 +150,6 @@ sg_list allocate_sg_list(void)
     sg->count = 0;
     return sg;
 }
-KLIB_EXPORT(allocate_sg_list);
 
 void deallocate_sg_list(sg_list sg)
 {
@@ -160,13 +159,6 @@ void deallocate_sg_list(sg_list sg)
     list_insert_after(&free_sg_lists, &sg->l);
     sg_unlock();
 }
-KLIB_EXPORT(deallocate_sg_list);
-
-sg_buf kern_sg_list_tail_add(sg_list sg, word length)
-{
-    return sg_list_tail_add(sg, length);
-}
-KLIB_EXPORT_RENAME(kern_sg_list_tail_add, sg_list_tail_add);
 
 closure_function(4, 0, void, sg_wrapped_buf_release,
                  refcount, refcount, heap, backed, void *, buf, bytes, padlen)

--- a/src/runtime/string.c
+++ b/src/runtime/string.c
@@ -33,7 +33,6 @@ runtime_strstr(const char *haystack, const char *needle)
     else
         return 0;
 }
-KLIB_EXPORT(runtime_strstr);
 
 char *
 runtime_strtok_r (char *s, const char *delimiters, char **save_ptr)
@@ -75,4 +74,3 @@ runtime_strcmp (const char *string1, const char *string2)
 
     return *(const unsigned char *)string1 - *(const unsigned char *)string2;
 }
-KLIB_EXPORT(runtime_strcmp);

--- a/src/runtime/symbol.c
+++ b/src/runtime/symbol.c
@@ -35,7 +35,6 @@ symbol intern_u64(u64 u)
     print_number(b, u, 10, 0);
     return intern(b);
 }
-KLIB_EXPORT(intern_u64);
 
 symbol intern(string name)
 {
@@ -59,7 +58,6 @@ symbol intern(string name)
   alloc_fail:
     halt("intern: alloc fail\n");
 }
-KLIB_EXPORT(intern);
 
 string symbol_string(symbol s)
 {

--- a/src/runtime/table.c
+++ b/src/runtime/table.c
@@ -61,7 +61,6 @@ void deallocate_table(table t)
     deallocate(t->h, t->entries, t->buckets * sizeof(void *));
     deallocate(t->h, t, sizeof(struct table));
 }
-KLIB_EXPORT(deallocate_table);
 
 static inline key position(int buckets, key x)
 {
@@ -99,7 +98,6 @@ void *table_find(table t, void *c)
     }
     return EMPTY;
 }
-KLIB_EXPORT(table_find);
 
 void table_set(table t, void *c, void *v)
 {
@@ -141,7 +139,6 @@ void table_set(table t, void *c, void *v)
         }
     }
 }
-KLIB_EXPORT(table_set);
 
 int table_elements(table t)
 {

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -160,4 +160,3 @@ s64 rtime(s64 *result)
         *result = t;
     return t;
 }
-KLIB_EXPORT(rtime);

--- a/src/runtime/tuple.c
+++ b/src/runtime/tuple.c
@@ -29,7 +29,6 @@ value get(value e, symbol a)
         assert(0);
     }
 }
-KLIB_EXPORT(get);
 
 void set(value e, symbol a, value v)
 {
@@ -46,7 +45,6 @@ void set(value e, symbol a, value v)
         assert(0);
     }
 }
-KLIB_EXPORT(set);
 
 boolean iterate(value e, binding_handler h)
 {
@@ -65,7 +63,6 @@ boolean iterate(value e, binding_handler h)
         assert(0);
     }
 }
-KLIB_EXPORT(iterate);
 
 closure_function(1, 2, boolean, tuple_count_each,
                  int *, count,
@@ -111,7 +108,6 @@ tuple allocate_tuple(void)
 {
     return tag(allocate_table(theap, key_from_symbol, pointer_equal), tag_table_tuple);
 }
-KLIB_EXPORT(allocate_tuple);
 
 void destruct_tuple(tuple t, boolean recursive);
 
@@ -133,27 +129,12 @@ void destruct_tuple(tuple t, boolean recursive)
     iterate(t, stack_closure(destruct_tuple_each, t, recursive));
     deallocate_value(t);
 }
-KLIB_EXPORT(destruct_tuple);
-
-/* Compared to timm(), kern_timm() supports one key-value pair only. */
-tuple kern_timm(char *name, ...)
-{
-    tuple s = allocate_tuple();
-    assert(s != INVALID_ADDRESS);
-    vlist ap;
-    vstart(ap, name);
-    timm_term(s, name, &ap);
-    vend(ap);
-    return s;
-}
-KLIB_EXPORT_RENAME(kern_timm, timm);
 
 void timm_dealloc(tuple t)
 {
     if (t != STATUS_OK)
         destruct_tuple(t, true);
 }
-KLIB_EXPORT(timm_dealloc);
 
 // header: immediate(1)
 //         type(1)
@@ -401,7 +382,6 @@ void deallocate_value(tuple t)
         break;
     }
 }
-KLIB_EXPORT(deallocate_value);
 
 void init_tuples(heap h)
 {

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -70,7 +70,6 @@ u64 fsfile_get_length(fsfile f)
 {
     return f->length;
 }
-KLIB_EXPORT(fsfile_get_length);
 
 void fsfile_set_length(fsfile f, u64 length)
 {
@@ -96,7 +95,6 @@ sg_io fsfile_get_writer(fsfile f)
 {
     return f->write;
 }
-KLIB_EXPORT(fsfile_get_writer);
 
 pagecache_node fsfile_get_cachenode(fsfile f)
 {
@@ -1016,7 +1014,6 @@ void filesystem_write_linear(fsfile f, void *src, range q, io_status_handler io_
     filesystem_write_sg(f, sg, q, closure(f->fs->h, filesystem_write_complete,
                                           sg, length, io_complete));
 }
-KLIB_EXPORT(filesystem_write_linear);
 
 fs_status filesystem_truncate(filesystem fs, fsfile f, u64 len)
 {
@@ -1975,19 +1972,16 @@ u64 fs_blocksize(filesystem fs)
 {
     return U64_FROM_BIT(fs->blocksize_order);
 }
-KLIB_EXPORT(fs_blocksize);
 
 u64 fs_totalblocks(filesystem fs)
 {
     return fs->storage->total;
 }
-KLIB_EXPORT(fs_totalblocks);
 
 u64 fs_usedblocks(filesystem fs)
 {
     return fs->storage->allocated;
 }
-KLIB_EXPORT(fs_usedblocks);
 
 u64 fs_freeblocks(filesystem fs)
 {

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -160,7 +160,6 @@ thread blockq_wake_one(blockq bq)
     blockq_unlock(bq);
     return INVALID_ADDRESS;
 }
-KLIB_EXPORT(blockq_wake_one);
 
 boolean blockq_wake_one_for_thread(blockq bq, thread t, boolean nullify)
 {
@@ -175,12 +174,6 @@ boolean blockq_wake_one_for_thread(blockq bq, thread t, boolean nullify)
     return blockq_wake_internal_locked(bq, t, BLOCKQ_ACTION_BLOCKED |
                                        (nullify ? BLOCKQ_ACTION_NULLIFY : 0));
 }
-
-sysreturn kern_blockq_check(blockq bq, thread t, blockq_action a, boolean in_bh)
-{
-    return blockq_check(bq, t, a, in_bh);
-}
-KLIB_EXPORT_RENAME(kern_blockq_check, blockq_check);
 
 sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_bh,
                                clock_id clkid, timestamp timeout, boolean absolute)
@@ -222,13 +215,6 @@ sysreturn blockq_check_timeout(blockq bq, thread t, blockq_action a, boolean in_
     thread_sleep_interruptible();  /* no return */
     assert(0);
 }
-
-void kern_blockq_handle_completion(blockq bq, u64 bq_flags, io_completion completion, thread t,
-                                   sysreturn rv)
-{
-    blockq_handle_completion(bq, bq_flags, completion, t, rv);
-}
-KLIB_EXPORT_RENAME(kern_blockq_handle_completion, blockq_handle_completion);
 
 /* Wake all waiters and empty queue, typically for error conditions,
    closed pipe/connections, etc. Actions are called with nullify set,
@@ -341,10 +327,8 @@ blockq allocate_blockq(heap h, char * name)
     init_refcount(&bq->refcount, 1, init_closure(&bq->free, free_blockq, bq));
     return bq;
 }
-KLIB_EXPORT(allocate_blockq);
 
 void deallocate_blockq(blockq bq)
 {
     blockq_release(bq);
 }
-KLIB_EXPORT(deallocate_blockq);

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -383,7 +383,6 @@ void file_release(file f)
     else
         unix_cache_free(get_unix_heaps(), file, f);
 }
-KLIB_EXPORT(file_release);
 
 /* file_path is treated as an absolute path. */
 fsfile fsfile_open_or_create(buffer file_path)
@@ -409,11 +408,9 @@ fsfile fsfile_open_or_create(buffer file_path)
     }
     return 0;
 }
-KLIB_EXPORT(fsfile_open_or_create);
 
 /* Can be used for files in the root filesystem only. */
 fs_status fsfile_truncate(fsfile f, u64 len)
 {
     return (filesystem_truncate(get_root_fs(), f, len));
 }
-KLIB_EXPORT(fsfile_truncate);

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -40,6 +40,9 @@ sysreturn fallocate(int fd, int mode, long offset, long len);
 
 sysreturn fadvise64(int fd, s64 off, u64 len, int advice);
 
+sysreturn fs_rename(buffer oldpath, buffer newpath);
+
 void file_release(file f);
 
 fsfile fsfile_open_or_create(buffer file_path);
+fs_status fsfile_truncate(fsfile f, u64 len);

--- a/src/unix/mktime.c
+++ b/src/unix/mktime.c
@@ -76,4 +76,3 @@ struct tm *gmtime_r(u64 *timep, struct tm *result) {
     result->tm_sec = seconds - result->tm_min * 60;
     return result;
 }
-KLIB_EXPORT(gmtime_r);

--- a/src/unix/notify.c
+++ b/src/unix/notify.c
@@ -90,7 +90,6 @@ void notify_dispatch(notify_set s, u64 events)
 {
     notify_dispatch_for_thread(s, events, 0);
 }
-KLIB_EXPORT(notify_dispatch);
 
 void notify_release(notify_set s)
 {

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -331,7 +331,6 @@ boolean create_special_file(const char *path, spec_file_open open, u64 size)
     deallocate_value(entry);
     return false;
 }
-KLIB_EXPORT(create_special_file);
 
 void register_special_files(process p)
 {

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1937,7 +1937,6 @@ sysreturn fs_rename(buffer oldpath, buffer newpath)
     return sysreturn_from_fs_status(filesystem_rename(fs, root, buffer_to_cstring(oldpath),
         fs, root, buffer_to_cstring(newpath), false));
 }
-KLIB_EXPORT(fs_rename);
 
 sysreturn close(int fd)
 {
@@ -2052,7 +2051,6 @@ sysreturn ioctl_generic(fdesc f, unsigned long request, vlist ap)
         return -ENOSYS;
     }
 }
-KLIB_EXPORT(ioctl_generic);
 
 sysreturn ioctl(int fd, unsigned long request, ...)
 {

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -945,6 +945,7 @@ int do_eventfd2(unsigned int count, int flags);
 typedef closure_type(spec_file_open, sysreturn, file f);
 
 void register_special_files(process p);
+boolean create_special_file(const char *path, spec_file_open open, u64 size);
 sysreturn spec_open(file f, tuple t);
 file spec_allocate(tuple t);
 void spec_deallocate(file f);

--- a/src/x86_64/elf64.c
+++ b/src/x86_64/elf64.c
@@ -24,6 +24,21 @@ void elf_apply_relocate_add(buffer elf, Elf64_Shdr *s, u64 offset)
     }
 }
 
+boolean elf_apply_relocate_syms(buffer elf, Elf64_Shdr *s, elf_sym_relocator relocator)
+{
+    Elf64_Rela *rel = buffer_ref(elf, s->sh_addr);
+    for (int i = 0; i < s->sh_size / sizeof(*rel); i++) {
+        switch (ELF64_R_TYPE(rel[i].r_info)) {
+        case R_X86_64_GLOB_DAT:
+        case R_X86_64_JUMP_SLOT:
+            if (!apply(relocator, &rel[i]))
+                return false;
+            break;
+        }
+    }
+    return true;
+}
+
 void elf_dyn_relocate(u64 base, Elf64_Dyn *dyn)
 {
     Elf64_Rel *rel = 0;


### PR DESCRIPTION
This PR implements dynamic linking of klibs to the kernel, which uses the symbol definitions found in the kernel ELF file and removes the need for klibs to look up or define symbols explicitly.
Symbols defined in a klib are added to the main symbol table when the klib has been loaded and successfully initialized (so that they can be looked up by any klib that needs them), and are removed from the symbol table when a klib is unloaded.

In order to prevent the linker from discarding functions that are defined in the kernel but called exclusively by klibs, the list of dynamic relocation entries found in each klib is retrieved via objdump and transformed (using sed scripts) into a set of EXTERN linker commands, which are put in an auto-generated file that is included by the kernel linker script.

The now() kernel function cannot be dynamically linked to, because it's an inline function that references VDSO variables, which are declared with hidden visibility; for this reason, klibs have to call the kern_now() wrapper function instead of now().

Since loading a klib requires the kernel symbol table to be populated, if the kernel is not booted by stage2 (e.g. with Firecracker) klib initialization is now done after loading the symbols from the kernel ELF file, thus the boot filesystem needs to be read regardless of whether the klibs are in that filesystem.

The first commit is a fix needed for the cloud_init klib to work correctly when multiple downloads are specified in the configuration.
The third commit adds stack smashing protection to klibs, which is now possible because the symbols used by the stack protector can be resolved when a klib is loaded.