### PR TITLE
Klibs: fix make dependencies to generate symbol list

### DIFF
--- a/klib/Makefile
+++ b/klib/Makefile
@@ -114,11 +114,31 @@ SRCS-mbedtls-tls= \
 	$(MBEDTLS_DIR)/library/ssl_ticket.c \
 	$(MBEDTLS_DIR)/library/ssl_tls.c \
 
-all: $(PROGRAMS)
+all: klib-syms
 
 KLIB_SYMS= $(OBJDIR)/klib-syms.lds
 
 include ../rules.mk
+
+msg_add_syms=	KLIB_SYMS	$@
+cmd_add_syms=	$(foreach prog, $(PROGRAM_BINARIES), $(call add_syms,$(prog)))
+
+# append list of undefined symbols to linker script
+define add_syms
+
+	$(Q) $(OBJDUMP) -R $1 | $(SED) -n -E 's/.*(GLOB_DAT|JUMP_SLOT)[[:space:]]*/EXTERN(/p' | $(SED) -n 's/$$/)/p' >> $(KLIB_SYMS)
+
+endef
+
+klib-syms: $(KLIB_SYMS)
+
+$(KLIB_SYMS): $(PROGRAM_BINARIES)
+	$(Q) $(RM) $(KLIB_SYMS)
+	$(call cmd,add_syms)
+# remove duplicated lines in linker script
+	$(Q) $(SED) -i.bak -n 'G; s/\n/&&/; /^\([^\n]*\n\).*\n\1/d; s/\n//; h; P' $(KLIB_SYMS)
+# delete linker script backup file
+	$(Q) $(RM) $(KLIB_SYMS).bak
 
 ifeq ($(UNAME_s),Darwin)
 ELF_TARGET=     -target x86_64-elf

--- a/rules.mk
+++ b/rules.mk
@@ -190,14 +190,6 @@ ifneq ($$(OBJS-$1),)
 $$(PROG-$1): $$(OBJS-$1)
 	@$(MKDIR) $$(dir $$@)
 	$$(call cmd,ld)
-ifneq ($(KLIB_SYMS),)
-# Append list of undefined symbols to linker script
-	$(Q) $(OBJDUMP) -R $$(PROG-$1) | $(SED) -n -E 's/.*(GLOB_DAT|JUMP_SLOT)[[:space:]]*/EXTERN(/p' | $(SED) -n 's/$$$$/)/p' >> $(KLIB_SYMS)
-# Remove duplicated lines in linker script
-	$(Q) $(SED) -i.bak -n 'G; s/\n/&&/; /^\([^\n]*\n\).*\n\1/d; s/\n//; h; P' $(KLIB_SYMS)
-# Delete linker script backup file
-	$(Q) $(RM) $(KLIB_SYMS).bak
-endif
 ifeq ($1,kernel.elf)
 	$(call cmd,mvdis)
 endif
@@ -214,6 +206,8 @@ $(foreach prog, $(PROGRAMS) $(ADDITIONAL_PROGRAMS), $(eval $(call build_program,
 ifeq ($(filter print-% clean cleandepend,$(MAKECMDGOALS)),)
 -include $(sort $(DEPFILES))
 endif
+
+PROGRAM_BINARIES= $(foreach prog, $(PROGRAMS), $(OBJDIR)/bin/$(prog))
 
 ##############################################################################
 # closure_templates


### PR DESCRIPTION
Updating the symbol list in klib-syms.lds after a given klib binary is built does not work well when make is run with multiple parallel jobs, because different klib binaries can be built in parallel and thus the symbol list file can be updated concurrently by multiple jobs, which can lead to inconsistencies in the final contents of the file and ultimately cause klib loading to fail due to missing kernel symbols.
This PR changes the make target for generating the symbol list so that this target has the klib binaries as dependencies, and thus is executed only after all binaries have been built. In addition, the following improvements have been made:
- the symbol list is cleared before being re-built: this eliminates symbols that were used in previous versions of klibs but are no longer used
- duplicated entries in the symbol list are removed only once, instead of after building each klib binary
- similarly, the backup file is deleted only once, when the final symbol list is ready