### PR TITLE
C web server: fix memory leaks

### DIFF
--- a/klib/cloud_azure.c
+++ b/klib/cloud_azure.c
@@ -69,7 +69,6 @@ closure_function(1, 1, void, wireserver_parse_resp,
         azure_report_ready(az);
     }
   exit:
-    destruct_tuple(v, true);
     closure_finish();
 }
 

--- a/klib/cloud_init.c
+++ b/klib/cloud_init.c
@@ -138,9 +138,7 @@ closure_function(3, 2, void, cloud_download_save_complete,
                  status, s, bytes, len)
 {
     value v = bound(v);
-    if (v)
-        destruct_tuple(v, true);
-    else
+    if (!v)
         deallocate_buffer(bound(content));
     apply(bound(sh), s);
     closure_finish();
@@ -199,8 +197,6 @@ closure_function(5, 1, void, cloud_download_save,
     }
   error:
     *bound(content_len) = (bytes)-1;    /* special value that indicates error */
-    if (v)
-        destruct_tuple(v, true);
     apply(sh, s);
 }
 

--- a/klib/radar.c
+++ b/klib/radar.c
@@ -237,7 +237,6 @@ closure_function(0, 1, void, telemetry_crash_recv,
                     break;
                 }
         }
-        destruct_tuple(v, true);
     }
     closure_finish();
 }
@@ -320,7 +319,6 @@ closure_function(0, 1, void, telemetry_boot_recv,
         klog_set_boot_id(telemetry.boot_id);
     }
   exit:
-    destruct_tuple(v, true);
     closure_finish();
 }
 

--- a/src/unix_process/socket_user.c
+++ b/src/unix_process/socket_user.c
@@ -284,13 +284,6 @@ static void poll_spin(notifier n)
 #ifdef SOCKET_USER_EPOLL_DEBUG
             rprintf("   fd %d, events %x, revents %x:\n", fds[i], fds[i].events, fds[i].revents);
 #endif
-            if (fds[i].revents & POLLHUP) {
-                rprintf("   fd %d: POLLHUP, closing\n", fds[i].fd);
-                notifier_reset_fd(n, fds[i].fd);
-                // always the right thing to do?
-                close(fds[i].fd);
-                continue;
-            }
 
             registration r = vector_get(p->registrations, fds[i].fd);
             do {
@@ -394,14 +387,7 @@ static void epoll_spin(notifier n)
 #ifdef SOCKET_USER_EPOLL_DEBUG
 	    rprintf("   fd %d, events %x\n", r->fd, ev[i].events);
 #endif
-            if (ev[i].events & EPOLLHUP)  {
-                descriptor fd = r->fd;
-		notifier_reset_fd(n, fd);
-                // always the right thing to do?
-                close(fd);
-            } else {
-                apply(r->a);
-            }
+            apply(r->a);
         }
     }
 }


### PR DESCRIPTION
This change set enhances the HTTP parser and network socket implementation so that the C web server (as run with e.g. `make run TARGET=webs`) does not leak memory when handling client requests.