### PR TITLE
fix numerous signal handling issues, use a single context frame per thread

### DIFF
--- a/src/aarch64/crt0.S
+++ b/src/aarch64/crt0.S
@@ -45,10 +45,12 @@
         mrs     x0, spsr_el1
         mrs     x1, esr_el1
         mrs     x2, elr_el1
+        mrs     x3, far_el1
 
         add     x17, x17, #256
         stp     w0, w1, [x17, #((FRAME_ESR_SPSR - 32) * 8)]
         str     x2, [x17, #((FRAME_ELR - 32) * 8)]
+        str     x3, [x17, #((FRAME_FAULT_ADDRESS - 32) * 8)]
         .endm
 
         .text

--- a/src/aarch64/frame.h
+++ b/src/aarch64/frame.h
@@ -53,7 +53,7 @@ https://developer.arm.com/cache-speculation-vulnerability-firmware-specification
 #define FRAME_FULL          41
 #define FRAME_THREAD        42
 #define FRAME_HEAP          43
-#define FRAME_SAVED_ARG0    44
+#define FRAME_SAVED_X0      44
 #define FRAME_TXCTX_FLAGS   45
 #define FRAME_TXCTX_TPIDR_EL0_SAVED 1
 #define FRAME_TXCTX_FPSIMD_SAVED    2

--- a/src/aarch64/frame.h
+++ b/src/aarch64/frame.h
@@ -45,19 +45,20 @@ https://developer.arm.com/cache-speculation-vulnerability-firmware-specification
 #define FRAME_N_PSTATE      35
 
 #define FRAME_VECTOR        35
-#define FRAME_FAULT_HANDLER 36
-#define FRAME_STACK_TOP     37
-#define FRAME_RUN           38
-#define FRAME_EL            39
-#define FRAME_QUEUE         40
-#define FRAME_FULL          41
-#define FRAME_THREAD        42
-#define FRAME_HEAP          43
-#define FRAME_SAVED_X0      44
-#define FRAME_TXCTX_FLAGS   45
+#define FRAME_FAULT_ADDRESS 36
+#define FRAME_FAULT_HANDLER 37
+#define FRAME_STACK_TOP     38
+#define FRAME_RUN           39
+#define FRAME_EL            40
+#define FRAME_QUEUE         41
+#define FRAME_FULL          42
+#define FRAME_THREAD        43
+#define FRAME_HEAP          44
+#define FRAME_SAVED_X0      45
+#define FRAME_TXCTX_FLAGS   46
 #define FRAME_TXCTX_TPIDR_EL0_SAVED 1
 #define FRAME_TXCTX_FPSIMD_SAVED    2
-#define FRAME_MAX           46
+#define FRAME_MAX           47
 
 #define FRAME_EXTENDED_SAVE 64
 

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -147,6 +147,7 @@
 #define SCTLR_EL1_M       U64_FROM_BIT(0) /* MMU enable */
 
 #define SPSR_I U64_FROM_BIT(7)
+#define SPSR_TCO U64_FROM_BIT(25)
 
 #ifndef __ASSEMBLY__
 /* interrupt control */

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -274,10 +274,7 @@ static inline u64 frame_return_address(context f)
 
 static inline u64 fault_address(context f)
 {
-    // store in frame?
-    register u64 far;
-    asm("mrs %0, FAR_EL1" : "=r"(far));
-    return far;
+    return f[FRAME_FAULT_ADDRESS];
 }
 
 #define esr_from_frame(frame) (frame[FRAME_ESR_SPSR] >> 32)

--- a/src/aarch64/unix_machine.c
+++ b/src/aarch64/unix_machine.c
@@ -3,17 +3,7 @@
 
 struct rt_sigframe *get_rt_sigframe(thread t)
 {
-    return pointer_from_u64(t->sighandler_frame[SYSCALL_FRAME_SP]);
-}
-
-void syscall_entry_arch_fixup(thread t)
-{
-    t->active_frame[FRAME_SAVED_ARG0] = t->active_frame[FRAME_X0];
-}
-
-void syscall_restart_arch_fixup(thread t)
-{
-    t->active_frame[FRAME_X0] = t->active_frame[FRAME_SAVED_ARG0];
+    return pointer_from_u64(t->frame[SYSCALL_FRAME_SP]);
 }
 
 struct frame_record {
@@ -28,75 +18,65 @@ void setup_sigframe(thread t, int signum, struct siginfo *si)
     assert(sizeof(struct siginfo) == 128);
     thread_resume(t);
 
-    /* copy only what we really need */
-    t->sighandler_frame[FRAME_X18] = t->default_frame[FRAME_X18];
-    set_tls(t->sighandler_frame, get_tls(t->default_frame));
-    t->sighandler_frame[FRAME_SP] = (sa->sa_flags & SA_ONSTACK) && t->signal_stack ?
-        u64_from_pointer(t->signal_stack + t->signal_stack_length) :
-        t->default_frame[FRAME_SP];
+    context f = thread_frame(t);
+    u64 sp;
+
+    if ((sa->sa_flags & SA_ONSTACK) && t->signal_stack)
+        sp = u64_from_pointer(t->signal_stack + t->signal_stack_length);
+    else
+        sp = f[FRAME_SP];
 
     /* align sp */
-    t->sighandler_frame[FRAME_SP] = (t->sighandler_frame[FRAME_SP] -
-                                     sizeof(struct frame_record)) & ~15;
-    struct frame_record *rec = pointer_from_u64(t->sighandler_frame[FRAME_SP]);
+    sp = (sp - sizeof(struct frame_record)) & ~15;
+    struct frame_record *rec = pointer_from_u64(sp);
 
     /* create space for rt_sigframe */
-    t->sighandler_frame[FRAME_SP] -= pad(sizeof(struct rt_sigframe), 16);
+    sp -= pad(sizeof(struct rt_sigframe), 16);
 
     /* setup sigframe for user sig trampoline */
-    struct rt_sigframe *frame = (struct rt_sigframe *)t->sighandler_frame[FRAME_SP];
+    struct rt_sigframe *frame = (struct rt_sigframe *)sp;
 
+    setup_ucontext(&frame->uc, sa, si, t);
     if (sa->sa_flags & SA_SIGINFO) {
         runtime_memcpy(&frame->info, si, sizeof(struct siginfo));
-        setup_ucontext(&frame->uc, sa, si, t->default_frame);
-        t->sighandler_frame[FRAME_X1] = u64_from_pointer(&frame->info);
-        t->sighandler_frame[FRAME_X2] = u64_from_pointer(&frame->uc);
+        f[FRAME_X1] = u64_from_pointer(&frame->info);
+        f[FRAME_X2] = u64_from_pointer(&frame->uc);
     } else {
-        t->sighandler_frame[FRAME_X1] = 0;
-        t->sighandler_frame[FRAME_X2] = 0;
+        f[FRAME_X1] = 0;
+        f[FRAME_X2] = 0;
     }
+    f[FRAME_SP] = sp;
 
     /* setup regs for signal handler */
-    t->sighandler_frame[FRAME_EL] = 0;
-    t->sighandler_frame[FRAME_ELR] = u64_from_pointer(sa->sa_handler);
-    t->sighandler_frame[FRAME_X0] = signum;
-    t->sighandler_frame[FRAME_X29] = u64_from_pointer(&rec->fp);
-    t->sighandler_frame[FRAME_X30] = (sa->sa_flags & SA_RESTORER) ?
+    f[FRAME_EL] = 0;
+    f[FRAME_ELR] = u64_from_pointer(sa->sa_handler);
+    f[FRAME_X0] = signum;
+    f[FRAME_ESR_SPSR] &= ~SPSR_TCO;
+    f[FRAME_X29] = u64_from_pointer(&rec->fp);
+    f[FRAME_X30] = (sa->sa_flags & SA_RESTORER) ?
         u64_from_pointer(sa->sa_restorer) : t->p->vdso_base + VDSO_OFFSET_RT_SIGRETURN;
 
     /* TODO address BTI if supported */
-
-    /* save signo for safer sigreturn */
-    t->active_signo = signum;
-
-#if 0
-    rprintf("sigframe tid %d, sig %d, rip 0x%lx, rsp 0x%lx, "
-            "rdi 0x%lx, rsi 0x%lx, rdx 0x%lx, r8 0x%lx\n", t->tid, signum,
-            t->sighandler_frame[FRAME_RIP], t->sighandler_frame[FRAME_RSP],
-            t->sighandler_frame[FRAME_RDI], t->sighandler_frame[FRAME_RSI],
-            t->sighandler_frame[FRAME_RDX], t->sighandler_frame[FRAME_R8]);
-#endif
 }
 
 /*
  * Copy the context in frame 'f' to the ucontext *uctx
  */
 void setup_ucontext(struct ucontext * uctx, struct sigaction * sa,
-                    struct siginfo * si, context f)
+                    struct siginfo * si, thread t)
 {
+    context f = thread_frame(t);
     struct sigcontext * mcontext = &(uctx->uc_mcontext);
-
-    /* XXX for now we ignore everything but mcontext, incluing FP state ... */
 
     // XXX really need?
     runtime_memset((void *)uctx, 0, sizeof(struct ucontext));
 
     mcontext->fault_address = 0; /* XXX need to save to frame on entry */
-    runtime_memcpy(mcontext->regs, &f[FRAME_X0], sizeof(u64) * 31);
+    runtime_memcpy(mcontext->regs, f, sizeof(u64) * 31);
     mcontext->sp = f[FRAME_SP];
     mcontext->pc = f[FRAME_ELR];
     mcontext->pstate = f[FRAME_ESR_SPSR] & MASK(32); // XXX validate?
-    uctx->uc_sigmask.sig[0] = sa->sa_mask.sig[0];
+    uctx->uc_sigmask.sig[0] = t->signal_mask;
 
     /* XXX fpsimd */
     /* XXX sve */
@@ -106,15 +86,16 @@ void setup_ucontext(struct ucontext * uctx, struct sigaction * sa,
 /*
  * Copy the context from *uctx to the context in frame f
  */
-void restore_ucontext(struct ucontext * uctx, context f)
+void restore_ucontext(struct ucontext * uctx, thread t)
 {
+    context f = thread_frame(t);
     struct sigcontext * mcontext = &(uctx->uc_mcontext);
-    runtime_memcpy(&f[FRAME_X0], mcontext->regs, sizeof(u64) * 31);
+    runtime_memcpy(f, mcontext->regs, sizeof(u64) * 31);
     f[FRAME_SP] = mcontext->sp;
     f[FRAME_ELR] = mcontext->pc;
 
-    /* XXX validate here or rely on thread run psr fixup? */
     f[FRAME_ESR_SPSR] = (f[FRAME_ESR_SPSR] & ~MASK(32)) | (mcontext->pstate & MASK(32));
+    t->signal_mask = normalize_signal_mask(uctx->uc_sigmask.sig[0]);
 
     /* XXX fpsimd */
     /* XXX sve */

--- a/src/aarch64/unix_machine.h
+++ b/src/aarch64/unix_machine.h
@@ -40,16 +40,16 @@ struct epoll_event {
 
 /* kernel stuff */
 
-#define SYSCALL_FRAME_ARG0    FRAME_X0
-#define SYSCALL_FRAME_ARG1    FRAME_X1
-#define SYSCALL_FRAME_ARG2    FRAME_X2
-#define SYSCALL_FRAME_ARG3    FRAME_X3
-#define SYSCALL_FRAME_ARG4    FRAME_X4
-#define SYSCALL_FRAME_ARG5    FRAME_X5
-#define SYSCALL_FRAME_RETVAL1 FRAME_X0
-#define SYSCALL_FRAME_RETVAL2 FRAME_X1
-#define SYSCALL_FRAME_SP      FRAME_SP
-#define SYSCALL_FRAME_PC      FRAME_ELR
+#define SYSCALL_FRAME_ARG0       FRAME_X0
+#define SYSCALL_FRAME_ARG1       FRAME_X1
+#define SYSCALL_FRAME_ARG2       FRAME_X2
+#define SYSCALL_FRAME_ARG3       FRAME_X3
+#define SYSCALL_FRAME_ARG4       FRAME_X4
+#define SYSCALL_FRAME_ARG5       FRAME_X5
+#define SYSCALL_FRAME_RETVAL1    FRAME_X0
+#define SYSCALL_FRAME_RETVAL2    FRAME_X1
+#define SYSCALL_FRAME_SP         FRAME_SP
+#define SYSCALL_FRAME_PC         FRAME_ELR
 
 #define MINSIGSTKSZ 5120
 
@@ -98,6 +98,18 @@ static inline void set_tls(context f, u64 tls)
     f[FRAME_TXCTX_FLAGS] |= FRAME_TXCTX_TPIDR_EL0_SAVED;
 }
 
+static inline void syscall_restart_arch_setup(context f)
+{
+    f[FRAME_SAVED_X0] = f[FRAME_X0];
+}
+
+static inline void syscall_restart_arch_fixup(context f)
+{
+    /* rewind to syscall */
+    f[FRAME_X0] = f[FRAME_SAVED_X0];
+    f[FRAME_ELR] -= 4; /* rewind to syscall; no thumb mode support */
+}
+
 void frame_save_fpsimd(context f);
 void frame_restore_fpsimd(context f);
 
@@ -132,6 +144,3 @@ static inline void thread_frame_restore_tls(context f)
         write_psr(TPIDR_EL0, f[FRAME_TPIDR_EL0]);
     }
 }
-
-void syscall_entry_arch_fixup(thread t);
-void syscall_restart_arch_fixup(thread t);

--- a/src/aarch64/unix_machine.h
+++ b/src/aarch64/unix_machine.h
@@ -62,6 +62,20 @@ struct sigcontext {
     u8 reserved[4096] __attribute__((__aligned__(16)));
 };
 
+struct _aarch64_ctx {
+    u32 magic;
+    u32 size;
+};
+
+#define FPSIMD_MAGIC 0x46508001
+
+struct fpsimd_context {
+    struct _aarch64_ctx head;
+    u32 fpsr;
+    u32 fpcr;
+    u128 vregs[32];
+};
+
 struct ucontext {
     unsigned long uc_flags;
     struct ucontext * uc_link;

--- a/src/gdb/gdbstub.c
+++ b/src/gdb/gdbstub.c
@@ -167,7 +167,7 @@ closure_function(0, 1, boolean, sched_thread,
        and is kind of racey with unblocking */
     thread t = struct_from_field(n, thread, n);
     if (!t->blocked_on)
-        schedule_frame(t->active_frame);
+        schedule_frame(thread_frame(t));
     return true;
 }
 
@@ -553,10 +553,8 @@ static fault_handler gdb_fh;
 
 void gdb_check_fault_handler(thread t)
 {
-    if (gdb_fh) {
-        t->default_frame[FRAME_FAULT_HANDLER] = u64_from_pointer(gdb_fh);
-        t->sighandler_frame[FRAME_FAULT_HANDLER] = u64_from_pointer(gdb_fh);
-    }
+    if (gdb_fh)
+        t->frame[FRAME_FAULT_HANDLER] = u64_from_pointer(gdb_fh);
 }
 
 buffer_handler init_gdb(heap h,

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -125,6 +125,8 @@ static inline boolean blockq_wake_internal_locked(blockq bq, thread t, u64 bq_fl
         goto unlock_fail;
     }
     list_delete(&t->bq_l);
+    if (bq_flags & BLOCKQ_ACTION_NULLIFY)
+        t->interrupting_syscall = true;
     thread_unlock(t);
     blockq_unlock(bq);
     boolean terminal = blockq_apply(bq, t, bq_flags);

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -135,17 +135,17 @@ static void build_exec_stack(process p, thread t, Elf64_Ehdr * e, void *start,
     // stack should be 16-byte aligned
     assert(pad(u64_from_pointer(s), STACK_ALIGNMENT) == u64_from_pointer(s));
 
-    frame_set_sp(t->default_frame, u64_from_pointer(s));
+    frame_set_sp(t->frame, u64_from_pointer(s));
 }
 
 void start_process(thread t, void *start)
 {
-    t->default_frame[SYSCALL_FRAME_PC] = u64_from_pointer(start);
+    t->frame[SYSCALL_FRAME_PC] = u64_from_pointer(start);
     if (get(t->p->process_root, sym(gdb))) {
         rputs("NOTE: in-kernel gdb is a work in progress\n");
         init_tcp_gdb(heap_locked(get_kernel_heaps()), t->p, 9090);
     } else {
-        schedule_frame(t->default_frame);
+        schedule_frame(t->frame);
     }
 }
 

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -1070,7 +1070,7 @@ out:
     }
     thread t = bound(t);
     if (bound(sig_set))
-        t->signals.mask = iour->sigmask;
+        t->signal_mask = iour->sigmask;
     blockq_handle_completion(bq, flags, bound(completion), t, rv);
     closure_finish();
     iour_debug("returning %d", rv);
@@ -1138,8 +1138,8 @@ sysreturn io_uring_enter(int fd, unsigned int to_submit,
             goto out;
         }
         if (sig) {
-            iour->sigmask = current->signals.mask;
-            current->signals.mask = (*(u64 *)sig);
+            iour->sigmask = current->signal_mask;
+            current->signal_mask = (*(u64 *)sig);
             bh->sig_set = true;
         } else
             bh->sig_set = false;

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2376,7 +2376,7 @@ void syscall_debug(context f)
     u64 call = f[FRAME_VECTOR];
     thread t = pointer_from_u64(f[FRAME_THREAD]);
     u64 arg0 = f[SYSCALL_FRAME_ARG0]; /* aliases retval on arm; cache arg */
-    syscall_entry_arch_fixup(t);
+    syscall_restart_arch_setup(f);
     set_syscall_return(t, -ENOSYS);
 
     if (call >= sizeof(_linux_syscalls) / sizeof(_linux_syscalls[0])) {

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -775,8 +775,6 @@ void threads_to_vector(process p, vector v);
 /* machine-specific signal dispatch */
 struct rt_sigframe *get_rt_sigframe(thread t);
 void setup_sigframe(thread t, int signum, struct siginfo *si);
-void setup_ucontext(struct ucontext * uctx, struct sigaction * sa,
-                    struct siginfo * si, thread t);
 void restore_ucontext(struct ucontext * uctx, thread t);
 
 void _register_syscall(struct syscall *m, int n, sysreturn (*f)(), const char *name);

--- a/src/x86_64/frame.h
+++ b/src/x86_64/frame.h
@@ -47,6 +47,7 @@
 #define FRAME_FULL 34 
 #define FRAME_THREAD 35
 #define FRAME_HEAP 36
-#define FRAME_MAX 37
+#define FRAME_SAVED_RAX 37
+#define FRAME_MAX 38
 #define FRAME_EXTENDED_SAVE 40
 

--- a/src/x86_64/gdb_machine.h
+++ b/src/x86_64/gdb_machine.h
@@ -9,14 +9,14 @@ static inline int computeSignal (context frame)
 
 static inline void clear_thread_stepping(thread t)
 {
-    thread_frame(t)[FRAME_FLAGS] &= ~U64_FROM_BIT(FLAG_TRAP);
-    thread_frame(t)[FRAME_FLAGS] |= U64_FROM_BIT(FLAG_RESUME);
+    thread_frame(t)[FRAME_FLAGS] &= ~U64_FROM_BIT(EFLAG_TRAP);
+    thread_frame(t)[FRAME_FLAGS] |= U64_FROM_BIT(EFLAG_RESUME);
 }
 
 static inline void set_thread_stepping(thread t)
 {
-    thread_frame(t)[FRAME_FLAGS] &= ~U64_FROM_BIT(FLAG_RESUME);
-    thread_frame(t)[FRAME_FLAGS] |= U64_FROM_BIT(FLAG_TRAP);
+    thread_frame(t)[FRAME_FLAGS] &= ~U64_FROM_BIT(EFLAG_RESUME);
+    thread_frame(t)[FRAME_FLAGS] |= U64_FROM_BIT(EFLAG_TRAP);
 }
 
 /* XXX This is a hack. The numbering of the registers is based on

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -153,7 +153,7 @@ void print_stack(context c)
              validate_virtual(x, sizeof(u64)); x++) {
         print_u64(u64_from_pointer(x));
         rputs(":   ");
-        print_u64_with_sym(*x++);
+        print_u64_with_sym(*x);
         rputs("\n");
     }
     rputs("\n");

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -60,9 +60,36 @@
 #define CR4_OSXMMEXCPT  (1 << 10)
 #define CR4_OSXSAVE     (1 << 18)
 
-#define FLAG_TRAP 8
-#define FLAG_INTERRUPT 9
-#define FLAG_RESUME 16
+#define EFLAG_CARRY                     0
+#define EFLAG_FIXED                     1
+#define EFLAG_PARITY                    2
+#define EFLAG_AUX_CARRY                 4
+#define EFLAG_ZERO                      6
+#define EFLAG_SIGN                      7
+#define EFLAG_TRAP                      8
+#define EFLAG_INTERRUPT                 9
+#define EFLAG_DIRECTION                 10
+#define EFLAG_OVERFLOW                  11
+#define EFLAG_IOPL                      12
+#define EFLAG_NESTED_TASK               14
+#define EFLAG_RESUME                    16
+#define EFLAG_VIRTUAL_MODE              17
+#define EFLAG_ALIGN_CHECK               18
+#define EFLAG_VIRTUAL_INTERRUPT         19
+#define EFLAG_VIRTUAL_INTERRUPT_PENDING 20
+#define EFLAG_CPUID_DETECT              21
+
+#define SAFE_EFLAGS \
+    (U64_FROM_BIT(EFLAG_ALIGN_CHECK) | \
+     U64_FROM_BIT(EFLAG_OVERFLOW) | \
+     U64_FROM_BIT(EFLAG_DIRECTION) | \
+     U64_FROM_BIT(EFLAG_TRAP) | \
+     U64_FROM_BIT(EFLAG_SIGN) | \
+     U64_FROM_BIT(EFLAG_ZERO) | \
+     U64_FROM_BIT(EFLAG_AUX_CARRY) | \
+     U64_FROM_BIT(EFLAG_PARITY) | \
+     U64_FROM_BIT(EFLAG_CARRY) | \
+     U64_FROM_BIT(EFLAG_RESUME))
 
 #define TSS_SIZE 0x68
 
@@ -200,7 +227,7 @@ static inline void set_syscall_handler(void *syscall_entry)
     write_msr(LSTAR_MSR, u64_from_pointer(syscall_entry));
     u32 selectors = ((USER_CODE32_SELECTOR | 0x3) << 16) | KERNEL_CODE_SELECTOR;
     write_msr(STAR_MSR, (u64)selectors << 32);
-    write_msr(SFMASK_MSR, U64_FROM_BIT(FLAG_INTERRUPT) | U64_FROM_BIT(FLAG_TRAP));
+    write_msr(SFMASK_MSR, U64_FROM_BIT(EFLAG_INTERRUPT) | U64_FROM_BIT(EFLAG_TRAP));
     write_msr(EFER_MSR, read_msr(EFER_MSR) | EFER_SCE);
 }
 
@@ -298,12 +325,12 @@ static inline u64 total_frame_size(void)
 
 static inline void frame_enable_interrupts(context f)
 {
-    f[FRAME_FLAGS] |= U64_FROM_BIT(FLAG_INTERRUPT);
+    f[FRAME_FLAGS] |= U64_FROM_BIT(EFLAG_INTERRUPT);
 }
 
 static inline void frame_disable_interrupts(context f)
 {
-    f[FRAME_FLAGS] &= ~U64_FROM_BIT(FLAG_INTERRUPT);
+    f[FRAME_FLAGS] &= ~U64_FROM_BIT(EFLAG_INTERRUPT);
 }
 
 extern void xsave(context f);

--- a/src/x86_64/unix_machine.h
+++ b/src/x86_64/unix_machine.h
@@ -45,16 +45,16 @@ struct epoll_event {
 
 /* kernel stuff */
 
-#define SYSCALL_FRAME_ARG0    FRAME_RDI
-#define SYSCALL_FRAME_ARG1    FRAME_RSI
-#define SYSCALL_FRAME_ARG2    FRAME_RDX
-#define SYSCALL_FRAME_ARG3    FRAME_R10
-#define SYSCALL_FRAME_ARG4    FRAME_R8
-#define SYSCALL_FRAME_ARG5    FRAME_R9
-#define SYSCALL_FRAME_RETVAL1 FRAME_RAX
-#define SYSCALL_FRAME_RETVAL2 FRAME_RDX
-#define SYSCALL_FRAME_SP      FRAME_RSP
-#define SYSCALL_FRAME_PC      FRAME_RIP
+#define SYSCALL_FRAME_ARG0       FRAME_RDI
+#define SYSCALL_FRAME_ARG1       FRAME_RSI
+#define SYSCALL_FRAME_ARG2       FRAME_RDX
+#define SYSCALL_FRAME_ARG3       FRAME_R10
+#define SYSCALL_FRAME_ARG4       FRAME_R8
+#define SYSCALL_FRAME_ARG5       FRAME_R9
+#define SYSCALL_FRAME_RETVAL1    FRAME_RAX
+#define SYSCALL_FRAME_RETVAL2    FRAME_RDX
+#define SYSCALL_FRAME_SP         FRAME_RSP
+#define SYSCALL_FRAME_PC         FRAME_RIP
 
 #define UC_FP_XSTATE            0x1
 #define UC_SIGCONTEXT_SS        0x2
@@ -207,8 +207,16 @@ static inline void set_tls(context f, u64 tls)
     f[FRAME_FSBASE] = tls;
 }
 
-#define syscall_entry_arch_fixup(t) ((void)t)
-#define syscall_restart_arch_fixup(t) ((void)t)
+static inline void syscall_restart_arch_setup(context f)
+{
+    f[FRAME_SAVED_RAX] = f[FRAME_VECTOR];
+}
+
+static inline void syscall_restart_arch_fixup(context f)
+{
+    f[FRAME_RAX] = f[FRAME_SAVED_RAX];
+    f[FRAME_RIP] -= 2; /* rewind to syscall */
+}
 
 /* stubs, for intel sdm recommends using xsave* over manual lazy save/restore */
 #define thread_frame_save_fpsimd(f) ((void)f)


### PR DESCRIPTION
The previous signal handling construction required switching to an alternate frame (the "sighandler_frame") when dispatching a signal handler. As such, any signal handling pattern which bypasses rt_sigreturn (such as the use of siglongjmp) will not work, as doing so would prevent signal state stored in the thread struct from being reverted, and threads execution would continue on the sighandler_frame rather than reverting to running on to the default_frame. For the same reasons, nested signal handling was also not supported.

This behavior is corrected by moving all thread execution to a single frame (which, incidentally, is also needed for pending context-switching work) and making use of the sigcontext stored on the thread stack to save and restore program state. Special state held for the duration of signal handling has been eliminated from the thread struct, thus enabling the use of siglongjmp.

An issue in syscall restarting has also been resolved. Previously, rt_sigreturn would check if a siginfo contained the SA_RESTART flag, applying a check for -ERESTARTSYS in the position of the thread frame where a syscall return value would be stored. This was done unconditionally, whether a syscall was interrupted or not. This could pose a problem if a thread was interrupted while running and by chance contained the value -ERESTARTSYS in the register used for syscall return values. The solution here is to have blockq_wake_internal_locked() set the "interrupting_syscall" flag in the thread struct, which in turn later triggers the call to check_syscall_restart() from dispatch_signals().

To allow reliance on the stored sigcontext in restoring program state, extended frame data (FP & SIMD state) is now being saved and restored for both x86 and aarch64 architectures.

Tests for sigsetjmp/siglongjmp use in signal handling and nested signal handling have been added to the signal runtime test.

Resolves #1396, #1616, #1617, and #1618