### PR TITLE
Global/static variables: prevent unwanted modifications

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -230,7 +230,7 @@ msg_sed=	SED	$@
 cmd_sed=	$(SED) -e 's/\#/%/' <$^ >$@
 
 msg_version=	VERSION	$@
-cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "const char *gitversion = \"$(shell $(GIT) rev-parse HEAD)\";" >$@
+cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "const char * const gitversion = \"$(shell $(GIT) rev-parse HEAD)\";" >$@
 
 include ../../rules.mk
 

--- a/platform/pc/linker_script
+++ b/platform/pc/linker_script
@@ -56,13 +56,21 @@ SECTIONS
 
     .data ALIGN(4096): AT(ADDR(.data) - LOAD_OFFSET)
     {
+        ro_after_init_start = .;
+        *(.ro_after_init)
+        . = ALIGN(4096);
+        ro_after_init_end = .;
         *(.data)
         *(.data.*)
     } :data
 
     PROVIDE(bss_start = .);
-    .bss  ALIGN(32): AT(ADDR(.bss) - LOAD_OFFSET)
+    .bss  ALIGN(4096): AT(ADDR(.bss) - LOAD_OFFSET)
     {
+        bss_ro_after_init_start = .;
+        *(.bss.ro_after_init)
+        . = ALIGN(4096);
+        bss_ro_after_init_end = .;
         *(.bss)
         *(.bss.*)
         *(COMMON)

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -66,8 +66,8 @@ void read_kernel_syms(void)
     }
 }
 
-static boolean have_rdseed = false;
-static boolean have_rdrand = false;
+BSS_RO_AFTER_INIT static boolean have_rdseed;
+BSS_RO_AFTER_INIT static boolean have_rdrand;
 
 static boolean hw_seed(u64 * seed, boolean rdseed)
 {
@@ -122,7 +122,7 @@ void reclaim_regions(void)
     unmap(PAGESIZE, INITIAL_MAP_SIZE - PAGESIZE);
 }
 
-halt_handler vm_halt;
+BSS_RO_AFTER_INIT halt_handler vm_halt;
 
 void vm_exit(u8 code)
 {
@@ -156,7 +156,7 @@ void vm_exit(u8 code)
 }
 
 u64 total_processors = 1;
-u64 present_processors = 1;
+BSS_RO_AFTER_INIT u64 present_processors;
 
 #ifdef SMP_ENABLE
 /* Value comes from LDMXCSR instruction reference in Intel Architectures SDM */
