### PR TITLE
restore gdbstub operation; add validate_virtual_writable()

### DIFF
--- a/src/aarch64/page_machine.h
+++ b/src/aarch64/page_machine.h
@@ -263,6 +263,11 @@ static inline pageflags pageflags_default_user(void)
     return pageflags_user(pageflags_minpage(pageflags_memory()));
 }
 
+static inline boolean pageflags_is_present(pageflags flags)
+{
+    return (flags.w & PAGE_L0_3_DESC_VALID) != 0;
+}
+
 static inline boolean pageflags_is_writable(pageflags flags)
 {
     return (flags.w & PAGE_READONLY) == 0;
@@ -347,6 +352,11 @@ static inline u64 flags_from_pte(u64 pte)
     return pte & PAGE_FLAGS_MASK;
 }
 
+static inline pageflags pageflags_from_pte(pte pte)
+{
+    return (pageflags){.w = flags_from_pte(pte)};
+}
+
 static inline u64 page_pte(u64 phys, u64 flags)
 {
     return flags | (phys & PAGE_4K_NEXT_TABLE_OR_PAGE_OUT_MASK) |
@@ -398,10 +408,5 @@ static inline u64 page_from_pte(pte pte)
 }
 
 #define table_from_pte page_from_pte
-
-static inline pageflags pageflags_from_pteptr(pteptr pp)
-{
-    return (pageflags){.w = PAGE_FLAGS_MASK & *pp};
-}
 
 void init_mmu(range init_pt, u64 vtarget);

--- a/src/gdb/gdbtcp.c
+++ b/src/gdb/gdbtcp.c
@@ -9,12 +9,8 @@ closure_function(1, 1, status, gdb_send,
                  tcpgdb, g,
                  buffer, b)
 {
-    //    u64 len = tcp_sndbuf(g->pcb);
-    // flags can force a stack copy or toggle push
-    // pool?
-    lwip_lock();
+    /* invoked exclusively by gdbserver_input with lwIP lock held */
     err_t err = tcp_write(bound(g)->p, buffer_ref(b, 0), buffer_length(b), TCP_WRITE_FLAG_COPY);
-    lwip_unlock();
     if (err != ERR_OK)
         return timm("result", "%s: tcp_write returned with error %d", __func__, err);
     return STATUS_OK;

--- a/src/gdb/gdbutil.c
+++ b/src/gdb/gdbutil.c
@@ -8,18 +8,13 @@ boolean parse_hex_pair(buffer in, u64 *first, u64 *second)
     return(true);
 }
 
-/* convert the memory pointed to by mem into hex, placing result in buf */
-/* return a pointer to the last char put in buf (null) */
-/* If MAY_FAULT is non-zero, then we should set mem_err in response to
-   a fault; if zero treat a fault like any other fault in the stub.  */
+/* encode count bytes of mem in hex */
 boolean mem2hex (string b, void *mem, int count)
 {
     int i;
     unsigned char ch;
-    if (!validate_virtual(mem, count)) {
-        rprintf ("validation failed\n");
+    if (!validate_virtual(mem, count))
         return false;
-    }
     for (i = 0; i < count; i++) {
         ch = *(unsigned char *)(mem++);
         print_number(b, (u64)ch, 16, 2);
@@ -27,12 +22,13 @@ boolean mem2hex (string b, void *mem, int count)
     return (true);
 }
 
+/* write count bytes from hex buffer into mem */
 boolean hex2mem (buffer b, void *mem, int count)
 {
     int i;
     unsigned char ch;
 
-    if (!validate_virtual(mem, count)) 
+    if (!validate_virtual_writable(mem, count))
         return false;
     
     for (i = 0; i < count; i++) {

--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -194,6 +194,21 @@ boolean validate_virtual(void * base, u64 length)
     return traverse_ptes(u64_from_pointer(base), length, stack_closure(validate_entry));
 }
 
+closure_function(0, 3, boolean, validate_entry_writable,
+                 int, level, u64, vaddr, pteptr, entry)
+{
+    pte pte = pte_from_pteptr(entry);
+    if (!pte_is_present(pte))
+        return false;
+    return !pte_is_mapping(level, pte) || pageflags_is_writable(pageflags_from_pte(pte));
+}
+
+boolean validate_virtual_writable(void * base, u64 length)
+{
+    page_debug("base %p, length 0x%lx\n", base, length);
+    return traverse_ptes(u64_from_pointer(base), length, stack_closure(validate_entry_writable));
+}
+
 /* called with lock held */
 closure_function(2, 3, boolean, update_pte_flags,
                  pageflags, flags, flush_entry, fe,

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -127,6 +127,7 @@ physical vtop(void *x);
 heap zero_wrap(heap meta, heap parent);
 
 boolean validate_virtual(void *base, u64 length);
+boolean validate_virtual_writable(void *base, u64 length);
 
 void sha256(buffer dest, buffer source);
 

--- a/src/x86_64/page_machine.h
+++ b/src/x86_64/page_machine.h
@@ -90,6 +90,11 @@ static inline pageflags pageflags_default_user(void)
     return pageflags_user(pageflags_minpage(pageflags_memory()));
 }
 
+static inline boolean pageflags_is_present(pageflags flags)
+{
+    return (flags.w & PAGE_PRESENT) != 0;
+}
+
 static inline boolean pageflags_is_writable(pageflags flags)
 {
     return (flags.w & PAGE_WRITABLE) != 0;
@@ -136,6 +141,11 @@ static inline boolean pte_is_block_mapping(pte entry)
 static inline u64 flags_from_pte(u64 pte)
 {
     return pte & PAGE_FLAGS_MASK;
+}
+
+static inline pageflags pageflags_from_pte(pte pte)
+{
+    return (pageflags){.w = flags_from_pte(pte)};
 }
 
 static inline u64 page_pte(u64 phys, u64 flags)


### PR DESCRIPTION
This change deletes the incorrect attempt to acquire the lwIP lock in gdb_send
and removes unnecessary setting of the current thread during memory transfers,
instead relying on validate_virtual() (and the newly-added
validate_virtual_writable()) to insure that memory accesses won't fault. Some
extraneous console output during memory access failures has been removed as
well.