### PR TITLE
Reorder mkfs debug_exit argument before image argument

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -277,7 +277,7 @@ ifeq ($(IMAGE),)
 endif
 	@ echo "MKFS	$@"
 	@ $(MKDIR) $(dir $(IMAGE))
-	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) $(IMAGE) -t "(debug_exit:t)"
+	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) -t "(debug_exit:t)" $(IMAGE)
 
 release: mkfs boot kernel
 	$(Q) $(RM) -r release


### PR DESCRIPTION
The BSD/OS X implementation of getopt stops processing at the first non-option
argument. The mkfs command had the debug_exit option specified after the image
and so that option was not getting processed by getopt, causing test failures on OS X
not to be registered. This change moves the debug_exit argument with the others
so that it will be processed.