### PR TITLE
Unix pipe: only report EPOLLIN event when data is available to read

### DIFF
--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -113,7 +113,7 @@ static inline void pipe_dealloc_end(pipe p, pipe_file pf)
         deallocate_closure(pf->f.events);
     }
     if (&p->files[PIPE_WRITE] == pf) {
-        pipe_notify_reader(pf, EPOLLIN | EPOLLHUP);
+        pipe_notify_reader(pf, (buffer_length(p->data) ? EPOLLIN : 0) | EPOLLHUP);
         pipe_debug("%s(%p): reader notified\n", __func__, p);
         deallocate_closure(pf->f.write);
         deallocate_closure(pf->f.close);
@@ -258,7 +258,7 @@ closure_function(1, 1, u32, pipe_read_events,
     pipe_lock(pf->pipe);
     u32 events = buffer_length(pf->pipe->data) ? EPOLLIN : 0;
     if (pf->pipe->files[PIPE_WRITE].fd == -1)
-        events |= EPOLLIN | EPOLLHUP;
+        events |= EPOLLHUP;
     pipe_unlock(pf->pipe);
     return events;
 }

--- a/test/runtime/pipe.c
+++ b/test/runtime/pipe.c
@@ -176,6 +176,7 @@ int main(int argc, char **argv)
 {
     int fds[2] = {0,0};
     int status;
+    struct pollfd pfd;
 
     heap h = init_process_runtime();
     parse_arguments(h, argc, argv);
@@ -190,7 +191,16 @@ int main(int argc, char **argv)
 
     blocking_test(h, fds);
 
-    close(fds[0]);
     close(fds[1]);
+    pfd.fd = fds[0];
+    pfd.events = POLLIN | POLLOUT;
+    status = poll(&pfd, 1, -1);
+    if ((status != 1) || (pfd.revents != POLLHUP)) {
+        printf("after closing writer fd: poll on reader fd returned %d, pfd.revents 0x%x\n",
+               status, pfd.revents);
+        exit(EXIT_FAILURE);
+    }
+
+    close(fds[0]);
     return(EXIT_SUCCESS);
 }


### PR DESCRIPTION
The Unix pipe implementation is incorrectly reporting both EPOLLIN and EPOLLHUP events on a pipe reader file descriptor after closing the writer file descriptor. This is causing `Null check operator used on a null value` unhandled exceptions when running a Dart program without AOT compilation.
This change fixes the above issue by only reporting EPOLLIN if data is available in the pipe buffer. A test case is being added to the pipe runtime test to check that the correct poll events are reported after closing the write side of a pipe.