### PR TITLE
TFS: run flush completions asynchronously in kernel code

### DIFF
--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -477,7 +477,11 @@ static void run_flush_completions(log tl, status s)
     if (tl->flush_completions) {
         status_handler sh;
         vector_foreach(tl->flush_completions, sh)
+#ifdef KERNEL
+            async_apply_status_handler(sh, s);
+#else
             apply(sh, s);
+#endif
         vector_clear(tl->flush_completions);
     }
 }


### PR DESCRIPTION
run_flush_completions() in tfs/tlog.c is called with the TFS lock held. In the kernel code, one of the flush completions can trigger the following sequence of function calls: pagecache_sync_volume -> pagecache_scan -> pagecache_commit_dirty_pages -> filesystem_storage_write; the last function in this sequence tries to acquire the TFS lock, which results in a deadlock.
This change solves the above issue by invoking the TFS log flush completions asynchronously.