### PR TITLE
use an MCS lock for mutex spinwaiters

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -33,6 +33,9 @@
 /* per-cpu queue */
 #define CPU_QUEUE_SIZE 512
 
+/* locking */
+#define MUTEX_ACQUIRE_SPIN_LIMIT (1ull << 20)
+
 /* could probably find progammatically via cpuid... */
 #define DEFAULT_CACHELINE_SIZE 64
 
@@ -78,4 +81,4 @@
 /* net parameters (not covered by lwipopts.h) */
 
 /* number of iterations to spin for lwip lock acquire before suspending context */
-#define LWIP_LOCK_SPIN_ITERATIONS (1ull << 12)
+#define LWIP_LOCK_SPIN_ITERATIONS (1ull << 16)

--- a/src/config.h
+++ b/src/config.h
@@ -74,3 +74,8 @@
 /* debug parameters */
 #define FRAME_TRACE_DEPTH 32
 #define STACK_TRACE_DEPTH 32
+
+/* net parameters (not covered by lwipopts.h) */
+
+/* number of iterations to spin for lwip lock acquire before suspending context */
+#define LWIP_LOCK_SPIN_ITERATIONS (1ull << 12)

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -148,6 +148,9 @@ cpuinfo init_cpuinfo(heap backed, int cpu)
     assert(ci->cpu_queue != INVALID_ADDRESS);
     ci->last_timer_update = 0;
     ci->frcount = 0;
+    ci->mcs_prev = 0;
+    ci->mcs_next = 0;
+    ci->mcs_waiting = false;
     init_cpuinfo_machine(ci, backed);
     return ci;
 }

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -65,7 +65,6 @@ static void kernel_context_resume(context c)
 static void kernel_context_schedule_return(context c)
 {
     kernel_context kc = (kernel_context)c;
-    assert(frame_is_full(kc->context.frame));
     assert(enqueue_irqsafe(runqueue, &kc->kernel_return));
 }
 
@@ -74,10 +73,10 @@ define_closure_function(1, 0, void, kernel_context_return,
 {
     kernel_context kc = bound(kc);
     context_frame f = kc->context.frame;
-    assert(f[FRAME_FULL]);
     context_switch(&kc->context);
     assert(kc->context.refcount.c > 1);
     context_release_refcount(&kc->context);
+    assert(frame_is_full(f));
     frame_return(f);
 }
 

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -284,6 +284,15 @@ static inline void context_schedule_return(context ctx)
     ctx->schedule_return(ctx);
 }
 
+static inline void context_reschedule(context ctx)
+{
+    context_debug("%s: suspend ctx %p, cpu %d\n", __func__, ctx, current_cpu()->id);
+    context_pre_suspend(ctx);
+    context_schedule_return(ctx);
+    context_suspend();
+    context_debug("%s: resume ctx %p, cpu %d\n", __func__, ctx, current_cpu()->id);
+}
+
 void __attribute__((noreturn)) context_switch_finish(context prev, context next, void *a, u64 arg0, u64 arg1);
 
 /* TODO: make into varargs / macro to avoid unneeded arg copies */

--- a/src/kernel/mutex.c
+++ b/src/kernel/mutex.c
@@ -2,7 +2,7 @@
 
 //#define MUTEX_DEBUG
 #ifdef MUTEX_DEBUG
-#define mutex_debug(x, ...) do {log_printf(" MTX", "%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#define mutex_debug(x, ...) do {log_printf(" MTX", "cpu %.2d %s: " x, ci->id, __func__, ##__VA_ARGS__);} while(0)
 #else
 #define mutex_debug(x, ...)
 #endif
