### PR TITLE
Track frame syscall status via CS register instead of context field

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -200,8 +200,7 @@ static void setup_thread_frame(heap h, context frame, thread t)
     frame[FRAME_FAULT_HANDLER] = u64_from_pointer(&t->fault_handler);
     frame[FRAME_QUEUE] = u64_from_pointer(current_cpu()->thread_queue);
 #ifdef __x86_64__
-    frame[FRAME_IS_SYSCALL] = 1;
-    frame[FRAME_CS] = 0x2b; // where is this defined?
+    frame[FRAME_CS] = 0x2b & ~1; // CS 0x28 + CPL 3 but clear bit 0 to indicate syscall
 #endif
 #ifdef __aarch64__
     frame[FRAME_EL] = 0;

--- a/src/x86_64/frame.h
+++ b/src/x86_64/frame.h
@@ -42,12 +42,11 @@
 
 #define FRAME_CR2 30
 #define FRAME_RUN 31 /*dont like this construction */
-#define FRAME_IS_SYSCALL 32 
-#define FRAME_QUEUE 33
-#define FRAME_FULL 34 
-#define FRAME_THREAD 35
-#define FRAME_HEAP 36
-#define FRAME_SAVED_RAX 37
-#define FRAME_MAX 38
+#define FRAME_QUEUE 32
+#define FRAME_FULL 33
+#define FRAME_THREAD 34
+#define FRAME_HEAP 35
+#define FRAME_SAVED_RAX 36
+#define FRAME_MAX 37
 #define FRAME_EXTENDED_SAVE 40
 

--- a/src/x86_64/unix_machine.c
+++ b/src/x86_64/unix_machine.c
@@ -157,7 +157,6 @@ void setup_sigframe(thread t, int signum, struct siginfo *si)
     /* setup regs for signal handler */
     f[FRAME_RIP] = u64_from_pointer(sa->sa_handler);
     f[FRAME_RDI] = signum;
-    f[FRAME_IS_SYSCALL] = 1;
 }
 
 /*


### PR DESCRIPTION
In x86 arch, a user context can return to user mode by either iret or sysret,
with the latter having less state to reload. Therefore, the user frame must
track whether or not it entered the kernel from a syscall or not. There was a
field in the context struct to track this state, but properly updating when
changing the frame, such as with sighandling, is error prone. If the sysret
path is taken instead of iret, some user frame register values may be
incorrect causing crashes or other bad behavior.
This commit removes the field from the context struct and instead tracks
syscall state through the CPL portion of the CS register. This way the syscall
state moves with the registers through context switches or sighandling
frames. The syscall entry point clears bit 0 of the CPL in the saved frame,
and in frame_return the CPL value is checked. A value of 2 uses the
sysret path while any other value uses the normal iret path. The proper CPL
value of 3 is then restored to the user frame while on the sysret path.