### PR TITLE
fix uninitialized variable in init_context(), refactor

### DIFF
--- a/src/aarch64/kernel_machine.c
+++ b/src/aarch64/kernel_machine.c
@@ -89,13 +89,8 @@ void psci_shutdown(void)
 
 #ifdef KERNEL
 #define EXTENDED_FRAME_SIZE (FRAME_EXTENDED_MAX * sizeof(u64))
-void init_context(context c, int type)
+void init_context_machine(context c)
 {
-    c->type = type;
-    c->transient_heap = 0;
-    c->waiting_on = 0;
-    c->active_cpu = -1;
-    zero_context_frame(c->frame);
     void *e = allocate_zero((heap)heap_page_backed(get_kernel_heaps()),
                             EXTENDED_FRAME_SIZE);
     assert(e != INVALID_ADDRESS);

--- a/src/x86_64/kernel_machine.c
+++ b/src/x86_64/kernel_machine.c
@@ -107,13 +107,8 @@ void init_cpuinfo_machine(cpuinfo ci, heap backed)
 }
 
 #ifdef KERNEL
-void init_context(context c, int type)
+void init_context_machine(context c)
 {
-    c->type = type;
-    c->transient_heap = 0;
-    c->waiting_on = 0;
-    c->active_cpu = -1;
-    zero_context_frame(c->frame);
     void *e = allocate_zero((heap)heap_page_backed(get_kernel_heaps()), extended_frame_size);
     assert(e != INVALID_ADDRESS);
     c->frame[FRAME_EXTENDED] = u64_from_pointer(e);


### PR DESCRIPTION
This fixes missing initialization of the context's next_waiter field and moves
init_context() to kernel.h. Per-architecture context initialization now occurs
in init_context_machine().

#1661