### PR TITLE
Syscalls: add inotify implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test test-noaccel: image
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws io_uring klibs mkdir mmap netlink netsock pipe readv rename sendfile signal socketpair syslog time unlink thread_test tlbshootdown tun unixsocket vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws inotify io_uring klibs mkdir mmap netlink netsock pipe readv rename sendfile signal socketpair syslog time unlink thread_test tlbshootdown tun unixsocket vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -52,6 +52,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/unix/eventfd.c \
 	$(SRCDIR)/unix/filesystem.c \
 	$(SRCDIR)/unix/futex.c \
+	$(SRCDIR)/unix/inotify.c \
 	$(SRCDIR)/unix/io_uring.c \
 	$(SRCDIR)/unix/mktime.c \
 	$(SRCDIR)/unix/mmap.c \

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -52,6 +52,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/unix/eventfd.c \
 	$(SRCDIR)/unix/filesystem.c \
 	$(SRCDIR)/unix/futex.c \
+	$(SRCDIR)/unix/inotify.c \
 	$(SRCDIR)/unix/io_uring.c \
 	$(SRCDIR)/unix/mktime.c \
 	$(SRCDIR)/unix/mmap.c \

--- a/src/aarch64/unix_machine.c
+++ b/src/aarch64/unix_machine.c
@@ -222,8 +222,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, keyctl, 0);
     register_syscall(map, ioprio_set, 0);
     register_syscall(map, ioprio_get, 0);
-    register_syscall(map, inotify_add_watch, 0);
-    register_syscall(map, inotify_rm_watch, 0);
     register_syscall(map, migrate_pages, 0);
     register_syscall(map, mknodat, 0);
     register_syscall(map, fchownat, syscall_ignore);
@@ -236,7 +234,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, vmsplice, 0);
     register_syscall(map, move_pages, 0);
     register_syscall(map, utimensat, 0);
-    register_syscall(map, inotify_init1, 0);
     register_syscall(map, preadv, 0);
     register_syscall(map, pwritev, 0);
     register_syscall(map, perf_event_open, 0);

--- a/src/runtime/files.mk
+++ b/src/runtime/files.mk
@@ -15,6 +15,7 @@ RUNTIME=$(SRCDIR)/runtime/bitmap.c \
 	$(SRCDIR)/runtime/random.c \
 	$(SRCDIR)/runtime/range.c \
 	$(SRCDIR)/runtime/rbtree.c \
+	$(SRCDIR)/runtime/ringbuf.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/sha256.c \

--- a/src/runtime/metadata.h
+++ b/src/runtime/metadata.h
@@ -61,6 +61,10 @@ static inline string contents(tuple x)
 
 static inline tuple lookup(tuple t, symbol a)
 {
+    if (a == sym_this(".."))
+        return get_tuple(t, a);
+    if (a == sym_this("."))
+        return t;
     tuple c = children(t);
     if (!c)
         return c;

--- a/src/runtime/ringbuf.c
+++ b/src/runtime/ringbuf.c
@@ -1,0 +1,82 @@
+#include <runtime.h>
+
+boolean ringbuf_read(ringbuf b, void *dest, bytes len)
+{
+    if (!ringbuf_peek(b, dest, len))
+        return false;
+    ringbuf_consume(b, len);
+    return true;
+}
+
+boolean ringbuf_peek(ringbuf b, void *dest, bytes len)
+{
+    if (buffer_length(b) < len)
+        return false;
+    void *start = b->contents + (b->start & (b->length - 1));
+    bytes avail = MIN(len, b->contents + b->length - start);
+    runtime_memcpy(dest, start, avail);
+    if (avail < len)
+        runtime_memcpy(dest + avail, b->contents, len - avail);
+    return true;
+}
+
+boolean ringbuf_write(ringbuf b, const void *src, bytes len)
+{
+    if (!ringbuf_extend(b, len))
+        return false;
+    void *end = b->contents + (b->end & (b->length - 1));
+    bytes avail = MIN(len, b->contents + b->length - end);
+    runtime_memcpy(end, src, avail);
+    if (avail < len)
+        runtime_memcpy(b->contents, src + avail, len - avail);
+    ringbuf_produce(b, len);
+    return true;
+}
+
+boolean ringbuf_memset(ringbuf b, u8 c, bytes len)
+{
+    if (!ringbuf_extend(b, len))
+        return false;
+    void *end = b->contents + (b->end & (b->length - 1));
+    bytes avail = MIN(len, b->contents + b->length - end);
+    runtime_memset(end, c, avail);
+    if (avail < len)
+        runtime_memset(b->contents, c, len - avail);
+    ringbuf_produce(b, len);
+    return true;
+}
+
+boolean ringbuf_extend(ringbuf b, bytes len)
+{
+    if (ringbuf_space(b) < len) {
+        bytes new_len;
+        if (len <= b->length)
+            new_len = 2 * b->length;
+        else
+            new_len = U64_FROM_BIT(find_order(len) + 1);
+        return (ringbuf_set_capacity(b, new_len) == new_len);
+    }
+    return true;
+}
+
+bytes ringbuf_set_capacity(ringbuf b, bytes len)
+{
+    if (len < buffer_length(b))
+        len = buffer_length(b);
+
+    /* ensure that length is a power of 2 */
+    len = U64_FROM_BIT(find_order(len));
+
+    if (len != b->length) {
+        void *new = allocate(b->h, len);
+        if (new == INVALID_ADDRESS)
+            return b->length;
+        ringbuf_peek(b, new, buffer_length(b));
+        deallocate(b->h, b->contents, b->length);
+        b->length = len;
+        b->end = b->end - b->start;
+        b->start = 0;
+        b->contents = new;
+    }
+    return len;
+}

--- a/src/runtime/ringbuf.h
+++ b/src/runtime/ringbuf.h
@@ -1,0 +1,34 @@
+typedef buffer ringbuf;
+
+static inline ringbuf allocate_ringbuf(heap h, bytes len)
+{
+    /* ensure that length is a power of 2 */
+    return allocate_buffer(h, U64_FROM_BIT(find_order(len)));
+}
+
+#define ringbuf_length      buffer_length
+#define ringbuf_ref         buffer_ref
+#define deallocate_ringbuf  deallocate_buffer
+
+boolean ringbuf_read(ringbuf b, void *dest, bytes len);
+boolean ringbuf_peek(ringbuf b, void *dest, bytes len);
+boolean ringbuf_write(ringbuf b, const void *src, bytes len);
+boolean ringbuf_memset(ringbuf b, u8 c, bytes len);
+
+static inline void ringbuf_produce(ringbuf b, bytes len)
+{
+    b->end += len;
+}
+
+static inline void ringbuf_consume(ringbuf b, bytes len)
+{
+    b->start += len;
+}
+
+static inline bytes ringbuf_space(ringbuf b)
+{
+    return b->length - buffer_length(b);
+}
+
+boolean ringbuf_extend(ringbuf b, bytes len);
+bytes ringbuf_set_capacity(ringbuf b, bytes len);

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -116,6 +116,7 @@ extern heap transient;
 #include <boot.h>
 #endif
 #include <buffer.h>
+#include <ringbuf.h>
 
 typedef u64 physical;
 

--- a/src/runtime/tuple.c
+++ b/src/runtime/tuple.c
@@ -88,6 +88,23 @@ int tuple_count(tuple t)
     }
 }
 
