### PR TITLE
Klibs: syslog improvements

### DIFF
--- a/klib/syslog.c
+++ b/klib/syslog.c
@@ -439,7 +439,10 @@ int init(status_handler complete)
     }
     if (syslog.server) {
         syslog_server_resolve();
-        syslog.program = get(root, sym(program));
+        tuple env = get_environment();
+        syslog.program = get(env, sym(IMAGE_NAME));
+        if (!syslog.program)
+            syslog.program = get(root, sym(program));
         syslog.max_hdr_len = 1 + sizeof(__XSTRING(SYSLOG_PRIORITY)) + sizeof(SYSLOG_VERSION) +
                 sizeof("YYYY-MM-ddThh:mm:ss.uuuuuuZ") + sizeof(syslog.local_ip) +
                 buffer_length(syslog.program) + 7;

--- a/klib/syslog.c
+++ b/klib/syslog.c
@@ -194,7 +194,7 @@ static void syslog_dns_failure(void)
 {
     if (syslog.dns_backoff == 0)
         syslog.dns_backoff = seconds(1);
-    else
+    else if (syslog.dns_backoff < seconds(60))
         syslog.dns_backoff *= 2;
     syslog.dns_req_next = kern_now(CLOCK_ID_MONOTONIC) + syslog.dns_backoff;
 }
@@ -239,10 +239,9 @@ static void syslog_set_hdr_len(void)
 
 static void syslog_udp_flush(void)
 {
-    if (ip_addr_isany_val(syslog.server_ip)) {
-        syslog_server_resolve();
+    syslog_server_resolve();
+    if (ip_addr_isany_val(syslog.server_ip))
         return;
-    }
     if (!syslog.hdr_len) {
         syslog_set_hdr_len();
         if (!syslog.hdr_len)


### PR DESCRIPTION
This PR contains miscellaneous improvements to the syslog klib:
- in case of failure to resolve the syslog server name, the backoff delay for retrying DNS resolution is limited to 1 minute, to prevent long delays before logs start to be shipped after a previously unresolvable server becomes resolvable
- the dns_gethostbyname() function is now called before sending syslog packets, even after the server name has been
successfully resolved, so that when the cached DNS entry expires a new DNS request will be sent and any changes to the server IP address will be observed
- if the IMAGE_NAME environment variable is present, it is used to populate the APP_NAME field in syslog messages, while
the program name is used as a fallback