@@ -14,31 +14,66 @@
 #endif
 
 /* This implements a two-phase mutex which optionally allows a degree for
-   spinning when aquiring the lock. A limitation of this is that the spinning
-   is only for an uncondended lock, and the waiter does not enter the queue of
-   waiters until the second phase (context suspend). As such, waiters for a
-   mutex are not strictly processed in FIFO order.
+   spinning when aquiring the lock. The spinning phase is implemented using a
+   cancelable MCS (Mellor-Crummey and Scott) lock, which allows only one spin
+   waiter to contend for the mutex at a time. After spinning the specified
+   number of times (m->spin_iterations), the cpuinfo is removed from the MCS,
+   and the corresponding context is added to the mutex's queue of waiters and
+   suspended. If the MCS lock is acquired, then the mutex itself is then
+   acquired (looped CAS on m->turn) and the MCS lock is released, passing
+   ownership to the next queued spinner, if there is one.
 
-   Linux uses an MCS lock for the first phase, but the unqueueing (removal)
-   operation is complex (yet necessary in order to migrate waiters into the
-   queue of suspended tasks). It may be worth implementing something similar
-   here, perhaps moreso for the lessened bus contention than the FIFO
-   property. */
+   On an unlock, the mutex is released by zeroing m->turn. This may allow the
+   current holder of the MCS lock, which is spinning while trying to acquire
+   m->turn, to proceed with taking the mutex. If there is a (suspended)
+   context waiting on the mutex, it is treated with equal priority to the MCS
+   owner and is scheduled to be resumed. The resumed context then spins to
+   acquire the mutex.
 
-static inline void mutex_acquired(mutex m, context ctx)
+   While MCS is relatively straightforward to implement, the ability to exit
+   the MCS queue - critical to prevent cores from spinning indefinitely - is a
+   somewhat delicate process that has been adapted from the optimistic spin
+   queue implementation in Linux by Peter Zijlstra, et al. */
+
+static inline cpuinfo mutex_get_next(mutex m, cpuinfo ci, cpuinfo prev)
 {
-    assert(!ctx->waiting_on);
-    assert(!m->turn);
-    m->turn = ctx;
+    do {
+        /* If we're removing ci from the list and it is the last item queued,
+           try to rewind tail to point to prev.
+
+           If we're unlocking ci and at the end of the list, then this is just
+           a simple removal. */
+        if (m->mcs_tail == ci &&
+            compare_and_swap_64((u64*)&m->mcs_tail, u64_from_pointer(ci),
+                                u64_from_pointer(prev)))
+            return 0;
+
+        /* If a spin waiter has latched onto us, exchange its next with
+           null. This is necessary to keep step A spinning until the node
+           being removed gets a new prev link. */
+        if (ci->mcs_next) {
+            cpuinfo next = pointer_from_u64(atomic_swap_64((u64*)&ci->mcs_next, 0));
+            if (next)
+                return next;
+        }
+        mutex_pause();
+    } while (1);
 }
 
-static inline boolean mutex_cas_take(mutex m, context ctx)
+static inline void mcs_unlock(mutex m, cpuinfo ci)
 {
-    boolean acquired = compare_and_swap_64((u64*)&m->waiters_tail, 0,
-                                           u64_from_pointer(ctx));
-    if (acquired)
-        mutex_acquired(m, ctx);
-    return acquired;
+    /* cover race between m->mcs_tail swap and write to ci->mcs_next */
+    if (compare_and_swap_64((u64*)&m->mcs_tail, u64_from_pointer(ci), 0))
+        return;        /* no successor */
+
+    /* atomic_swap_64 uses __ATOMIC_SEQ_CST; this is safe, though release
+       semantics would be sufficient here */
+    cpuinfo next = pointer_from_u64(atomic_swap_64((u64*)&ci->mcs_next, 0));
+    if (!next)
+        next = mutex_get_next(m, ci, 0);
+
+    if (next)
+        next->mcs_waiting = false;
 }
 
 static inline boolean mutex_lock_internal(mutex m, boolean wait)
@@ -46,8 +81,7 @@ static inline boolean mutex_lock_internal(mutex m, boolean wait)
     cpuinfo ci = current_cpu();
     context ctx = get_current_context(ci);
 
-    mutex_debug("cpu %d, mutex %p, wait %d, ra %p\n", ci->id, m, wait,
-                __builtin_return_address(0));
+    mutex_debug("mutex %p, wait %d, ra %p\n", m, wait, __builtin_return_address(0));
     mutex_debug("   ctx %p, turn %p\n", ctx, m->turn);
 
     /* not preemptable (could become option on allocate) */
