### PR TITLE
PC physical ID heap: do not use low memory area

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -285,6 +285,18 @@ id_heap init_physical_id_heap(heap h)
     u64 phys_length = 0;
     for_regions(e) {
         if (e->type == REGION_PHYSICAL) {
+            /* Remove low memory area from physical memory regions, so that it can be used for
+             * things like starting secondary CPUs. */
+            if (e->base < MB) {
+                u64 end = e->base + e->length;
+                if (end > MB) {
+                    e->base = MB;
+                    e->length = end - MB;
+                } else {
+                    e->length = 0;
+                }
+            }
+
             phys_length += e->length;
         }
     }


### PR DESCRIPTION
The low memory address range from 0 to 1MB is used for things like starting secondary CPUs, so it should not be used for the bootstrap heap and should not be available for general memory allocation, otherwise when a secondary CPU is being started the trampoline code that is copied to low memory could overwrite data used for other purposes.