### PR TITLE
Add getsockopt support for reuseport/addr and tcp_nodelay

### DIFF
--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -738,6 +738,7 @@ struct io_uring_params {
 #define SO_RCVBUF       8
 #define SO_PRIORITY     12
 #define SO_LINGER       13
+#define SO_REUSEPORT    15
 #define SO_ACCEPTCONN   30
 
 #define IPV6_V6ONLY     26


### PR DESCRIPTION
This adds support in getsockopt for reading the values of SO_REUSEADDR,
SO_REUSEPORT, and TCP_NODELAY. SO_REUSEPORT is not currently
supported so it always returns 0 and setting it is a no-op. This also fixes
setting TCP_NODELAY in setsockopt which was setting the opposite value
requested.