### PR TITLE
Make kernel.dis objdump output a separate Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,9 @@ run-bridge: contgen image
 run-noaccel: contgen image
 	$(Q) $(MAKE) -C $(PLATFORMDIR) TARGET=$(TARGET) run-noaccel
 
+kernel.dis: contgen image
+	$(Q) $(MAKE) -C $(PLATFORMDIR) kernel.dis
+
 ##############################################################################
 # VMware
 

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -245,7 +245,9 @@ mkfs vdsogen:
 boot:
 	$(Q) $(MAKE) -C boot
 
-kernel: $(KERNEL) $(OBJDIR)/kernel.dis
+kernel: $(KERNEL)
+
+kernel.dis: $(KERNEL) $(OBJDIR)/kernel.dis
 
 target:
 ifeq ($(TARGET),)
@@ -262,7 +264,7 @@ ifneq ($(ENABLE_UEFI),)
 MKFS_UEFI=	-u $(OBJDIR)/boot/bootx64.efi
 endif
 
-image: mkfs boot kernel target
+image: mkfs boot $(DEFAULT_KERNEL_TARGET) target
 ifeq ($(IMAGE),)
 	@echo IMAGE variable not specified
 	@false
@@ -279,7 +281,7 @@ release: mkfs boot kernel
 	$(CP) $(KERNEL) release
 	cd release && $(TAR) -czvf nanos-release-$(REL_OS)-${version}.tar.gz *
 
-.PHONY: mkfs vdsogen boot kernel target image release
+.PHONY: mkfs vdsogen boot kernel kernel.dis target image release
 
 $(VDSOGEN):
 	@$(MAKE) -C $(ROOTDIR)/tools vdsogen

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -211,7 +211,9 @@ all: $(KERNEL) kernel.dis
 mkfs vdsogen:
 	$(Q) $(MAKE) -C $(ROOTDIR)/tools $@
 
-kernel: $(KERNEL) $(OBJDIR)/kernel.dis
+kernel: $(KERNEL)
+
+kernel.dis: $(KERNEL) $(OBJDIR)/kernel.dis
 
 target:
 ifeq ($(TARGET),)
@@ -224,7 +226,7 @@ ifneq ($(NANOS_TARGET_ROOT),)
 TARGET_ROOT_OPT=	-r $(NANOS_TARGET_ROOT)
 endif
 
-image: mkfs kernel target $(BOOTIMG)
+image: mkfs $(DEFAULT_KERNEL_TARGET) target $(BOOTIMG)
 ifeq ($(IMAGE),)
 	@echo IMAGE variable not specified
 	@false
@@ -240,7 +242,7 @@ release: mkfs kernel
 	$(CP) $(KERNEL) release
 	cd release && $(TAR) -czvf nanos-release-$(REL_OS)-${version}.tar.gz *
 
-.PHONY: mkfs vdsogen kernel target image release
+.PHONY: mkfs vdsogen kernel kernel.dis target image release
 
 $(VDSOGEN):
 	@$(MAKE) -C $(ROOTDIR)/tools vdsogen


### PR DESCRIPTION
Generating the objdump output, kernel.dis, can be a significant portion of time
for incremental compiles and is not necessary for running images. This change
makes a new target to generate the kernel.dis and has the image target generate
only the kernel binary. However, if the variable BUILD_KERNEL_DIS is set then
it will use the old behavior, forcing generation of kernel.dis even if it's not
specified as a make argument. In any case, whenever a new kernel binary is
generated, any existing kernel.dis file is moved to kernel.dis.old so there is no
confusion as to whether or not the disassembly reflects the current binary.