### PR TITLE
Add print_tree command to gdb script to print rbtree

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,5 +1,8 @@
 set architecture i386:x86-64
 
+macro define offsetof(t, f) (size_t)&((t *)0)->f
+macro define container_of(p, t, f) (t *)((void *)p - offsetof(t, f))
+
 source tools/nanos_gdb.py
 display/i $pc
 symbol-file ./output/platform/pc/bin/kernel.elf

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -13,6 +13,9 @@
 #define pf_debug(x, ...) thread_log(current, x, ##__VA_ARGS__);
 #endif
 
+#define MAX_PROCESSES 2
+process processes[MAX_PROCESSES];
+
 BSS_RO_AFTER_INIT static unix_heaps u_heap;
 
 unix_heaps get_unix_heaps()
@@ -398,6 +401,8 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     p->aio = allocate_vector(locked, 8);
     p->trace = 0;
     p->trap = 0;
+    if ((u64)p->pid - 1 < MAX_PROCESSES)
+        processes[p->pid - 1] = p;
     return p;
 }
 


### PR DESCRIPTION
This change adds a new python gdb command, print_tree, to print the pointers of
rbnodes of an rbtree in order. If a second argument, containing type, is passed
the script will print the pointers to the containing struct instead of the
rbnode. Also added are helper macros offsetof() and container_of() which can
be used in gdb expressions.

Also added is a new array called 'processes' containing the pointers to the two
process structs in order to facilitate easier process debugging.

Example usage:
```
(gdb) print_tree processes[1]->threads thread
(struct thread *)0xffffc00000e03000
(struct thread *)0xffffc00000e04000
(struct thread *)0xffffc00000e05000
(struct thread *)0xffffc00000e06000
(gdb) 
```