### PR TITLE
Aarch64: add support for AWS Graviton instances

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
       - run: gcloud config set project ${GOOGLE_PROJECT_ID}
       - run: gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
 
-      - run: mkdir temp && cp output/platform/virt/bin/kernel.img temp/ && cp output/tools/bin/mkfs temp/ && cp output/tools/bin/dump temp/ && mkdir temp/klibs && cp output/klib/bin/* temp/klibs
+      - run: mkdir temp && cp output/platform/virt/bin/kernel.img temp/ && cp output/platform/virt/boot/bootaa64.efi temp/ && cp output/tools/bin/mkfs temp/ && cp output/tools/bin/dump temp/ && mkdir temp/klibs && cp output/klib/bin/* temp/klibs
       - run: cd temp && tar cvzf nanos-nightly-linux-virt.tar.gz * && gsutil cp nanos-nightly-linux-virt.tar.gz gs://nanos/release/nightly
       - run: gsutil acl ch -u AllUsers:R gs://nanos/release/nightly/nanos-nightly-linux-virt.tar.gz
       - run: rm -r temp

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ AWS_AMI_IMAGE=	nanos-$(TARGET)
 MKFS=		$(TOOLDIR)/mkfs
 DUMP=		$(TOOLDIR)/dump
 BOOTIMG=	$(PLATFORMOBJDIR)/boot/boot.img
+UEFI_LOADER=$(PLATFORMOBJDIR)/boot/$(UEFI_FILE)
 KERNEL=		$(PLATFORMOBJDIR)/bin/kernel.img
 
 all: image
@@ -39,6 +40,14 @@ all: image
 .PHONY: distclean image release target tools
 
 include rules.mk
+
+ifeq ($(ARCH),x86_64)
+UEFI_FILE=	bootx64.efi
+else
+ifeq ($(ARCH),aarch64)
+UEFI_FILE=	bootaa64.efi
+endif
+endif
 
 THIRD_PARTY= $(ACPICA_DIR)/.vendored $(LWIPDIR)/.vendored $(MBEDTLS_DIR)/.vendored
 
@@ -58,7 +67,8 @@ release: $(THIRD_PARTY) tools
 	$(Q) $(MKDIR) release
 	$(CP) $(MKFS) release
 	$(CP) $(DUMP) release
-	$(CP) $(BOOTIMG) release
+	if [ -f $(BOOTIMG) ]; then $(CP) $(BOOTIMG) release; fi
+	if [ -f $(UEFI_LOADER) ]; then $(CP) $(UEFI_LOADER) release; fi
 	$(CP) $(KERNEL) release
 	$(Q) $(MKDIR) release/klibs
 	$(CP) $(OUTDIR)/klib/bin/* release/klibs

--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -59,7 +59,6 @@ cmd_objcopy=	$(OBJCOPY) $(OBJCOPYFLAGS) $(OBJCOPYFLAGS_$(@F)) $< $@
 SRCS-uefi= \
 	$(SRCDIR)/boot/uefi.c \
 	$(SRCDIR)/kernel/elf.c \
-	$(SRCDIR)/kernel/kvm_platform.c \
 	$(SRCDIR)/kernel/page.c \
 	$(SRCDIR)/kernel/pagecache.c \
 	$(SRCDIR)/runtime/buffer.c \

--- a/platform/riscv-virt/pci.c
+++ b/platform/riscv-virt/pci.c
@@ -1,6 +1,5 @@
 #include <kernel.h>
 #include <pci.h>
-#include <drivers/console.h>
 
 //#define PCI_PLATFORM_DEBUG
 #ifdef PCI_PLATFORM_DEBUG
@@ -16,11 +15,6 @@
 #define pio_out8(port, source) mmio_write_8(PIO_DATA + port, source)
 #define pio_out16(port, source) mmio_write_16(PIO_DATA + port, source)
 #define pio_out32(port, source) mmio_write_32(PIO_DATA + port, source)
-
-/* stub ... really shouldn't be hardwired into console.c */
-void vga_pci_register(kernel_heaps kh, console_attach a)
-{
-}
 
 u32 pci_cfgread(pci_dev dev, int reg, int bytes)
 {

--- a/platform/riscv-virt/service.c
+++ b/platform/riscv-virt/service.c
@@ -1,4 +1,5 @@
 #include <kernel.h>
+#include <drivers/console.h>
 #include <pagecache.h>
 #include <tfs.h>
 #include <management.h>
@@ -179,6 +180,16 @@ void __attribute__((noreturn)) start(void *a0, void *dtb)
     init_mmu(irange(INIT_PAGEMEM, pad(INIT_PAGEMEM,PAGESIZE_2M)), u64_from_pointer(init_mmu_target));
 
     while (1);
+}
+
+void init_platform_devices(kernel_heaps kh)
+{
+    RO_AFTER_INIT static struct console_driver serial_console_driver = {
+        .name = "serial",
+        .write = serial_console_write,
+    };
+
+    attach_console_driver(&serial_console_driver);
 }
 
 void detect_hypervisor(kernel_heaps kh)

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -1,3 +1,4 @@
+ACPICA_DIR=	$(VENDORDIR)/acpica
 LWIPDIR=	$(VENDORDIR)/lwip
 PROGRAMS=	kernel.elf
 
@@ -8,6 +9,8 @@ SRCS-kernel.elf= \
 	$(CURDIR)/service.c \
 	$(CURDIR)/pci.c \
 	$(OBJDIR)/gitversion.c \
+	$(ACPICA) \
+	$(SRCDIR)/aarch64/acpi.c \
 	$(SRCDIR)/aarch64/clock.c \
 	$(SRCDIR)/aarch64/crt0.S \
 	$(SRCDIR)/aarch64/elf64.c \
@@ -18,8 +21,15 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/aarch64/rtc.c \
 	$(SRCDIR)/aarch64/serial.c \
 	$(SRCDIR)/aarch64/unix_machine.c \
+	$(SRCDIR)/aws/ena/ena.c \
+	$(SRCDIR)/aws/ena/ena_com/ena_com.c \
+	$(SRCDIR)/aws/ena/ena_com/ena_eth_com.c \
+	$(SRCDIR)/aws/ena/ena_datapath.c \
+	$(SRCDIR)/drivers/acpi.c \
 	$(SRCDIR)/drivers/console.c \
 	$(SRCDIR)/drivers/netconsole.c \
+	$(SRCDIR)/drivers/ns16550.c \
+	$(SRCDIR)/drivers/nvme.c \
 	$(SRCDIR)/gdb/gdbstub.c \
 	$(SRCDIR)/gdb/gdbtcp.c \
 	$(SRCDIR)/gdb/gdbutil.c \
@@ -130,6 +140,7 @@ INCLUDES=\
 	-I$(SRCDIR)/unix \
 	-I$(SRCDIR)/unix_process \
 	-I$(SRCDIR)/xen/public \
+	-I$(ACPICA_DIR)/source/include \
 	-I$(LWIPDIR)/src/include \
 	-I$(VDSO_OBJDIR)
 
@@ -168,9 +179,42 @@ VDSO_DEPS=      $(patsubst %.o,%.d,$(VDSO_OBJS))
 OBJDUMPFLAGS=	-d -S
 STRIPFLAGS=	-g
 
-DEPFILES+=      $(VDSO_DEPS)
-CLEANFILES+=    $(foreach f,gitversion.c frame.inc kernel.dis bin/kernel.elf src/unix/ftrace.* $(ARCHDIR)/ftrace.*,$(OBJDIR)/$f) $(VDSO_OBJDIR)/vdso.so $(VDSO_OBJDIR)/vdso-image.c $(VDSO_OBJDIR)/vdso-offset.h $(VDSO_OBJS) $(VDSO_DEPS) $(BOOTIMG) $(KERNEL)
-CLEANDIRS+=     $(foreach d,output/platform output src vdso/src/$(ARCH) vdso/src vdso vendor vendor/lwip vendor/lwip/src vendor/lwip/src/netif vendor/lwip/src/netif/ppp platform,$(OBJDIR)/$d)
+BOOT_OBJDIR=    $(OBJDIR)/boot
+
+UEFI_SRCS= \
+	$(SRCDIR)/aarch64/elf64.c \
+	$(SRCDIR)/aarch64/uefi.c \
+	$(SRCDIR)/boot/uefi.c \
+	$(SRCDIR)/kernel/elf.c \
+	$(SRCDIR)/kernel/pagecache.c \
+	$(SRCDIR)/runtime/buffer.c \
+	$(SRCDIR)/runtime/format.c \
+	$(SRCDIR)/runtime/memops.c \
+	$(SRCDIR)/runtime/merge.c \
+	$(SRCDIR)/runtime/range.c \
+	$(SRCDIR)/runtime/rbtree.c \
+	$(SRCDIR)/runtime/runtime_init.c \
+	$(SRCDIR)/runtime/sg.c \
+	$(SRCDIR)/runtime/symbol.c \
+	$(SRCDIR)/runtime/table.c \
+	$(SRCDIR)/runtime/tuple.c \
+	$(SRCDIR)/tfs/tfs.c \
+	$(SRCDIR)/tfs/tlog.c \
+
+UEFI_OBJDIR=    $(BOOT_OBJDIR)/uefi
+UEFI_OBJS=      $(patsubst $(SRCDIR)/%.c,$(UEFI_OBJDIR)/%.o,$(UEFI_SRCS)) \
+	$(UEFI_OBJDIR)/aarch64/uefi-crt0.o
+UEFI_OBJDIRS=	$(sort $(dir $(UEFI_OBJS))) $(UEFI_OBJDIR)
+UEFI_DEPS=      $(patsubst %.o,%.d,$(UEFI_OBJS))
+UEFI_CFLAGS=    -Wall -Werror -fpic -fshort-wchar -O3 -std=gnu11 \
+	-ffreestanding -DBOOT -DUEFI $(call cc-option, -mno-outline-atomics, "") \
+	-I$(SRCDIR) -I$(SRCDIR)/aarch64 -I$(SRCDIR)/boot -I$(SRCDIR)/kernel \
+	-I$(SRCDIR)/runtime -I$(SRCDIR)/tfs -I$(PLATFORMDIR) -I$(OBJDIR)
+UEFI_LDFLAGS=   -nostdlib -shared -Bsymbolic -T $(SRCDIR)/aarch64/uefi.lds
+
+DEPFILES+=      $(VDSO_DEPS) $(UEFI_DEPS)
+CLEANFILES+=    $(foreach f,gitversion.c frame.inc kernel.dis bin/kernel.elf boot/uefi.so src/unix/ftrace.* $(ARCHDIR)/ftrace.*,$(OBJDIR)/$f) $(VDSO_OBJDIR)/vdso.so $(VDSO_OBJDIR)/vdso-image.c $(VDSO_OBJDIR)/vdso-offset.h $(VDSO_OBJS) $(VDSO_DEPS) $(UEFI_OBJS) $(UEFI_DEPS) $(UEFI_LOADER) $(BOOTIMG) $(KERNEL)
+CLEANDIRS+=     $(foreach d,output/platform output src src/aws vdso/src/$(ARCH) vdso/src vdso vendor vendor/lwip vendor/lwip/src vendor/lwip/src/netif vendor/lwip/src/netif/ppp vendor/acpica vendor/acpica/source vendor/acpica/source/components platform,$(OBJDIR)/$d) $(BOOT_OBJDIR) $(UEFI_OBJDIRS)
 
 OBJCOPYFLAGS	= -S -O binary
 
@@ -198,10 +242,20 @@ cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "const char * const gitversion = \"$(sh
 msg_xxd_r=	XXD_R	$@
 cmd_xxd_r=	$(XXD) -r $< $@
 