@@ -55,29 +89,93 @@ static inline boolean mutex_lock_internal(mutex m, boolean wait)
         halt("%s: lock already held - cpu %d, mutex %p, ctx %p, ra %p\n", __func__,
              ci->id, m, ctx, __builtin_return_address(0));
 
-    assert(!ctx->next_waiter);
-    if (!wait)
-        return mutex_cas_take(m, ctx);
-
-    u64 spins_remain = m->spin_iterations;
-    while (spins_remain-- > 0) {
-        if (mutex_cas_take(m, ctx))
-            return true;
-        mutex_pause();
+    assert(!ctx->waiting_on);
+    if (!wait) {
+        boolean acquired = false;
+        if (compare_and_swap_64((u64*)&m->mcs_tail, 0, u64_from_pointer(ci))) {
+            acquired = compare_and_swap_64((u64*)&m->turn, 0, u64_from_pointer(ctx));
+            mcs_unlock(m, ci);
+        }
+        return acquired;
     }
 
     assert(!frame_is_full(ctx->frame));
+    boolean on_mcs = true;
+    ci->mcs_waiting = true;
+    cpuinfo prev = pointer_from_u64(atomic_swap_64((u64*)&m->mcs_tail,
+                                                   u64_from_pointer(ci)));
+    mutex_debug("   add ci %p to tail, prev %p\n", ci, prev);
+
+    if (!prev) {
+        ci->mcs_waiting = false;
+        goto acquire;
+    }
+
+    /* prev write must occur before next */
+    ci->mcs_prev = prev;
+    write_barrier();
+    prev->mcs_next = ci;
+
+    /* limited spin to acquire lock */
+    u64 spins_remain = m->spin_iterations;
+    while (spins_remain-- > 0) {
+        if (!ci->mcs_waiting)
+            goto acquire;
+        mutex_pause();
+    }
+    mutex_debug("   spin timeout; removing from MCS list\n");
+
+    /* spin timed out; extract waiter from list and block
+
+       step A: first undo the setting of prev->mcs_next (unless we are handed
+       the lock in the meantime), thus making prev spin wait in
+       mutex_get_next() for a valid next pointer */
+    while (prev->mcs_next != ci || !compare_and_swap_64((u64*)&prev->mcs_next,
+                                                        u64_from_pointer(ci), 0)) {
+        /* unlock might hand us the lock */
+        if (!ci->mcs_waiting) {
+            compiler_barrier(); /* load aquire */
+            goto acquire;
+        }
+        mutex_pause();
+
+        /* re-sample ci->mcs_prev as it may have been updated by a competing deletion */
+        prev = ci->mcs_prev;
+    }
+
+    /* step B: either wait for ci->mcs_next to be written or, if ci is at tail, rewind to prev */
+    cpuinfo next = mutex_get_next(m, ci, prev);
+    if (next) {
+        /* step C: next will spin wait on the null ci->mcs_next until we
+           update next->mcs_prev, and prev is spinning in mutex_get_next()
+           awaiting a valid next pointer - this completes the removal */
+        next->mcs_prev = prev;
+        prev->mcs_next = next;
+    }
+    ci->mcs_waiting = false;
+    on_mcs = false;
+
+    /* To cover the race where an unlock occurs between removal from MCS list
+       and insertion into waiters, attempt to grab the mutex under waiters_lock. */
+    mutex_debug("   removed; taking waiters_lock\n");
     ctx->waiting_on = m;
-    context prev_tail = pointer_from_u64(atomic_swap_64((u64*)&m->waiters_tail,
-                                                        u64_from_pointer(ctx)));
-    mutex_debug("   add ctx %p to tail, prev_tail %p\n", ctx, prev_tail);
-    if (!prev_tail) {
-        mutex_acquired(m, ctx);
+    spin_lock(&m->waiters_lock);
+    if (compare_and_swap_64((u64*)&m->turn, 0, u64_from_pointer(ctx))) {
+        ctx->waiting_on = 0;
+        mutex_debug("   mutex acquired; not suspending\n");
+        spin_unlock(&m->waiters_lock);
         return true;
     }
-    prev_tail->next_waiter = ctx;
+    mutex_debug("   inserting into waiters list and suspending\n");
+    list_insert_before(&m->waiters, &ctx->mutex_l);
+    spin_unlock(&m->waiters_lock);
     context_pre_suspend(ctx);
     context_suspend();
+  acquire:
+    while (!compare_and_swap_64((u64*)&m->turn, 0, u64_from_pointer(ctx)))
+        mutex_pause();
+    if (on_mcs)
+        mcs_unlock(m, ci);
     return true;
 }
 
@@ -95,23 +193,22 @@ void mutex_unlock(mutex m)
 {
     cpuinfo ci = current_cpu();
     context ctx = get_current_context(ci);
-    mutex_debug("cpu %d, mutex %p, ra %p\n", ci->id, m, __builtin_return_address(0));
-    mutex_debug("   ctx %p, next_waiter %p\n", ctx, ctx->next_waiter);
+    mutex_debug("mutex %p, ctx %p, ra %p\n", m, ctx, __builtin_return_address(0));
     assert(ctx == m->turn);
-    if (!ctx->next_waiter) {
-        /* cover race between m->waiters_tail swap and write to ctx->next_waiter */
-        m->turn = 0;
-        if (compare_and_swap_64((u64*)&m->waiters_tail, u64_from_pointer(ctx), 0))
-            return;        /* no successor */
+    m->turn = 0;
 
-        /* enqueue pending; spin until next waiter is set */
-        while (!ctx->next_waiter)
-            mutex_pause();
+    /* MCS owner can grab the mutex now, but we'll also schedule a waiter if we can. */
+    context next = 0;
+    spin_lock(&m->waiters_lock);
+    list l = list_get_next(&m->waiters);
+    if (l) {
+        list_delete(l);
+        next = struct_from_list(l, context, mutex_l);
     }
-
-    context next = ctx->next_waiter;
-    ctx->next_waiter = 0;
-    m->turn = next;
+    spin_unlock(&m->waiters_lock);
+    if (!next)
+        return;
+    mutex_debug("   dequeued context %p\n", next);
     assert(next->waiting_on == m);
     next->waiting_on = 0;
 
@@ -119,11 +216,11 @@ void mutex_unlock(mutex m)
     while (!frame_is_full(next->frame))
         kern_pause();
 
-    mutex_debug("scheduling return to %p, type %d\n", next, next->type);
+    mutex_debug("   scheduling return to %p, type %d\n", next, next->type);
     context_schedule_return(next);
 }
 
-mutex allocate_mutex(heap h, u64 depth, u64 spin_iterations)
+mutex allocate_mutex(heap h, u64 spin_iterations)
 {
     u64 msize = sizeof(struct mutex);
     mutex m = allocate(h, msize);
@@ -132,6 +229,8 @@ mutex allocate_mutex(heap h, u64 depth, u64 spin_iterations)
 
     m->spin_iterations = spin_iterations;
     m->turn = 0;
-    m->waiters_tail = 0;
+    m->mcs_tail = 0;
+    spin_lock_init(&m->waiters_lock);
+    list_init(&m->waiters);
     return m;
 }

--- a/src/kernel/mutex.h
+++ b/src/kernel/mutex.h
@@ -4,6 +4,8 @@ typedef struct mutex {
     void *mcs_tail;             /* cpuinfo */
     struct spinlock waiters_lock;
     struct list waiters;
+    u64 mcs_spinouts;           /* stats */
+    u64 acquire_spinouts;
 } *mutex;
 
 boolean mutex_try_lock(mutex ql);

--- a/src/kernel/mutex.h
+++ b/src/kernel/mutex.h
@@ -1,7 +1,9 @@
 typedef struct mutex {
     u64 spin_iterations;
     context turn;
-    context waiters_tail;
+    void *mcs_tail;             /* cpuinfo */
+    struct spinlock waiters_lock;
+    struct list waiters;
 } *mutex;
 
 boolean mutex_try_lock(mutex ql);
@@ -12,4 +14,4 @@ void mutex_unlock(mutex ql);
 
 #define mutex_is_acquired(m)    ((m)->turn == get_current_context(current_cpu()))
 
-mutex allocate_mutex(heap h, u64 depth, u64 spin_iterations);
+mutex allocate_mutex(heap h, u64 spin_iterations);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -344,9 +344,6 @@ void init_network_iface(tuple root) {
 
 extern void lwip_init();
 
-#define LWIP_LOCK_WAITER_QUEUE_DEPTH 64
-#define LWIP_LOCK_SPIN_ITERATIONS (1ull << 20)
-
 void init_net(kernel_heaps kh)
 {
     heap h = heap_general(kh);
@@ -354,7 +351,7 @@ void init_net(kernel_heaps kh)
     bytes pagesize = is_low_memory_machine(kh) ?
                      U64_FROM_BIT(MAX_LWIP_ALLOC_ORDER + 1) : PAGESIZE_2M;
     lwip_heap = allocate_mcache(h, backed, 5, MAX_LWIP_ALLOC_ORDER, pagesize);
-    lwip_mutex = allocate_mutex(h, LWIP_LOCK_WAITER_QUEUE_DEPTH, LWIP_LOCK_SPIN_ITERATIONS);
+    lwip_mutex = allocate_mutex(h, LWIP_LOCK_SPIN_ITERATIONS);
     assert(lwip_mutex != INVALID_ADDRESS);
     lwip_lock();
     lwip_init();

--- a/src/runtime/context.h
+++ b/src/runtime/context.h
@@ -16,8 +16,8 @@ struct context {
     void (*schedule_return)(struct context *);
     fault_handler fault_handler;
     heap transient_heap;
-    void *waiting_on;
-    void *next_waiter;
+    void *waiting_on;           /* should use tag types here */
+    struct list mutex_l;        /* mutex waiters */
     u32 active_cpu;
     u8 type;
 };

--- a/src/runtime/list.h
+++ b/src/runtime/list.h
@@ -14,6 +14,11 @@ static inline void list_init(struct list * head)
     head->prev = head->next = head;
 }
 
+static inline void list_init_member(struct list * p)
+{
+    p->prev = p->next = 0;
+}
+
 static inline boolean list_empty(struct list * head)
 {
 #ifndef KLIB

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2390,7 +2390,6 @@ static void syscall_context_schedule_return(context ctx)
     thread t = sc->t;
     assert(t);
     assert(t->syscall == sc); // XXX bringup
-    assert(frame_is_full(sc->context.frame));
     assert(enqueue_irqsafe(runqueue, &sc->syscall_return));
 }
 
@@ -2404,9 +2403,9 @@ define_closure_function(1, 0, void, syscall_context_return,
 {
     syscall_context sc = bound(sc);
     context_frame f = sc->context.frame;
-    assert(f[FRAME_FULL]);
     context_switch(&sc->context);
     context_release_refcount(&sc->context);
+    assert(frame_is_full(f));
     frame_return(f);
 }
 


### PR DESCRIPTION
This updates the two-phase mutex to use a cancelable MCS (Mellor-Crummey and
Scott) lock, which allows only one spin waiter to contend for the mutex at a
time. As before, a mutex lock operation will spin for only m->spin_iterations
before reverting to suspending the context. Before suspending, the cpuinfo is
removed from the MCS list, and the corresponding context is added to the
mutex's queue of waiters. (The waiters list is now a standard doubly-linked
list, protected by a spinlock within the mutex.) If the MCS lock was acquired
while spinning, the mutex itself is then taken and the MCS lock is released,
passing ownership to the next queued spinner, if there is one.

On an unlock, the mutex is released by zeroing m->turn. This may allow the
current holder of the MCS lock, which is spinning while trying to acquire
m->turn, to proceed with taking the mutex. If there is a (suspended) context
waiting on the mutex, it is treated with equal priority to the MCS owner and
is scheduled to be resumed. The resumed context then spins to acquire the
mutex.

While MCS is relatively straightforward to implement, the ability to exit the
MCS queue - critical to prevent cores from spinning indefinitely - is a
somewhat delicate process that has been adapted from the optimistic spin queue
implementation in Linux by Peter Zijlstra, et al.