+closure_function(2, 2, boolean, tuple_get_symbol_each,
+                 value, val, symbol *, sym,
+                 value, s, value, v)
+{
+    if (v != bound(val))
+        return true;
+    *bound(sym) = s;
+    return false;
+}
+
+symbol tuple_get_symbol(tuple t, value v)
+{
+    symbol sym = 0;
+    iterate(t, stack_closure(tuple_get_symbol_each, v, &sym));
+    return sym;
+}
+
 static inline void drecord(table dictionary, void *x)
 {
     u64 count = dictionary->count + 1;

--- a/src/runtime/tuple.h
+++ b/src/runtime/tuple.h
@@ -24,6 +24,7 @@ boolean iterate(value e, binding_handler h);
 
 void init_tuples(heap theap);
 int tuple_count(tuple t);
+symbol tuple_get_symbol(tuple t, value v);
 tuple allocate_tuple();
 void destruct_tuple(tuple t, boolean recursive);
 void deallocate_value(tuple t);

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -196,3 +196,22 @@ int filesystem_follow_links(filesystem *fs, tuple link, tuple parent,
                             tuple *target);
 
 int file_get_path(filesystem fs, inode ino, char *buf, u64 len);
+
+#ifdef KERNEL
+
+/* Functions called by TFS code to notify filesystem operations */
+void fs_notify_create(tuple t, tuple parent, symbol name);
+void fs_notify_move(tuple t, tuple old_parent, symbol old_name, tuple new_parent, symbol new_name);
+void fs_notify_delete(tuple t, tuple parent, symbol name);
+void fs_notify_modify(tuple t);
+void fs_notify_release(tuple t, boolean unmounted);
+
+#else
+
+#define fs_notify_create(t, p, n)
+#define fs_notify_move(t, op, on, np, nn)
+#define fs_notify_delete(t, p, n)
+#define fs_notify_modify(t)
+#define fs_notify_release(t, u)             (void)(t)
+
+#endif

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -46,3 +46,6 @@ void file_release(file f);
 
 fsfile fsfile_open_or_create(buffer file_path);
 fs_status fsfile_truncate(fsfile f, u64 len);
+
+notify_entry fs_watch(heap h, tuple n, u64 eventmask, event_handler eh, notify_set *s);
+void fs_notify_event(tuple n, u64 event);

--- a/src/unix/inotify.c
+++ b/src/unix/inotify.c
@@ -1,0 +1,422 @@
+#include <unix_internal.h>
+#include <filesystem.h>
+
+#define INOTIFY_BUFLEN_MIN  PAGESIZE
+#define INOTIFY_BUFLEN_MAX  (16384 * sizeof(struct inotify_event))
+#define INOTIFY_WATCH_MAX   8192
+
+struct inotify_event {
+    int wd;
+    u32 mask;
+    u32 cookie;
+    u32 len;
+    char name[];
+} __attribute__((packed));
+
+declare_closure_struct(0, 6, sysreturn, inotify_read,
+                       void *, buf, u64, length, u64, offset, thread, t, boolean, bh, io_completion, completion);
+declare_closure_struct(0, 1, u32, inotify_events,
+                       thread, t);
+declare_closure_struct(0, 2, sysreturn, inotify_ioctl,
+                       unsigned long, request, vlist, ap);
+declare_closure_struct(0, 2, sysreturn, inotify_close,
+                       thread, t, io_completion, completion);
+
+typedef struct inotify {
+    struct fdesc f; /* must be first */
+    closure_struct(inotify_read, read);
+    closure_struct(inotify_events, events);
+    closure_struct(inotify_ioctl, ioctl);
+    closure_struct(inotify_close, close);
+    heap h;
+    struct list watches;
+    int watch_count;
+    int next_wd;
+    ringbuf event_buf;
+    blockq bq;
+} *inotify;
+
+declare_closure_struct(0, 2, boolean, inotify_event_handler,
+                       u64, events, void *, arg);
+
+typedef struct inotify_watch {
+    struct list l;
+    inotify in;
+    int wd;
+    inode n;
+    notify_set ns;
+    notify_entry ne;
+    closure_struct(inotify_event_handler, eh);
+} *inotify_watch;
+
+#define inotify_lock(in)    spin_lock(&(in)->f.lock)
+#define inotify_trylock(in) spin_try(&(in)->f.lock)
+#define inotify_unlock(in)  spin_unlock(&(in)->f.lock)
+
+static sysreturn inotify_resolve_fd(int fd, inotify *in)
+{
+    fdesc f = fdesc_get(current->p, fd);
+    if (!f)
+        return -EBADF;
+    if (f->type != FDESC_TYPE_INOTIFY) {
+        fdesc_put(f);
+        return -EINVAL;
+    }
+    *in = (inotify)f;
+    return 0;
+}
+
+closure_function(5, 1, sysreturn, inotify_read_bh,
+                 inotify, in, thread, t, void *, buf, u64, length, io_completion, completion,
+                 u64, flags)
+{
+    inotify in = bound(in);
+    sysreturn rv;
+    if (flags & BLOCKQ_ACTION_NULLIFY) {
+        rv = -ERESTARTSYS;
+        goto out;
+    }
+    inotify_lock(in);
+    ringbuf b = in->event_buf;
+    bytes avail = ringbuf_length(b);
+    if (avail == 0) {
+        inotify_unlock(in);
+        if (in->f.flags & O_NONBLOCK) {
+            rv = -EAGAIN;
+            goto out;
+        }
+        return BLOCKQ_BLOCK_REQUIRED;
+    }
+    void *buf = bound(buf);
+    u64 length = bound(length);
+    boolean empty = false;
+    rv = 0;
+    while (true) {
+        struct inotify_event event;
+        if (!ringbuf_peek(b, &event, sizeof(event))) {
+            empty = true;
+            break;
+        }
+        bytes event_len = sizeof(event) + event.len;
+        if (length < event_len)
+            break;
+        runtime_memcpy(buf, &event, sizeof(event));
+        ringbuf_consume(b, sizeof(event));
+        buf += sizeof(event);
+        length -= sizeof(event);
+        rv += sizeof(event);
+        if (event.len) {
+            ringbuf_read(b, buf, event.len);
+            buf += event.len;
+            length -= event.len;
+            rv += event.len;
+        }
+    }
+    inotify_unlock(in);
+    if (rv == 0)
+        rv = -EINVAL;
+    else if (empty)
+        notify_dispatch(in->f.ns, 0);
+out:
+    blockq_handle_completion(in->bq, flags, bound(completion), bound(t), rv);
+    closure_finish();
+    return rv;
+}
+
+define_closure_function(0, 6, sysreturn, inotify_read,
+                       void *, buf, u64, length, u64, offset, thread, t, boolean, bh, io_completion, completion)
+{
+    inotify in = struct_from_field(closure_self(), inotify, read);
+    blockq_action ba = closure(in->h, inotify_read_bh, in, t, buf, length, completion);
+    if (ba == INVALID_ADDRESS)
+        return io_complete(completion, t, -ENOMEM);
+    return blockq_check(in->bq, t, ba, bh);
+}
+
+define_closure_function(0, 1, u32, inotify_events,
+                        thread, t)
+{
+    inotify in = struct_from_field(closure_self(), inotify, events);
+    inotify_lock(in);
+    boolean empty = (ringbuf_length(in->event_buf) == 0);
+    inotify_unlock(in);
+    return empty ? 0 : EPOLLIN;
+}
+
+define_closure_function(0, 2, sysreturn, inotify_ioctl,
+                        unsigned long, request, vlist, ap)
+{
+    inotify in = struct_from_field(closure_self(), inotify, ioctl);
+    switch (request) {
+    case FIONREAD: {
+        int *nbytes = varg(ap, int *);
+        if (!validate_user_memory(nbytes, sizeof(int), true))
+            return -EFAULT;
+        inotify_lock(in);
+        *nbytes = ringbuf_length(in->event_buf);
+        inotify_unlock(in);
+        return 0;
+    }
+    default:
+        return ioctl_generic(&in->f, request, ap);
+    }
+}
+
+define_closure_function(0, 2, sysreturn, inotify_close,
+                        thread, t, io_completion, completion)
+{
+    inotify in = struct_from_field(closure_self(), inotify, close);
+    inotify_lock(in);
+    list_foreach(&in->watches, e) {
+        inotify_watch watch = struct_from_field(e, inotify_watch, l);
+        list_delete(e);
+        notify_remove(watch->ns, watch->ne, false);
+        deallocate(in->h, watch, sizeof(*watch));
+    }
+    release_fdesc(&in->f);
+    deallocate_blockq(in->bq);
+    deallocate_ringbuf(in->event_buf);
+    deallocate(in->h, in, sizeof(struct inotify));
+    return 0;
+}
+
+static boolean inotify_queue_event(inotify in, inotify_watch watch, u32 eventmask,
+                                   inotify_evdata evdata)
+{
+    struct inotify_event event;
+    int event_len = sizeof(event);
+    int name_len = (evdata && evdata->name) ? buffer_length(evdata->name) : 0;
+    if (name_len > 0) {
+        event_len += name_len + 1;
+
+        /* Ensure total length is multiple of struct inotify_event size. */
+        int mod = (name_len + 1) % sizeof(event);
+        if (mod)
+            event_len += sizeof(event) - mod;
+    }
+    ringbuf b = in->event_buf;
+    boolean empty = (ringbuf_length(b) == 0);
+
+    /* Ensure there is always room for an overflow event. */
+    if ((ringbuf_space(b) < event_len + sizeof(event)) && (b->length < INOTIFY_BUFLEN_MAX))
+        ringbuf_extend(b, event_len + sizeof(event));
+    bytes buf_space = ringbuf_space(b);
+    if (buf_space < event_len + sizeof(event)) {
+        if (buf_space >= sizeof(event)) {
+            event.wd = -1;
+            event.mask = IN_Q_OVERFLOW;
+            event.cookie = 0;
+            event.len = 0;
+            ringbuf_write(b, &event, sizeof(event));
+        }
+        return false;
+    }
+
+    event.wd = watch->wd;
+    event.mask = eventmask;
+    event.cookie = evdata ? evdata->cookie : 0;
+    event.len = name_len ? (event_len - sizeof(event)) : 0;
+    ringbuf_write(b, &event, sizeof(event));
+    if (name_len) {
+        ringbuf_write(b, ringbuf_ref(evdata->name, 0), name_len);
+        ringbuf_memset(b, '\0', event.len - name_len);
+    }
+    return empty;
+}
+
+static boolean inotify_rm_watch_locked(inotify in, inotify_watch watch, boolean delete_from_list)
+{
+    boolean notify_readers = inotify_queue_event(in, watch, IN_IGNORED, 0);
+    if (delete_from_list)
+        list_delete(&watch->l);
+    deallocate(in->h, watch, sizeof(*watch));
+    in->watch_count--;
+    return notify_readers;
+}
+
+static void inotify_noti_readers(inotify in)
+{
+    notify_dispatch(in->f.ns, EPOLLIN);
+    blockq_wake_one(in->bq);
+}
+
+define_closure_function(0, 2, boolean, inotify_event_handler,
+                        u64, events, void *, arg)
+{
+    boolean rv = false;
+    if (!events)
+        return rv;
+    inotify_watch watch = struct_from_field(closure_self(), inotify_watch, eh);
+    inotify in = watch->in;
+
+    /* Guard against potential deadlock if an event is notified while the watch is being removed
+     * (the inotify and notify_set locks are acquired in different order). */
+    while (!inotify_trylock(in)) {
+        if (!list_inserted(&watch->l))
+            return rv;
+        kern_pause();
+    }
+
+    boolean notify_readers;
+    if (events != NOTIFY_EVENTS_RELEASE) {
+        notify_readers = inotify_queue_event(in, watch, events, arg);
+        if (notify_entry_get_eventmask(watch->ne) & IN_ONESHOT) {
+            notify_readers |= inotify_rm_watch_locked(in, watch, true);
+            rv = true;
+        }
+    } else {
+        notify_readers = inotify_rm_watch_locked(in, watch, true);
+    }
+    inotify_unlock(in);
+    if (notify_readers)
+        inotify_noti_readers(in);
+    return rv;
+}
+
+sysreturn inotify_init(void)
+{
+    return inotify_init1(0);
+}
+
+sysreturn inotify_init1(int flags)
+{
+    if (flags & ~(O_NONBLOCK | O_CLOEXEC))
+        return -EINVAL;
+    heap h = heap_locked(get_kernel_heaps());
+    inotify in = allocate(h, sizeof(struct inotify));
+    if (in == INVALID_ADDRESS) {
+        return -ENOMEM;
+    }
+    in->event_buf = allocate_ringbuf(h, INOTIFY_BUFLEN_MIN);
+    if (in->event_buf == INVALID_ADDRESS) {
+        goto nomem;
+    }
+    in->bq = allocate_blockq(h, "inotify");
+    if (in->bq == INVALID_ADDRESS) {
+        deallocate_ringbuf(in->event_buf);
+        goto nomem;
+    }
+    init_fdesc(h, &in->f, FDESC_TYPE_INOTIFY);
+    in->f.read = init_closure(&in->read, inotify_read);
+    in->f.events = init_closure(&in->events, inotify_events);
+    in->f.ioctl = init_closure(&in->ioctl, inotify_ioctl);
+    in->f.close = init_closure(&in->close, inotify_close);
+    in->f.flags = flags & (O_NONBLOCK | O_CLOEXEC);
+    in->h = h;
+    list_init(&in->watches);
+    in->watch_count = 0;
+    in->next_wd = 0;
+    sysreturn fd = allocate_fd(current->p, in);
+    if (fd == INVALID_PHYSICAL) {
+        apply(in->f.close, 0, io_completion_ignore);
+        return -EMFILE;
+    }
+    return fd;
+  nomem:
+    deallocate(h, in, sizeof(struct inotify));
+    return -ENOMEM;
+}
+
+sysreturn inotify_add_watch(int fd, const char *pathname, u32 mask)
+{
+    if (!validate_user_string(pathname))
+        return -EFAULT;
+    if (!mask)
+        return -EINVAL;
+    inotify in;
+    sysreturn rv = inotify_resolve_fd(fd, &in);
+    if (rv)
+        return rv;
+    filesystem fs;
+    inode cwd;
+    process_get_cwd(current->p, &fs, &cwd);
+    filesystem cwd_fs = fs;
+    tuple n;
+    fs_status fss = filesystem_get_node(&fs, cwd, pathname, (mask & IN_DONT_FOLLOW) != 0, false,
+                                        false, &n, 0);
+    if (fss != FS_STATUS_OK) {
+        rv = sysreturn_from_fs_status(fss);
+        goto out;
+    }
+    if ((mask & IN_ONLYDIR) && !is_dir(n)) {
+        rv = -ENOTDIR;
+        filesystem_put_node(fs, n);
+        goto out;
+    }
+    mask |= IN_IGNORED | IN_ISDIR | IN_Q_OVERFLOW | IN_UNMOUNT;
+    inotify_watch watch = 0;
+    inotify_lock(in);
+    list_foreach(&in->watches, e) {
+        inotify_watch w = struct_from_field(e, inotify_watch, l);
+        if (w->n == inode_from_tuple(n)) {
+            notify_entry_update_eventmask(w->ne,
+                (mask & IN_MASK_ADD) ? (notify_entry_get_eventmask(w->ne) | mask) : mask);
+            watch = w;
+            break;
+        }
+    }
+    if (!watch) {
+        if (in->watch_count >= INOTIFY_WATCH_MAX) {
+            rv = -ENOSPC;
+            goto unlock;
+        }
+        watch = allocate(in->h, sizeof(*watch));
+        if (watch == INVALID_ADDRESS) {
+            rv = -ENOMEM;
+            goto unlock;
+        }
+        watch->ne = fs_watch(in->h, n, mask, init_closure(&watch->eh, inotify_event_handler),
+                             &watch->ns);
+        if (watch->ne) {
+            watch->in = in;
+            in->watch_count++;
+            watch->wd = in->next_wd++;
+            if (in->next_wd < 0)
+                in->next_wd = 0;    /* negative watch descriptors are not allowed */
+            watch->n = inode_from_tuple(n);
+            list_push_back(&in->watches, &watch->l);
+        } else {
+            deallocate(in->h, watch, sizeof(*watch));
+            watch = 0;
+            rv = -ENOMEM;
+        }
+    }
+    if (watch)
+        rv = watch->wd;
+  unlock:
+    inotify_unlock(in);
+    filesystem_put_node(fs, n);
+  out:
+    filesystem_release(cwd_fs);
+    fdesc_put(&in->f);
+    return rv;
+}
+
+sysreturn inotify_rm_watch(int fd, int wd)
+{
+    inotify in;
+    sysreturn rv = inotify_resolve_fd(fd, &in);
+    if (rv)
+        return rv;
+    rv = -EINVAL;
+    boolean notify_readers = false;
+    inotify_lock(in);
+    list_foreach(&in->watches, e) {
+        inotify_watch watch = struct_from_field(e, inotify_watch, l);
+        if (watch->wd == wd) {
+            /* Delete the watch from the inotify list before removing the notify entry, otherwise if
+             * an event is triggered the event handler could access a deallocated watch structure.
+             */
+            list_delete(&watch->l);
+            notify_remove(watch->ns, watch->ne, false);
+            notify_readers = inotify_rm_watch_locked(in, watch, false);
+            rv = 0;
+            break;
+        }
+    }
+    inotify_unlock(in);
+    if (notify_readers)
+        inotify_noti_readers(in);
+    fdesc_put(&in->f);
+    return rv;
+}

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -174,7 +174,7 @@ typedef struct io_uring {
 
 declare_closure_struct(2, 2, boolean, iour_poll_notify,
                        io_uring, iour, struct iour_poll *, p,
-                       u64, events, thread, t);
+                       u64, events, void *, arg);
 
 typedef struct iour_poll {
     struct list l;
@@ -625,7 +625,7 @@ static void iour_rw(io_uring iour, fdesc f, boolean write, void *addr, u32 len,
 
 define_closure_function(2, 2, boolean, iour_poll_notify,
                         io_uring, iour, iour_poll, p,
-                        u64, events, thread, t)
+                        u64, events, void *, arg)
 {
     if (!events)
         return false;

--- a/src/unix/notify.c
+++ b/src/unix/notify.c
@@ -70,7 +70,7 @@ u64 notify_get_eventmask_union(notify_set s)
     return u;
 }
 
-void notify_dispatch_for_thread(notify_set s, u64 events, thread t)
+void notify_dispatch_with_arg(notify_set s, u64 events, void *arg)
 {
     spin_lock(&s->lock);
     list_foreach(&s->entries, l) {
@@ -78,7 +78,7 @@ void notify_dispatch_for_thread(notify_set s, u64 events, thread t)
         /* no guarantee that a transition is represented here; event
            handler needs to keep track itself if edge trigger is used */
         assert(n->eh);
-        if (apply(n->eh, events & n->eventmask, t)) {
+        if (apply(n->eh, events & n->eventmask, arg)) {
             list_delete(l);
             deallocate(s->h, n, sizeof(struct notify_entry));
         }

--- a/src/unix/notify.c
+++ b/src/unix/notify.c
@@ -52,6 +52,11 @@ void notify_remove(notify_set s, notify_entry e, boolean release)
     deallocate(s->h, e, sizeof(struct notify_entry));
 }
 
+u64 notify_entry_get_eventmask(notify_entry n)
+{
+    return n->eventmask;
+}
+
 // XXX poll waiters too
 void notify_entry_update_eventmask(notify_entry n, u64 eventmask)
 {

--- a/src/unix/notify.h
+++ b/src/unix/notify.h
@@ -20,6 +20,7 @@ notify_entry notify_add(notify_set s, u64 eventmask, event_handler eh);
 
 void notify_remove(notify_set s, notify_entry e, boolean release);
 
+u64 notify_entry_get_eventmask(notify_entry n);
 void notify_entry_update_eventmask(notify_entry n, u64 eventmask);
 
 u64 notify_get_eventmask_union(notify_set s);

--- a/src/unix/notify.h
+++ b/src/unix/notify.h
@@ -1,9 +1,10 @@
 typedef struct notify_set *notify_set;
 typedef struct notify_entry *notify_entry;
 
-/* notify handlers receive event changes, including falling edges,
-   which are relevant only for waiters on thread t if t is nonzero */
-typedef closure_type(event_handler, boolean, u64 events, thread t);
+/* Notify handlers receive event changes, including falling edges;
+   if the last argument is a non-zero thread pointer, event changes
+   are relevant only for waiters on that thread. */
+typedef closure_type(event_handler, boolean, u64 events, void *arg);
 
 /* NOTIFY_EVENTS_RELEASE is a special value of events to signal to the
    event_handler that a notify_set is being deallocated.
@@ -25,6 +26,8 @@ u64 notify_get_eventmask_union(notify_set s);
 
 void notify_dispatch(notify_set s, u64 events);
 
-void notify_dispatch_for_thread(notify_set s, u64 events, thread t);
+void notify_dispatch_with_arg(notify_set s, u64 events, void *arg);
+
+#define notify_dispatch_for_thread  notify_dispatch_with_arg
 
 void notify_release(notify_set s);

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -193,7 +193,7 @@ static inline u32 report_from_notify_events(epollfd efd, u64 notify_events);
 
 closure_function(1, 2, boolean, wait_notify,
                  epollfd, efd,
-                 u64, notify_events, thread, t)
+                 u64, notify_events, void *, t)
 {
     epollfd efd = bound(efd);
 

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -911,8 +911,7 @@ closure_function(1, 2, sysreturn, signalfd_close,
 
 closure_function(1, 2, boolean, signalfd_notify,
                  signal_fd, sfd,
-                 u64, events,
-                 thread, t)
+                 u64, events, void *, t)
 {
     signal_fd sfd = bound(sfd);
     if (events == NOTIFY_EVENTS_RELEASE) {

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -8,7 +8,7 @@ declare_closure_struct(1, 0, void, sharedbuf_free,
 
 declare_closure_struct(1, 2, boolean, unixsock_event_handler,
                        struct unixsock *, s,
-                       u64, events, thread, t);
+                       u64, events, void *, arg);
 declare_closure_struct(1, 0, void, unixsock_free,
     struct unixsock *, s);
 
@@ -59,7 +59,7 @@ define_closure_function(1, 0, void, sharedbuf_free,
 
 define_closure_function(1, 2, boolean, unixsock_event_handler,
                         unixsock, s,
-                        u64, events, thread, t)
+                        u64, events, void *, arg)
 {
     unixsock s = bound(s);
     if (events == NOTIFY_EVENTS_RELEASE)    /* the peer socket is being closed */

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1138,7 +1138,9 @@ static sysreturn getdents_internal(int fd, void *dirp, unsigned int count, boole
     int read_sofar = 0, written_sofar = 0;
     binding_handler h = stack_closure(getdents_each, f, &dirp, dirent64,
                                       &read_sofar, &written_sofar, &count, &r);
-    iterate(c, h);
+    symbol parent_sym = sym_this("..");
+    if (apply(h, sym_this("."), md) && apply(h, parent_sym, get_tuple(md, parent_sym)))
+        iterate(c, h);
     filesystem_update_atime(f->fs, md);
     f->offset = read_sofar;
     if (r < 0 && written_sofar == 0)

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -774,3 +774,31 @@ struct io_uring_params {
 #define POSIX_FADV_WILLNEED     3
 #define POSIX_FADV_DONTNEED     4
 #define POSIX_FADV_NOREUSE      5
+
+/* inotify events that user-space can watch for */
+#define IN_ACCESS           0x00000001
+#define IN_MODIFY           0x00000002
+#define IN_ATTRIB           0x00000004
+#define IN_CLOSE_WRITE      0x00000008
+#define IN_CLOSE_NOWRITE    0x00000010
+#define IN_OPEN             0x00000020
+#define IN_MOVED_FROM       0x00000040
+#define IN_MOVED_TO         0x00000080
+#define IN_CREATE           0x00000100
+#define IN_DELETE           0x00000200
+#define IN_DELETE_SELF      0x00000400
+#define IN_MOVE_SELF        0x00000800
+
+/* inotify events that can be sent to any watch */
+#define IN_UNMOUNT          0x00002000
+#define IN_Q_OVERFLOW       0x00004000
+#define IN_IGNORED          0x00008000
+
+/* inotify flags */
+#define IN_ONLYDIR          0x01000000
+#define IN_DONT_FOLLOW      0x02000000
+#define IN_EXCL_UNLINK      0x04000000
+#define IN_MASK_CREATE      0x10000000
+#define IN_MASK_ADD         0x20000000
+#define IN_ISDIR            0x40000000
+#define IN_ONESHOT          0x80000000

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -365,6 +365,7 @@ typedef closure_type(sg_file_io, sysreturn, sg_list sg, u64 length, u64 offset, 
 #define FDESC_TYPE_TIMERFD     10
 #define FDESC_TYPE_SYMLINK     11
 #define FDESC_TYPE_IORING      12
+#define FDESC_TYPE_INOTIFY     13
 
 declare_closure_struct(1, 2, void, fdesc_io_complete,
                        struct fdesc *, f,
@@ -939,6 +940,16 @@ int pipe_set_capacity(fdesc f, int capacity);
 int pipe_get_capacity(fdesc f);
 
 sysreturn socketpair(int domain, int type, int protocol, int sv[2]);
+
+typedef struct inotify_evdata {
+    string name;
+    u32 cookie;
+} *inotify_evdata;
+
+sysreturn inotify_init(void);
+sysreturn inotify_init1(int flags);
+sysreturn inotify_add_watch(int fd, const char *pathname, u32 mask);
+sysreturn inotify_rm_watch(int fd, int wd);
 
 int do_eventfd2(unsigned int count, int flags);
 

--- a/src/x86_64/unix_machine.c
+++ b/src/x86_64/unix_machine.c
@@ -321,9 +321,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, keyctl, 0);
     register_syscall(map, ioprio_set, 0);
     register_syscall(map, ioprio_get, 0);
-    register_syscall(map, inotify_init, 0);
-    register_syscall(map, inotify_add_watch, 0);
-    register_syscall(map, inotify_rm_watch, 0);
     register_syscall(map, migrate_pages, 0);
     register_syscall(map, mknodat, 0);
     register_syscall(map, fchownat, syscall_ignore);
@@ -337,7 +334,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, vmsplice, 0);
     register_syscall(map, move_pages, 0);
     register_syscall(map, utimensat, 0);
-    register_syscall(map, inotify_init1, 0);
     register_syscall(map, preadv, 0);
     register_syscall(map, pwritev, 0);
     register_syscall(map, perf_event_open, 0);

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -19,6 +19,7 @@ PROGRAMS= \
 	hwg \
 	hws \
 	klibs \
+	inotify \
 	io_uring \
 	mkdir \
 	mmap \
@@ -126,6 +127,12 @@ SRCS-hw=		$(CURDIR)/hw.c
 
 SRCS-hws=		$(SRCS-hw)
 LDFLAGS-hws=		-static
+
+SRCS-inotify= \
+	$(CURDIR)/inotify.c \
+	$(SRCDIR)/unix_process/ssp.c
+LDFLAGS-inotify=	-static
+LIBS-inotify=		-lpthread
 
 SRCS-io_uring= \
 	$(CURDIR)/io_uring.c \

--- a/test/runtime/inotify.c
+++ b/test/runtime/inotify.c
@@ -1,0 +1,415 @@
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/inotify.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#define test_assert(expr) do { \
+    if (!(expr)) { \
+        printf("Error: %s -- failed at %s:%d\n", #expr, __FILE__, __LINE__); \
+        exit(EXIT_FAILURE); \
+    } \
+} while (0)
+
+#define INOTIFY_TEST_DIR1   "tmp1"
+#define INOTIFY_TEST_DIR2   "tmp2"
+#define INOTIFY_TEST_FILE   "foo"
+#define INOTIFY_TEST_FILE1  "foo1"
+#define INOTIFY_TEST_FILE2  "foo2"
+#define INOTIFY_TEST_LINK   "link"
+#define INOTIFY_TEST_SOCKET "socket"
+
+static void *inotify_thread(void *arg)
+{
+    DIR *dir;
+    int fd;
+    struct sockaddr_un addr;
+    uint8_t buf[8];
+
+    /* INOTIFY_TEST_DIR1 */
+    dir = opendir(INOTIFY_TEST_DIR1);   /* IN_OPEN */
+    readdir(dir);   /* IN_ACCESS */
+    closedir(dir);  /* IN_CLOSE_NOWRITE */
+    test_assert(mkdir(INOTIFY_TEST_DIR1 "/" INOTIFY_TEST_DIR1, S_IRWXU) == 0);  /* IN_CREATE */
+    rmdir(INOTIFY_TEST_DIR1 "/" INOTIFY_TEST_DIR1); /* IN_DELETE */
+    test_assert(symlink(".", INOTIFY_TEST_DIR1 "/" INOTIFY_TEST_LINK) == 0);    /* IN_CREATE */
+    unlink(INOTIFY_TEST_DIR1 "/" INOTIFY_TEST_LINK);    /* IN_DELETE */
+    fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+    addr.sun_family = AF_UNIX;
+    strcpy(addr.sun_path, INOTIFY_TEST_DIR1 "/" INOTIFY_TEST_SOCKET);
+    test_assert(bind(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0); /* IN_CREATE */
+    close(fd);
+    unlink(INOTIFY_TEST_DIR1 "/" INOTIFY_TEST_SOCKET);  /* IN_DELETE */
+
+    /* INOTIFY_TEST_DIR2 */
+    /* IN_CREATE + IN_OPEN */
+    fd = open(INOTIFY_TEST_DIR2 "/" INOTIFY_TEST_FILE1, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    close(fd);  /* IN_CLOSE_WRITE */
+    fd = open(INOTIFY_TEST_DIR2 "/" INOTIFY_TEST_FILE1, O_RDWR);    /* IN_OPEN */
+    test_assert(write(fd, buf, sizeof(buf)) == sizeof(buf));    /* IN_MODIFY */
+
+    test_assert(rename(INOTIFY_TEST_DIR2 "/" INOTIFY_TEST_FILE1,
+                       INOTIFY_TEST_DIR1 "/" INOTIFY_TEST_FILE2) == 0);
+
+    /* INOTIFY_TEST_DIR1 */
+    close(fd);  /* IN_CLOSE_WRITE */
+    unlink(INOTIFY_TEST_DIR1 "/" INOTIFY_TEST_FILE2);   /* IN_DELETE */
+
+    /* INOTIFY_TEST_FILE */
+    fd = open(INOTIFY_TEST_FILE, O_RDWR);   /* IN_OPEN */
+    test_assert(write(fd, buf, sizeof(buf)) == sizeof(buf));    /* IN_MODIFY */
+    test_assert(lseek(fd, 0, SEEK_SET) == 0);
+    test_assert(read(fd, buf, sizeof(buf)) == sizeof(buf)); /* IN_ACCESS */
+    test_assert(ftruncate(fd, 0) == 0); /* IN_MODIFY */
+    /* IN_MOVE_SELF */
+    test_assert(rename(INOTIFY_TEST_FILE, INOTIFY_TEST_FILE INOTIFY_TEST_FILE) == 0);
+    close(fd);  /* IN_CLOSE_WRITE */
+    /* IN_MOVE_SELF */
+    test_assert(rename(INOTIFY_TEST_FILE INOTIFY_TEST_FILE, INOTIFY_TEST_FILE) == 0);
+
+    return NULL;
+}
+
+static int inotify_events_check(const char *buf, ssize_t len,
+                                const struct inotify_event *expected, const char **names, int num)
+{
+    const struct inotify_event *ev;
+    const char *ptr;
+    int count = 0;
+
+    for (ptr = buf; ptr < buf + len; count++, ptr += sizeof(struct inotify_event) + ev->len) {
+        ev = (const struct inotify_event *)ptr;
+        test_assert(count < num);
+        test_assert(ev->wd == expected[count].wd);
+        test_assert(ev->mask == expected[count].mask);
+        test_assert(ev->cookie == expected[count].cookie);
+        if (expected[count].len == 0) {
+            test_assert(ev->len == 0);
+        } else {
+            test_assert(ev->len > strlen(names[count]));
+            test_assert(!strcmp(ev->name, names[count]));
+        }
+    }
+    return count;
+}
+
+static void inotify_assert_event(int fd, int wd, uint32_t mask)
+{
+    struct inotify_event ev;
+
+    test_assert(read(fd, &ev, sizeof(ev)) == sizeof(ev));
+    test_assert((ev.wd == wd) && (ev.mask == mask));
+    test_assert((ev.cookie == 0) && (ev.len == 0));
+}
+
+/* Remove watch and receive IN_IGNORED event. */
+static void inotify_test_rm(int fd, int wd)
+{
+    test_assert(inotify_rm_watch(fd, wd) == 0);
+    inotify_assert_event(fd, wd, IN_IGNORED);
+}
+
+static void inotify_test_basic(int flags, struct inotify_event *expected, const char **names,
+                               int event_num)
+{
+    int fd;
+    int nbytes;
+    int wd[4];
+    uint32_t event_mask = IN_ACCESS | IN_CREATE | IN_OPEN | IN_CLOSE | IN_DELETE | IN_MODIFY |
+                          IN_MOVE_SELF;
+    pthread_t th;
+    struct pollfd pfd;
+    char buf[512] __attribute__ ((aligned(__alignof__(struct inotify_event))));
+    ssize_t len;
+    int i, count = 0;
+
+    fd = inotify_init1(flags);
+    test_assert(fd >= 0);
+    test_assert((ioctl(fd, FIONREAD, NULL) == -1) && (errno == EFAULT));
+    test_assert((ioctl(fd, FIONREAD, &nbytes) == 0) && (nbytes == 0));
+    pfd.fd = fd;
+    pfd.events = POLLIN;
+
+    /* Invalid file descriptor */
+    test_assert((inotify_add_watch(-1, INOTIFY_TEST_DIR1, IN_ACCESS) == -1) && (errno == EBADF));
+    test_assert(inotify_add_watch(fileno(stdin), INOTIFY_TEST_DIR1, IN_ACCESS) == -1);
+    test_assert(errno == EINVAL);
+
+    /* Invalid path name */
+    test_assert((inotify_add_watch(fd, NULL, IN_ACCESS) == -1) && (errno == EFAULT));
+    test_assert((inotify_add_watch(fd, "abc", IN_ACCESS) == -1) && (errno == ENOENT));
+
+    /* Invalid event mask */
+    test_assert((inotify_add_watch(fd, INOTIFY_TEST_DIR1, 0) == -1) && (errno == EINVAL));
+
+    wd[0] = inotify_add_watch(fd, INOTIFY_TEST_DIR1, event_mask);
+    test_assert(wd[0] >= 0);
+    wd[1] = inotify_add_watch(fd, INOTIFY_TEST_DIR2, IN_ACCESS);
+    test_assert(wd[1] >= 0);
+
+    /* Modify existing watch. */
+    test_assert(inotify_add_watch(fd, INOTIFY_TEST_DIR2, event_mask) == wd[1]);
+
+    test_assert(inotify_add_watch(fd, INOTIFY_TEST_FILE, event_mask | IN_ONLYDIR) == -1);
+    test_assert(errno == ENOTDIR);
+    wd[2] = inotify_add_watch(fd, INOTIFY_TEST_FILE, event_mask);
+    test_assert(wd[2] >= 0);
+
+    /* Modify existing watch. */
+    test_assert(inotify_add_watch(fd, INOTIFY_TEST_LINK, event_mask & ~IN_MOVE_SELF) == wd[2]);
+    test_assert(inotify_add_watch(fd, INOTIFY_TEST_LINK, IN_MOVE_SELF | IN_MASK_ADD) == wd[2]);
+
+    wd[3] = inotify_add_watch(fd, INOTIFY_TEST_LINK, event_mask | IN_DONT_FOLLOW);
+    test_assert(wd[3] != wd[2]);
+    inotify_test_rm(fd, wd[3]);
+
+    for (i = 0; i < 9; i++)
+        expected[count++].wd = wd[0];
+    for (i = 0; i < 5; i++)
+        expected[count++].wd = wd[1];
+    for (i = 0; i < 2; i++)
+        expected[count++].wd = wd[0];
+    for (i = 0; i < 7; i++)
+        expected[count++].wd = wd[2];
+    if (flags & IN_NONBLOCK)
+        test_assert((read(fd, buf, sizeof(buf)) == -1) && (errno == EAGAIN));
+    test_assert(pthread_create(&th, NULL, inotify_thread, NULL) == 0);
+    count = 0;
+    while (count < event_num) {
+        if (flags & IN_NONBLOCK) {
+            test_assert((poll(&pfd, 1, -1) == 1) && (pfd.revents == POLLIN));
+            test_assert(ioctl(fd, FIONREAD, &nbytes) == 0);
+            test_assert(nbytes >= sizeof(struct inotify_event));
+        }
+
+        /* Invalid buffer length */
+        test_assert((read(fd, buf, 0) == -1) && (errno == EINVAL));
+
+        len = read(fd, buf, sizeof(buf));
+        test_assert(len >= sizeof(struct inotify_event));
+        count += inotify_events_check(buf, len, expected + count, names + count, event_num - count);
+    }
+    pthread_join(th, NULL);
+
+    /* Invalid watch descriptor */
+    test_assert((inotify_rm_watch(fd, -1) == -1) && (errno == EINVAL));
+
+    /* Remove watches, re-execute filesystem operations and verify that no events are generated. */
+    inotify_test_rm(fd, wd[0]);
+    inotify_test_rm(fd, wd[1]);
+    inotify_test_rm(fd, wd[2]);
+    test_assert(pthread_create(&th, NULL, inotify_thread, NULL) == 0);
+    pthread_join(th, NULL);
+    test_assert(poll(&pfd, 1, 0) == 0);
+
+    test_assert(close(fd) == 0);
+}
+
+static void inotify_test_move(void)
+{
+    int fd;
+    int wd;
+    char buf[64];
+    ssize_t len;
+    void *ptr;
+    struct inotify_event *ev;
+    uint32_t cookie;
+
+    fd = creat("file1", S_IRUSR | S_IWUSR);
+    test_assert(fd >= 0);
+    close(fd);
+
+    fd = inotify_init();
+    test_assert(fd >= 0);
+    wd = inotify_add_watch(fd, ".", IN_MOVE);
+    test_assert(wd >= 0);
+    test_assert(rename("file1", "file2") == 0);
+    len = read(fd, buf, sizeof(buf));
+    ptr = buf;
+    ev = ptr;
+    test_assert(len >= sizeof(*ev) + ev->len);
+    test_assert((ev->wd == wd) && (ev->mask == IN_MOVED_FROM));
+    cookie = ev->cookie;
+    ptr += sizeof(*ev);
+    test_assert((ev->len > 0) && !strcmp(ptr, "file1"));
+    len -= sizeof(*ev) + ev->len;
+    if (len == 0) {
+        len = read(fd, buf, sizeof(buf));
+        ptr = buf;
+    } else {
+        ptr += ev->len;
+    }
+    ev = ptr;
+    test_assert(len == sizeof(*ev) + ev->len);
+    test_assert((ev->wd == wd) && (ev->mask == IN_MOVED_TO) && (ev->cookie == cookie));
+    test_assert((ev->len > 0) && !strcmp(ptr + sizeof(*ev), "file2"));
+
+    unlink("file2");
+    test_assert(close(fd) == 0);
+}
+
+static void inotify_test_delete(void)
+{
+    int fd;
+    int wd;
+
+    fd = creat("file1", S_IRUSR | S_IWUSR);
+    test_assert(fd >= 0);
+    close(fd);
+
+    fd = inotify_init();
+    test_assert(fd >= 0);
+    wd = inotify_add_watch(fd, "file1", IN_DELETE_SELF);
+    test_assert(wd >= 0);
+    test_assert(unlink("file1") == 0);
+    inotify_assert_event(fd, wd, IN_DELETE_SELF);
+    inotify_assert_event(fd, wd, IN_IGNORED);
+    test_assert(close(fd) == 0);
+}
+
+static void inotify_test_oneshot(void)
+{
+    int fd;
+    int wd;
+
+    fd = creat("file1", S_IRUSR | S_IWUSR);
+    test_assert(fd >= 0);
+    close(fd);
+
+    fd = inotify_init();
+    test_assert(fd >= 0);
+    wd = inotify_add_watch(fd, "file1", IN_ALL_EVENTS | IN_ONESHOT);
+    test_assert(wd >= 0);
+    /* IN_MOVE_SELF event, plus IN_IGNORED because of IN_ONESHOT */
+    test_assert(rename("file1", "file2") == 0);
+    test_assert(unlink("file2") == 0);  /* no event, because of IN_ONESHOT */
+    inotify_assert_event(fd, wd, IN_MOVE_SELF);
+    inotify_assert_event(fd, wd, IN_IGNORED);
+    test_assert((inotify_rm_watch(fd, wd) == -1) && (errno == EINVAL));
+    test_assert(close(fd) == 0);
+}
+
+static void inotify_test_overflow(void)
+{
+    int fd;
+    int wd;
+    const int iterations = 20000;
+
+    fd = creat("file1", S_IRUSR | S_IWUSR);
+    test_assert(fd >= 0);
+    close(fd);
+
+    fd = inotify_init();
+    test_assert(fd >= 0);
+    wd = inotify_add_watch(fd, "file1", IN_ALL_EVENTS);
+    test_assert(wd >= 0);
+    for (int i = 0; i < iterations; i++) {
+        int fd = open("file1", O_RDONLY);
+
+        close(fd);
+    }
+    for (int i = 0; i < 2 * iterations; i++) {  /* 2 events (open and close) per iteration */
+        struct inotify_event ev;
+
+        test_assert(read(fd, &ev, sizeof(ev)) == sizeof(ev));
+        test_assert((ev.cookie == 0) && (ev.len == 0));
+        if (ev.wd == wd) {
+            test_assert((ev.mask == IN_OPEN) || (ev.mask == IN_CLOSE_NOWRITE));
+        } else {
+            test_assert((ev.wd == -1) && (ev.mask == IN_Q_OVERFLOW));
+            break;
+        }
+    }
+    test_assert(unlink("file1") == 0);
+    test_assert(close(fd) == 0);
+}
+
+int main(int argc, char* argv[])
+{
+    int fd;
+    const int event_num = 23;
+    struct inotify_event expected[event_num];
+    const char *names[event_num];
+    int i = 0;
+
+    test_assert((inotify_init1(~0) == -1) && (errno == EINVAL));    /* invalid flags */
+
+    test_assert(mkdir(INOTIFY_TEST_DIR1, S_IRWXU) == 0);
+    test_assert(mkdir(INOTIFY_TEST_DIR2, S_IRWXU) == 0);
+    fd = creat(INOTIFY_TEST_FILE, S_IRUSR | S_IWUSR);
+    test_assert(fd >= 0);
+    close(fd);
+    test_assert(symlink(INOTIFY_TEST_FILE, INOTIFY_TEST_LINK) == 0);
+
+    /* INOTIFY_TEST_DIR1 */
+    for (int j = 0; j < 3; j++)
+        names[i + j] = "";
+    expected[i++].mask = IN_OPEN | IN_ISDIR;
+    expected[i++].mask = IN_ACCESS | IN_ISDIR;
+    expected[i++].mask = IN_CLOSE_NOWRITE | IN_ISDIR;
+    for (int j = 0; j < 2; j++)
+        names[i + j] = INOTIFY_TEST_DIR1;
+    expected[i++].mask = IN_CREATE | IN_ISDIR;
+    expected[i++].mask = IN_DELETE | IN_ISDIR;
+    for (int j = 0; j < 2; j++)
+        names[i + j] = INOTIFY_TEST_LINK;
+    expected[i++].mask = IN_CREATE;
+    expected[i++].mask = IN_DELETE;
+    for (int j = 0; j < 2; j++)
+        names[i + j] = INOTIFY_TEST_SOCKET;
+    expected[i++].mask = IN_CREATE;
+    expected[i++].mask = IN_DELETE;
+
+    /* INOTIFY_TEST_DIR2 */
+    for (int j = 0; j < 5; j++)
+        names[i + j] = INOTIFY_TEST_FILE1;
+    expected[i++].mask = IN_CREATE;
+    expected[i++].mask = IN_OPEN;
+    expected[i++].mask = IN_CLOSE_WRITE;
+    expected[i++].mask = IN_OPEN;
+    expected[i++].mask = IN_MODIFY;
+
+    /* INOTIFY_TEST_DIR1 */
+    for (int j = 0; j < 2; j++)
+        names[i + j] = INOTIFY_TEST_FILE2;
+    expected[i++].mask = IN_CLOSE_WRITE;
+    expected[i++].mask = IN_DELETE;
+
+    /* INOTIFY_TEST_FILE */
+    for (int j = 0; j < 7; j++)
+        names[i + j] = "";
+    expected[i++].mask = IN_OPEN;
+    expected[i++].mask = IN_MODIFY;
+    expected[i++].mask = IN_ACCESS;
+    expected[i++].mask = IN_MODIFY;
+    expected[i++].mask = IN_MOVE_SELF;
+    expected[i++].mask = IN_CLOSE_WRITE;
+    expected[i++].mask = IN_MOVE_SELF;
+
+    for (i = 0; i < event_num; i++) {
+        expected[i].cookie = 0;
+        expected[i].len = strlen(names[i]);
+    }
+    inotify_test_basic(0, expected, names, event_num);
+    inotify_test_basic(IN_NONBLOCK, expected, names, event_num);
+    inotify_test_move();
+    inotify_test_delete();
+    inotify_test_oneshot();
+    inotify_test_overflow();
+
+    printf("inotify test OK\n");
+    unlink(INOTIFY_TEST_LINK);
+    unlink(INOTIFY_TEST_FILE);
+    rmdir(INOTIFY_TEST_DIR1);
+    rmdir(INOTIFY_TEST_DIR2);
+    return 0;
+}

--- a/test/runtime/inotify.manifest
+++ b/test/runtime/inotify.manifest
@@ -1,0 +1,7 @@
+(
+    children:(
+        inotify:(contents:(host:output/test/runtime/bin/inotify))
+    )
+    program:/inotify
+    environment:()
+)

--- a/test/unit/tuple_test.c
+++ b/test/unit/tuple_test.c
@@ -54,6 +54,16 @@ boolean all_tests(heap h)
         test_assert(j3 == j2);//rprintf("j3=%d,j2=%d\n",j3, j2);
     }
 
+    // get symbol associated to a value
+    symbol sym1 = sym(tuple_test1), sym2 = sym(tuple_test2);
+    test_assert(tuple_get_symbol(t1, t2) == 0);
+    set(t1, sym1, t2);
+    test_assert(tuple_get_symbol(t1, t2) == sym1);
+    set(t1, sym2, t2);
+    test_assert((tuple_get_symbol(t1, t2) == sym1) || (tuple_get_symbol(t1, t2) == sym2));
+    set(t1, sym1, 0);
+    set(t1, sym2, 0);
+
     failure = false;
 fail:
     destruct_tuple(t1, true);


### PR DESCRIPTION
This change set implements the Linux inotify syscalls, and adds a runtime test program to exercise them.
An inotify instance stores filesystem-related events in an internal buffer (implemented as a ring buffer), and allows userspace to retrieve these events by reading from the file descriptor created by inotify_init().
Closes #884.