### PR TITLE
Add new mem_debug compile options and nohdr flag for mem_debug_backed; smp for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,13 +45,13 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install nasm qemu-system-x86 ent ruby rustc
       - run: cd .. && git clone git@github.com:nanovms/ops.git
-      - run: make MEMDEBUG=mcache
+      - run: make MEMDEBUG=all
       - run: curl https://ops.city/get.sh -sSfL | sh
       - run:
           command: |
             OPS_DIR=$HOME/.ops
             PATH=$HOME/.ops/bin:$PATH
-            make MEMDEBUG=mcache test-noaccel
+            make MEMDEBUG=all test-noaccel
 
   nightly-build:
     docker:

--- a/rules.mk
+++ b/rules.mk
@@ -114,6 +114,10 @@ KERNLDFLAGS=	--gc-sections -z max-page-size=4096 -L $(OUTDIR)/klib
 
 ifeq ($(MEMDEBUG),mcache)
 CFLAGS+= -DMEMDEBUG_MCACHE
+else ifeq ($(MEMDEBUG),backed)
+CFLAGS+= -DMEMDEBUG_BACKED
+else ifeq ($(MEMDEBUG),all)
+CFLAGS+= -DMEMDEBUG_ALL
 endif
 
 TARGET_ROOT=	$(NANOS_TARGET_ROOT)

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -65,7 +65,11 @@ void init_kernel_heaps(void)
     heaps.physical = init_physical_id_heap(&bootstrap);
     assert(heaps.physical != INVALID_ADDRESS);
 
+#if defined(MEMDEBUG_BACKED) || defined(MEMDEBUG_ALL)
+    heaps.linear_backed = mem_debug_backed(&bootstrap, allocate_linear_backed_heap(&bootstrap, heaps.physical), PAGESIZE_2M, true);
+#else
     heaps.linear_backed = allocate_linear_backed_heap(&bootstrap, heaps.physical);
+#endif
     assert(heaps.linear_backed != INVALID_ADDRESS);
 
     bytes pagesize = is_low_memory_machine(&heaps) ?

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -442,7 +442,7 @@ void msi_map_vector(int slot, int msislot, int vector);
 
 void syscall_enter(void);
 
-backed_heap mem_debug_backed(heap m, backed_heap bh, u64 padsize);
+backed_heap mem_debug_backed(heap m, backed_heap bh, u64 padsize, boolean nohdr);
 
 backed_heap allocate_page_backed_heap(heap meta, heap virtual, heap physical,
                                       u64 pagesize, boolean locking);

--- a/src/runtime/heap/mcache.c
+++ b/src/runtime/heap/mcache.c
@@ -294,7 +294,7 @@ heap allocate_mcache(heap meta, heap parent, int min_order, int max_order, bytes
 
     for(int i = 0, order = min_order; order <= max_order; i++, order++) {
 	u64 obj_size = U64_FROM_BIT(order);
-#if MEMDEBUG_MCACHE
+#if defined(MEMDEBUG_MCACHE) || defined(MEMDEBUG_ALL)
 	heap h = mem_debug_objcache(meta, parent, obj_size, pagesize);
 #else
 	heap h = allocate_objcache(meta, parent, obj_size, pagesize);

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -127,9 +127,9 @@ func testPackages(t *testing.T) {
 				tt.prebuild(t)
 			}
 			if tt.elf != "" {
-				execcmd = fmt.Sprintf("ops run %s -c config.json", tt.elf)
+				execcmd = fmt.Sprintf("ops run %s -c config.json --smp %d", tt.elf, runtime.NumCPU())
 			} else {
-				execcmd = fmt.Sprintf("ops pkg load %s -c config.json", tt.pkg)
+				execcmd = fmt.Sprintf("ops pkg load %s -c config.json --smp %d", tt.pkg, runtime.NumCPU())
 			}
 			p, buffer, err := AsyncCmdStart(execcmd)
 			defer KillProcess(p)


### PR DESCRIPTION
This change adds new convenience compile options to add a mem_debug wrapper to the linear
backed heap with MEMDEBUG=backed or MEMDEBUG=all. However, the linear backed heap uses
2MB pages, which would require 4MB additional memory for padding on each allocation. For
a non-trivial program this consumes too much memory, so mem_debug_backed has been
modified with a nohdr flag that does not allocate padding, forgoing allocation metadata and
overrun checks, leaving only the initialized and freed patterns checks since they require no
additional memory. The CI script has been modified to use MEMDEBUG=all.

The e2e.go program has also been modified to pass the number of host cpus to ops in
order to have smp testing for the e2e tests.