### PR TITLE
init_fdesc/release_fdesc: change from inline to regular functions

### DIFF
--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -619,36 +619,8 @@ static inline void fdesc_put(fdesc f)
         apply(f->close, 0, io_completion_ignore);
 }
 
-define_closure_function(1, 2, void, fdesc_io_complete,
-                        struct fdesc *, f,
-                        thread, t, sysreturn, rv)
-{
-    fdesc_put(bound(f));
-    apply(syscall_io_complete, t, rv);
-}
-
-static inline void init_fdesc(heap h, fdesc f, int type)
-{
-    f->read = 0;
-    f->write = 0;
-    f->sg_read = 0;
-    f->sg_write = 0;
-    f->close = 0;
-    f->events = 0;
-    f->edge_trigger_handler = 0;
-    init_closure(&f->io_complete, fdesc_io_complete, f);
-    f->ioctl = 0;
-    f->refcnt = 1;
-    f->type = type;
-    f->flags = 0;
-    f->ns = allocate_notify_set(h);
-    spin_lock_init(&f->lock);
-}
-
-static inline void release_fdesc(fdesc f)
-{
-    deallocate_notify_set(f->ns);
-}
+void init_fdesc(heap h, fdesc f, int type);
+void release_fdesc(fdesc f);
 
 static inline int fdesc_type(fdesc f)
 {


### PR DESCRIPTION
The definition of the fdesc_io_complete closure in the unix_internal.h header file causes the closure function and the symbols it references to be included in the VDSO shared library, which bloats the VDSO with unneeded code and relocations.
This has a noticeable performance impact and is causing intermittent failures in the Jenkins job that measures web server performance.
This change moves the fdesc_io_complete and fdesc_init function definitions to unix.c, so that the VDSO library does not have unneeded code; for uniformity, the fdesc_release function is also being moved to unix.c.