### PR TITLE
uname(2): derive nodename from either /etc/hostname or IP address

### DIFF
--- a/src/runtime/vector.h
+++ b/src/runtime/vector.h
@@ -90,7 +90,10 @@ static inline vector split(heap h, buffer source, char divider)
             push_character(each, i);
         }
     }
-    if (buffer_length(each) > 0)  vector_push(result, each);
+    if (buffer_length(each) > 0)
+        vector_push(result, each);
+    else
+        deallocate_buffer(each);
     return result;
 }
 
@@ -105,6 +108,15 @@ static inline buffer join(heap h, vector source, char between)
 }
 
 #define vector_foreach(__v, __i) for(u32 _i = 0, _len = vector_length(__v); _i< _len && (__i = vector_get(__v, _i), 1); _i++)
+
+static inline void split_dealloc(vector v)
+{
+    buffer b;
+    vector_foreach(v, b) {
+        deallocate_buffer(b);
+    }
+    deallocate_vector(v);
+}
 
 static inline void bitvector_set(buffer b, int position)
 {


### PR DESCRIPTION
With this change, the string placed in the `nodename` field of the struct passed to the uname syscall is derived from the contents of the /etc/hostname file, if present in the root filesystem, or from the IP address of the default network interface.
Using the IP address allows different instances created from the same image to have different host names, similarly to what happens with Linux instances in AWS or GCP.