### PR TITLE
Initialize atomic_test_*_bit variable for older compilers

### DIFF
--- a/src/aarch64/machine.h
+++ b/src/aarch64/machine.h
@@ -164,7 +164,7 @@ static inline __attribute__((always_inline)) void memory_barrier(void)
 }
 
 /* XXX something b0rked with ldset here...ordering, or asm constraints? */
-static inline __attribute__((always_inline)) int atomic_test_and_set_bit(u64 *target, u64 bit)
+static inline __attribute__((always_inline)) u8 atomic_test_and_set_bit(u64 *target, u64 bit)
 {
 #if 0
     register u64 a = u64_from_pointer(target);
@@ -179,7 +179,7 @@ static inline __attribute__((always_inline)) int atomic_test_and_set_bit(u64 *ta
 #endif
 }
 
-static inline __attribute__((always_inline)) int atomic_test_and_clear_bit(u64 *target, u64 bit)
+static inline __attribute__((always_inline)) u8 atomic_test_and_clear_bit(u64 *target, u64 bit)
 {
 #if 0
     register u64 a = u64_from_pointer(target);

--- a/src/x86_64/machine.h
+++ b/src/x86_64/machine.h
@@ -97,9 +97,9 @@ static inline __attribute__((always_inline)) void atomic_clear_bit(u64 *target, 
     asm volatile("lock btrq %1, %0": "+m"(*target):"r"(bit) : "memory");
 }
 
-static inline __attribute__((always_inline)) int atomic_test_and_set_bit(u64 *target, u64 bit)
+static inline __attribute__((always_inline)) u8 atomic_test_and_set_bit(u64 *target, u64 bit)
 {
-    int oldbit;
+    u8 oldbit;
     #ifdef __GCC_ASM_FLAG_OUTPUTS__
     asm volatile("lock btsq %2, %0" : "+m"(*target), "=@ccc"(oldbit) : "r"(bit) : "memory");
     #else
@@ -108,9 +108,9 @@ static inline __attribute__((always_inline)) int atomic_test_and_set_bit(u64 *ta
     return oldbit;
 }
 
-static inline __attribute__((always_inline)) int atomic_test_and_clear_bit(u64 *target, u64 bit)
+static inline __attribute__((always_inline)) u8 atomic_test_and_clear_bit(u64 *target, u64 bit)
 {
-    int oldbit;
+    u8 oldbit;
     #ifdef __GCC_ASM_FLAG_OUTPUTS__
     asm volatile("lock btrq %2, %0" : "+m"(*target), "=@ccc"(oldbit) : "r"(bit) : "memory");
     #else


### PR DESCRIPTION
When the compiler does not support setting the carry flag value directly into
a variable for the atomic test bit functions, it uses a second instruction, setc,
to set the variable. This instruction doesn't appear to set the variable when
the carry flag is zero, although the intel manual suggests otherwise. Therefore
the variable must be initialized to zero since it's on the stack to let the
function return the correct value when the bit being checked is zero.