### PR TITLE
Sockets: add management of receive buffer size

### DIFF
--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -499,16 +499,14 @@ closure_function(7, 1, sysreturn, nl_read_bh,
         if ((rv < hdr->nlmsg_len) && (bound(flags) & MSG_TRUNC))
             rv = hdr->nlmsg_len;
         deallocate(s->sock.h, hdr, hdr->nlmsg_len);
-        if (dest_len > 0)
-            hdr = dequeue(s->data);
-        else
-            hdr = queue_peek(s->data);
+        hdr = queue_peek(s->data);
         if (hdr == INVALID_ADDRESS) { /* no more data available to read */
             fdesc_notify_events(&s->sock.f);
             break;
         }
         if (hdr->nlmsg_len > dest_len)
             break;
+        dequeue(s->data);
     } while (dest_len > 0);
 unlock:
     if (lock)

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -57,6 +57,7 @@ struct sock {
     heap h;
     blockq rxbq;
     blockq txbq;
+    u64 rx_len;
     unsigned int msg_count;
     sysreturn (*bind)(struct sock *sock, struct sockaddr *addr,
             socklen_t addrlen);
@@ -92,6 +93,7 @@ static inline int socket_init(process p, heap h, int domain, int type, u32 flags
         msg_err("failed to allocate blockq\n");
         goto err_tx;
     }
+    s->rx_len = 0;
     init_fdesc(h, &s->f, FDESC_TYPE_SOCKET);
     s->f.flags = (flags & ~O_ACCMODE) | O_RDWR;
     s->domain = domain;
@@ -139,3 +141,5 @@ sysreturn unixsock_open(int type, int protocol);
 
 void netlink_init(void);
 sysreturn netlink_open(int type, int family);
+
+extern int so_rcvbuf;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -506,7 +506,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     if (ftrace_init(uh, fs))
 	goto alloc_fail;
 #ifdef NET
-    if (!netsyscall_init(uh))
+    if (!netsyscall_init(uh, root))
         goto alloc_fail;
 #endif
     process kernel_process = create_process(uh, root, fs);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -55,7 +55,7 @@ typedef s64 sysreturn;
 // conditionalize
 // fix config/build, remove this include to take off network
 #include <net.h>
-boolean netsyscall_init(unix_heaps uh);
+boolean netsyscall_init(unix_heaps uh, tuple cfg);
 
 typedef struct process *process;
 typedef struct thread *thread;

--- a/test/runtime/netsock.manifest
+++ b/test/runtime/netsock.manifest
@@ -4,5 +4,6 @@
     )
     program:/netsock
     fault:t
+    so_rcvbuf:65536
     environment:()
 )


### PR DESCRIPTION
This PR changes the socket implementation (for network sockets, Unix domain sockets, and netlink sockets) so that the total length (in bytes) of the input data buffered in a given socket does not exceed the value of the so_rcvbuf parameter (that is configurable via a "so_rcvbuf" attribute in the manifest). The existing limit on the maximum number of packets given by the size of the input queues is kept in place.
In addition, any UDP packets that are discarded due the length of a socket receive buffer being exceeded are now properly deallocated.
getsockopt() has been amended so that it returns the correct value for the SO_SNDBUF and SO_RCVBUF socket options.
The network socket runtime test has been amended to exercise these new features.

The first commit fixes a bug in which a netlink message can be dequeued (and the memory allocated for it can be leaked) without having been read by userspace.