### PR TITLE
restore correct detection of runtime test errors by defaulting to qemu debug exit

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -276,7 +276,7 @@ ifeq ($(IMAGE),)
 endif
 	@ echo "MKFS	$@"
 	@ $(MKDIR) $(dir $(IMAGE))
-	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) $(IMAGE)
+	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) $(IMAGE) -t "(debug_exit:t)"
 
 release: mkfs boot kernel
 	$(Q) $(RM) -r release

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -145,14 +145,18 @@ void vm_exit(u8 code)
 
     /* TODO MP: coordinate via IPIs */
     tuple root = get_root_tuple();
-    if (root && get(root, sym(reboot_on_exit))) {
-        triple_fault();
-    } else if (vm_halt) {
+    if (root) {
+        if (get(root, sym(reboot_on_exit)))
+            triple_fault();
+        if (get(root, sym(debug_exit)))
+            goto debug_exit;
+    }
+    if (vm_halt) {
         apply(vm_halt, code);
         while (1);  /* to honor noreturn attribute */
-    } else {
-        QEMU_HALT(code);
     }
+  debug_exit:
+    QEMU_HALT(code);
 }
 
 u64 total_processors = 1;

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -234,7 +234,7 @@ ifeq ($(IMAGE),)
 endif
 	@ echo "MKFS	$@"
 	@ $(MKDIR) $(dir $(IMAGE))
-	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) -k $(KERNEL) $(IMAGE)
+	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) -k $(KERNEL) $(IMAGE) -t "(debug_exit:t)"
 
 release: mkfs kernel
 	$(Q) $(RM) -r release


### PR DESCRIPTION
With the introduction of acpica and the default installation of the
acpi_powerdown vm_halt method on the PC platform, runtime CI tests have not
been passing the test exit codes back to the shell. This results in "make
runtime-tests" passing even if tests have failed with a non-zero exit code.

This adds a "debug_exit" manifest flag to indicate that vm_exit() should
return to qemu via the QEMU_HALT() function regardless of whether the platform
has installed a vm_halt method. An option has been added to mkfs to allow the
amending of manifest root tuples from the command line. Runtime tests are now
built with "debug_exit:t" added to the root tuples by default.