### PR TITLE
mutex implementation

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -33,6 +33,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/kernel/linear_backed_heap.c \
 	$(SRCDIR)/kernel/locking_heap.c \
 	$(SRCDIR)/kernel/log.c \
+	$(SRCDIR)/kernel/mutex.c \
 	$(SRCDIR)/kernel/page.c \
 	$(SRCDIR)/kernel/page_backed_heap.c \
 	$(SRCDIR)/kernel/pagecache.c \

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -31,6 +31,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/kernel/linear_backed_heap.c \
 	$(SRCDIR)/kernel/locking_heap.c \
 	$(SRCDIR)/kernel/log.c \
+	$(SRCDIR)/kernel/mutex.c \
 	$(SRCDIR)/kernel/page.c \
 	$(SRCDIR)/kernel/page_backed_heap.c \
 	$(SRCDIR)/kernel/pagecache.c \

--- a/src/aarch64/crt0.S
+++ b/src/aarch64/crt0.S
@@ -2,7 +2,7 @@
 #include <frame.h>
 #include <kernel_machine.h>
         
-.macro  frame_save el
+.macro  frame_save el ex
         /* In the kernel, x18 always points to cpuinfo. */
 
         .if \el == 0
@@ -43,14 +43,20 @@
         str     x0, [x17, #(FRAME_EL * 8)]
 
         mrs     x0, spsr_el1
+        .if \ex == 1
         mrs     x1, esr_el1
         mrs     x2, elr_el1
         mrs     x3, far_el1
+        .endif
 
         add     x17, x17, #256
+        .if \ex == 1
         stp     w0, w1, [x17, #((FRAME_ESR_SPSR - 32) * 8)]
         str     x2, [x17, #((FRAME_ELR - 32) * 8)]
         str     x3, [x17, #((FRAME_FAULT_ADDRESS - 32) * 8)]
+        .else
+        str     w0, [x17, #((FRAME_ESR_SPSR - 32) * 8)]
+        .endif
         .endm
 
         .text
@@ -73,35 +79,35 @@ _start:
 
 // exception entries
 entry_sync_el1h:
-        frame_save 1
+        frame_save 1 1
         b       synchronous_handler
 
 entry_irq_el1h:
-        frame_save 1
+        frame_save 1 1
         b       irq_handler
 
 entry_serror_el1h:
-        frame_save 1
+        frame_save 1 1
         b       serror_handler
         
 entry_sync_el0: 
-        frame_save 0
+        frame_save 0 1
         b       synchronous_handler
 
 entry_irq_el0:
-        frame_save 0
+        frame_save 0 1
         b       irq_handler
 
 entry_serror_el0:
-        frame_save 0
+        frame_save 0 1
         b       serror_handler
 
 entry_invalid_el0:
-        frame_save 0
+        frame_save 0 1
         b       invalid_handler
 
 entry_invalid_el1:
-        frame_save 1
+        frame_save 1 1
         b       invalid_handler
 
 // universal frame return
@@ -138,6 +144,13 @@ frame_return:
         ldp     x28, x29, [x0, #(FRAME_X28 * 8)]
         ldp     x0, x1, [x0, #(FRAME_X0 * 8)]
         eret
+
+.globl context_suspend
+context_suspend:
+        frame_save 1 0
+        str     x30, [x17, #((FRAME_ELR - 32) * 8)]
+        ldr     x0, [x18]
+        b context_suspend_finish
 
         .globl arm_hvc
 arm_hvc:

--- a/src/aarch64/kernel_machine.c
+++ b/src/aarch64/kernel_machine.c
@@ -93,6 +93,7 @@ void init_context(context c, int type)
 {
     c->type = type;
     c->transient_heap = 0;
+    c->waiting_on = 0;
     c->active_cpu = -1;
     zero_context_frame(c->frame);
     void *e = allocate_zero((heap)heap_page_backed(get_kernel_heaps()),

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -191,6 +191,7 @@ static inline void wait_for_interrupt(void)
 
 /* locking constructs */
 #include <lock.h>
+#include <mutex.h>
 
 /* device mmio region access */
 #define MK_MMIO_READ(BITS, ISUFFIX, RPREFIX) \

--- a/src/aarch64/machine.h
+++ b/src/aarch64/machine.h
@@ -210,6 +210,12 @@ static inline __attribute__((always_inline)) word fetch_and_add(word *target, wo
     return __sync_fetch_and_add(target, num);
 }
 
+static inline __attribute__((always_inline)) word fetch_and_add_32(u32 *target, u32 num)
+{
+    asm volatile("prfm pstl1strm, %0" :: "Q" (*target));
+    return __sync_fetch_and_add(target, num);
+}
+
 static inline __attribute__((always_inline)) u8 compare_and_swap_32(u32 *p, u32 old, u32 new)
 {
     asm volatile("prfm pstl1strm, %0" :: "Q" (*p));

--- a/src/aarch64/machine.h
+++ b/src/aarch64/machine.h
@@ -216,6 +216,17 @@ static inline __attribute__((always_inline)) word fetch_and_add_32(u32 *target, 
     return __sync_fetch_and_add(target, num);
 }
 
+static inline __attribute__((always_inline)) u64 atomic_swap_64(u64 *variable, u64 value)
+{
+    return __atomic_exchange_n(variable, value, __ATOMIC_SEQ_CST);
+}
+
+static inline __attribute__((always_inline)) u8 compare_and_swap_64(u64 *p, u64 old, u64 new)
+{
+    asm volatile("prfm pstl1strm, %0" :: "Q" (*p));
+    return __sync_bool_compare_and_swap(p, old, new);
+}
+
 static inline __attribute__((always_inline)) u8 compare_and_swap_32(u32 *p, u32 old, u32 new)
 {
     asm volatile("prfm pstl1strm, %0" :: "Q" (*p));

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -153,6 +153,14 @@ void init_kernel_contexts(heap backed)
     current_cpu()->state = cpu_kernel;
 }
 
+/* finish suspend after frame save */
+void __attribute__((noreturn)) context_suspend_finish(context ctx)
+{
+    context_reserve_refcount(ctx);
+    ctx->frame[FRAME_FULL] = true; /* must be last */
+    runloop();
+}
+
 void __attribute__((noreturn)) context_switch_finish(context prev, context next, void *a, u64 arg0, u64 arg1)
 {
     if (prev != next) {

--- a/src/kernel/mutex.c
+++ b/src/kernel/mutex.c
@@ -1,0 +1,148 @@
+#include <kernel.h>
+
+//#define MUTEX_DEBUG
+#ifdef MUTEX_DEBUG
+#define mutex_debug(x, ...) do {log_printf(" MTX", "%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#else
+#define mutex_debug(x, ...)
+#endif
+
+#ifdef KERNEL
+#define mutex_pause kern_pause
+#else
+#define mutex_pause()
+#endif
+
+/* This implements a two-phase mutex which optionally allows a degree for
+   spinning when aquiring the lock. A limitation of this is that the spinning
+   is only for an uncondended lock, and the waiter does not enter the queue of
+   waiters until the second phase (context suspend). As such, waiters for a
+   mutex are not strictly processed in FIFO order.
+
+   Linux uses an MCS lock for the first phase, but the unqueueing (removal)
+   operation is complex (yet necessary in order to migrate waiters into the
+   queue of suspended tasks). It may be worth implementing something similar
+   here, perhaps moreso for the lessened bus contention than the FIFO
+   property. */
+
+static inline void mutex_acquired(mutex m, context ctx)
+{
+    assert(!m->turn);
+    m->turn = ctx;
+    ctx->waiting_on = 0;
+}
+
+static inline boolean mutex_cas_take(mutex m, context ctx)
+{
+    if (compare_and_swap_32(&m->count, 0, 1)) {
+        mutex_acquired(m, ctx);
+        return true;
+    }
+    return false;
+}
+
+static inline boolean mutex_lock_internal(mutex m, boolean wait)
+{
+    cpuinfo ci = current_cpu();
+    context ctx = get_current_context(ci);
+
+    mutex_debug("cpu %d, mutex %p, wait %d, ra %p\n", ci->id, m, wait,
+                __builtin_return_address(0));
+    mutex_debug("   ctx %p, turn %p, count %d\n", ctx, m->turn, m->count);
+
+    /* not preemptable (but could become so if needed) */
+    if (m->turn == ctx)
+        halt("%s: lock already held - cpu %d, mutex %p, ctx %p, ra %p\n", __func__,
+             ci->id, m, ctx, __builtin_return_address(0));
+
+    if (!wait)
+        return mutex_cas_take(m, ctx);
+
+    u64 spins_remain = m->spin_iterations;
+    while (spins_remain-- > 0) {
+        if (mutex_cas_take(m, ctx))
+            return true;
+        mutex_pause();
+    }
+
+    if (fetch_and_add_32(&m->count, 1) == 0) {
+        mutex_acquired(m, ctx);
+        return true;
+    }
+
+    /* race covered by dequeue loop in unlock */
+    assert(!frame_is_full(ctx->frame));
+
+    mutex_debug("ctx %p about to wait, count %d\n", ctx, m->count);
+    ctx->waiting_on = m;
+    while (!enqueue(m->waiters, ctx)) {
+        mutex_pause();      /* XXX timeout */
+    }
+    context_pre_suspend(ctx);
+    context_suspend();
+    return true;
+}
+
+boolean mutex_try_lock(mutex m)
+{
+    return mutex_lock_internal(m, false);
+}
+
+void mutex_lock(mutex m)
+{
+    assert(mutex_lock_internal(m, true));
+}
+
+void mutex_unlock(mutex m)
+{
+    cpuinfo ci = current_cpu();
+    context ctx = get_current_context(ci);
+    mutex_debug("cpu %d, mutex %p, ra %p\n", ci->id, m, __builtin_return_address(0));
+    mutex_debug("   ctx %p turn %p, count %d\n", ctx, m->turn, m->count);
+    assert(ctx == m->turn);
+    context next = INVALID_ADDRESS;
+  retry:
+    /* loop to cover race between fetch_and_add and enqueue */
+    while (m->count > 1) {
+        next = dequeue(m->waiters);
+        if (next != INVALID_ADDRESS)
+            break;
+    }
+
+    if (next != INVALID_ADDRESS) {
+        assert(fetch_and_add_32(&m->count, -1) > 1);
+        m->turn = next;
+        assert(next->waiting_on == m);
+        next->waiting_on = 0;
+        /* cover race between enqueue and context_suspend() */
+        while (!frame_is_full(next->frame))
+            kern_pause();
+        mutex_debug("returning to %p, type %d\n", next, next->type);
+        context_schedule_return(next);
+        return;
+    }
+
+    m->turn = 0;
+
+    /* cover race between dequeue and final release */
+    if (!compare_and_swap_32(&m->count, 1, 0))
+        goto retry;
+}
+
+mutex allocate_mutex(heap h, u64 depth, u64 spin_iterations)
+{
+    u64 msize = sizeof(struct mutex);
+    mutex m = allocate(h, msize);
+    if (m == INVALID_ADDRESS)
+        return m;
+
+    m->count = 0;
+    m->turn = 0;
+    m->spin_iterations = spin_iterations;
+    m->waiters = allocate_queue(h, depth);
+    if (m->waiters == INVALID_ADDRESS) {
+        deallocate(h, m, msize);
+        return INVALID_ADDRESS;
+    }
+    return m;
+}

--- a/src/kernel/mutex.h
+++ b/src/kernel/mutex.h
@@ -1,0 +1,14 @@
+typedef struct mutex {
+    u32 count;
+    context turn;
+    u64 spin_iterations;
+    queue waiters;
+} *mutex;
+
+boolean mutex_try_lock(mutex ql);
+
+void mutex_lock(mutex ql);
+
+void mutex_unlock(mutex ql);
+
+mutex allocate_mutex(heap h, u64 depth, u64 spin_iterations);

--- a/src/kernel/mutex.h
+++ b/src/kernel/mutex.h
@@ -1,8 +1,7 @@
 typedef struct mutex {
-    u32 count;
-    context turn;
     u64 spin_iterations;
-    queue waiters;
+    context turn;
+    context waiters_tail;
 } *mutex;
 
 boolean mutex_try_lock(mutex ql);

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -28,17 +28,14 @@ void netif_name_cpy(char *dest, struct netif *netif);
 
 #define netif_is_loopback(netif)    (((netif)->name[0] == 'l') && ((netif)->name[1] == 'o'))
 
-extern struct spinlock lwip_spinlock;
+extern mutex lwip_mutex;
 
 static inline void lwip_lock(void)
 {
-#ifdef KERNEL
-    assert(!in_interrupt());    /* XXX remove me after no-kernel-lock transition complete */
-#endif
-    spin_lock(&lwip_spinlock);
+    mutex_lock(lwip_mutex);
 }
 
 static inline void lwip_unlock(void)
 {
-    spin_unlock(&lwip_spinlock);
+    mutex_unlock(lwip_mutex);
 }

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -11,7 +11,7 @@
 #define IFF_MULTICAST   (1 << 12)
 
 BSS_RO_AFTER_INIT static heap lwip_heap;
-struct spinlock lwip_spinlock;
+BSS_RO_AFTER_INIT mutex lwip_mutex;
 
 /* Pretty silly. LWIP offers lwip_cyclic_timers for use elsewhere, but
    says to use LWIP_ARRAYSIZE(), which isn't possible with an
@@ -344,6 +344,9 @@ void init_network_iface(tuple root) {
 
 extern void lwip_init();
 
+#define LWIP_LOCK_WAITER_QUEUE_DEPTH 64
+#define LWIP_LOCK_SPIN_ITERATIONS (1ull << 20)
+
 void init_net(kernel_heaps kh)
 {
     heap h = heap_general(kh);
@@ -351,7 +354,8 @@ void init_net(kernel_heaps kh)
     bytes pagesize = is_low_memory_machine(kh) ?
                      U64_FROM_BIT(MAX_LWIP_ALLOC_ORDER + 1) : PAGESIZE_2M;
     lwip_heap = allocate_mcache(h, backed, 5, MAX_LWIP_ALLOC_ORDER, pagesize);
-    spin_lock_init(&lwip_spinlock);
+    lwip_mutex = allocate_mutex(h, LWIP_LOCK_WAITER_QUEUE_DEPTH, LWIP_LOCK_SPIN_ITERATIONS);
+    assert(lwip_mutex != INVALID_ADDRESS);
     lwip_lock();
     lwip_init();
     BSS_RO_AFTER_INIT NETIF_DECLARE_EXT_CALLBACK(netif_callback);

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -138,8 +138,9 @@ BSS_RO_AFTER_INIT static thunk net_loop_poll;
 static boolean net_loop_poll_queued;
 
 closure_function(0, 0, void, netsock_poll) {
-    net_loop_poll_queued = false;
+    /* taking the lock here can block, so clear the flag after acquiring */
     lwip_lock();
+    net_loop_poll_queued = false;
     netif_poll_all();
     lwip_unlock();
 }
@@ -372,7 +373,8 @@ static sysreturn sock_read_bh_internal(netsock s, thread t, void * dest,
                                        u64 length, int flags, struct sockaddr *src_addr,
                                        socklen_t *addrlen, io_completion completion, u64 bqflags)
 {
-    /* called with corresponding blockq lock held */
+    lwip_lock();
+
     sysreturn rv = 0;
     err_t err = get_lwip_error(s);
     net_debug("sock %d, thread %ld, dest %p, len %ld, flags 0x%x, bqflags 0x%lx, lwip err %d\n",
@@ -382,35 +384,33 @@ static sysreturn sock_read_bh_internal(netsock s, thread t, void * dest,
 
     if (s->sock.type == SOCK_STREAM && s->info.tcp.state != TCP_SOCK_OPEN) {
         rv = 0;
-        goto out;
+        goto out_unlock;
     }
 
     if (err != ERR_OK) {
         rv = lwip_to_errno(err);
-        goto out;
+        goto out_unlock;
     }
 
     if (bqflags & BLOCKQ_ACTION_NULLIFY) {
         rv = -ERESTARTSYS;
-        goto out;
+        goto out_unlock;
     }
-
-    lwip_lock();
 
     /* check if we actually have data */
     void * p = queue_peek(s->incoming);
     if (p == INVALID_ADDRESS) {
-        lwip_unlock();
         if (s->sock.type == SOCK_STREAM &&
-            s->info.tcp.lw->state != ESTABLISHED) {
+            (!s->info.tcp.lw || s->info.tcp.lw->state != ESTABLISHED)) {
             rv = 0;
-            goto out;
+            goto out_unlock;
         }
         if ((s->sock.f.flags & SOCK_NONBLOCK) || (flags & MSG_DONTWAIT)) {
             rv = -EAGAIN;
-            goto out;
+            goto out_unlock;
         }
-        return blockq_block_required(t, bqflags); /* back to chewing more cud */
+        lwip_unlock();
+        return blockq_block_required(t, bqflags);
     }
 
     if (src_addr) {
@@ -467,14 +467,13 @@ static sysreturn sock_read_bh_internal(netsock s, thread t, void * dest,
         }
     } while(s->sock.type == SOCK_STREAM && length > 0 && p != INVALID_ADDRESS); /* XXX simplify expression */
 
-    lwip_unlock();
-
     if (s->sock.type == SOCK_STREAM)
         /* Calls to tcp_recved() may have enqueued new packets in the loopback interface. */
         netsock_check_loop();
 
     rv = xfer_total;
-  out:
+  out_unlock:
+    lwip_unlock();
     net_debug("   completion %p, rv %ld\n", completion, rv);
     apply(completion, t, rv);
     return rv;
@@ -555,6 +554,8 @@ static sysreturn socket_write_tcp_bh_internal(netsock s, thread t, void * buf,
                                               u64 remain, int flags, io_completion completion,
                                               u64 bqflags)
 {
+    lwip_lock();
+
     sysreturn rv = 0;
     err_t err = get_lwip_error(s);
     net_debug("fd %d, thread %ld, buf %p, remain %ld, flags 0x%x, bqflags 0x%lx, lwip err %d\n",
@@ -563,35 +564,38 @@ static sysreturn socket_write_tcp_bh_internal(netsock s, thread t, void * buf,
 
     if (err != ERR_OK) {
         rv = lwip_to_errno(err);
-        goto out;
+        goto out_unlock;
     }
 
     if (s->sock.type == SOCK_STREAM && s->info.tcp.state != TCP_SOCK_OPEN) {
         rv = -ENOTCONN;
-        goto out;
+        goto out_unlock;
     }
 
     if (bqflags & BLOCKQ_ACTION_NULLIFY) {
         rv = -ERESTARTSYS;
-        goto out;
+        goto out_unlock;
     }
 
     /* Note that the actual transmit window size is truncated to 16
        bits here (and tcp_write() doesn't accept more than 2^16
        anyway), so even if we have a large transmit window due to
        LWIP_WND_SCALE, we still can't write more than 2^16. Sigh... */
-    lwip_lock();
     u64 avail = tcp_sndbuf(s->info.tcp.lw);
     if (avail == 0) {
-      full:
-        lwip_unlock();
-        if ((bqflags & BLOCKQ_ACTION_BLOCKED) == 0 &&
+        /* directly poll for loopback traffic in case the enqueued netsock_poll is backed up */
+        netif_poll_all();
+        avail = tcp_sndbuf(s->info.tcp.lw);
+        if (avail == 0) {
+          full:
+            if ((bqflags & BLOCKQ_ACTION_BLOCKED) == 0 &&
                 ((s->sock.f.flags & SOCK_NONBLOCK) || (flags & MSG_DONTWAIT))) {
-            net_debug(" send buf full and non-blocking, return EAGAIN\n");
-            rv = -EAGAIN;
-            goto out;
-        } else {
+                net_debug(" send buf full and non-blocking, return EAGAIN\n");
+                rv = -EAGAIN;
+                goto out_unlock;
+            }
             net_debug(" send buf full, sleep\n");
+            lwip_unlock();
             return blockq_block_required(t, bqflags); /* block again */
         }
     }
@@ -624,15 +628,18 @@ static sysreturn socket_write_tcp_bh_internal(netsock s, thread t, void * buf,
             rv = lwip_to_errno(err);
             /* XXX map error to socket tcp state */
         }
-    } else if (err == ERR_MEM) {
+        goto out;
+    }
+    if (err == ERR_MEM) {
         /* XXX some ambiguity in lwIP - investigate */
         net_debug(" tcp_write() returned ERR_MEM\n");
         goto full;
     } else {
-        lwip_unlock();
         net_debug(" tcp_write() lwip error: %d\n", err);
         rv = lwip_to_errno(err);
     }
+  out_unlock:
+    lwip_unlock();
   out:
     net_debug("   completion %p, rv %ld\n", completion, rv);
     apply(completion, t, rv);

--- a/src/runtime/context.h
+++ b/src/runtime/context.h
@@ -16,6 +16,7 @@ struct context {
     void (*schedule_return)(struct context *);
     fault_handler fault_handler;
     heap transient_heap;
+    void *waiting_on;
     u32 active_cpu;
     u8 type;
 };

--- a/src/runtime/context.h
+++ b/src/runtime/context.h
@@ -17,6 +17,7 @@ struct context {
     fault_handler fault_handler;
     heap transient_heap;
     void *waiting_on;
+    void *next_waiter;
     u32 active_cpu;
     u8 type;
 };

--- a/src/x86_64/kernel_machine.c
+++ b/src/x86_64/kernel_machine.c
@@ -111,11 +111,12 @@ void init_context(context c, int type)
 {
     c->type = type;
     c->transient_heap = 0;
+    c->waiting_on = 0;
     c->active_cpu = -1;
     zero_context_frame(c->frame);
-    u64 e = allocate_u64((heap)heap_page_backed(get_kernel_heaps()), extended_frame_size);
-    assert(e != INVALID_PHYSICAL);
-    c->frame[FRAME_EXTENDED] = e;
+    void *e = allocate_zero((heap)heap_page_backed(get_kernel_heaps()), extended_frame_size);
+    assert(e != INVALID_ADDRESS);
+    c->frame[FRAME_EXTENDED] = u64_from_pointer(e);
     xsave(c->frame);
 }
 

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -165,6 +165,7 @@ void install_gdt64_and_tss(void *tss_desc, void *tss, void *gdt, void *gdt_point
 #ifdef KERNEL
 /* locking constructs */
 #include <lock.h>
+#include <mutex.h>
 #endif
 
 /* device mmio region access */

--- a/src/x86_64/machine.h
+++ b/src/x86_64/machine.h
@@ -77,6 +77,11 @@ static inline __attribute__((always_inline)) word fetch_and_add(word *variable, 
     return __sync_fetch_and_add(variable, value);
 }
 
+static inline __attribute__((always_inline)) word fetch_and_add_32(u32 *variable, u32 value)
+{
+    return __sync_fetch_and_add(variable, value);
+}
+
 static inline __attribute__((always_inline)) u8 compare_and_swap_32(u32 *p, u32 old, u32 new)
 {
     return __sync_bool_compare_and_swap(p, old, new);

--- a/src/x86_64/machine.h
+++ b/src/x86_64/machine.h
@@ -82,6 +82,16 @@ static inline __attribute__((always_inline)) word fetch_and_add_32(u32 *variable
     return __sync_fetch_and_add(variable, value);
 }
 
+static inline __attribute__((always_inline)) u64 atomic_swap_64(u64 *variable, u64 value)
+{
+    return __atomic_exchange_n(variable, value, __ATOMIC_SEQ_CST);
+}
+
+static inline __attribute__((always_inline)) u8 compare_and_swap_64(u64 *p, u64 old, u64 new)
+{
+    return __sync_bool_compare_and_swap(p, old, new);
+}
+
 static inline __attribute__((always_inline)) u8 compare_and_swap_32(u32 *p, u32 old, u32 new)
 {
     return __sync_bool_compare_and_swap(p, old, new);


### PR DESCRIPTION
Building off of the context switching work, this change implements a two-phase
mutex lock which will first spin for some number of iterations (specified on mutex
allocation) before finally suspending the running context if the mutex could
not be acquired. Suspended contexts are queued and processed in a FIFO
fashion, with the unlock function dequeueing and directly scheduling the next
context waiting on the mutex, if any. This is useful for preventing cores from being
excessively tied up with spinning while there is resource contention. The spin
factor argument given on instantiation may be adjusted according to the needs
of the workload; a value of 0 indicates no spinning is desired - in which case
a context will suspend whenever the mutex cannot be immediately acquired - but
may also be made large to prioritize spinning, leaving suspension as a
fallback option that frees up cpu cycles for other contexts to run.

The new context_suspend() function suspends a context by saving the running
processor state to its frame and then adjusting it to return to the caller on
frame return.

As a first client, the lwIP lock has been converted from a spinlock to a
mutex. It is instantiated with a large spin factor in order to maintain
existing performance levels observed with our webg test. As with spinlocks,
the factor of bus contention when considering performance increases with the
number of cores contending for a mutex. This could potentially be ameliorated
in the future by using something like the MCS lock in place of the
compare-and-swap loop for the first phase. Using MCS would also insure that
waiters are processed in a FIFO order for both phases of lock acquisition, not
just the second one.