@@ -197,7 +197,6 @@ closure_function(0, 2, void, count_processors_handler,
 
 static void count_processors()
 {
-    present_processors = 0;
     if (acpi_walk_madt(stack_closure(count_processors_handler))) {
         init_debug("ACPI reports %d processors", present_processors);
     } else {
@@ -236,7 +235,7 @@ void count_cpus_present(void)
 
 u64 xsave_features();
 
-static range initial_pages;
+BSS_RO_AFTER_INIT static range initial_pages;
 
 static void __attribute__((noinline)) init_service_new_stack()
 {

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -192,7 +192,7 @@ msg_sed=	SED	$@
 cmd_sed=	$(SED) -e 's/\#/%/' <$^ >$@
 
 msg_version=	VERSION	$@
-cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "const char *gitversion = \"$(shell $(GIT) rev-parse HEAD)\";" >$@
+cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "const char * const gitversion = \"$(shell $(GIT) rev-parse HEAD)\";" >$@
 
 msg_xxd_r=	XXD_R	$@
 cmd_xxd_r=	$(XXD) -r $< $@

--- a/platform/virt/linker_script
+++ b/platform/virt/linker_script
@@ -51,6 +51,10 @@ SECTIONS
 
         .data ALIGN(4096): AT(ADDR(.data) - LOAD_OFFSET)
         {
+            ro_after_init_start = .;
+            *(.ro_after_init)
+            . = ALIGN(4096);
+            ro_after_init_end = .;
             *(.data)
             *(.data.*)
         }
@@ -58,6 +62,10 @@ SECTIONS
         .bss  ALIGN(4096): AT(ADDR(.bss) - LOAD_OFFSET)
         {
             PROVIDE(bss_start = .);
+            bss_ro_after_init_start = .;
+            *(.bss.ro_after_init)
+            . = ALIGN(4096);
+            bss_ro_after_init_end = .;
             *(.bss)
             *(.bss.*)
             *(COMMON)

--- a/rules.mk
+++ b/rules.mk
@@ -110,7 +110,7 @@ KERNCFLAGS+=    -mno-sse \
 		-mno-sse2
 endif
 KERNCFLAGS+=	-fno-omit-frame-pointer
-KERNLDFLAGS=	--gc-sections -n -L $(OUTDIR)/klib
+KERNLDFLAGS=	--gc-sections -z max-page-size=4096 -L $(OUTDIR)/klib
 
 ifeq ($(MEMDEBUG),mcache)
 CFLAGS+= -DMEMDEBUG_MCACHE

--- a/src/aarch64/clock.c
+++ b/src/aarch64/clock.c
@@ -3,9 +3,9 @@
 
 #define __vdso_dat (&(VVAR_REF(vdso_dat)))
 
-clock_now platform_monotonic_now;
-clock_timer platform_timer;
-thunk platform_timer_percpu_init;
+BSS_RO_AFTER_INIT clock_now platform_monotonic_now;
+BSS_RO_AFTER_INIT clock_timer platform_timer;
+BSS_RO_AFTER_INIT thunk platform_timer_percpu_init;
 
 static inline u64 cntfrq(void)
 {
@@ -30,9 +30,9 @@ closure_function(0, 0, void, arm_timer_percpu_init)
 {
 }
 
-closure_struct(arm_clock_now, _clock_now);
-closure_struct(arm_deadline_timer, _deadline_timer);
-closure_struct(arm_timer_percpu_init, _timer_percpu_init);
+BSS_RO_AFTER_INIT closure_struct(arm_clock_now, _clock_now);
+BSS_RO_AFTER_INIT closure_struct(arm_deadline_timer, _deadline_timer);
+BSS_RO_AFTER_INIT closure_struct(arm_timer_percpu_init, _timer_percpu_init);
 
 void init_clock(void)
 {

--- a/src/aarch64/gic.c
+++ b/src/aarch64/gic.c
@@ -8,8 +8,8 @@
 #define gic_debug(x, ...)
 #endif
 
-static boolean gicc_v3_iface;
-static u32 gic_intid_mask;
+BSS_RO_AFTER_INIT static boolean gicc_v3_iface;
+BSS_RO_AFTER_INIT static u32 gic_intid_mask;
 
 void gic_disable_int(int irq)
 {
@@ -179,8 +179,8 @@ static void init_gicc(void)
     }
 }
 
-u16 gic_msi_vector_base;
-u16 gic_msi_vector_num;
+BSS_RO_AFTER_INIT u16 gic_msi_vector_base;
+BSS_RO_AFTER_INIT u16 gic_msi_vector_num;
 
 void init_gic(void)
 {

--- a/src/aarch64/interrupt.c
+++ b/src/aarch64/interrupt.c
@@ -17,7 +17,7 @@ typedef struct inthandler {
     const char *name;
 } *inthandler;
 
-static struct list *handlers;
+BSS_RO_AFTER_INIT static struct list *handlers;
 
 extern u32 n_interrupt_vectors;
 extern u32 interrupt_vector_size;
@@ -325,10 +325,10 @@ void invalid_handler(void)
     halt("%s\n", __func__);
 }
 
-static id_heap ipi_vector_heap;
-static id_heap msi_vector_heap;
-static id_heap mmio_vector_heap;
-static heap int_general;
+BSS_RO_AFTER_INIT static id_heap ipi_vector_heap;
+BSS_RO_AFTER_INIT static id_heap msi_vector_heap;
+BSS_RO_AFTER_INIT static id_heap mmio_vector_heap;
+BSS_RO_AFTER_INIT static heap int_general;
 
 #define MK_INT_ALLOC_FNS(name)                                          \
     u64 allocate_## name ##_interrupt(void)                             \
@@ -391,7 +391,7 @@ closure_function(0, 0, void, arm_timer)
     schedule_timer_service();
 }
 
-closure_struct(arm_timer, _timer);
+BSS_RO_AFTER_INIT closure_struct(arm_timer, _timer);
 
 void init_interrupts(kernel_heaps kh)
 {

--- a/src/aarch64/page.c
+++ b/src/aarch64/page.c
@@ -12,8 +12,8 @@
 #define page_init_dump(p, len)
 #endif
 
-u64 kernel_tablebase;
-u64 user_tablebase;
+BSS_RO_AFTER_INIT u64 kernel_tablebase;
+BSS_RO_AFTER_INIT u64 user_tablebase;
 
 /* TODO until flush code is ported to aarch64... */
 void page_invalidate(flush_entry f, u64 address)

--- a/src/aarch64/serial.c
+++ b/src/aarch64/serial.c
@@ -1,8 +1,8 @@
 #include <kernel.h>
 #include "serial.h"
 
-volatile u32 *UART0_DR = (volatile u32 *)DEV_BASE_UART;
-volatile u32 *UART0_FR = (volatile u32 *)(DEV_BASE_UART + 0x18);
+RO_AFTER_INIT volatile u32 *UART0_DR = (volatile u32 *)DEV_BASE_UART;
+RO_AFTER_INIT volatile u32 *UART0_FR = (volatile u32 *)(DEV_BASE_UART + 0x18);
 
 #define UART_FR_TXFF (1 << 5)   /* TX FIFO full */
 

--- a/src/aws/ena/ena.c
+++ b/src/aws/ena/ena.c
@@ -98,9 +98,9 @@ static int ena_enable_msix_and_set_admin_interrupts(struct ena_adapter *);
 static void ena_update_on_link_change(void *, struct ena_admin_aenq_entry *);
 static void unimplemented_aenq_handler(void *, struct ena_admin_aenq_entry *);
 
-static char ena_version[] = DEVICE_NAME " " DRV_MODULE_NAME " v" DRV_MODULE_VERSION;
+static const char ena_version[] = DEVICE_NAME " " DRV_MODULE_NAME " v" DRV_MODULE_VERSION;
 
-static ena_vendor_info_t ena_vendor_info_array[] = {
+static const ena_vendor_info_t ena_vendor_info_array[] = {
         { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_PF, 0 },
         { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_PF_RSERV0, 0 },
         { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_VF, 0 },
@@ -112,7 +112,7 @@ static ena_vendor_info_t ena_vendor_info_array[] = {
 /*
  * Contains pointers to event handlers, e.g. link state chage.
  */
-static struct ena_aenq_handlers aenq_handlers;
+static const struct ena_aenq_handlers aenq_handlers;
 
 int ena_dma_alloc(struct ena_adapter *adapter, u64 size, ena_mem_handle_t *dma,
                   int mapflags, u64 alignment)
@@ -138,7 +138,7 @@ closure_function(2, 1, boolean, ena_probe,
         heap, general, heap, page_allocator,
         pci_dev, d)
 {
-    ena_vendor_info_t *ent;
+    const ena_vendor_info_t *ent;
     uint16_t pci_vendor_id = 0;
     uint16_t pci_device_id = 0;
 
@@ -2224,7 +2224,7 @@ static void unimplemented_aenq_handler(void *adapter_data, struct ena_admin_aenq
         "Unknown event was received or event with unimplemented handler\n");
 }
 
-static struct ena_aenq_handlers aenq_handlers = {
+static const struct ena_aenq_handlers aenq_handlers = {
         .handlers = {
                 [ENA_ADMIN_LINK_CHANGE] = ena_update_on_link_change,
                 [ENA_ADMIN_NOTIFICATION] = ena_notification,

--- a/src/aws/ena/ena_com/ena_com.c
+++ b/src/aws/ena/ena_com/ena_com.c
@@ -161,7 +161,7 @@ static int ena_com_admin_init_cq(struct ena_com_admin_queue *admin_queue)
 }
 
 static int ena_com_admin_init_aenq(struct ena_com_dev *ena_dev,
-                                   struct ena_aenq_handlers *aenq_handlers)
+                                   const struct ena_aenq_handlers *aenq_handlers)
 {
     struct ena_com_aenq *aenq = &ena_dev->aenq;
     u32 addr_low, addr_high, aenq_caps;
@@ -1596,7 +1596,7 @@ void ena_com_mmio_reg_read_request_write_dev_addr(struct ena_com_dev *ena_dev)
     ENA_REG_WRITE32(ena_dev->bus, addr_high, ena_dev->reg_bar + ENA_REGS_MMIO_RESP_HI_OFF);
 }
 
-int ena_com_admin_init(struct ena_com_dev *ena_dev, struct ena_aenq_handlers *aenq_handlers)
+int ena_com_admin_init(struct ena_com_dev *ena_dev, const struct ena_aenq_handlers *aenq_handlers)
 {
     struct ena_com_admin_queue *admin_queue = &ena_dev->admin_queue;
     u32 aq_caps, acq_caps, dev_sts, addr_low, addr_high;
@@ -1844,7 +1844,7 @@ void ena_com_admin_q_comp_intr_handler(struct ena_com_dev *ena_dev)
  */
 static ena_aenq_handler ena_com_get_specific_aenq_cb(struct ena_com_dev *ena_dev, u16 group)
 {
-    struct ena_aenq_handlers *aenq_handlers = ena_dev->aenq.aenq_handlers;
+    const struct ena_aenq_handlers *aenq_handlers = ena_dev->aenq.aenq_handlers;
 
     if ((group < ENA_MAX_HANDLERS) && aenq_handlers->handlers[group])
         return aenq_handlers->handlers[group];

--- a/src/aws/ena/ena_com/ena_com.h
+++ b/src/aws/ena/ena_com/ena_com.h
@@ -263,7 +263,7 @@ struct ena_com_aenq {
     dma_addr_t dma_addr;
     ena_mem_handle_t mem_handle;
     u16 q_depth;
-    struct ena_aenq_handlers *aenq_handlers;
+    const struct ena_aenq_handlers *aenq_handlers;
 };
 
 struct ena_com_mmio_read {
@@ -422,7 +422,7 @@ void ena_com_mmio_reg_read_request_destroy(struct ena_com_dev *ena_dev);
  *
  * @return - 0 on success, negative value on failure.
  */
-int ena_com_admin_init(struct ena_com_dev *ena_dev, struct ena_aenq_handlers *aenq_handlers);
+int ena_com_admin_init(struct ena_com_dev *ena_dev, const struct ena_aenq_handlers *aenq_handlers);
 
 /* ena_com_admin_destroy - Destroy the admin and the async events queues.
  * @ena_dev: ENA communication layer struct

--- a/src/drivers/console.c
+++ b/src/drivers/console.c
@@ -11,7 +11,7 @@ static void serial_console_write(void *d, const char *s, bytes count)
     }
 }
 
-struct console_driver serial_console_driver = {
+RO_AFTER_INIT struct console_driver serial_console_driver = {
     .write = serial_console_write,
     .name = "serial"
 };

--- a/src/drivers/dmi.c
+++ b/src/drivers/dmi.c
@@ -22,7 +22,7 @@ struct dmi_header {
     u16 handle;
 } __attribute__((packed));
 
-u64 smbios_entry_point;
+BSS_RO_AFTER_INIT u64 smbios_entry_point;
 
 static u32 dmi_len;
 static u16 dmi_num;

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -300,7 +300,7 @@ buffer_handler allocate_http_parser(heap h, value_handler each)
     return closure(h, http_recv, p);
 }
 
-const char *http_request_methods[] = {
+const char * const http_request_methods[] = {
     [HTTP_REQUEST_METHOD_GET] = "GET",
     [HTTP_REQUEST_METHOD_HEAD] = "HEAD",
     [HTTP_REQUEST_METHOD_POST] = "POST",

--- a/src/http/http.h
+++ b/src/http/http.h
@@ -24,7 +24,7 @@ status send_http_chunk(buffer_handler out, buffer c);
 status send_http_chunked_response(buffer_handler out, tuple t);
 status send_http_response(buffer_handler out, tuple t, buffer c);
 
-extern const char *http_request_methods[];
+extern const char * const http_request_methods[];
 
 typedef struct http_listener *http_listener;
 typedef closure_type(http_request_handler, void, http_method, buffer_handler, value);

--- a/src/hyperv/netvsc/hv_net_vsc.h
+++ b/src/hyperv/netvsc/hv_net_vsc.h
@@ -976,7 +976,6 @@ typedef struct hn_softc {
 /*
  * Externs
  */
-extern int hv_promisc_mode;
 
 extern void netvsc_linkstatus_callback(struct hv_device *device_obj,
 				       uint32_t status);

--- a/src/hyperv/netvsc/hv_rndis_filter.c
+++ b/src/hyperv/netvsc/hv_rndis_filter.c
@@ -650,15 +650,10 @@ hv_rf_open_device(rndis_device *device)
         return (0);
     }
 
-    if (hv_promisc_mode != 1) {
-        ret = hv_rf_set_packet_filter(device,
+    ret = hv_rf_set_packet_filter(device,
             NDIS_PACKET_TYPE_BROADCAST     |
             NDIS_PACKET_TYPE_ALL_MULTICAST |
             NDIS_PACKET_TYPE_DIRECTED);
-    } else {
-        ret = hv_rf_set_packet_filter(device, 
-            NDIS_PACKET_TYPE_PROMISCUOUS);
-    }
 
     if (ret == 0) {
         device->state = RNDIS_DEV_DATAINITIALIZED;

--- a/src/hyperv/netvsc/netvsc.c
+++ b/src/hyperv/netvsc/netvsc.c
@@ -43,8 +43,6 @@
 
 #define NETVSC_RX_MAXSEGSIZE       NETVSC_MAX_CONFIGURABLE_MTU
 
-int hv_promisc_mode = 0;
-
 typedef struct xpbuf
 {
     struct pbuf_custom p;

--- a/src/hyperv/storvsc/storvsc.c
+++ b/src/hyperv/storvsc/storvsc.c
@@ -173,7 +173,7 @@ struct storvsc_softc {
  * to a win8 host.
  * Track the correct size we need to apply.
  */
-static int vmscsi_size_delta = sizeof(struct vmscsi_win8_extension);
+RO_AFTER_INIT static int vmscsi_size_delta = sizeof(struct vmscsi_win8_extension);
 
 struct storvsc_driver_props {
     char        *drv_name;
@@ -203,7 +203,7 @@ static const struct hyperv_guid gBlkVscDeviceType={
          0x9b, 0x5c, 0x50, 0xd1, 0x41, 0x73, 0x54, 0xf5}
 };
 
-static struct storvsc_driver_props g_drv_props_table[] = {
+RO_AFTER_INIT static struct storvsc_driver_props g_drv_props_table[] = {
     {"blkvsc", "Hyper-V IDE",
      BLKVSC_MAX_IDE_DISKS_PER_TARGET, BLKVSC_MAX_IO_REQUESTS,
      20*PAGESIZE},
@@ -216,14 +216,14 @@ static struct storvsc_driver_props g_drv_props_table[] = {
  * Sense buffer size changed in win8; have a run-time
  * variable to track the size we should use.
  */
-static int sense_buffer_size = PRE_WIN8_STORVSC_SENSE_BUFFER_SIZE;
+RO_AFTER_INIT static int sense_buffer_size = PRE_WIN8_STORVSC_SENSE_BUFFER_SIZE;
 
 /*
  * The storage protocol version is determined during the
  * initial exchange with the host.  It will indicate which
  * storage functionality is available in the host.
 */
-static int vmstor_proto_version;
+BSS_RO_AFTER_INIT static int vmstor_proto_version;
 
 struct vmstor_proto {
         int proto_version;

--- a/src/hyperv/vmbus/hyperv.c
+++ b/src/hyperv/vmbus/hyperv.c
@@ -72,7 +72,7 @@ typedef struct hyperv_platform_info {
     boolean initialized;
 } *hyperv_platform_info;
 
-struct hyperv_platform_info hyperv_info;
+BSS_RO_AFTER_INIT struct hyperv_platform_info hyperv_info;
 
 u64
 hypercall_md(volatile void *hc_addr, u64 in_val,

--- a/src/hyperv/vmbus/vmbus.c
+++ b/src/hyperv/vmbus/vmbus.c
@@ -40,7 +40,7 @@ struct vmbus_msghc {
     struct hypercall_postmsg_in mh_inprm_save;
 };
 
-uint32_t            vmbus_current_version;
+BSS_RO_AFTER_INIT uint32_t vmbus_current_version;
 
 static __inline void
 vmbus_handle_intr1(vmbus_dev sc, int cpu)

--- a/src/hyperv/vmbus/vmbus_et.c
+++ b/src/hyperv/vmbus/vmbus_et.c
@@ -53,7 +53,7 @@ struct vmbus_timer {
 
 typedef struct vmbus_timer *vmbus_timer_t;
 
-static vmbus_timer_t vmbus_et;
+BSS_RO_AFTER_INIT static vmbus_timer_t vmbus_et;
 
 static __inline u64
 hyperv_sbintime2count(timestamp time)

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -16,15 +16,15 @@
 #define init_debug(x, ...)
 #endif
 
-filesystem root_fs;
-static kernel_heaps init_heaps;
+BSS_RO_AFTER_INIT filesystem root_fs;
+BSS_RO_AFTER_INIT static kernel_heaps init_heaps;
 
 //#define MAX_BLOCK_IO_SIZE PAGE_SIZE
 #define MAX_BLOCK_IO_SIZE (64 * 1024)
 #define SHUTDOWN_COMPLETIONS_SIZE 8
 
 static u64 bootstrap_base = BOOTSTRAP_BASE;
-static u64 bootstrap_limit;
+BSS_RO_AFTER_INIT static u64 bootstrap_limit;
 static u64 bootstrap_alloc(heap h, bytes length)
 {
     u64 result = bootstrap_base;
@@ -36,8 +36,8 @@ static u64 bootstrap_alloc(heap h, bytes length)
     return result;
 }
 
-static struct kernel_heaps heaps;
-static vector shutdown_completions;
+BSS_RO_AFTER_INIT static struct kernel_heaps heaps;
+BSS_RO_AFTER_INIT static vector shutdown_completions;
 
 u64 init_bootstrap_heap(u64 phys_length)
 {
@@ -58,7 +58,7 @@ u64 init_bootstrap_heap(u64 phys_length)
 
 void init_kernel_heaps(void)
 {
-    static struct heap bootstrap;
+    BSS_RO_AFTER_INIT static struct heap bootstrap;
     bootstrap.alloc = bootstrap_alloc;
     bootstrap.dealloc = leak;
 
@@ -120,7 +120,7 @@ extern filesystem_complete bootfs_handler(kernel_heaps kh, tuple root,
                                           status_handler klibs_complete, boolean klibs_in_bootfs,
                                           boolean ingest_kernel_syms);
 
-static tuple_notifier wrapped_root;
+BSS_RO_AFTER_INIT static tuple_notifier wrapped_root;
 
 closure_function(3, 2, void, fsstarted,
                  u8 *, mbr, block_io, r, block_io, w,

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -81,7 +81,7 @@ void resume_kernel_context(kernel_context c)
     frame_return(c->frame);
 }
 
-vector cpuinfos;
+BSS_RO_AFTER_INIT vector cpuinfos;
 
 cpuinfo init_cpuinfo(heap backed, int cpu)
 {

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -320,7 +320,7 @@ void register_root_notify(symbol s, set_value_notify n);
 boolean first_boot(void);
 
 extern void interrupt_exit(void);
-extern char **state_strings;
+extern const char * const * const state_strings;
 
 // static inline void schedule_frame(context f) stupid header deps
 #define schedule_frame(___f)  do { context __f = ___f; assert((__f)[FRAME_QUEUE] != INVALID_PHYSICAL); if ((__f)[FRAME_THREAD]) apply(((nanos_thread)(__f)[FRAME_THREAD])->pause); assert(enqueue_irqsafe((queue)pointer_from_u64((__f)[FRAME_QUEUE]), pointer_from_u64((__f)[FRAME_RUN]))); } while(0)

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -11,10 +11,10 @@
 #define klib_debug(x, ...)
 #endif
 
-static kernel_heaps klib_kh;
-static filesystem klib_fs;
-static tuple klib_root;
-static id_heap klib_heap;
+BSS_RO_AFTER_INIT static kernel_heaps klib_kh;
+BSS_RO_AFTER_INIT static filesystem klib_fs;
+BSS_RO_AFTER_INIT static tuple klib_root;
+BSS_RO_AFTER_INIT static id_heap klib_heap;
 
 closure_function(1, 1, void, klib_elf_walk,
                  klib, kl,

--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -41,7 +41,7 @@ static struct {
     u64 levelmask;              /* bitmap of levels allowed to map */
 } pagemem;
 
-boolean bootstrapping;
+BSS_RO_AFTER_INIT boolean bootstrapping;
 
 #ifndef physical_from_virtual
 physical physical_from_virtual(void *x)

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -35,7 +35,7 @@ typedef void *nanos_thread;
    queueing a ton with the polled ATA driver. There's only one queue globally anyhow. */
 #define MAX_PAGE_COMPLETION_VECS 16384
 
-static pagecache global_pagecache;
+BSS_RO_AFTER_INIT static pagecache global_pagecache;
 
 static inline u64 cache_pagesize(pagecache pc)
 {

--- a/src/kernel/pci.c
+++ b/src/kernel/pci.c
@@ -13,11 +13,11 @@ typedef struct pci_bus {
 } *pci_bus;
 
 // use the global nodespace
-static vector pci_buses;
-static vector devices;
-static vector drivers;
+BSS_RO_AFTER_INIT static vector pci_buses;
+BSS_RO_AFTER_INIT static vector devices;
+BSS_RO_AFTER_INIT static vector drivers;
 static struct spinlock pci_lock;
-static heap virtual_page;
+BSS_RO_AFTER_INIT static heap virtual_page;
 
 static u32 pci_bar_len(pci_dev dev, int bar)
 {

--- a/src/kernel/pvclock.c
+++ b/src/kernel/pvclock.c
@@ -2,8 +2,8 @@
 #include <pvclock.h>
 #include <apic.h>
 
-static heap pvclock_heap;
-static volatile struct pvclock_vcpu_time_info *vclock = 0;
+BSS_RO_AFTER_INIT static heap pvclock_heap;
+BSS_RO_AFTER_INIT static volatile struct pvclock_vcpu_time_info *vclock;
 
 u64 pvclock_now_ns(void)
 {

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -18,16 +18,16 @@ static const char * const state_strings_backing[] = {
 };
 
 const char * const * const state_strings = state_strings_backing;
-static int wakeup_vector;
-int shutdown_vector;
+BSS_RO_AFTER_INIT static int wakeup_vector;
+BSS_RO_AFTER_INIT int shutdown_vector;
 boolean shutting_down;
 
-queue runqueue;                 /* kernel space from ?*/
-queue bhqueue;                  /* kernel from interrupt */
-bitmap idle_cpu_mask;
+BSS_RO_AFTER_INIT queue runqueue;   /* kernel space from ?*/
+BSS_RO_AFTER_INIT queue bhqueue;    /* kernel from interrupt */
+BSS_RO_AFTER_INIT bitmap idle_cpu_mask;
 
-timerqueue kernel_timers;
-thunk timer_interrupt_handler;
+BSS_RO_AFTER_INIT timerqueue kernel_timers;
+BSS_RO_AFTER_INIT thunk timer_interrupt_handler;
 
 static struct spinlock kernel_lock;
 

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -9,8 +9,7 @@
 #define sched_debug(x, ...)
 #endif
 
-// currently defined in x86_64.h
-static char *state_strings_backing[] = {
+static const char * const state_strings_backing[] = {
     "not present",
     "idle",
     "kernel",
@@ -18,7 +17,7 @@ static char *state_strings_backing[] = {
     "user",         
 };
 
-char **state_strings = state_strings_backing;
+const char * const * const state_strings = state_strings_backing;
 static int wakeup_vector;
 int shutdown_vector;
 boolean shutting_down;

--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -15,6 +15,18 @@ closure_function(2, 1, void, program_start,
 {
     if (!is_ok(s))
         halt("%s: aborting %v\n", __func__, s);
+
+    /* Set mapping flags to read-only for data that has been initialized during boot and should not
+     * be modified afterwards. */
+    extern void *ro_after_init_start, *ro_after_init_end;
+    extern void *bss_ro_after_init_start, *bss_ro_after_init_end;
+    update_map_flags(u64_from_pointer(&ro_after_init_start),
+                     &ro_after_init_end - &ro_after_init_start,
+                     pageflags_memory());
+    update_map_flags(u64_from_pointer(&bss_ro_after_init_start),
+                     &bss_ro_after_init_end - &bss_ro_after_init_start,
+                     pageflags_memory());
+
     exec_elf(bound(elf), bound(kp));
     closure_finish();
 }

--- a/src/kernel/symtab.c
+++ b/src/kernel/symtab.c
@@ -2,8 +2,8 @@
 #include <elf64.h>
 
 /* really this should be an instance... */
-static heap general;
-static rangemap elf_symtable;
+BSS_RO_AFTER_INIT static heap general;
+BSS_RO_AFTER_INIT static rangemap elf_symtable;
 
 typedef struct elfsym {
     struct rmnode node;

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -10,7 +10,7 @@
 #define IFF_NOARP       (1 << 7)
 #define IFF_MULTICAST   (1 << 12)
 
-static heap lwip_heap;
+BSS_RO_AFTER_INIT static heap lwip_heap;
 struct spinlock lwip_spinlock;
 
 /* Pretty silly. LWIP offers lwip_cyclic_timers for use elsewhere, but
@@ -354,7 +354,7 @@ void init_net(kernel_heaps kh)
     spin_lock_init(&lwip_spinlock);
     lwip_lock();
     lwip_init();
-    NETIF_DECLARE_EXT_CALLBACK(netif_callback);
+    BSS_RO_AFTER_INIT NETIF_DECLARE_EXT_CALLBACK(netif_callback);
     netif_add_ext_callback(&netif_callback, lwip_ext_callback);
     lwip_unlock();
 }

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -134,7 +134,7 @@ static sysreturn netsock_sendmsg(struct sock *sock, const struct msghdr *msg,
 static sysreturn netsock_recvmsg(struct sock *sock, struct msghdr *msg,
                                  int flags);
 
-static thunk net_loop_poll;
+BSS_RO_AFTER_INIT static thunk net_loop_poll;
 static boolean net_loop_poll_queued;
 
 closure_function(0, 0, void, netsock_poll) {

--- a/src/runtime/attributes.h
+++ b/src/runtime/attributes.h
@@ -5,3 +5,10 @@
 #define VDSO     HIDDEN
 #define VVAR     HIDDEN
 #define VSYSCALL NOTRACE __attribute__((section(".vsyscall")))
+#ifdef KERNEL
+#define RO_AFTER_INIT       __attribute__((section(".ro_after_init")))
+#define BSS_RO_AFTER_INIT   __attribute__((section(".bss.ro_after_init")))
+#else
+#define RO_AFTER_INIT
+#define BSS_RO_AFTER_INIT
+#endif

--- a/src/runtime/format.c
+++ b/src/runtime/format.c
@@ -20,7 +20,7 @@ void register_format(character c, formatter f, int accepts_long)
 
 static void invalid_format(buffer d, buffer fmt, int start_idx, int idx)
 {
-    static char header[] = "[invalid format ";
+    static const char header[] = "[invalid format ";
 
     assert(buffer_write(d, header, sizeof(header) - 1));
     for (int i = 0; i < idx - start_idx + 1; i++)

--- a/src/runtime/format.c
+++ b/src/runtime/format.c
@@ -5,7 +5,7 @@ struct formatter {
 	int accepts_long;
 };
 
-static struct formatter formatters[96];
+BSS_RO_AFTER_INIT static struct formatter formatters[96];
 #define FORMATTER(c) (formatters[c - 32])
 
 void register_format(character c, formatter f, int accepts_long)

--- a/src/runtime/runtime_init.c
+++ b/src/runtime/runtime_init.c
@@ -4,9 +4,9 @@
 void initialize_buffer();
 
 closure_function(0, 0, void, ignore_body) {}
-thunk ignore;
-status_handler ignore_status;
-value null_value;
+BSS_RO_AFTER_INIT thunk ignore;
+BSS_RO_AFTER_INIT status_handler ignore_status;
+BSS_RO_AFTER_INIT value null_value;
 static char *hex_digits="0123456789abcdef";
 
 void print_u64(u64 s)
@@ -111,8 +111,8 @@ static void format_spaces(buffer dest, struct formatter_state *s, vlist *a)
 }
 
 // maybe the same?
-heap errheap;
-heap transient;
+BSS_RO_AFTER_INIT heap errheap;
+BSS_RO_AFTER_INIT heap transient;
 
 // init linker sets would clean up the platform dependency, if you link
 // with it, it gets initialized
@@ -142,7 +142,7 @@ void rputs(const char *s)
 
 #define STACK_CHK_GUARD 0x595e9fbd94fda766
 
-u64 __attribute__((weak)) __stack_chk_guard = STACK_CHK_GUARD;
+RO_AFTER_INIT u64 __attribute__((weak)) __stack_chk_guard = STACK_CHK_GUARD;
 
 void __stack_chk_guard_init()
 {

--- a/src/runtime/sg.c
+++ b/src/runtime/sg.c
@@ -13,7 +13,7 @@
 
 #define DEFAULT_SG_FRAGS 8
 
-static heap sg_heap;
+BSS_RO_AFTER_INIT static heap sg_heap;
 static struct list free_sg_lists;
 
 #ifdef KERNEL

--- a/src/runtime/symbol.c
+++ b/src/runtime/symbol.c
@@ -4,9 +4,9 @@
 #include <runtime.h>
 #endif
 
-static table symbols;
-static heap sheap;
-static heap iheap;
+BSS_RO_AFTER_INIT static table symbols;
+BSS_RO_AFTER_INIT static heap sheap;
+BSS_RO_AFTER_INIT static heap iheap;
 
 #ifdef KERNEL
 

--- a/src/runtime/tuple.c
+++ b/src/runtime/tuple.c
@@ -7,7 +7,7 @@
 #define tuple_debug(x, ...)
 #endif
 
-static heap theap;
+BSS_RO_AFTER_INIT static heap theap;
 
 // use runtime tags directly?
 #define type_tuple 1

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -411,7 +411,7 @@ closure_function(3, 1, void, zero_hole,
     sg_zero_fill(bound(sg), length);
 }
 
-io_status_handler ignore_io_status;
+BSS_RO_AFTER_INIT io_status_handler ignore_io_status;
 
 /* whole block reads, file length resolved in cache */
 closure_function(2, 3, void, filesystem_storage_read,
@@ -1975,7 +1975,7 @@ u64 fs_freeblocks(filesystem fs)
     return heap_free((heap)fs->storage);
 }
 
-static struct {
+BSS_RO_AFTER_INIT static struct {
     filesystem (*get_root_fs)();    /* return filesystem at "/" */
     inode (*get_mountpoint)(tuple, filesystem *);   /* find mount point and parent filesystem */
 } fs_path_helper;

--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -831,7 +831,7 @@ void netlink_init(void)
     assert(netlink.sockets != INVALID_ADDRESS);
     spin_lock_init(&netlink.lock);
     lwip_lock();
-    NETIF_DECLARE_EXT_CALLBACK(netif_callback);
+    BSS_RO_AFTER_INIT NETIF_DECLARE_EXT_CALLBACK(netif_callback);
     netif_add_ext_callback(&netif_callback, nl_lwip_ext_callback);
     lwip_unlock();
 }

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -38,7 +38,7 @@ enum epoll_type {
     EPOLL_TYPE_EPOLL,
 };
 
-static heap epoll_heap;
+BSS_RO_AFTER_INIT static heap epoll_heap;
 
 struct epoll_blocked {
     epoll e;

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -198,7 +198,7 @@ static u32 cpu_online_events(file f)
     return (EPOLLIN | EPOLLOUT);
 }
 
-static special_file special_files[] = {
+static const special_file special_files[] = {
     { "/dev/urandom", .read = urandom_read, .write = 0, .events = urandom_events },
     { "/dev/null", .read = null_read, .write = null_write, .events = null_events },
     { "/proc/mounts", .open = mounts_open, .close = mounts_close, .read = mounts_read, .events = mounts_events, .alloc_size = sizeof(struct mounts_notify_data)},
@@ -208,10 +208,10 @@ static special_file special_files[] = {
 };
 
 closure_function(2, 6, sysreturn, spec_read,
-                 special_file *, sf, file, f,
+                 const special_file *, sf, file, f,
                  void *, dest, u64, len, u64, offset, thread, t, boolean, bh, io_completion, completion)
 {
-    special_file *sf = bound(sf);
+    const special_file *sf = bound(sf);
     thread_log(t, "spec_read: %s", sf->path);
     file f = bound(f);
     sysreturn nr;
@@ -227,10 +227,10 @@ closure_function(2, 6, sysreturn, spec_read,
 }
 
 closure_function(2, 6, sysreturn, spec_write,
-                 special_file *, sf, file, f,
+                 const special_file *, sf, file, f,
                  void *, dest, u64, len, u64, offset, thread, t, boolean, bh, io_completion, completion)
 {
-    special_file *sf = bound(sf);
+    const special_file *sf = bound(sf);
     thread_log(t, "spec_write: %s", sf->path);
     file f = bound(f);
     sysreturn nr;
@@ -246,10 +246,10 @@ closure_function(2, 6, sysreturn, spec_write,
 }
 
 closure_function(2, 1, u32, spec_events,
-                 special_file *, sf, file, f,
+                 const special_file *, sf, file, f,
                  thread, t)
 {
-    special_file *sf = bound(sf);
+    const special_file *sf = bound(sf);
     thread_log(current, "spec_events: %s", sf->path);
     if (sf->events)
         return sf->events(bound(f));
@@ -257,10 +257,10 @@ closure_function(2, 1, u32, spec_events,
 }
 
 closure_function(2, 2, sysreturn, spec_close,
-                 special_file *, sf, file, f,
+                 const special_file *, sf, file, f,
                  thread, t, io_completion, completion)
 {
-    special_file *sf = bound(sf);
+    const special_file *sf = bound(sf);
     thread_log(current, "spec_close: %s", sf->path);
     file f = bound(f);
     sysreturn ret;
@@ -277,10 +277,10 @@ closure_function(2, 2, sysreturn, spec_close,
 }
 
 closure_function(1, 1, sysreturn, special_open,
-                 special_file *, sf,
+                 const special_file *, sf,
                  file, f)
 {
-    special_file *sf = bound(sf);
+    const special_file *sf = bound(sf);
     heap h = heap_locked(get_kernel_heaps());
     sysreturn ret;
 
@@ -352,7 +352,7 @@ void register_special_files(process p)
     }
 
     for (int i = 0; i < sizeof(special_files) / sizeof(special_files[0]); i++) {
-        special_file *sf = special_files + i;
+        const special_file *sf = special_files + i;
 
         /* create special file */
         spec_file_open open = closure(h, special_open, sf);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2305,7 +2305,7 @@ struct syscall {
 };
 
 static struct syscall _linux_syscalls[SYS_MAX];
-struct syscall *linux_syscalls = _linux_syscalls;
+struct syscall * const linux_syscalls = _linux_syscalls;
 
 void count_syscall(thread t, sysreturn rv)
 {

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -20,16 +20,16 @@ typedef struct syscall_stat {
 } *syscall_stat;
 
 static struct syscall_stat stats[SYS_MAX];
-boolean do_syscall_stats;
-static boolean do_missing_files;
-static vector missing_files;
+BSS_RO_AFTER_INIT boolean do_syscall_stats;
+BSS_RO_AFTER_INIT static boolean do_missing_files;
+BSS_RO_AFTER_INIT static vector missing_files;
 
 sysreturn close(int fd);
 
-io_completion syscall_io_complete;
-io_completion io_completion_ignore;
-shutdown_handler print_syscall_stats;
-shutdown_handler print_missing_files;
+BSS_RO_AFTER_INIT io_completion syscall_io_complete;
+BSS_RO_AFTER_INIT io_completion io_completion_ignore;
+BSS_RO_AFTER_INIT shutdown_handler print_syscall_stats;
+BSS_RO_AFTER_INIT shutdown_handler print_missing_files;
 
 boolean validate_iovec(struct iovec *iov, u64 len, boolean write)
 {
@@ -2394,7 +2394,7 @@ boolean syscall_notrace(process p, int syscall)
 
 // should hang off the thread context, but the assembly handler needs
 // to find it.
-void (*syscall)(context f);
+BSS_RO_AFTER_INIT void (*syscall)(context f);
 
 closure_function(0, 2, void, syscall_io_complete_cfn,
                  thread, t, sysreturn, rv)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -2,7 +2,7 @@
 #include <ftrace.h>
 #include <gdb.h>
 
-thread dummy_thread;
+BSS_RO_AFTER_INIT thread dummy_thread;
 
 sysreturn gettid()
 {

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -70,7 +70,7 @@ typedef struct unix_timer {
     closure_struct(unix_timer_free, free);
 } *unix_timer;
 
-static heap unix_timer_heap;
+BSS_RO_AFTER_INIT static heap unix_timer_heap;
 
 define_closure_function(1, 0, void, unix_timer_free,
                         unix_timer, ut)

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -12,7 +12,7 @@
 #define pf_debug(x, ...) thread_log(current, x, ##__VA_ARGS__);
 #endif
 
-static unix_heaps u_heap;
+BSS_RO_AFTER_INIT static unix_heaps u_heap;
 
 unix_heaps get_unix_heaps()
 {

--- a/src/virtio/virtio_mmio.c
+++ b/src/virtio/virtio_mmio.c
@@ -21,7 +21,7 @@
 #define virtio_mmio_debug(x, ...)
 #endif
 
-static struct list vtmmio_devices = {
+RO_AFTER_INIT static struct list vtmmio_devices = {
         &vtmmio_devices, &vtmmio_devices
 };
 

--- a/src/x86_64/apic.c
+++ b/src/x86_64/apic.c
@@ -24,10 +24,10 @@
 #define apic_debug(x, ...)
 #endif
 
-static heap apic_heap;
-static u64 ioapic_membase;
-apic_iface apic_if;
-buffer apic_id_map;
+BSS_RO_AFTER_INIT static heap apic_heap;
+BSS_RO_AFTER_INIT static u64 ioapic_membase;
+BSS_RO_AFTER_INIT apic_iface apic_if;
+BSS_RO_AFTER_INIT buffer apic_id_map;
 
 static inline void apic_write(int reg, u32 val)
 {
@@ -71,7 +71,7 @@ static inline void apic_clear(int reg, u32 v)
     apic_write(reg, apic_read(reg) & ~v);
 }
 
-static u32 apic_timer_cal_sec;
+BSS_RO_AFTER_INIT static u32 apic_timer_cal_sec;
 
 /* We could possibly trim this if the extra delay in boot becomes a concern. */
 #define CALIBRATE_DURATION_MS 10
@@ -158,7 +158,7 @@ boolean init_lapic_timer(clock_timer *ct, thunk *per_cpu_init)
     return true;
 }
 
-static u64 lvt_err_irq;
+BSS_RO_AFTER_INIT static u64 lvt_err_irq;
 extern u32 spurious_int_vector;
 
 void apic_per_cpu_init(void)
@@ -180,7 +180,7 @@ void apic_enable(void)
 
 extern struct apic_iface xapic_if, x2apic_if;
 
-static void *ioapic_vbase;
+BSS_RO_AFTER_INIT static void *ioapic_vbase;
 
 static void ioapic_init(kernel_heaps kh, u64 membase)
 {

--- a/src/x86_64/clock.c
+++ b/src/x86_64/clock.c
@@ -7,9 +7,9 @@
 #define PIT_FREQUENCY   1193182ul   /* Hz */
 #define PIT_PERIOD_MSB  nanoseconds(256 * BILLION / PIT_FREQUENCY)
 
-clock_now platform_monotonic_now;
-clock_timer platform_timer;
-thunk platform_timer_percpu_init;
+BSS_RO_AFTER_INIT clock_now platform_monotonic_now;
+BSS_RO_AFTER_INIT clock_timer platform_timer;
+BSS_RO_AFTER_INIT thunk platform_timer_percpu_init;
 
 void init_clock(void)
 {

--- a/src/x86_64/flush.c
+++ b/src/x86_64/flush.c
@@ -8,7 +8,6 @@
 
 static boolean initialized = false;
 static int flush_ipi;
-static heap flush_heap;
 static volatile word inval_gen;
 static queue free_flush_entries;
 static struct list entries;
@@ -220,12 +219,11 @@ void init_flush(heap h)
 {
     flush_ipi = allocate_interrupt();
     register_interrupt(flush_ipi, closure(h, flush_handler), "flush ipi");
-    flush_heap = h;
     list_init(&entries);
-    flush_service = closure(flush_heap, do_flush_service);
-    free_flush_entries = allocate_queue(flush_heap, MAX_FLUSH_ENTRIES + 1);
-    flush_completion_queue = allocate_queue(flush_heap, COMP_QUEUE_SIZE);
-    flush_entry fa = allocate(flush_heap, sizeof(struct flush_entry) * MAX_FLUSH_ENTRIES);
+    flush_service = closure(h, do_flush_service);
+    free_flush_entries = allocate_queue(h, MAX_FLUSH_ENTRIES + 1);
+    flush_completion_queue = allocate_queue(h, COMP_QUEUE_SIZE);
+    flush_entry fa = allocate(h, sizeof(struct flush_entry) * MAX_FLUSH_ENTRIES);
     assert(fa);
     for (flush_entry f = fa; f < fa + MAX_FLUSH_ENTRIES; f++)
         assert(enqueue(free_flush_entries, f));

--- a/src/x86_64/flush.c
+++ b/src/x86_64/flush.c
@@ -6,15 +6,15 @@
 #define COMP_QUEUE_SIZE (MAX_FLUSH_ENTRIES*2)
 #define ENTRIES_SERVICE_THRESHOLD (MAX_FLUSH_ENTRIES/2)
 
-static boolean initialized = false;
-static int flush_ipi;
+BSS_RO_AFTER_INIT static boolean initialized;
+BSS_RO_AFTER_INIT static int flush_ipi;
 static volatile word inval_gen;
-static queue free_flush_entries;
+BSS_RO_AFTER_INIT static queue free_flush_entries;
 static struct list entries;
 static int entries_count;
 static volatile boolean service_scheduled;
-static thunk flush_service;
-static queue flush_completion_queue;
+BSS_RO_AFTER_INIT static thunk flush_service;
+BSS_RO_AFTER_INIT static queue flush_completion_queue;
 static struct rw_spinlock flush_lock;
 
 static void queue_flush_service();

--- a/src/x86_64/gdb_machine.h
+++ b/src/x86_64/gdb_machine.h
@@ -1,4 +1,4 @@
-int signalmap[]={8, 5, 0, 5, 8, 10, 4, 8, 7, 10, 11, 11, 11, 11, 0, 0, 8, 10, 10, 8, 10};
+const int signalmap[]={8, 5, 0, 5, 8, 10, 4, 8, 7, 10, 11, 11, 11, 11, 0, 0, 8, 10, 10, 8, 10};
 static inline int computeSignal (context frame)
 {
     u64 exceptionVector = frame[FRAME_VECTOR];

--- a/src/x86_64/hpet.c
+++ b/src/x86_64/hpet.c
@@ -92,8 +92,8 @@ struct HPETMemoryMap {
     struct HPETTimer timers[32];
 } __attribute__((__packed__));
 
-static volatile struct HPETMemoryMap* hpet;
-static timestamp hpet_period_scaled_32;
+BSS_RO_AFTER_INIT static volatile struct HPETMemoryMap* hpet;
+BSS_RO_AFTER_INIT static timestamp hpet_period_scaled_32;
 static struct hpet_timer_cfg {
     int interrupt;
     u64 config;

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -88,7 +88,7 @@ static inline char *register_name(u64 s)
     return textoreg[s];
 }
 
-static u64 *idt;
+BSS_RO_AFTER_INIT static u64 *idt;
 
 static inline void *idt_from_interrupt(int interrupt)
 {
@@ -112,8 +112,8 @@ static void __attribute__((noinline)) write_idt(int interrupt, u64 offset, u64 i
     target[1] = offset >> 32;   /*  95 - 64 */
 }
 
-static thunk *handlers;
-u32 spurious_int_vector;
+BSS_RO_AFTER_INIT static thunk *handlers;
+BSS_RO_AFTER_INIT u32 spurious_int_vector;
 
 extern void *text_start;
 extern void *text_end;
@@ -300,8 +300,8 @@ void common_handler()
     vm_exit(VM_EXIT_FAULT);
 }
 
-static id_heap interrupt_vector_heap;
-static heap int_general;
+BSS_RO_AFTER_INIT static id_heap interrupt_vector_heap;
+BSS_RO_AFTER_INIT static heap int_general;
 
 u64 allocate_interrupt(void)
 {

--- a/src/x86_64/mp.c
+++ b/src/x86_64/mp.c
@@ -3,7 +3,8 @@
 #include <kernel.h>
 #include <apic.h>
 
-static void *apboot = INVALID_ADDRESS;
+#define apboot  pointer_from_u64(AP_BOOT_START)
+
 extern u8 apinit, apinit_end;
 extern void *ap_pagetable, *ap_idt_pointer, *ap_stack;
 void *ap_stack;
@@ -115,7 +116,6 @@ void ap_start()
 void allocate_apboot(heap stackheap, void (*ap_entry)())
 {
     start_callback = ap_entry;
-    apboot = pointer_from_u64(AP_BOOT_START);
     map((u64)apboot, (u64)apboot, PAGESIZE,
         pageflags_writable(pageflags_exec(pageflags_memory())));
 

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -1,6 +1,6 @@
 #include <kernel.h>
 
-u64 pagebase;
+BSS_RO_AFTER_INIT u64 pagebase;
 
 /* assumes page table is consistent when called */
 void flush_tlb()

--- a/src/x86_64/x2apic.c
+++ b/src/x86_64/x2apic.c
@@ -78,7 +78,7 @@ static void per_cpu_init(apic_iface i)
                  x2apic_read(i, APIC_APICVER));
 }
 
-struct apic_iface x2apic_if = {
+const struct apic_iface x2apic_if = {
     "x2apic",
     x2apic_get_id,
     x2apic_write,

--- a/src/x86_64/xapic.c
+++ b/src/x86_64/xapic.c
@@ -16,7 +16,7 @@
 
 #define APIC_ICRL_DELIVERY_STATUS (1 << 12)
 
-static u64 xapic_vbase;
+BSS_RO_AFTER_INIT static u64 xapic_vbase;
 
 static u64 xapic_from_x2apic_reg(int reg)
 {

--- a/src/x86_64/xapic.c
+++ b/src/x86_64/xapic.c
@@ -79,7 +79,7 @@ static boolean detect(apic_iface i, kernel_heaps kh)
     return true;
 }
 
-struct apic_iface xapic_if = {
+const struct apic_iface xapic_if = {
     "xapic",
     xapic_get_id,
     xapic_write,

--- a/tools/vdsogen.c
+++ b/tools/vdsogen.c
@@ -27,7 +27,7 @@ write_header(FILE * fp)
     fprintf(fp, " * - DO NOT MODIFY -\n");
     fprintf(fp, " */\n");
 
-    fprintf(fp, "unsigned char vdso_raw[] __attribute__((aligned (%d))) = {", PAGESIZE);
+    fprintf(fp, "const unsigned char vdso_raw[] __attribute__((aligned (%d))) = {", PAGESIZE);
 }
 
 static void
@@ -35,7 +35,7 @@ write_footer(FILE * fp, unsigned long total)
 {
     fprintf(fp, "\n");
     fprintf(fp, "};\n");
-    fprintf(fp, "unsigned long vdso_raw_length = %ld;\n", total);
+    fprintf(fp, "const unsigned long vdso_raw_length = %ld;\n", total);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
This change set aims at reducing the kernel attack surface by minimizing the amount of global and static variables whose memory is mapped as read-write in the MMU. To this end, the `const` modifier is being added to constant variables (this instructs the linker to put those variables in the rodata section, which can be mapped as read-only when mapping the kernel ELF file), and variables that are only modified during boot are placed in two new linker sections that are initially mapped as read-write but re-mapped as read-only before starting the user program.
The first 3 commits remove some global/static variables that are not needed.