+msg_uefi_cc=    $(msg_cc)
+cmd_uefi_cc=    $(CC) $(DEPFLAGS) $(UEFI_CFLAGS) -c $< -o $@
+
+msg_uefi_ld=    $(msg_ld)
+cmd_uefi_ld=    $(LD) $(UEFI_LDFLAGS) $(UEFI_OBJS) -o $@
+
+msg_uefi_objcopy=    $(msg_objcopy)
+cmd_uefi_objcopy=    $(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .dynsym  -j .rel -j .rela -j .rel.* -j .rela.* -j .reloc -O binary --subsystem=10 $< $@
+
 include ../../rules.mk
 
 MKFS=		$(TOOLDIR)/mkfs
 BOOTIMG=	$(OBJDIR)/boot-stub.img
+UEFI_LOADER=$(OBJDIR)/boot/bootaa64.efi
 KERNEL=		$(OBJDIR)/bin/kernel.img
 
 ifneq ($(ARCH),aarch64)
@@ -212,6 +266,8 @@ all: $(KERNEL) kernel.dis
 
 mkfs vdsogen:
 	$(Q) $(MAKE) -C $(ROOTDIR)/tools $@
+
+boot: $(UEFI_LOADER)
 
 kernel: $(KERNEL)
 
@@ -228,14 +284,18 @@ ifneq ($(NANOS_TARGET_ROOT),)
 TARGET_ROOT_OPT=	-r $(NANOS_TARGET_ROOT)
 endif
 
-image: mkfs $(DEFAULT_KERNEL_TARGET) target $(BOOTIMG)
+ifneq ($(ENABLE_UEFI),)
+MKFS_UEFI=	-u $(UEFI_LOADER)
+endif
+
+image: mkfs $(DEFAULT_KERNEL_TARGET) target $(BOOTIMG) $(UEFI_LOADER)
 ifeq ($(IMAGE),)
 	@echo IMAGE variable not specified
 	@false
 endif
 	@ echo "MKFS	$@"
 	@ $(MKDIR) $(dir $(IMAGE))
-	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) -k $(KERNEL) $(IMAGE) -t "(debug_exit:t)"
+	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) $(IMAGE) -t "(debug_exit:t)"
 
 release: mkfs kernel
 	$(Q) $(RM) -r release
@@ -277,6 +337,20 @@ $(OBJDIR)/gitversion.c: $(ROOTDIR)/.git/index $(ROOTDIR)/.git/HEAD
 
 $(BOOTIMG): mbr.hex
 	$(call cmd,xxd_r)
+
+$(UEFI_OBJDIR)/aarch64/uefi-crt0.o:	$(SRCDIR)/aarch64/uefi-crt0.s
+	@$(MKDIR) $(dir $@)
+	$(call cmd,uefi_cc)
+
+$(UEFI_OBJDIR)/%.o: $(SRCDIR)/%.c $(GENHEADERS)
+	@$(MKDIR) $(dir $@)
+	$(call cmd,uefi_cc)
+
+$(BOOT_OBJDIR)/uefi.so:	$(UEFI_OBJS)
+	$(call cmd,uefi_ld)
+
+$(UEFI_LOADER):	$(BOOT_OBJDIR)/uefi.so
+	$(call cmd,uefi_objcopy)
 
 LD=             $(CROSS_COMPILE)ld
 REL_OS=		linux

--- a/platform/virt/pci.c
+++ b/platform/virt/pci.c
@@ -64,8 +64,8 @@ void pci_cfgwrite(pci_dev dev, int reg, int bytes, u32 source)
     {                                                                   \
         pci_plat_debug("%s:  bar %p, %s addr + offset 0x%lx: ", __func__, b, \
                        b->type == PCI_BAR_MEMORY ? "memory" : "ioport", \
-                       b->addr + offset);                               \
-        u##BITS rv = b->type == PCI_BAR_MEMORY ? mmio_read_##BITS(b->addr + offset) : \
+                       (b->type == PCI_BAR_MEMORY ? b->vaddr : b->addr) + offset);      \
+        u##BITS rv = b->type == PCI_BAR_MEMORY ? mmio_read_##BITS(b->vaddr + offset) :  \
             pio_in##BITS(b->addr + offset);                             \
         pci_plat_debug("0x%x\n", rv);                                   \
         return rv;                                                      \
@@ -76,9 +76,9 @@ void pci_cfgwrite(pci_dev dev, int reg, int bytes, u32 source)
     {                                                                   \
         pci_plat_debug("%s: bar %p, %s addr + offset 0x%lx= 0x%x\n", __func__, b, \
                        b->type == PCI_BAR_MEMORY ? "memory" : "ioport", \
-                       b->addr + offset, val);                          \
+                       (b->type == PCI_BAR_MEMORY ? b->vaddr : b->addr) + offset, val); \
         if (b->type == PCI_BAR_MEMORY)                                  \
-            mmio_write_##BITS(b->addr + offset, val);                   \
+            mmio_write_##BITS(b->vaddr + offset, val);                  \
         else                                                            \
             pio_out##BITS(b->addr + offset, val);                       \
     }

--- a/platform/virt/pci.c
+++ b/platform/virt/pci.c
@@ -1,7 +1,6 @@
 #include <kernel.h>
 #include <pci.h>
 #include <gic.h>
-#include <drivers/console.h>
 
 //#define PCI_PLATFORM_DEBUG
 #ifdef PCI_PLATFORM_DEBUG
@@ -17,11 +16,6 @@
 #define pio_out8(port, source) mmio_write_8(PIO_DATA + port, source)
 #define pio_out16(port, source) mmio_write_16(PIO_DATA + port, source)
 #define pio_out32(port, source) mmio_write_32(PIO_DATA + port, source)
-
-/* stub ... really shouldn't be hardwired into console.c */
-void vga_pci_register(kernel_heaps kh, console_attach a)
-{
-}
 
 /* ECAM */
 u32 pci_cfgread(pci_dev dev, int reg, int bytes)

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -1,6 +1,7 @@
 #include <kernel.h>
 #include <pagecache.h>
 #include <tfs.h>
+#include <drivers/console.h>
 #include <management.h>
 #include <virtio/virtio.h>
 #include "serial.h"
@@ -202,6 +203,17 @@ void __attribute__((noreturn)) start(void)
     init_mmu(irangel(INIT_PAGEMEM, PAGESIZE_2M), u64_from_pointer(init_mmu_target));
 
     while (1);
+}
+
+void init_platform_devices(kernel_heaps kh)
+{
+    struct console_driver *console_driver = 0;
+    if (!console_driver) {
+        console_driver = allocate_zero(heap_general(kh), sizeof(*console_driver));
+        console_driver->name = "serial";
+        console_driver->write = serial_console_write;
+    }
+    attach_console_driver(console_driver);
 }
 
 void detect_hypervisor(kernel_heaps kh)

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -1,10 +1,20 @@
 #include <kernel.h>
 #include <pagecache.h>
+#include <pci.h>
 #include <tfs.h>
+#include <aws/aws.h>
+#include <boot/uefi.h>
+#include <drivers/acpi.h>
 #include <drivers/console.h>
+#include <drivers/ns16550.h>
+#include <drivers/nvme.h>
 #include <management.h>
 #include <virtio/virtio.h>
 #include "serial.h"
+
+#define SERIAL_16550_COMPATIBLE 0x00
+#define SERIAL_16550_SUBSET     0x01
+#define SERIAL_16550_WITH_GAS   0x12
 
 //#define INIT_DEBUG
 #ifdef INIT_DEBUG
@@ -16,6 +26,8 @@
 #define init_debug_u64(n)
 #define init_dump(p, len)
 #endif
+
+BSS_RO_AFTER_INIT struct uefi_boot_params boot_params;
 
 u64 random_seed(void)
 {
@@ -29,6 +41,103 @@ u64 random_seed(void)
     return rdtsc();
 }
 
