### PR TITLE
x86_64 cpu: add support for SMEP and UMIP

### DIFF
--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -223,6 +223,11 @@ define_closure_function(1, 1, context, default_fault_handler,
             goto bug;
         }
 
+        if (is_instruction_fault(frame) && !user) {
+            msg_err("kernel instruction fault\n");
+            goto bug;
+        }
+
         if (handle_protection_fault(frame, vaddr, vm)) {
             if (is_current_kernel_context(frame)) {
                 current_cpu()->state = cpu_kernel;

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -58,7 +58,9 @@
 #define CR4_PGE         (1 << 7)
 #define CR4_OSFXSR      (1 << 9)
 #define CR4_OSXMMEXCPT  (1 << 10)
+#define CR4_UMIP        (1 << 11)
 #define CR4_OSXSAVE     (1 << 18)
+#define CR4_SMEP        (1 << 20)
 
 #define EFLAG_CARRY                     0
 #define EFLAG_FIXED                     1


### PR DESCRIPTION
Supervisor Memory Execute Protection (SMEP) is a security feature that generates a page fault exception if the kernel tries to execute an instruction from a memory address accessible by the user program. If this exception occurs, the kernel dumps the current execution context to the console and halts.
User-Mode Instruction Prevention (UMIP) is a security feature that generates a general protection exception if the user program tries to execute one of the the SGDT, SIDT, SLDT, SMSW, and STR instructions. If this exception occurs, the kernel sends a SEGV signal to the program. Tested on Google Cloud N2 instance with Intel Ice Lake CPU.