### PR TITLE
fix altsigstack(2) failure due to an uninitialized variable

### DIFF
--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -548,9 +548,10 @@ sysreturn rt_sigsuspend(const u64 * mask, u64 sigsetsize)
 
 static boolean thread_is_on_altsigstack(thread t)
 {
-    return point_in_range(irangel(u64_from_pointer(t->signal_stack),
-                                  t->signal_stack_length),
-                          t->frame[SYSCALL_FRAME_SP]);
+    return t->signal_stack != 0 &&
+        point_in_range(irangel(u64_from_pointer(t->signal_stack),
+                               t->signal_stack_length),
+                       t->frame[SYSCALL_FRAME_SP]);
 }
 
 sysreturn sigaltstack(const stack_t *ss, stack_t *oss)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -326,6 +326,7 @@ thread create_thread(process p)
     t->frame[FRAME_RUN] = u64_from_pointer(init_closure(&t->run_thread, run_thread, t));
     
     t->signal_stack = 0;
+    t->signal_stack_length = 0;
     t->thrd.pause = init_closure(&t->pause_thread, pause_thread, t);
     t->affinity = allocate_bitmap(h, h, total_processors);
     if (t->affinity == INVALID_ADDRESS)


### PR DESCRIPTION
Running the fst runtime test with MEMDEBUG=mcache revealed that the
signal_stack_length field in the thread struct was being used without being
initialized in thread_is_on_altstack(). This could cause sigaltstack() to fail
with an -EPERM error for a thread that was not running on an alternate signal
stack. The fix here is to make thread_is_on_altsigstack() first check if
t->signal_stack is set before testing if the thread stack pointer is on the
signal stack.