+static void uefi_mem_map_iterate(uefi_mem_map mem_map, range_handler h)
+{
+    int num_desc = mem_map->map_size / mem_map->desc_size;
+    for (int i = 0; i < num_desc; i++) {
+        efi_memory_desc d = mem_map->map + i * mem_map->desc_size;
+        switch (d->type) {
+        case efi_loader_code:
+        case efi_loader_data:
+        case efi_boot_services_code:
+        case efi_boot_services_data:
+        case efi_conventional_memory:
+            apply(h, irangel(d->physical_start, d->number_of_pages * PAGESIZE));
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+closure_function(1, 1, void, get_mem_size,
+                 u64 *, mem_size,
+                 range, r)
+{
+    *bound(mem_size) += range_span(r);
+}
+
+closure_function(3, 1, void, get_bootstrap_base,
+                 range, rsvd, u64, bootstrap_size, u64 *, base,
+                 range, r)
+{
+    if (!*bound(base)) {
+        u64 bootstrap_size = bound(bootstrap_size);
+        range r1, r2;
+        range_difference(r, bound(rsvd), &r1, &r2);
+        if (range_span(r1) >= bootstrap_size)
+            *bound(base) = r1.start;
+        else if (range_span(r2) >= bootstrap_size)
+            *bound(base) = r2.start;
+    }
+}
+
+static void add_heap_range_internal(id_heap h, range r, range *remainder)
+{
+    if (remainder) {
+        if (range_empty(*remainder)) {
+            /* Do not add the current range to the heap yet: it might be mergeable with the next
+             * range. */
+            remainder->start = r.start;
+            remainder->end = r.end;
+            return;
+        }
+        if (r.start == remainder->end) {
+            /* Merge current range with remainder. */
+            remainder->end = r.end;
+            return;
+        }
+        /* The current range cannot be merged with the remainder: add the remainder to the heap and
+         * make the current range the new remainder. */
+        range tmp = r;
+        r = *remainder;
+        *remainder = tmp;
+    }
+    r.start = pad(r.start, PAGESIZE_2M);
+    if (r.start >= r.end)
+        return;
+    init_debug("adding range [0x");
+    init_debug_u64(r.start);
+    init_debug(" 0x");
+    init_debug_u64(r.end);
+    init_debug(")\n");
+    id_heap_add_range(h, r.start, range_span(r));
+}
+
+static inline void add_heap_range_helper(id_heap h, range r, range rsvd, range *remainder)
+{
+    if (!range_empty(r)) {
+        range r1, r2;
+        range_difference(r, rsvd, &r1, &r2);
+        if (!range_empty(r1))
+            add_heap_range_internal(h, r1, remainder);
+        if (!range_empty(r2))
+            add_heap_range_internal(h, r2, remainder);
+    }
+}
+
+closure_function(4, 1, void, add_heap_range,
+                 id_heap, h, range, rsvd1, range, rsvd2, range *, remainder,
+                 range, r)
+{
+    id_heap h = bound(h);
+    range *remainder = bound(remainder);
+    range r1, r2;
+    range_difference(r, bound(rsvd1), &r1, &r2);
+    add_heap_range_helper(h, r1, bound(rsvd2), remainder);
+    add_heap_range_helper(h, r2, bound(rsvd2), remainder);
+}
+
 extern void *START, *END;
 id_heap init_physical_id_heap(heap h)
 {
@@ -39,20 +148,51 @@ id_heap init_physical_id_heap(heap h)
     init_debug("init_setup_stack: kernel size ");
     init_debug_u64(kernel_size);
 
-    u64 base = KERNEL_PHYS + kernel_size;
-    u64 end = 0x80000000; // XXX 1G fixed til we can parse tree
-    u64 bootstrap_size = init_bootstrap_heap(end - base);
-    map(BOOTSTRAP_BASE, base, bootstrap_size, pageflags_writable(pageflags_memory()));
-    base = pad(base + bootstrap_size, PAGESIZE_2M);
-    init_debug("\nfree base ");
-    init_debug_u64(base);
-    init_debug("\nend ");
-    init_debug_u64(end);
-    init_debug("\n");
-    id_heap physical = allocate_id_heap(h, h, PAGESIZE, true);
-    if (!id_heap_add_range(physical, base, end - base)) {
-        halt("init_physical_id_heap: failed to add range %R\n",
-             irange(base, end));
+    id_heap physical;
+    if (boot_params.mem_map.map) {
+        u64 map_base = u64_from_pointer(boot_params.mem_map.map);
+        u64 map_size = pad((map_base & PAGEMASK) + boot_params.mem_map.map_size, PAGESIZE);
+        map_base &= ~PAGEMASK;
+        map(map_base, map_base, map_size, pageflags_memory());
+        u64 mem_size = 0;
+        uefi_mem_map_iterate(&boot_params.mem_map, stack_closure(get_mem_size, &mem_size));
+        init_debug("\nmem size ");
+        init_debug_u64(mem_size);
+        u64 bootstrap_size = init_bootstrap_heap(mem_size);
+        range reserved = irange(INIT_PAGEMEM, KERNEL_PHYS + kernel_size);
+        u64 base = 0;
+        uefi_mem_map_iterate(&boot_params.mem_map,
+                             stack_closure(get_bootstrap_base, reserved, bootstrap_size, &base));
+        init_debug("\nbootstrap base ");
+        init_debug_u64(base);
+        init_debug(", size ");
+        init_debug_u64(bootstrap_size);
+        init_debug("\n");
+        assert(!(base & PAGEMASK));
+        map(BOOTSTRAP_BASE, base, bootstrap_size, pageflags_writable(pageflags_memory()));
+        physical = allocate_id_heap(h, h, PAGESIZE, true);
+        range remainder = irange(0, 0);
+        uefi_mem_map_iterate(&boot_params.mem_map, stack_closure(add_heap_range, physical, reserved,
+                                                                 irangel(base, bootstrap_size),
+                                                                 &remainder));
+        add_heap_range_internal(physical, remainder, 0);
+        unmap(map_base, map_size);
+    } else {
+        u64 base = KERNEL_PHYS + kernel_size;
+        u64 end = 0x80000000; // XXX 1G fixed til we can parse tree
+        u64 bootstrap_size = init_bootstrap_heap(end - base);
+        map(BOOTSTRAP_BASE, base, bootstrap_size, pageflags_writable(pageflags_memory()));
+        base = pad(base + bootstrap_size, PAGESIZE_2M);
+        init_debug("\nfree base ");
+        init_debug_u64(base);
+        init_debug("\nend ");
+        init_debug_u64(end);
+        init_debug("\n");
+        physical = allocate_id_heap(h, h, PAGESIZE, true);
+        if (!id_heap_add_range(physical, base, end - base)) {
+            halt("init_physical_id_heap: failed to add range %R\n",
+                 irange(base, end));
+        }
     }
     return physical;
 }
@@ -178,7 +318,7 @@ extern void *bss_start;
 extern void *bss_end;
 extern void *LOAD_OFFSET;
 
-void __attribute__((noreturn)) start(void)
+void __attribute__((noreturn)) start(u64 x0, u64 x1)
 {
     /* clear bss */
     u64 *p = pointer_from_u64((void *)&bss_start - (void *)&LOAD_OFFSET);
@@ -196,6 +336,10 @@ void __attribute__((noreturn)) start(void)
     init_debug("dtb:\n");
     init_dump(pointer_from_u64(0x40000000), 0x100);
 #endif
+    if (x1) {
+        struct uefi_boot_params *params = pointer_from_u64(x1);
+        runtime_memcpy(&boot_params, params, sizeof(boot_params));
+    }
 
     init_debug("calling init_mmu with target ");
     init_debug_u64(u64_from_pointer(init_mmu_target));
@@ -205,15 +349,31 @@ void __attribute__((noreturn)) start(void)
     while (1);
 }
 
+closure_function(2, 2, void, plat_spcr_handler,
+                 kernel_heaps, kh, struct console_driver **, driver,
+                 u8, type, u64, addr)
+{
+    switch (type) {
+    case SERIAL_16550_COMPATIBLE:
+    case SERIAL_16550_SUBSET:
+    case SERIAL_16550_WITH_GAS:
+        *bound(driver) = ns16550_console_init(bound(kh), pointer_from_u64(DEVICE_BASE + addr));
+        break;
+    }
+}
+
 void init_platform_devices(kernel_heaps kh)
 {
     struct console_driver *console_driver = 0;
+    init_acpi_tables(kh);
+    acpi_parse_spcr(stack_closure(plat_spcr_handler, kh, &console_driver));
     if (!console_driver) {
         console_driver = allocate_zero(heap_general(kh), sizeof(*console_driver));
         console_driver->name = "serial";
         console_driver->write = serial_console_write;
     }
     attach_console_driver(console_driver);
+    pci_platform_init();
 }
 
 void detect_hypervisor(kernel_heaps kh)
@@ -222,9 +382,10 @@ void detect_hypervisor(kernel_heaps kh)
 
 void detect_devices(kernel_heaps kh, storage_attach sa)
 {
-    /* virtio only at the moment */
     init_virtio_network(kh);
+    init_aws_ena(kh);
     init_virtio_blk(kh, sa);
     init_virtio_scsi(kh, sa);
+    init_nvme(kh, sa);
     init_virtio_balloon(kh);
 }

--- a/rules.mk
+++ b/rules.mk
@@ -152,6 +152,9 @@ endef
 # $2 - source file
 objfile=	$(patsubst $(ROOTDIR)/%$(suffix $2),$(OBJDIR)/%$1,$2)
 
+cc-option=	$(shell if $(CC) -Werror $(1) -S -o /dev/null -xc /dev/null \
+	> /dev/null 2>&1; then echo "$(1)"; else echo "$(2)"; fi ;)
+
 cmd=		$(if $(Q),@ echo "$(msg_$(1))";) $(cmd_$(1))
 
 ##############################################################################

--- a/src/aarch64/acpi.c
+++ b/src/aarch64/acpi.c
@@ -1,0 +1,58 @@
+#include <acpi.h>
+#include <kernel.h>
+#include <boot/uefi.h>
+#include <drivers/acpi.h>
+
+/* OS services layer */
+
+ACPI_PHYSICAL_ADDRESS AcpiOsGetRootPointer(void)
+{
+    return boot_params.acpi_rsdp;
+}
+
+ACPI_STATUS AcpiOsReadPort(ACPI_IO_ADDRESS address, UINT32 *value, UINT32 width)
+{
+    switch (width) {
+    case 8:
+        *value = mmio_read_8(address);
+        break;
+    case 16:
+        *value = mmio_read_16(address);
+        break;
+    case 32:
+        *value = mmio_read_32(address);
+        break;
+    default:
+        return AE_BAD_PARAMETER;
+    }
+    return AE_OK;
+}
+
+ACPI_STATUS AcpiOsWritePort(ACPI_IO_ADDRESS address, UINT32 value, UINT32 width)
+{
+    switch (width) {
+    case 8:
+        mmio_write_8(address, value);
+        break;
+    case 16:
+        mmio_write_16(address, value);
+        break;
+    case 32:
+        mmio_write_32(address, value);
+        break;
+    default:
+        return AE_BAD_PARAMETER;
+    }
+    return AE_OK;
+}
+
+UINT32 AcpiOsInstallInterruptHandler(UINT32 interrupt_number, ACPI_OSD_HANDLER service_routine,
+                                     void *context)
+{
+    return AE_NOT_IMPLEMENTED;
+}
+
+ACPI_STATUS AcpiOsRemoveInterruptHandler(UINT32 interrupt_number, ACPI_OSD_HANDLER service_routine)
+{
+    return AE_NOT_IMPLEMENTED;
+}

--- a/src/aarch64/gic.c
+++ b/src/aarch64/gic.c
@@ -1,5 +1,8 @@
 #include <kernel.h>
+#include <drivers/acpi.h>
 #include <gic.h>
+
+#define GIC_LPI_ENABLE  0x01
 
 //#define GIC_DEBUG
 #ifdef GIC_DEBUG
@@ -8,52 +11,136 @@
 #define gic_debug(x, ...)
 #endif
 
-BSS_RO_AFTER_INIT static boolean gicc_v3_iface;
-BSS_RO_AFTER_INIT static u32 gic_intid_mask;
+#define GIC_ICID    0   /* a single interrupt collection is being used */
+
+/* The physical address of the command queue must be aligned to 64 KB. */
+#define GIC_CMD_QUEUE_SIZE  (64 * KB)
+
+static struct {
+    boolean v3_iface;
+    u32 intid_mask;
+    u64 dist_base;
+    struct {
+        u64 base;
+        u64 rdbase;
+    } redist;   /* redistributor associated to CPU 0 */
+    u64 its_base;
+    u8 *lpi_cfg_table;
+    u64 its_typer;
+    u32 dev_id_limit;
+    void *its_cmd_queue;
+    struct list devices;
+} gic;
+
+typedef struct its_dev {
+    struct list l;
+    u32 id;
+    void *itt;
+} *its_dev;
+
+#define gicd_read_32(reg)           mmio_read_32(gic.dist_base + GICD_ ## reg)
+#define gicd_write_32(reg, value)   mmio_write_32(gic.dist_base + GICD_ ## reg, value)
+
+#define gicr_read_32(reg)           mmio_read_32(gic.redist.base + GICR_ ## reg)
+#define gicr_read_64(reg)           mmio_read_64(gic.redist.base + GICR_ ## reg)
+#define gicr_write_32(reg, value)   mmio_write_32(gic.redist.base + GICR_ ## reg, value)
+#define gicr_write_64(reg, value)   mmio_write_64(gic.redist.base + GICR_ ## reg, value)
+
+#define gits_read_64(reg)           mmio_read_64(gic.its_base + GITS_ ## reg)
+#define gits_write_32(reg, value)   mmio_write_32(gic.its_base + GITS_ ## reg, value)
+#define gits_write_64(reg, value)   mmio_write_64(gic.its_base + GITS_ ## reg, value)
+
+static void gic_its_cmd(u64 dw0, u64 dw1, u64 dw2, u64 dw3)
+{
+    u64 cwrite = gits_read_64(CWRITER);
+    u64 cread = gits_read_64(CREADR);
+    gic_debug("cread 0x%lx, cwrite 0x%lx\n", cread, cwrite);
+    while (cread == cwrite + 32) {  /* command queue full */
+        kern_pause();
+        cread = gits_read_64(CREADR);
+        assert(!(cread & GITS_CREADR_STALLED));
+    }
+    u64 *cmd = gic.its_cmd_queue + cwrite;
+    cmd[0] = dw0;
+    cmd[1] = dw1;
+    cmd[2] = dw2;
+    cmd[3] = dw3;
+    cwrite += 32;
+    if (cwrite == GIC_CMD_QUEUE_SIZE)
+        cwrite = 0;
+    gits_write_64(CWRITER, cwrite);
+}
 
 void gic_disable_int(int irq)
 {
-    int w = irq / GICD_INTS_PER_IENABLE_REG;
-    u64 a = (!gicc_v3_iface || w) ? GICD_ICENABLER(w) : GICR_ICENABLER;
-    u32 x = U32_FROM_BIT(irq & (GICD_INTS_PER_IENABLE_REG - 1)); /* same as redist */
-    gic_debug("irq %d, a 0x%lx, x 0x%x, before 0x%x\n", irq, a, x, mmio_read_32(a));
-    mmio_write_32(a, x);
+    if (irq < GIC_LPI_INTS_START) {
+        int w = irq / GICD_INTS_PER_IENABLE_REG;
+        boolean redist = gic.v3_iface && (w == 0);
+        u32 x = U32_FROM_BIT(irq & (GICD_INTS_PER_IENABLE_REG - 1)); /* same as redist */
+        if (!redist) {
+            gic_debug("irq %d, x 0x%x, before 0x%x\n", irq, x, gicd_read_32(ICENABLER(w)));
+            gicd_write_32(ICENABLER(w), x);
+        } else {
+            gic_debug("irq %d, x 0x%x, before 0x%x\n", irq, x, gicr_read_32(ICENABLER));
+            gicr_write_32(ICENABLER, x);
+        }
+    } else {
+        gic.lpi_cfg_table[irq - GIC_LPI_INTS_START] &= ~GIC_LPI_ENABLE;
+    }
 }
 
 void gic_enable_int(int irq)
 {
-    int w = irq / GICD_INTS_PER_IENABLE_REG;
-    u64 a = (!gicc_v3_iface || w) ? GICD_ISENABLER(w) : GICR_ISENABLER;
-    u32 x = U32_FROM_BIT(irq & (GICD_INTS_PER_IENABLE_REG - 1));
-    gic_debug("irq %d, x 0x%lx, x 0x%x, before 0x%x\n", irq, a, x, mmio_read_32(a));
-    mmio_write_32(a, x);
+    if (irq < GIC_LPI_INTS_START) {
+        int w = irq / GICD_INTS_PER_IENABLE_REG;
+        boolean redist = gic.v3_iface && (w == 0);
+        u32 x = U32_FROM_BIT(irq & (GICD_INTS_PER_IENABLE_REG - 1));
+        if (!redist) {
+            gic_debug("irq %d, x 0x%x, before 0x%x\n", irq, x, gicd_read_32(ISENABLER(w)));
+            gicd_write_32(ISENABLER(w), x);
+        } else {
+            gic_debug("irq %d, x 0x%x, before 0x%x\n", irq, x, gicr_read_32(ISENABLER));
+            gicr_write_32(ISENABLER, x);
+        }
+    } else {
+        gic.lpi_cfg_table[irq - GIC_LPI_INTS_START] |= GIC_LPI_ENABLE;
+    }
 }
 
 void gic_clear_pending_int(int irq)
 {
-    int w = irq / GICD_INTS_PER_IPEND_REG;
-    u64 a = (!gicc_v3_iface || w) ? GICD_ICPENDR(w) : GICR_ICPENDR;
-    u32 x = U32_FROM_BIT(irq & (GICD_INTS_PER_IPEND_REG - 1));
-    gic_debug("irq %d, a 0x%lx, x 0x%x, before 0x%x\n", irq, a, x, mmio_read_32(a));
-    mmio_write_32(a, x);
+    if (irq < GIC_LPI_INTS_START) {
+        int w = irq / GICD_INTS_PER_IPEND_REG;
+        boolean redist = gic.v3_iface && (w == 0);
+        u32 x = U32_FROM_BIT(irq & (GICD_INTS_PER_IPEND_REG - 1));
+        if (!redist) {
+            gic_debug("irq %d, x 0x%x, before 0x%x\n", irq, x, gicd_read_32(ICPENDR(w)));
+            gicd_write_32(ICPENDR(w), x);
+        } else {
+            gic_debug("irq %d, x 0x%x, before 0x%x\n", irq, x, gicr_read_32(ICPENDR));
+            gicr_write_32(ICPENDR, x);
+        }
+    }
 }
 
 #define GIC_SET_INTFIELD(name, type)                                    \
     void gic_set_int_##name(int irq, u32 v)                             \
     {                                                                   \
+        if (irq >= GIC_LPI_INTS_START)                                  \
+            return;                                                     \
         int w = 32 / GICD_INTS_PER_ ## type ## _REG;                    \
         int r = irq / GICD_INTS_PER_ ## type ## _REG;                   \
         u32 i;                                                          \
-        if (!gicc_v3_iface || r)                                        \
-            i = mmio_read_32(GICD_ ## type ## R(r));                    \
+        if (!gic.v3_iface || r)                                         \
+            i = gicd_read_32(type ## R(r));                             \
         else                                                            \
-            i = mmio_read_32(GICR_ ## type ## R);                       \
+            i = gicr_read_32(type ## R);                                \
         int s = (irq % GICD_INTS_PER_ ## type ## _REG) * w;             \
         u32 n = (i & ~(MASK32(w) << s)) | (v << s);                     \
-        if (!gicc_v3_iface || r)                                        \
-            mmio_write_32(GICD_ ## type ## R(r), n);                    \
+        if (!gic.v3_iface || r)                                         \
+            gicd_write_32(type ## R(r), n);                             \
         else                                                            \
-            mmio_write_32(GICR_ ## type ## R, n);                       \
+            gicr_write_32(type ## R, n);                                \
         gic_debug("irq %d, v %d, reg was 0x%x, now 0x%x\n", irq, v, i, n); \
     }
 
@@ -64,45 +151,45 @@ GIC_SET_INTFIELD(target, ITARGETS)
 boolean gic_int_is_pending(int irq)
 {
     int w = irq / GICD_INTS_PER_IPEND_REG;
-    u64 a = (!gicc_v3_iface || w) ? GICD_ISPENDR(w) : GICR_ISPENDR;
-    boolean pending = (mmio_read_32(a) & U32_FROM_BIT(irq & (GICD_INTS_PER_IPEND_REG - 1))) != 0;
+    u64 v = (!gic.v3_iface || w) ? gicd_read_32(ISPENDR(w)) : gicr_read_32(ISPENDR);
+    boolean pending = (v & U32_FROM_BIT(irq & (GICD_INTS_PER_IPEND_REG - 1))) != 0;
     gic_debug("irq %d, pending %d\n", irq, pending);
     return pending;
 }
 
 static void init_gicd(void)
 {
-    mmio_write_32(GICD_CTLR, GICD_CTLR_DISABLE);
+    gicd_write_32(CTLR, GICD_CTLR_DISABLE);
 
     /* disable and clear pending */
     for (int i = 0; i < GIC_MAX_INT / GICD_INTS_PER_IENABLE_REG; i++)
-        mmio_write_32(GICD_ICENABLER(i), MASK(32));
+        gicd_write_32(ICENABLER(i), MASK(32));
     
     for (int i = 0; i < GIC_MAX_INT / GICD_INTS_PER_IPEND_REG; i++)
-        mmio_write_32(GICD_ICPENDR(i), MASK(32));
+        gicd_write_32(ICPENDR(i), MASK(32));
 
     /* set all to low priority */
     for (int i = 0; i < GIC_MAX_INT / GICD_INTS_PER_IPRIORITY_REG; i++)
-        mmio_write_32(GICD_IPRIORITYR(i), MASK(32));
+        gicd_write_32(IPRIORITYR(i), MASK(32));
 
     /* set all to group 1, non-secure */
-    if (gicc_v3_iface)
-        mmio_write_32(GICR_IGROUPR, MASK(32));
+    if (gic.v3_iface)
+        gicr_write_32(IGROUPR, MASK(32));
     else
-        mmio_write_32(GICD_IGROUPR(0), MASK(32));
+        gicd_write_32(IGROUPR(0), MASK(32));
     for (int i = GIC_SPI_INTS_START / GICD_INTS_PER_IGROUP_REG;
          i < GIC_SPI_INTS_END / GICD_INTS_PER_IGROUP_REG; i++)
-        mmio_write_32(GICD_IGROUPR(i), MASK(32));
+        gicd_write_32(IGROUPR(i), MASK(32));
 
     /* shared periph target cpu0 */
     for (int i = GIC_SPI_INTS_START / GICD_INTS_PER_ITARGETS_REG;
          i < GIC_SPI_INTS_END / GICD_INTS_PER_ITARGETS_REG; i++)
-        mmio_write_32(GICD_ITARGETSR(i), 0x01010101);
+        gicd_write_32(ITARGETSR(i), 0x01010101);
 
     /* set all to level triggered, active low */
     for (int i = GIC_PPI_INTS_START / GICD_INTS_PER_ICFG_REG;
          i < GIC_PPI_INTS_END / GICD_INTS_PER_ICFG_REG; i++)
-        mmio_write_32(GICD_ICFGR(i), 0); /* all level */
+        gicd_write_32(ICFGR(i), 0); /* all level */
     
     /* enable
        XXX - turn on affinity routing (ARE)? */
@@ -111,7 +198,7 @@ static void init_gicd(void)
        bit 1 as GRP1 enable, and another (qemu w/ kvm on bcm2711) which
        doesn't, so set both for now until the variants can be sorted
        out. (This may be due to the presence of GIC Security Extensions. */
-    mmio_write_32(GICD_CTLR, GICD_CTLR_ENABLEGRP1 | GICD_CTLR_ENABLEGRP0);
+    gicd_write_32(CTLR, GICD_CTLR_ENABLEGRP1 | GICD_CTLR_ENABLEGRP0);
 }
 
 /* aliases for macro use */
@@ -119,15 +206,15 @@ static void init_gicd(void)
 #define GICC_IAR1 GICC_IAR
 #define GICC_EOIR1 GICC_EOIR
 
-#define gicc_read(reg) (gicc_v3_iface ? read_psr_s(ICC_ ## reg ## _EL1) : (GICC_ ## reg))
-#define gicc_write(reg, v) do { if (gicc_v3_iface) write_psr_s(ICC_ ## reg ## _EL1, (v)); \
+#define gicc_read(reg) (gic.v3_iface ? read_psr_s(ICC_ ## reg ## _EL1) : (GICC_ ## reg))
+#define gicc_write(reg, v) do { if (gic.v3_iface) write_psr_s(ICC_ ## reg ## _EL1, (v)); \
         else mmio_write_32(GICC_ ## reg, v); } while (0)
 #define gicc_set(reg, v) do { gicc_write(reg, gicc_read(reg) | (v)); } while(0)
 #define gicc_clear(reg, v) do { gicc_write(reg, gicc_read(reg) & ~(v)); } while(0)
 
 u64 gic_dispatch_int(void)
 {
-    u64 v = (gicc_v3_iface ? read_psr_s(ICC_IAR1_EL1) : mmio_read_32(GICC_IAR)) & gic_intid_mask;
+    u64 v = (gic.v3_iface ? read_psr_s(ICC_IAR1_EL1) : mmio_read_32(GICC_IAR)) & gic.intid_mask;
     gic_debug("intid %ld\n", v);
     return v;
 }
@@ -138,16 +225,78 @@ void gic_eoi(int irq)
     gicc_write(EOIR1, irq);
 }
 
+boolean dev_irq_enable(u32 dev_id, int vector)
+{
+    gic_debug("dev 0x%x, irq %d\n", dev_id, vector);
+    if ((vector >= gic_msi_vector_base) && gic.its_base) {
+        its_dev dev = 0;
+        list_foreach(&gic.devices, l) {
+            its_dev d = struct_from_list(l, its_dev, l);
+            if (d->id == dev_id) {
+                dev = d;
+                break;
+            }
+        }
+        if (!dev) {
+            assert(dev_id < gic.dev_id_limit);
+            kernel_heaps kh = get_kernel_heaps();
+            dev = allocate(heap_locked(kh), sizeof(*dev));
+            if (dev == INVALID_ADDRESS)
+                return false;
+
+            /* The number of interrupt table entries must be a power of 2. */
+            u64 ite_num = U64_FROM_BIT(find_order(gic_msi_vector_num));
+            u64 itt_size = ite_num * (GITS_ITT_entry_size(gic.its_typer) + 1);
+            itt_size = MAX(itt_size, U64_FROM_BIT(8));  /* ensure 256-byte alignment */
+            gic_debug("creating ITT with %ld entries (%ld bytes)\n", ite_num, itt_size);
+            u64 pa;
+            dev->itt = alloc_map(heap_page_backed(kh), itt_size, &pa);
+            if (dev->itt == INVALID_ADDRESS) {
+                deallocate(heap_locked(kh), dev, sizeof(*dev));
+                return false;
+            }
+
+            zero(dev->itt, itt_size);
+            dev->id = dev_id;
+            list_insert_before(list_begin(&gic.devices), &dev->l);
+            gic_its_cmd(((u64)dev_id << 32) | ITS_CMD_MAPD, find_order(ite_num) - 1,
+                        ITS_MAPD_V | pa, 0);
+        }
+        u32 event_id = vector - gic_msi_vector_base;
+        gic_its_cmd(((u64)dev_id << 32) | ITS_CMD_MAPTI, ((u64)vector << 32) | event_id,
+                    GIC_ICID, 0);
+        gic_its_cmd(((u64)dev_id << 32) | ITS_CMD_INV, event_id, 0, 0);
+        gic_its_cmd(ITS_CMD_SYNC, 0, gic.redist.rdbase << 16, 0);
+    }
+    return true;
+}
+
+void dev_irq_disable(u32 dev_id, int vector)
+{
+    gic_debug("dev 0x%x, irq %d\n", dev_id, vector);
+    if ((vector >= gic_msi_vector_base) && gic.its_base) {
+        u32 event_id = vector - gic_msi_vector_base;
+        gic_its_cmd(((u64)dev_id << 32) | ITS_CMD_DISCARD, event_id, 0, 0);
+        gic_its_cmd(((u64)dev_id << 32) | ITS_CMD_INV, event_id, 0, 0);
+        gic_its_cmd(ITS_CMD_SYNC, 0, gic.redist.rdbase << 16, 0);
+    }
+}
+
 void msi_format(u32 *address, u32 *data, int vector)
 {
-    *address = DEV_BASE_GIC_V2M + GIC_V2M_MSI_SETSPI_NS;
-    *data = vector;
+    if (gic.its_base) {
+        *address = gic.its_base + GITS_TRANSLATER - DEVICE_BASE;
+        *data = vector - gic_msi_vector_base;
+    } else {
+        *address = DEV_BASE_GIC_V2M + GIC_V2M_MSI_SETSPI_NS;
+        *data = vector;
+    }
 }
 
 static void init_gicc(void)
 {
     /* disable all interrupt groups */
-    if (gicc_v3_iface) {
+    if (gic.v3_iface) {
         write_psr_s(ICC_IGRPEN0_EL1, 0);
         write_psr_s(ICC_IGRPEN1_EL1, 0);
     } else {
@@ -164,13 +313,13 @@ static void init_gicc(void)
     gicc_write(BPR0, 0);
 
     /* no EOI mode */
-    gicc_clear(CTLR, gicc_v3_iface ? ICC_CTLR_EL1_EOImode : GICC_CTLR_EOImode);
+    gicc_clear(CTLR, gic.v3_iface ? ICC_CTLR_EL1_EOImode : GICC_CTLR_EOImode);
 
     /* clear active */
     while (gic_dispatch_int() != INTID_NO_PENDING);
 
     /* enable */
-    if (gicc_v3_iface)
+    if (gic.v3_iface)
         write_psr_s(ICC_IGRPEN1_EL1, ICC_IGRPENx_ENABLE);
     else {
         /* XXX see comment above */
@@ -179,30 +328,135 @@ static void init_gicc(void)
     }
 }
 
+static void init_gits(kernel_heaps kh)
+{
+    gic.its_typer = gits_read_64(TYPER);
+    gic_debug("typer 0x%lx\n", gic.its_typer);
+    if (gic.its_typer & GITS_TYPER_PTA)
+        gic.redist.rdbase = gic.redist.base >> 16;
+    else
+        gic.redist.rdbase = GICR_TYPER_PROC_NUM(gicr_read_64(TYPER));
+    u64 pa;
+    for (int n = 0; n < 8; n++) {
+        u64 base = gits_read_64(BASER(n));
+        u64 page_size;
+        void *table;
+        switch (GITS_TABLE_TYPE(base)) {
+        case GITS_TABLE_DEVICES:
+        case GITS_TABLE_COLLECTIONS:
+            switch (GITS_PAGE_SIZE(base)) {
+            case GITS_PGSZ_4K:
+                page_size = 4 * KB;
+                break;
+            case GITS_PGSZ_16K:
+                page_size = 16 * KB;
+                break;
+            default:
+                page_size = 64 * KB;
+                break;
+            }
+
+            /* Allocate a single (flat) table. This will need to be revised for the device table if
+             * we hit the device ID limit. */
+            gic_debug("allocating table type %d (entry size %d, page size %d)\n",
+                      GITS_TABLE_TYPE(base), GITS_TABLE_ENTRY_SIZE(base) + 1, page_size);
+            if (GITS_TABLE_TYPE(base) == GITS_TABLE_DEVICES)
+                gic.dev_id_limit = page_size / (GITS_TABLE_ENTRY_SIZE(base) + 1);
+            table = alloc_map(heap_page_backed(kh), page_size, &pa);
+            assert(table != INVALID_ADDRESS);
+            zero(table, page_size);
+            base = (base & ~GITS_BASE_PA_MASK) | pa;
+            gits_write_64(BASER(n), GITS_BASER_VALID | base);
+            break;
+        }
+    }
+    list_init(&gic.devices);
+
+    /* Set up the command queue. */
+    gic.its_cmd_queue = alloc_map(heap_page_backed(kh), GIC_CMD_QUEUE_SIZE, &pa);
+    assert(gic.its_cmd_queue != INVALID_ADDRESS);
+    gits_write_64(CBASER, GITS_CBASER_VALID | pa | (GIC_CMD_QUEUE_SIZE / PAGESIZE));
+    gits_write_64(CWRITER, 0);
+
+    gits_write_32(CTLR, GITS_CTRL_ENABLED); /* Enable the ITS. */
+
+    /* Map an interrupt collection to the redistributor associated to CPU 0. */
+    gic_its_cmd(ITS_CMD_MAPC, 0, ITS_MAPC_V | (gic.redist.rdbase << 16) | GIC_ICID, 0);
+}
+
 BSS_RO_AFTER_INIT u16 gic_msi_vector_base;
 BSS_RO_AFTER_INIT u16 gic_msi_vector_num;
 
-void init_gic(void)
+closure_function(0, 2, void, gic_madt_handler,
+                 u8, type, void *, p)
 {
+    switch (type) {
+    case ACPI_MADT_GEN_DIST:
+        gic.dist_base = DEVICE_BASE + ((acpi_gen_dist)p)->base_address;
+        break;
+    case ACPI_MADT_GEN_RDIST:
+        gic.redist.base = DEVICE_BASE + ((acpi_gen_redist)p)->base_address;
+        break;
+    case ACPI_MADT_GEN_TRANS:
+        gic.its_base = DEVICE_BASE + ((acpi_gen_trans)p)->base_address;
+        break;
+    }
+}
+
+int init_gic(void)
+{
+    acpi_walk_madt(stack_closure(gic_madt_handler));
+    if (!gic.dist_base)
+        gic.dist_base = mmio_base_addr(GIC_DIST);
+    if (!gic.redist.base)
+        gic.redist.base = mmio_base_addr(GIC_REDIST);
+    gic_debug("dist %p, redist %p, its %p\n", gic.dist_base, gic.redist.base, gic.its_base);
     u64 aa64pfr0 = read_psr(ID_AA64PFR0_EL1);
     u8 gic_iface = field_from_u64(aa64pfr0, ID_AA64PFR0_EL1_GIC);
     switch (gic_iface) {
     case ID_AA64PFR0_EL1_GIC_GICC_SYSREG_NONE:
-        gicc_v3_iface = false;
         break;
     case ID_AA64PFR0_EL1_GIC_GICC_SYSREG_3_0_4_0:
-        gicc_v3_iface = true;
+        gic.v3_iface = true;
         break;
     default:
         halt("%s: gic type %d from ID_AA64PFR0_EL1 not supported\n", __func__, gic_iface);
     }
 
-    if (gicc_v3_iface) {
+    if (gic.v3_iface) {
         u64 icc_ctlr = read_psr_s(ICC_CTLR_EL1);
-        gic_intid_mask = (field_from_u64(icc_ctlr, ICC_CTLR_EL1_IDbits) ==
+        gic.intid_mask = (field_from_u64(icc_ctlr, ICC_CTLR_EL1_IDbits) ==
                           ICC_CTLR_EL1_IDbits_24) ? MASK(24) : MASK(16);
+        gic_msi_vector_base = GIC_LPI_INTS_START;
+        u64 typer = gicd_read_32(TYPER);
+        u8 num_lpis = field_from_u64(typer, GICD_num_LPIs);
+        if (num_lpis == 0)
+            gic_msi_vector_num = U32_FROM_BIT(field_from_u64(typer, GICD_IDbits) + 1) -
+                                 gic_msi_vector_base;
+        else
+            gic_msi_vector_num = U32_FROM_BIT(num_lpis + 1);
+
+        /* Set up a page-sized LPI configuration table. */
+        gic_msi_vector_num = MAX(gic_msi_vector_num, PAGESIZE); /* 1 byte per LPI */
+        kernel_heaps kh = get_kernel_heaps();
+        u64 pa;
+        gic.lpi_cfg_table = alloc_map(heap_page_backed(kh), PAGESIZE, &pa);
+        assert(gic.lpi_cfg_table != INVALID_ADDRESS);
+        zero(gic.lpi_cfg_table, PAGESIZE);
+        u64 id_bits = find_order(gic_msi_vector_base + gic_msi_vector_num) - 1;
+        gicr_write_64(PROPBASER, pa | id_bits);
+
+        /* Set up LPI pending table, which must be aligned to 64 KB. */
+        void *lpi_pending_table = alloc_map(heap_page_backed(kh), 64 * KB, &pa);
+        assert(lpi_pending_table != INVALID_ADDRESS);
+        zero(lpi_pending_table, 64 * KB);
+        gicr_write_64(PENDBASER, GICR_PENDBASER_PTZ | pa);
+
+        gicr_write_32(CTLR, GICR_CTLR_EnableLPIs);
+        if (gic.its_base)
+            init_gits(kh);
     } else {
-        gic_intid_mask = MASK(10);
+        gic.intid_mask = MASK(10);
 
         /* virt is currently the only aarch64 platform, so we trust that gicv2
            implies v2m - but really this should consult the dev tree or acpi
@@ -214,4 +468,5 @@ void init_gic(void)
 
     init_gicd();
     init_gicc();
+    return (gic.v3_iface ? gic_msi_vector_base + gic_msi_vector_num : GIC_MAX_INT);
 }

--- a/src/aarch64/gic.h
+++ b/src/aarch64/gic.h
@@ -4,6 +4,7 @@
 #define GIC_PPI_INTS_END   32
 #define GIC_SPI_INTS_START 32
 #define GIC_SPI_INTS_END   (GIC_SPI_INTS_START + 256) /* virt */
+#define GIC_LPI_INTS_START 8192
 #define GIC_MAX_INT        GIC_SPI_INTS_END
 #define GIC_MAX_PRIO       16
 #define GIC_TIMER_IRQ      27
@@ -51,45 +52,67 @@
 #define INTID_NO_PENDING 1023
 
 /* GIC Distributor */
-#define GICD_CTLR                   mmio_base_addr(GIC_DIST)
+#define GICD_CTLR                   0x0000
 #define GICD_CTLR_DISABLE           0
 #define GICD_CTLR_ENABLEGRP0        1
 #define GICD_CTLR_ENABLEGRP1        2
-#define GICD_TYPER                  (GICD_CTLR + 0x0004))
+#define GICD_TYPER                  0x0004
+#define GICD_IDbits_BITS            5
+#define GICD_IDbits_SHIFT           19
+#define GICD_num_LPIs_BITS          5
+#define GICD_num_LPIs_SHIFT         11
 #define GICD_ITLinesNumber_BITS     5
 #define GICD_ITLinesNumber_SHIFT    0
-#define GICD_IIDR                   (GICD_CTLR + 0x0008))
-#define GICD_TYPER2                 (GICD_CTLR + 0x000c))
-#define GICD_STATUSR                (GICD_CTLR + 0x0010))
-#define GICD_SETSPI_NSR             (GICD_CTLR + 0x0040))
-#define GICD_CLRSPI_NSR             (GICD_CTLR + 0x0048))
-#define GICD_SETSPI_SR              (GICD_CTLR + 0x0050))
-#define GICD_CLRSPI_SR              (GICD_CTLR + 0x0058))
-#define GICD_IGROUPR(n)             (GICD_CTLR + 0x0080 + 4 * (n))
+#define GICD_IIDR                   0x0008
+#define GICD_TYPER2                 0x000c
+#define GICD_STATUSR                0x0010
+#define GICD_SETSPI_NSR             0x0040
+#define GICD_CLRSPI_NSR             0x0048
+#define GICD_SETSPI_SR              0x0050
+#define GICD_CLRSPI_SR              0x0058
+#define GICD_IGROUPR(n)             (0x0080 + 4 * (n))
 #define GICD_INTS_PER_IGROUP_REG    32
-#define GICD_ISENABLER(n)           (GICD_CTLR + 0x0100 + 4 * (n))
-#define GICD_ICENABLER(n)           (GICD_CTLR + 0x0180 + 4 * (n))
+#define GICD_ISENABLER(n)           (0x0100 + 4 * (n))
+#define GICD_ICENABLER(n)           (0x0180 + 4 * (n))
 #define GICD_INTS_PER_IENABLE_REG   32
-#define GICD_ISPENDR(n)             (GICD_CTLR + 0x0200 + 4 * (n))
-#define GICD_ICPENDR(n)             (GICD_CTLR + 0x0280 + 4 * (n))
+#define GICD_ISPENDR(n)             (0x0200 + 4 * (n))
+#define GICD_ICPENDR(n)             (0x0280 + 4 * (n))
 #define GICD_INTS_PER_IPEND_REG     32
-#define GICD_ISACTIVER(n)           (GICD_CTLR + 0x0300 + 4 * (n))
-#define GICD_ICACTIVER(n)           (GICD_CTLR + 0x0380 + 4 * (n))
-#define GICD_IPRIORITYR(n)          (GICD_CTLR + 0x0400 + 4 * (n))
+#define GICD_ISACTIVER(n)           (0x0300 + 4 * (n))
+#define GICD_ICACTIVER(n)           (0x0380 + 4 * (n))
+#define GICD_IPRIORITYR(n)          (0x0400 + 4 * (n))
 #define GICD_INTS_PER_IPRIORITY_REG 4
-#define GICD_ITARGETSR(n)           (GICD_CTLR + 0x0800 + 4 * (n))
+#define GICD_ITARGETSR(n)           (0x0800 + 4 * (n))
 #define GICD_INTS_PER_ITARGETS_REG  4
-#define GICD_ICFGR(n)               (GICD_CTLR + 0x0c00 + 4 * (n))
+#define GICD_ICFGR(n)               (0x0c00 + 4 * (n))
 #define GICD_INTS_PER_ICFG_REG      16
 #define GICD_ICFGR_LEVEL            0
 #define GICD_ICFGR_EDGE             2
-#define GICD_IGRPMODR(n)            (GICD_CTLR + 0x0d00)
-#define GICD_NSACR(n)               (GICD_CTLR + 0x0e00)
-#define GICD_SGIR                   (GICD_CTLR + 0x0f00)
-#define GICD_CPENDSGIR(n)           (GICD_CTLR + 0x0f10)
-#define GICD_SPENDSGIR(n)           (GICD_CTLR + 0x0f20)
+#define GICD_IGRPMODR(n)            0x0d00
+#define GICD_NSACR(n)               0x0e00
+#define GICD_SGIR                   0x0f00
+#define GICD_CPENDSGIR(n)           0x0f10
+#define GICD_SPENDSGIR(n)           0x0f20
 
-#define _GICR_OFFSET                (mmio_base_addr(GIC_REDIST) + 0x10000)
+#define GICR_CTLR                   0x0000
+#define GICR_CTLR_EnableLPIs            U64_FROM_BIT(0)
+#define GICR_IIDR                   0x0004
+#define GICR_TYPER                  0x0008
+#define GICR_TYPER_PROC_NUM(type)       (((type) & 0xffff00) >> 8)
+#define GICR_STATUSR                0x0010
+#define GICR_WAKER                  0x0014
+#define GICR_MPAMIDR                0x0018
+#define GICR_PARTIDR                0x001c
+#define GICR_SETLPIR                0x0040
+#define GICR_CLRLPIR                0x0048
+#define GICR_PROPBASER              0x0070
+#define GICR_PENDBASER              0x0078
+#define GICR_PENDBASER_PTZ              U64_FROM_BIT(62)
+#define GICR_INVLPIR                0x00a0
+#define GICR_INVALLR                0x00b0
+#define GICR_SYNCR                  0x00c0
+
+#define _GICR_OFFSET                0x10000
 #define GICR_IGROUPR                (_GICR_OFFSET + 0x0080)
 #define GICR_INTS_PER_IGROUP_REG    32
 #define GICR_ISENABLER              (_GICR_OFFSET + 0x0100)
@@ -149,6 +172,53 @@
 #define GIC_V2M_MSI_SETSPI_NS        0x40
 #define GIC_V2M_MSI_IIDR             GIC_V2M_REG(0xfcc)
 
+/* Interrupt Translation Service */
+
+#define GITS_CTLR       0x0000
+#define GITS_CTRL_ENABLED   U64_FROM_BIT(0)
+#define GITS_IIDR       0x0004
+#define GITS_TYPER      0x0008
+#define GITS_TYPER_PTA              U64_FROM_BIT(19)
+#define GITS_ITT_entry_size(type)   (((type) & 0xf0) >> 4)
+#define GITS_MPAMIDR    0x0010
+#define GITS_PARTIDR    0x0014
+#define GITS_MPIDR      0x0018
+#define GITS_STATUSR    0x0040
+#define GITS_UMSIR      0x0048
+#define GITS_CBASER     0x0080
+#define GITS_CBASER_VALID   U64_FROM_BIT(63)
+#define GITS_CWRITER    0x0088
+#define GITS_CREADR     0x0090
+#define GITS_CREADR_STALLED U64_FROM_BIT(0)
+#define GITS_BASER(n)   (0x0100 + (n) * 8)
+#define GITS_BASER_VALID                U64_FROM_BIT(63)
+#define GITS_TABLE_TYPE(baser)          (((baser) & 0x700000000000000ull) >> 56)
+#define GITS_TABLE_ENTRY_SIZE(baser)    (((baser) & 0x1f000000000000ull) >> 48)
+#define GITS_TABLE_DEVICES              0b001
+#define GITS_TABLE_COLLECTIONS          0b100
+#define GITS_BASE_PA_MASK               0xfffffffff000
+#define GITS_PAGE_SIZE(baser)           (((baser) & 0x300) >> 8)
+#define GITS_PGSZ_4K                    0b00
+#define GITS_PGSZ_16K                   0b01
+#define GITS_PGSZ_64K                   0b10
+
+#define GITS_TRANSLATER 0x10040
+
+#define ITS_CMD_CLEAR   0x04
+#define ITS_CMD_DISCARD 0x0f
+#define ITS_CMD_INT     0x03
+#define ITS_CMD_INV     0x0c
+#define ITS_CMD_INVALL  0x0d
+#define ITS_CMD_MAPC    0x09
+#define ITS_MAPC_V          U64_FROM_BIT(63)
+#define ITS_CMD_MAPD    0x08
+#define ITS_MAPD_V          U64_FROM_BIT(63)
+#define ITS_CMD_MAPI    0x0b
+#define ITS_CMD_MAPTI   0x0a
+#define ITS_CMD_MOVALL  0x0e
+#define ITS_CMD_MOVI    0x01
+#define ITS_CMD_SYNC    0x05
+
 extern u16 gic_msi_vector_base;
 extern u16 gic_msi_vector_num;
 
@@ -160,7 +230,7 @@ void gic_set_int_config(int irq, u32 cfg);
 boolean gic_int_is_pending(int irq);
 u64 gic_dispatch_int(void);
 void gic_eoi(int irq);
-void init_gic(void);
+int init_gic(void);
 
 #define _GIC_SET_INTFIELD(name, type) void gic_set_int_##name(int irq, u32 v);
 _GIC_SET_INTFIELD(priority, IPRIORITY)

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -1,5 +1,5 @@
-#ifndef KERNEL
-#error must be in kernel build
+#if !(defined(KERNEL) || defined(BOOT))
+#error must be in kernel or bootloader build
 #endif
 
 #define KERNEL_LIMIT     0x00fffffffffff000ull
@@ -241,6 +241,8 @@ struct cpuinfo_machine {
 };
 
 typedef struct cpuinfo *cpuinfo;
+
+extern struct uefi_boot_params boot_params;
 
 static inline cpuinfo current_cpu(void)
 {

--- a/src/aarch64/machine.h
+++ b/src/aarch64/machine.h
@@ -119,6 +119,8 @@ __bswap64(u64 _x)
 typedef void *value;
 typedef u8 value_tag;
 
+#ifndef BOOT
+
 static inline __attribute__((always_inline)) value tag(void *v, value_tag t) {
     return pointer_from_u64(VA_TAG_BASE | (((u64)t) << VA_TAG_OFFSET) |
                             u64_from_pointer(v));
@@ -127,6 +129,8 @@ static inline __attribute__((always_inline)) value tag(void *v, value_tag t) {
 static inline __attribute__((always_inline)) value_tag tagof(value v) {
     return (u64_from_pointer(v) >> VA_TAG_OFFSET) & ((1ull << VA_TAG_WIDTH) - 1);
 }
+
+#endif
 
 typedef struct spinlock {
     word w;

--- a/src/aarch64/page.c
+++ b/src/aarch64/page.c
@@ -19,7 +19,7 @@ BSS_RO_AFTER_INIT u64 user_tablebase;
 void page_invalidate(flush_entry f, u64 address)
 {
     /* no final sync here; need "dsb ish" at end of operation */
-    register u64 a = (address >> PAGELOG) & MASK(55 - PAGELOG); /* no asid */
+    register u64 a = (address >> PAGELOG) & MASK(56 - PAGELOG); /* no asid */
     asm volatile("dsb ishst;"
                  "tlbi vale1is, %0" :: "r"(a) : "memory");
 }

--- a/src/aarch64/page_machine.h
+++ b/src/aarch64/page_machine.h
@@ -379,11 +379,6 @@ static inline boolean flags_has_minpage(u64 flags)
     return (flags & PAGE_NO_BLOCK) != 0;
 }
 
-static inline u64 canonize_address(u64 addr)
-{
-    return addr;
-}
-
 /* TODO: While the cpu type used under qemu is armv8.1-a, a read of
    ID_AA64MMFR1_EL1 does not indicate that hardware management of
    dirty pages is available (e.g. HD and HA bits are zero). If we

--- a/src/aarch64/page_machine.h
+++ b/src/aarch64/page_machine.h
@@ -170,6 +170,8 @@
 /* bits [58:55] reserved for sw use */
 #define PAGE_NO_BLOCK       U64_FROM_BIT(55)
 
+#ifndef physical_from_virtual
+
 // XXX kernel addr, also should return INVALID_PHYSICAL if PAR_EL1.F is set
 #define __physical_from_virtual_locked(v) ({                            \
             register u64 __r;                                           \
@@ -178,6 +180,8 @@
             (__r & (MASK(47) & ~MASK(12))) | (__x & MASK(12));})
 
 physical physical_from_virtual(void *x);
+
+#endif
 
 extern u64 kernel_tablebase;
 extern u64 user_tablebase;

--- a/src/aarch64/uefi-crt0.s
+++ b/src/aarch64/uefi-crt0.s
@@ -1,0 +1,88 @@
+    .section .text.head
+	.globl IMAGE_BASE
+IMAGE_BASE:
+
+/* PE/COFF header */
+
+msdos_stub:
+    .ascii "MZ"
+    .skip 0x3a
+    .long pe_signature - IMAGE_BASE // offset to the PE signature
+pe_signature:
+    .ascii "PE\0\0"
+coff_header:
+    .short 0xaa64                          // Machine
+    .short 2                               // NumberOfSections
+    .long 0                                // TimeDateStamp
+    .long 0                                // PointerToSymbolTable
+    .long 0                                // NumberOfSymbols
+    .short section_table - optional_header // SizeOfOptionalHeader
+    .short 0x0202                          // Characteristics
+optional_header:
+standard_fields:
+    .short 0x20b              // Magic (PE32+ executable)
+    .byte 0x02                // MajorLinkerVersion
+    .byte 0x24                // MinorLinkerVersion
+    .long _data - _start      // SizeOfCode
+    .long _data_size          // SizeOfInitializedData
+    .long 0                   // SizeOfUninitializedData
+    .long _start - IMAGE_BASE // AddressOfEntryPoint
+    .long _start - IMAGE_BASE // BaseOfCode
+windows_specific_fields:
+    .quad 0                   // ImageBase
+    .long 0x1000              // SectionAlignment
+    .long 0x1000              // FileAlignment
+    .short 0                  // MajorOperatingSystemVersion
+    .short 0                  // MinorOperatingSystemVersion
+    .short 0                  // MajorImageVersion
+    .short 0                  // MinorImageVersion
+    .short 0                  // MajorSubsystemVersion
+    .short 0                  // MinorSubsystemVersion
+    .long 0                   // Win32VersionValue
+    .long _edata - IMAGE_BASE // SizeOfImage
+    .long _start - IMAGE_BASE // SizeOfHeaders
+    .long 0                   // CheckSum
+    .short 10                 // Subsystem (EFI application)
+    .short 0                  // DllCharacteristics
+    .quad 0                   // SizeOfStackReserve
+    .quad 0                   // SizeOfStackCommit
+    .quad 0                   // SizeOfHeapReserve
+    .quad 0                   // SizeOfHeapCommit
+    .long 0                   // LoaderFlags
+    .long 0                   // NumberOfRvaAndSizes
+
+section_table:
+
+    .ascii ".text\0\0\0"      // Name
+    .long _data - _start      // VirtualSize
+    .long _start - IMAGE_BASE // VirtualAddress
+    .long _data - _start      // SizeOfRawData
+    .long _start - IMAGE_BASE // PointerToRawData
+    .long 0                   // PointerToRelocations
+    .long 0                   // PointerToLineNumbers
+    .short 0                  // NumberOfRelocations
+    .short 0                  // NumberOfLineNumbers
+    .long 0x60000020          // Characteristics
+
+    .ascii ".data\0\0\0"     // Name
+    .long _data_size         // VirtualSize
+    .long _data - IMAGE_BASE // VirtualAddress
+    .long _data_size         // SizeOfRawData
+    .long _data - IMAGE_BASE // PointerToRawData
+    .long 0                  // PointerToRelocations
+    .long 0                  // PointerToLineNumbers
+    .short 0                 // NumberOfRelocations
+    .short 0                 // NumberOfLineNumbers
+    .long 0xc0000040         // Characteristics
+
+    .align 8
+_start:
+    stp x29, x30, [sp, #-32]!
+    stp x0, x1, [sp, #16]
+    adr x0, IMAGE_BASE
+    adr x1, _DYNAMIC
+    bl  elf_dyn_relocate
+    ldp x0, x1, [sp, #16]
+    bl  efi_main
+    ldp x29, x30, [sp], #32
+    ret

--- a/src/aarch64/uefi.c
+++ b/src/aarch64/uefi.c
@@ -1,0 +1,37 @@
+#include <runtime.h>
+#include <page.h>
+#include <uefi.h>
+
+void uefi_arch_setup(heap general, heap aligned, uefi_arch_options options)
+{
+    options->load_to_physical = true;
+}
+
+void uefi_start_kernel(void *image_handle, efi_system_table system_table, buffer kern_elf,
+                       void *kern_entry)
+{
+    struct uefi_boot_params boot_params = {0};
+    for (int i = 0; i < system_table->number_of_table_entries; i++) {
+        efi_configuration_table table = &system_table->configuration_table[i];
+        if (!runtime_memcmp(&table->guid, &uefi_acpi20_table, sizeof(table->guid))) {
+            boot_params.acpi_rsdp = u64_from_pointer(table->table);
+            break;
+        }
+    }
+    uefi_exit_bs(&boot_params.mem_map);
+
+    /* disable MMU */
+    u64 sctlr = 0;
+    asm volatile ("msr SCTLR_EL1, %0;"
+                  "isb":: "r" (sctlr));
+
+    void (*start)(u64 x0, u64 x1) = kern_entry;
+    start(0, u64_from_pointer(&boot_params));
+}
+
+void map_with_complete(u64 v, physical p, u64 length, pageflags flags, status_handler complete)
+{
+    /* Mapping is not needed, since the MMU is disabled before starting the kernel. */
+    if (complete)
+        apply(complete, STATUS_OK);
+}

--- a/src/aarch64/uefi.lds
+++ b/src/aarch64/uefi.lds
@@ -1,0 +1,55 @@
+OUTPUT_FORMAT("elf64-littleaarch64", "elf64-littleaarch64", "elf64-littleaarch64")
+OUTPUT_ARCH(aarch64)
+ENTRY(_start)
+SECTIONS
+{
+    . = 0;
+    .text : {
+        *(.text.head)
+        *(.text)
+        *(.text.*)
+        *(.gnu.linkonce.t.*)
+    }
+
+    . = ALIGN(4096);
+    .reloc : {
+        *(.reloc)
+    }
+
+    . = ALIGN(4096);
+    .data : {
+        _data = .;
+        *(.rodata*)
+        *(.got.plt)
+        *(.got)
+        *(.data*)
+        *(.sdata)
+        *(.sbss)
+        *(.scommon)
+        *(.dynbss)
+        *(.bss)
+        *(COMMON)
+        *(.rel.local)
+    }
+    .note.gnu.build-id : { *(.note.gnu.build-id) }
+
+    . = ALIGN(4096);
+    .dynamic  : { *(.dynamic) }
+
+    _edata = .;
+    _data_size = . - _data;
+
+    . = ALIGN(4096);
+    .dynsym   : { *(.dynsym) }
+
+    . = ALIGN(4096);
+    .dynstr   : { *(.dynstr) }
+
+    . = ALIGN(4096);
+    .ignored.reloc : {
+        *(.rela.reloc)
+        *(.eh_frame)
+        *(.note.GNU-stack)
+    }
+    .comment 0 : { *(.comment) }
+}

--- a/src/aws/ena/ena.c
+++ b/src/aws/ena/ena.c
@@ -2055,6 +2055,7 @@ static boolean ena_attach(heap general, heap page_allocator, pci_dev d)
     ena_dev->dmadev = adapter;
 
     pci_bar_init(adapter->pdev, &adapter->registers, ENA_REG_BAR, 0, -1);
+    pci_enable_io_and_memory(adapter->pdev);
 
     ena_dev->bus = allocate(general, sizeof(struct ena_bus));
     if (ena_dev->bus == INVALID_ADDRESS)

--- a/src/aws/ena/ena_com/ena_plat.h
+++ b/src/aws/ena/ena_com/ena_plat.h
@@ -34,8 +34,6 @@
 #ifndef ENA_PLAT_H_
 #define ENA_PLAT_H_
 
-#include <atomic.h>
-
 #define __STRING(x)     #x
 #define __XSTRING(x)    __STRING(x)
 
@@ -283,8 +281,8 @@ static inline u32 ena_reg_read32(struct ena_bus *bus, u64 offset)
 #define prefetch(x)     (void)(x)
 #define prefetchw(x)    (void)(x)
 
-#define ATOMIC32_INC(I32_PTR)       atomic_add32(I32_PTR, 1)
-#define ATOMIC32_DEC(I32_PTR)       atomic_add32(I32_PTR, -1)
+#define ATOMIC32_INC(I32_PTR)       fetch_and_add_32(I32_PTR, 1)
+#define ATOMIC32_DEC(I32_PTR)       fetch_and_add_32(I32_PTR, -1)
 #define ATOMIC32_READ(I32_PTR)      (*(I32_PTR))
 #define ATOMIC32_SET(I32_PTR, VAL)  *(I32_PTR) = (VAL)
 

--- a/src/boot/uefi.c
+++ b/src/boot/uefi.c
@@ -1,5 +1,4 @@
 #include <runtime.h>
-#include <kernel_machine.h>
 #include <page.h>
 #include <elf64.h>
 #include <pagecache.h>
@@ -87,10 +86,15 @@ u64 random_u64()
     }
 }
 
-void kernel_shutdown(int status)
+void halt(char *format, ...)
 {
-    while (1)
-        wait_for_interrupt();
+    vlist a;
+    buffer b = little_stack_buffer(512);
+    vstart(a, format);
+    vbprintf(b, alloca_wrap_cstring(format), &a);
+    buffer_print(b);
+    UBS->exit(uefi_image_handle, EFI_LOAD_ERROR, 0, 0); /* does not return */
+    while(1);   /* to honor "noreturn" attribute */
 }
 
 static u64 uefi_alloc(heap h, bytes b)

--- a/src/boot/uefi.h
+++ b/src/boot/uefi.h
@@ -14,6 +14,10 @@ typedef u64 efi_status;
 #define EFI_BAD_BUFFER_SIZE     EFIERR(4)
 #define EFI_BUFFER_TOO_SMALL    EFIERR(5)
 
+#ifndef EFIAPI
+#define EFIAPI
+#endif
+
 typedef struct efi_guid {
     u32 data1;
     u16 data2;
@@ -352,6 +356,10 @@ typedef struct efi_system_table {
 
 /* End of UEFI standard definitions */
 
+typedef struct uefi_arch_options {
+    boolean load_to_physical;
+} *uefi_arch_options;
+
 typedef struct uefi_mem_map {
     void *map;
     u64 map_size;
@@ -359,14 +367,20 @@ typedef struct uefi_mem_map {
     u32 desc_version;
 } *uefi_mem_map;
 
+typedef struct uefi_boot_params {
+    u64 acpi_rsdp;
+    struct uefi_mem_map mem_map;
+} *uefi_boot_params;
+
 void uefi_exit_bs(uefi_mem_map map);
 
 extern struct efi_guid uefi_smbios_table;
+extern struct efi_guid uefi_acpi20_table;
 
 /* Arch-specific functions */
 
 /* Aligned heap allocates at page-aligned addresses. */
-void uefi_arch_setup(heap general, heap aligned);
+void uefi_arch_setup(heap general, heap aligned, uefi_arch_options options);
 
 void uefi_start_kernel(void *image_handle, efi_system_table system_table, buffer kern_elf,
                        void *kern_entry);

--- a/src/drivers/acpi.h
+++ b/src/drivers/acpi.h
@@ -19,6 +19,9 @@
 #define ACPI_MADT_LAPIC     0
 #define ACPI_MADT_IOAPIC    1
 #define ACPI_MADT_LAPICx2   9
+#define ACPI_MADT_GEN_DIST  12
+#define ACPI_MADT_GEN_RDIST 14
+#define ACPI_MADT_GEN_TRANS 15
 
 #define MADT_LAPIC_ENABLED  1
 /* ACPI table structures */
@@ -82,6 +85,34 @@ typedef struct acpi_ioapic {
     u32 gsi_base;
 } __attribute__((packed)) *acpi_ioapic;
 
+typedef struct acpi_gen_dist {  /* Generic Distributor */
+    u8 type;
+    u8 length;
+    u16 res;
+    u32 gic_id;
+    u64 base_address;
+    u32 global_irq_base;
+    u8 version;
+    u8 res2[3];
+} __attribute__((packed)) *acpi_gen_dist;
+
+typedef struct acpi_gen_redist {    /* Generic Redistributor */
+    u8 type;
+    u8 length;
+    u16 res;
+    u64 base_address;
+    u32 len;
+} __attribute__((packed)) *acpi_gen_redist;
+
+typedef struct acpi_gen_trans { /* Generic Translator */
+    u8 type;
+    u8 length;
+    u16 res;
+    u32 translation_id;
+    u64 base_address;
+    u32 res2;
+} __attribute__((packed)) *acpi_gen_trans;
+
 static inline boolean acpi_checksum(void *a, u8 len)
 {
     u8 *addr = a;
@@ -92,7 +123,11 @@ static inline boolean acpi_checksum(void *a, u8 len)
 }
 
 typedef closure_type(madt_handler, void, u8, void *);
+typedef closure_type(mcfg_handler, boolean, u64, u16, u8, u8);
+typedef closure_type(spcr_handler, void, u8, u64);
 
 void init_acpi(kernel_heaps kh);
 void init_acpi_tables(kernel_heaps kh);
 boolean acpi_walk_madt(madt_handler mh);
+boolean acpi_walk_mcfg(mcfg_handler mh);
+boolean acpi_parse_spcr(spcr_handler h);

--- a/src/drivers/console.c
+++ b/src/drivers/console.c
@@ -1,22 +1,16 @@
 #include <kernel.h>
 #include "serial.h"
 #include "console.h"
-#include "vga.h"
 #include "netconsole.h"
 
 static boolean inited;
 
-static void serial_console_write(void *d, const char *s, bytes count)
+void serial_console_write(void *d, const char *s, bytes count)
 {
     for (; count--; s++) {
         serial_putchar(*s);
     }
 }
-
-RO_AFTER_INIT struct console_driver serial_console_driver = {
-    .write = serial_console_write,
-    .name = "serial"
-};
 
 static struct list console_drivers;
 
@@ -61,10 +55,8 @@ closure_function(0, 1, void, attach_console,
 void init_console(kernel_heaps kh)
 {
     list_init(&console_drivers);
-    list_push_back(&console_drivers, &serial_console_driver.l);
     heap h = heap_general(kh);
     console_attach a = closure(h, attach_console);
-    vga_pci_register(kh, a);
     netconsole_register(kh, a);
     inited = true;
 }

--- a/src/drivers/console.h
+++ b/src/drivers/console.h
@@ -12,3 +12,5 @@ void init_console(kernel_heaps kh);
 void config_console(tuple root);
 void attach_console_driver(struct console_driver *driver);
 void console_force_unlock(void);
+
+void serial_console_write(void *d, const char *s, bytes count);

--- a/src/drivers/ns16550.c
+++ b/src/drivers/ns16550.c
@@ -1,0 +1,31 @@
+#include <kernel.h>
+#include "console.h"
+
+typedef struct ns16550_console {
+    struct console_driver driver;
+    u8 *addr;
+} *ns16550_console;
+
+static boolean tx_empty(u8 *addr) {
+    return *(addr + 5) & 0x20;
+}
+
+static void ns16550_write(void *d, const char *s, bytes count)
+{
+    ns16550_console console = d;
+    for (; count--; s++) {
+        while (!tx_empty(console->addr))
+            ;
+        *console->addr = *s;
+    }
+}
+
+struct console_driver *ns16550_console_init(kernel_heaps kh, void *base)
+{
+    ns16550_console console = allocate(heap_general(kh), sizeof(*console));
+    console->addr = base;
+    zero(&console->driver, sizeof(console->driver));
+    console->driver.name = "16550";
+    console->driver.write = ns16550_write;
+    return &console->driver;
+}

--- a/src/drivers/ns16550.h
+++ b/src/drivers/ns16550.h
@@ -1,0 +1,1 @@
+struct console_driver *ns16550_console_init(kernel_heaps kh, void *base);

--- a/src/drivers/vga.c
+++ b/src/drivers/vga.c
@@ -171,8 +171,8 @@ static void vga_console_write(void *_d, const char *s, bytes count)
     vga_set_cursor(d, d->cur_x, d->cur_y);
 }
 
-closure_function(3, 1, boolean, vga_pci_probe,
-                 heap, general, console_attach, a, heap, virtual,
+closure_function(2, 1, boolean, vga_pci_probe,
+                 heap, general, heap, virtual,
                  pci_dev, _d)
 {
     if (pci_get_class(_d) != PCIC_DISPLAY)
@@ -198,12 +198,12 @@ closure_function(3, 1, boolean, vga_pci_probe,
     vga_debug("%s: max buffer lines %d\n", __func__, d->max_lines);
     vga_set_offset(d, d->y_offset);
 
-    apply(bound(a), &d->c);
+    attach_console_driver(&d->c);
     return true;
 }
 
-void vga_pci_register(kernel_heaps kh, console_attach a)
+void vga_pci_register(kernel_heaps kh)
 {
     heap h = heap_general(kh);
-    register_pci_driver(closure(h, vga_pci_probe, h, a, (heap)heap_virtual_page(kh)), 0);
+    register_pci_driver(closure(h, vga_pci_probe, h, (heap)heap_virtual_page(kh)), 0);
 }

--- a/src/drivers/vga.h
+++ b/src/drivers/vga.h
@@ -1,1 +1,1 @@
-void vga_pci_register(kernel_heaps kh, console_attach a);
+void vga_pci_register(kernel_heaps kh);

--- a/src/kernel/elf64.h
+++ b/src/kernel/elf64.h
@@ -215,12 +215,15 @@ typedef struct {
 
 /* returns virtual address to access map (e.g. vaddr or identity in stage2) */
 typedef closure_type(elf_map_handler, u64, u64 /* vaddr */, u64 /* paddr, -1ull if bss */, u64 /* size */, pageflags /* flags */);
+typedef closure_type(elf_loader, void, u64 /* offset */, u64 /* length */, void * /* dest */,
+                     status_handler);
 typedef closure_type(elf_sym_handler, void, char *, u64, u64, u8);
 typedef closure_type(elf_sym_resolver, void *, const char *);
 void elf_symbols(buffer elf, elf_sym_handler each);
 boolean elf_dyn_link(buffer elf, void *load_addr, elf_sym_resolver resolver);
 void walk_elf(buffer elf, range_handler rh);
 void *load_elf(buffer elf, u64 load_offset, elf_map_handler mapper);
+void load_elf_to_physical(heap h, elf_loader loader, u64 *entry, status_handler sh);
 
 /* Architecture-specific */
 typedef closure_type(elf_sym_relocator, boolean, Elf64_Rela *);

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -344,6 +344,7 @@ void kernel_runtime_init(kernel_heaps kh)
     init_extra_prints();
     init_pci(kh);
     init_console(kh);
+    init_platform_devices(kh);
     init_symtab(kh);
     read_kernel_syms();
     reclaim_regions();          /* for pc: no accessing regions after this point */
@@ -352,8 +353,6 @@ void kernel_runtime_init(kernel_heaps kh)
     init_debug("init_interrupts");
     init_interrupts(kh);
 
-    init_debug("pci_discover (for VGA)");
-    pci_discover(); // early PCI discover to configure VGA console
     init_debug("clock");
     init_clock();
     init_debug("init_kernel_contexts");

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -503,6 +503,9 @@ void unregister_interrupt(int vector);
 u64 allocate_shirq(void);
 void register_shirq(int vector, thunk t, const char *name);
 
+boolean dev_irq_enable(u32 dev_id, int vector);
+void dev_irq_disable(u32 dev_id, int vector);
+
 static inline boolean in_interrupt(void)
 {
     return current_cpu()->state == cpu_interrupt;

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -426,6 +426,7 @@ static inline void schedule_timer_service(void)
 u64 init_bootstrap_heap(u64 phys_length);
 id_heap init_physical_id_heap(heap h);
 void init_kernel_heaps(void);
+void init_platform_devices(kernel_heaps kh);
 void init_cpuinfo_machine(cpuinfo ci, heap backed);
 void kernel_runtime_init(kernel_heaps kh);
 void read_kernel_syms(void);

--- a/src/kernel/pci.h
+++ b/src/kernel/pci.h
@@ -82,6 +82,8 @@ struct pci_dev {
     struct pci_bar msix_bar;
 };
 
+#define pci_dev_id(dev) ((dev->bus << 8) | (dev->slot << 3) | dev->function)
+
 void pci_cfgwrite(pci_dev dev, int reg, int bytes, u32 source);
 u32 pci_cfgread(pci_dev dev, int reg, int bytes);
 
@@ -146,6 +148,7 @@ static inline u8 pci_get_hdrtype(pci_dev dev)
 u64 pci_bar_size(pci_dev dev, u8 type, u8 flags, int bar);
 void pci_bar_init(pci_dev dev, struct pci_bar *b, int bar, bytes offset, bytes length);
 void pci_bar_deinit(struct pci_bar *b);
+void pci_platform_init(void);
 void pci_platform_init_bar(pci_dev dev, int bar);
 u64 pci_platform_allocate_msi(pci_dev dev, thunk h, const char *name, u32 *address, u32 *data);
 void pci_platform_deallocate_msi(pci_dev dev, u64 v);

--- a/src/riscv64/page_machine.h
+++ b/src/riscv64/page_machine.h
@@ -210,13 +210,6 @@ static inline boolean flags_has_minpage(u64 flags)
     return (flags & PAGE_NO_BLOCK) != 0;
 }
 
-static inline u64 canonize_address(u64 addr)
-{
-    if (addr & U64_FROM_BIT(47))
-        addr |= 0xffff000000000000;
-    return addr;
-}
-
 static inline boolean pte_is_dirty(pte entry)
 {
     return (entry & PAGE_DIRTY) != 0;

--- a/src/runtime/range.c
+++ b/src/runtime/range.c
@@ -1,5 +1,22 @@
 #include <runtime.h>
 
+/* Calculates the set difference between range a and range b, i.e. the sub-ranges of a that don't
+ * intersect with b. The result is returned in d1 and d2. */
+void range_difference(range a, range b, range *d1, range *d2)
+{
+    b = range_intersection(a, b);
+    if (range_span(b)) {
+        d1->start = a.start;
+        d1->end = b.start;
+        d2->start = b.end;
+        d2->end = a.end;
+    } else {
+        d1->start = a.start;
+        d1->end = a.end;
+        d2->start = d2->end = 0;
+    }
+}
+
 boolean rangemap_insert(rangemap rm, rmnode n)
 {
     init_rbnode(&n->n);

--- a/src/runtime/range.h
+++ b/src/runtime/range.h
@@ -103,6 +103,8 @@ static inline range range_intersection(range a, range b)
     return dest;
 }
 
+void range_difference(range a, range b, range *d1, range *d2);
+
 static inline u64 range_span(range r)
 {
     return r.end - r.start;

--- a/src/x86_64/page_machine.h
+++ b/src/x86_64/page_machine.h
@@ -168,13 +168,6 @@ static inline boolean flags_has_minpage(u64 flags)
     return (flags & PAGE_NO_PS) != 0;
 }
 
-static inline u64 canonize_address(u64 addr)
-{
-    if (addr & U64_FROM_BIT(47))
-        addr |= 0xffff000000000000;
-    return addr;
-}
-
 extern u64 pagebase;
 static inline u64 get_pagetable_base(u64 vaddr)
 {

--- a/src/x86_64/uefi.c
+++ b/src/x86_64/uefi.c
@@ -46,7 +46,7 @@ static void start_kernel(void *kern_entry)
     switch_stack((u64)INITIAL_MAP_SIZE - STACK_ALIGNMENT, START_FUNC_ADDR);
 }
 
-void uefi_arch_setup(heap general, heap aligned)
+void uefi_arch_setup(heap general, heap aligned, uefi_arch_options options)
 {
     uefi_heap = general;
     regions->type = 0;  /* initialize region area */
@@ -59,6 +59,7 @@ void uefi_arch_setup(heap general, heap aligned)
     pgdir = bootstrap_page_tables(region_allocator(general, PAGESIZE, REGION_INITIAL_PAGES));
     map(0, 0, INITIAL_MAP_SIZE, pageflags_writable(pageflags_exec(pageflags_memory())));
     map(PAGES_BASE, initial_pages, INITIAL_PAGES_SIZE, pageflags_writable(pageflags_memory()));
+    options->load_to_physical = false;
 }
 
 closure_function(1, 1, void, uefi_add_mem,

--- a/test/unit/range_test.c
+++ b/test/unit/range_test.c
@@ -136,6 +136,44 @@ boolean basic_test(heap h)
     return false;
 }
 
+static boolean range_diff_test(void)
+{
+    range a, b, d1, d2;
+    a.start = 10;
+    a.end = 20;
+    b.start = 9;
+    b.end = 10;
+    range_difference(a, b, &d1, &d2);
+    if ((d1.start != a.start) || (d1.end != a.end) || !range_empty(d2))
+        return false;
+    b.end = 12;
+    range_difference(a, b, &d1, &d2);
+    if (range_empty(d1)) {
+        if ((d2.start != b.end) || (d2.end != a.end))
+            return false;
+    } else {
+        if ((d1.start != b.end) || (d1.end != a.end) || !range_empty(d2))
+            return false;
+    }
+    b.start = 11;
+    range_difference(a, b, &d1, &d2);
+    if ((d1.start != a.start) || (d1.end != b.start) || (d2.start != b.end) || (d2.end != a.end))
+        return false;
+    b.end = 21;
+    range_difference(a, b, &d1, &d2);
+    if ((d1.start != a.start) || (d1.end != b.start) || !range_empty(d2))
+        return false;
+    b.start = 20;
+    range_difference(a, b, &d1, &d2);
+    if ((d1.start != a.start) || (d1.end != a.end) || !range_empty(d2))
+        return false;
+    b.start = 9;
+    range_difference(a, b, &d1, &d2);
+    if (!range_empty(d1) || !range_empty(d2))
+        return false;
+    return true;
+}
+
 int main(int argc, char **argv)
 {
     heap h = init_process_runtime();
@@ -143,10 +181,8 @@ int main(int argc, char **argv)
     if (!basic_test(h))
         goto fail;
 
-    /*
-      if (!random_test(h, 100, 1000))
-      goto fail;
-    */
+    if (!range_diff_test())
+        goto fail;
 
     msg_debug("range test passed\n");
     exit(EXIT_SUCCESS);


### PR DESCRIPTION
This change set implements a UEFI loader for aarch64. When the ENABLE_UEFI option is specified in the Makefile command line (as in `make PLATFORM=virt ENABLE_UEFI=1`), the resulting image contains a UEFI partition with the loader, which allows the image to boot on UEFI-based aarch64 machines.
The UEFI loader, before jumping to the kernel entry point, retrieves the physical memory map and the root pointer of the ACPI tables, and passes this information to the kernel, which uses it when creating the physical memory id heap and to retrieve platform-specific information for various peripherals from the ACPI tables.
The GIC driver has been enhanced to support MSI interrupts in the GICv3, which use the ITS (Interrupt Translation Service).
These changes allow running Nanos on AWS Graviton instances, which are aarch64-based machines with NVMe disks and ENA network adapters.