### PR TITLE
CircleCI: upload build artifacts to Google Cloud bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,24 @@ jobs:
             OPS_DIR=$HOME/.ops
             PATH=$HOME/.ops/bin:$PATH
             make test-noaccel
+      - run:
+          command: |
+            if [[ ! -v GCLOUD_SERVICE_KEY ]]; then
+              circleci-agent step halt
+            fi
+      - run: echo "deb http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+      - run: curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+      - run: sudo apt-get update && sudo apt-get install google-cloud-sdk
+      - run: echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+      - run: gcloud config set project ${GOOGLE_PROJECT_ID}
+      - run: gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+      - run: mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/platform/pc/boot/bootx64.efi temp/ && mkdir temp/klibs && cp output/klib/bin/* temp/klibs
+      - run: echo "export COMMIT_ID="`git rev-parse --short=7 HEAD` >> $BASH_ENV
+      - run: cd temp && tar cvzf ../nanos-release-linux-${COMMIT_ID}.tar.gz *
+      - run: gsutil cp nanos-release-linux-${COMMIT_ID}.tar.gz gs://nanos/release/${COMMIT_ID}/
+      - run: gsutil cp gs://nanos/release/${COMMIT_ID}/nanos-release-linux-${COMMIT_ID}.tar.gz gs://nanos/release/${COMMIT_ID}/nanos-release-darwin-${COMMIT_ID}.tar.gz
+      - run: gsutil setmeta -h "Custom-Time:`date -Iseconds`" gs://nanos/release/${COMMIT_ID}/*
+      - run: gsutil acl ch -u AllUsers:R gs://nanos/release/${COMMIT_ID}/*
 
   build-pc-memdebug:
     docker:


### PR DESCRIPTION
This change adds a few steps to the "build-pc" CircleCI job, to upload build artifacts to Google Cloud after a successful run of the test suite. These steps are only executed if the GCLOUD_SERVICE_KEY environment variable is set, so that the job will not fail when triggered by pull requests from forked repositories.
The mkfs and dump tools are not being included in the uploaded artifacts, because Ops provides similar functionalities to create and read image files; this means that the uploaded tarballs for Linux and Mac are identical (we still need separate tarballs because Ops uses the operating system name when downloading Nanos releases from the cloud bucket).
The uploaded tarballs have the "Custom-Time" metadata set, so that it's possible to delete them automatically from the bucket by setting a "DaysSinceCustomTime" condition in the object lifecycle management settings.