### PR TITLE
Microsoft Azure fixes

### DIFF
--- a/klib/cloud_azure.c
+++ b/klib/cloud_azure.c
@@ -72,7 +72,7 @@ closure_function(1, 1, void, wireserver_parse_resp,
     closure_finish();
 }
 
-closure_function(2, 1, status, wireserver_get_resp,
+closure_function(2, 1, boolean, wireserver_get_resp,
                  azure, az, buffer_handler, out,
                  buffer, data)
 {
@@ -91,18 +91,19 @@ closure_function(2, 1, status, wireserver_get_resp,
         apply(bound(out), 0);
         if (!success)
             azure_report_retry(az);
+        return true;
     } else {
         closure_finish();
     }
-    return STATUS_OK;
+    return false;
 }
 
-closure_function(1, 1, buffer_handler, wireserver_get_ch,
+closure_function(1, 1, input_buffer_handler, wireserver_get_ch,
                  azure, az,
                  buffer_handler, out)
 {
     azure az = bound(az);
-    buffer_handler in = INVALID_ADDRESS;
+    input_buffer_handler in = INVALID_ADDRESS;
     if (out) {    /* connection succeeded */
         tuple req = allocate_tuple();
         if (req == INVALID_ADDRESS)
@@ -124,23 +125,25 @@ closure_function(1, 1, buffer_handler, wireserver_get_ch,
     return in;
 }
 
-closure_function(1, 1, status, wireserver_post_resp,
+closure_function(1, 1, boolean, wireserver_post_resp,
                  buffer_handler, out,
                  buffer, data)
 {
-    if (data)
+    if (data) {
         apply(bound(out), 0);
-    else
+        return true;
+    } else {
         closure_finish();
-    return STATUS_OK;
+        return false;
+    }
 }
 
-closure_function(1, 1, buffer_handler, wireserver_post_ch,
+closure_function(1, 1, input_buffer_handler, wireserver_post_ch,
                  azure, az,
                  buffer_handler, out)
 {
     azure az = bound(az);
-    buffer_handler in = INVALID_ADDRESS;
+    input_buffer_handler in = INVALID_ADDRESS;
     if (out) {    /* connection succeeded */
         tuple req = allocate_tuple();
         if (req == INVALID_ADDRESS)

--- a/klib/radar.c
+++ b/klib/radar.c
@@ -116,7 +116,7 @@ static boolean telemetry_req(const char *url, buffer data, buffer_handler bh)
     }
 }
 
-closure_function(2, 1, status, telemetry_recv,
+closure_function(2, 1, boolean, telemetry_recv,
                  value_handler, vh, buffer_handler, out,
                  buffer, data)
 {
@@ -136,6 +136,7 @@ closure_function(2, 1, status, telemetry_recv,
             }
         }
         apply(bound(out), 0);   /* close connection */
+        return true;
     } else {  /* connection closed */
         closure_finish();
         if (telemetry.dump) {
@@ -164,15 +165,15 @@ closure_function(2, 1, status, telemetry_recv,
             }
         }
     }
-    return STATUS_OK;
+    return false;
 }
 
-closure_function(3, 1, buffer_handler, telemetry_ch,
+closure_function(3, 1, input_buffer_handler, telemetry_ch,
                  const char *, url, buffer, data, value_handler, vh,
                  buffer_handler, out)
 {
     buffer data = bound(data);
-    buffer_handler in = 0;
+    input_buffer_handler in = INVALID_ADDRESS;
     if (out) {
         boolean success = telemetry_req(bound(url), data, out);
         if (success)

--- a/src/hyperv/vmbus/vmbus_et.c
+++ b/src/hyperv/vmbus/vmbus_et.c
@@ -66,6 +66,7 @@ void
 vmbus_et_intr(void)
 {
     vmbus_timer_debug("%s\n", __func__);
+    schedule_timer_service();
 }
 
 closure_function(1, 1, void, vmbus_et_timer, hyperv_tc64_t, hyperv_tc64,

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -208,7 +208,8 @@ typedef closure_type(thunk, void);
 #include <timer.h>
 
 typedef closure_type(buffer_handler, status, buffer);
-typedef closure_type(connection_handler, buffer_handler, buffer_handler);
+typedef closure_type(input_buffer_handler, boolean, buffer);
+typedef closure_type(connection_handler, input_buffer_handler, buffer_handler);
 typedef closure_type(value_handler, void, value);
 typedef closure_type(io_status_handler, void, status, bytes);
 typedef closure_type(block_io, void, void *, range, status_handler);


### PR DESCRIPTION
The first commit adds a schedule_timer_service() call to the VMbus interrupt handler, which fixes an issue causing sporadic failures in IP address assignment on Azure instances.
The second commit modifies the net/direct.c code to ensure that the data structures for handling a network connection are not accessed after the connection has been closed; this fixes a crash occurring on Azure instances when the cloud_init klib reports the instance status to the wire server.