### PR TITLE
Update xen timers to per-cpu one-shot for better smp support

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -222,10 +222,14 @@ static void count_processors()
     }
 }
 
+void count_cpus_present(void)
+{
+    count_processors();
+}
+
 void start_secondary_cores(kernel_heaps kh)
 {
     memory_barrier();
-    count_processors();
     init_debug("init_mxcsr");
     init_mxcsr();
     init_debug("starting APs");
@@ -238,6 +242,10 @@ void start_secondary_cores(kernel_heaps kh)
 }
 #else
 void start_secondary_cores(kernel_heaps kh)
+{
+}
+
+void count_cpus_present(void)
 {
 }
 #endif

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -145,6 +145,10 @@ void start_secondary_cores(kernel_heaps kh)
 {
 }
 
+void count_cpus_present(void)
+{
+}
+
 static void init_kernel_heaps(void)
 {
     static struct heap bootstrap;

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -305,8 +305,9 @@ void kernel_runtime_init(kernel_heaps kh)
     init_net(kh);
 
     init_debug("start_secondary_cores");
-    start_secondary_cores(kh);
+    count_cpus_present();
     init_scheduler_cpus(misc);
+    start_secondary_cores(kh);
 
     init_debug("probe fs, register storage drivers");
     init_volumes(locked);

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -323,6 +323,7 @@ extern void xsave(context f);
 
 void cpu_init(int cpu);
 void start_secondary_cores(kernel_heaps kh);
+void count_cpus_present(void);
 void detect_hypervisor(kernel_heaps kh);
 void detect_devices(kernel_heaps kh, storage_attach sa);
 

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -99,8 +99,7 @@ NOTRACE void __attribute__((noreturn)) kernel_sleep(void)
     cpuinfo ci = current_cpu();
     sched_debug("sleep\n");
     ci->state = cpu_idle;
-    if (idle_cpu_mask)
-        bitmap_set_atomic(idle_cpu_mask, ci->id, 1);
+    bitmap_set_atomic(idle_cpu_mask, ci->id, 1);
 
     while (1) {
         wait_for_interrupt();
@@ -317,7 +316,7 @@ void init_scheduler(heap h)
 
 void init_scheduler_cpus(heap h)
 {
-    idle_cpu_mask = allocate_bitmap(h, h, total_processors);
+    idle_cpu_mask = allocate_bitmap(h, h, present_processors);
     assert(idle_cpu_mask != INVALID_ADDRESS);
-    bitmap_alloc(idle_cpu_mask, total_processors);
+    bitmap_alloc(idle_cpu_mask, present_processors);
 }


### PR DESCRIPTION
The existing timer is unreliable when running with multiple cpus and the
recent timer changes. The timer would not fire predictably on all cpus. The
xen interrupt handler was also assuming the interrupt would run only on cpu
0, which was not guaranteed even before the timer change. CPU initialization
has been refactored out to run for every cpu and the timer is now set by
set_singleshot_timer which is configured to fire on the cpu that set it.
This PR also moves idle_cpu_mask allocation to before the APs get started up,
using the present_processors value which is also now calculated before AP
startup. Otherwise if an AP wakes out of sleep and proceeds to runloop it will
try to access the unallocated mask.