### PR TITLE
Allocate init mbr from backed heap for alignment

### DIFF
--- a/src/xen/xenblk.c
+++ b/src/xen/xenblk.c
@@ -161,6 +161,7 @@ static void xenblk_service_pending(xenblk_dev xbd)
                 break;
             }
             rreq->grefs[req->nr_segments] = seg->gref;
+            assert((phys & MASK(SECTOR_OFFSET)) == 0);
             seg->first_sect = (phys & MASK(PAGELOG)) >> SECTOR_OFFSET;
             if (seg->first_sect + sectors > XENBLK_SECTORS_PER_PAGE)
                 sectors = XENBLK_SECTORS_PER_PAGE - seg->first_sect;


### PR DESCRIPTION
Some storage drivers require alignment for the buffer but the mbr was being
allocated from the general heap which makes no alignment guarantees. This
change allocates the mbr as a page from the backed heap to force a page
alignment.
An assert is also added to the xenblk driver which requires buffers to have
at least 512-byte sector alignment as per xen requirements.