### PR TITLE
Storage drivers: add scatter-gather I/O capability

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -17,8 +17,7 @@
 #include <pci.h>
 #include <xen_platform.h>
 #include <virtio/virtio.h>
-#include <vmware/storage.h>
-#include <vmware/vmxnet3.h>
+#include <vmware/vmware.h>
 #include "serial.h"
 
 #define BOOT_PARAM_OFFSET_E820_ENTRIES  0x01E8

--- a/src/drivers/ata-pci.c
+++ b/src/drivers/ata-pci.c
@@ -88,6 +88,7 @@ typedef struct ata_pci {
     closure_struct(ata_pci_io, read);
     closure_struct(ata_pci_io, write);
     block_io pio_read, pio_write;
+    closure_struct(storage_simple_req_handler, req_handler);
     closure_struct(ata_pci_irq, irq_handler);
     closure_struct(ata_pci_service, service);
     struct list reqs;
@@ -328,7 +329,8 @@ closure_function(3, 1, boolean, ata_pci_probe,
     assert(irq != INVALID_PHYSICAL);
     ioapic_set_int(ATA_IRQ(ATA_PRIMARY), irq);
     register_interrupt(irq, (thunk)&dev->irq_handler, "ata pci");
-    apply(bound(a), (block_io)&dev->read, (block_io)&dev->write, 0 /* TODO: flush */,
+    apply(bound(a),
+          storage_init_req_handler(&dev->req_handler, (block_io)&dev->read, (block_io)&dev->write),
           ata_get_capacity(dev->ata));
     return true;
 }

--- a/src/hyperv/storvsc/storvsc.c
+++ b/src/hyperv/storvsc/storvsc.c
@@ -37,6 +37,7 @@
 #include <kernel.h>
 #include <hyperv_internal.h>
 #include <hyperv.h>
+#include <storage.h>
 #include <vmbus.h>
 #include <net_system_structs.h>
 #include <virtio/scsi.h>
@@ -145,6 +146,7 @@ struct hv_storvsc_request {
 struct storvsc_softc {
     heap general;
     heap contiguous;                /* physically */
+    closure_struct(storage_simple_req_handler, req_handler);
 
     heap hcb_objcache;
     struct spinlock mem_lock;
@@ -730,7 +732,7 @@ closure_function(5, 0, void, storvsc_read_capacity_done,
 
     block_io in = closure(s->general, storvsc_read, s);
     block_io out = closure(s->general, storvsc_write, s);
-    apply(bound(a), in, out, 0 /* TODO: flush */, s->capacity);
+    apply(bound(a), storage_init_req_handler(&s->req_handler, in, out), s->capacity);
   out:
     closure_finish();
 }

--- a/src/kernel/log.h
+++ b/src/kernel/log.h
@@ -12,7 +12,7 @@ static inline void klog_print(const char *s)
     klog_write(s, runtime_strlen(s));
 }
 
-void klog_disk_setup(u64 disk_offset, block_io disk_read, block_io disk_write);
+void klog_disk_setup(u64 disk_offset, storage_req_handler req_handler);
 void klog_set_boot_id(u64 id);
 void klog_load(klog_dump dest, status_handler sh);
 void klog_save(int exit_code, status_handler sh);

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -48,7 +48,7 @@ struct _closure_common {
 
 #define closure_struct(__name, __field) struct _closure_##__name __field;
 
-#define closure_ref(__name, __var) struct _closure_##__name *__var = 0;
+#define closure_ref(__name, __var) struct _closure_##__name *__var
 
 #define __closure_struct_declare(nl, nr) CLOSURE_STRUCT_ ## nl ## _ ## nr
 #define __closure_function_declare(nl, nr) CLOSURE_DECLARE_FUNCS_ ## nl ## _ ## nr

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -213,8 +213,10 @@ typedef closure_type(connection_handler, input_buffer_handler, buffer_handler);
 typedef closure_type(value_handler, void, value);
 typedef closure_type(io_status_handler, void, status, bytes);
 typedef closure_type(block_io, void, void *, range, status_handler);
-typedef closure_type(block_flush, void, status_handler);
-typedef closure_type(storage_attach, void, block_io, block_io, block_flush, u64);
+
+struct storage_req;
+typedef closure_type(storage_req_handler, void, struct storage_req *);
+typedef closure_type(storage_attach, void, storage_req_handler, u64);
 
 #include <sg.h>
 

--- a/src/runtime/sg.c
+++ b/src/runtime/sg.c
@@ -38,6 +38,22 @@ static inline void sg_unlock(void)
 #define sg_unlock()
 #endif
 
+void sg_consume(sg_list sg, u64 length)
+{
+    sg_list_foreach(sg, sgb) {
+        if (length + sgb->offset >= sgb->size) {
+            sg_list_head_remove(sg);
+            length -= sg_buf_len(sgb);
+            sg_buf_release(sgb);
+            if (length == 0)
+                break;
+        } else {
+            sgb->offset += length;
+            break;
+        }
+    }
+}
+
 /* TODO clean up redundant parts of loop with macros or static closures */
 
 /* copy content of sg, up to length bytes, into target, releasing consumed buffers */

--- a/src/runtime/sg.c
+++ b/src/runtime/sg.c
@@ -49,7 +49,7 @@ u64 sg_copy_to_buf(void *target, sg_list sg, u64 n)
     sg_debug("%s: target %p, sg %p, length 0x%lx, count %ld\n", __func__, target, sg, length, sg->count);
     while (remain > 0 && (sgb = sg_list_head_peek(sg)) != INVALID_ADDRESS) {
         assert(sgb->size > sgb->offset); /* invariant: no null-length bufs */
-        u64 len = MIN(remain, sgb->size - sgb->offset);
+        u64 len = MIN(remain, sg_buf_len(sgb));
         runtime_memcpy(target, sgb->buf + sgb->offset, len);
         target += len;
         sgb->offset += len;
@@ -68,7 +68,7 @@ u64 sg_move(sg_list dest, sg_list src, u64 n)
     u64 remain = n;
     while (remain > 0 && (ssgb = sg_list_head_peek(src)) != INVALID_ADDRESS) {
         assert(ssgb->size > ssgb->offset);
-        u64 len = MIN(remain, ssgb->size - ssgb->offset);
+        u64 len = MIN(remain, sg_buf_len(ssgb));
         sg_buf dsgb = sg_list_tail_add(dest, len);
         dsgb->buf = ssgb->buf;
         dsgb->size = ssgb->offset + len;
@@ -91,7 +91,7 @@ u64 sg_zero_fill(sg_list sg, u64 n)
     u64 remain = n;
     while (remain > 0 && (sgb = sg_list_head_peek(sg)) != INVALID_ADDRESS) {
         assert(sgb->size > sgb->offset);
-        u64 len = MIN(remain, sgb->size - sgb->offset);
+        u64 len = MIN(remain, sg_buf_len(sgb));
         zero(sgb->buf + sgb->offset, len);
         sgb->offset += len;
         remain -= len;
@@ -113,7 +113,7 @@ u64 sg_copy_to_buf_and_release(void *target, sg_list sg, u64 n)
     sg_debug("%s: target %p, sg %p, limit 0x%lx, count %ld\n", __func__, target, sg, limit, sg->count);
     while ((sgb = sg_list_head_remove(sg)) != INVALID_ADDRESS) {
         assert(sgb->size > sgb->offset);
-        u64 len = MIN(remain, sgb->size - sgb->offset);
+        u64 len = MIN(remain, sg_buf_len(sgb));
         if (len > 0) {
             runtime_memcpy(target, sgb->buf, len);
             target += len;

--- a/src/runtime/sg.h
+++ b/src/runtime/sg.h
@@ -60,6 +60,9 @@ static inline sg_buf sg_list_head_remove(sg_list sg)
     return sgb;
 }
 
+#define sg_list_foreach(sg, sgb) \
+    for (sg_buf sgb = buffer_ref((sg)->b, 0); sgb != buffer_end((sg)->b); sgb++)
+
 static inline u32 sg_buf_len(sg_buf sgb)
 {
     return sgb->size - sgb->offset;
@@ -82,6 +85,7 @@ static inline void sg_list_release(sg_list sg)
 sg_list allocate_sg_list(void);
 void deallocate_sg_list(sg_list sg);
 void init_sg(heap h);
+void sg_consume(sg_list sg, u64 length);
 u64 sg_copy_to_buf(void *target, sg_list sg, u64 length);
 u64 sg_copy_to_buf_and_release(void *dest, sg_list src, u64 limit);
 u64 sg_move(sg_list dest, sg_list src, u64 n);

--- a/src/runtime/sg.h
+++ b/src/runtime/sg.h
@@ -60,6 +60,11 @@ static inline sg_buf sg_list_head_remove(sg_list sg)
     return sgb;
 }
 
+static inline u32 sg_buf_len(sg_buf sgb)
+{
+    return sgb->size - sgb->offset;
+}
+
 static inline void sg_buf_release(sg_buf sgb)
 {
     if (sgb->refcount)

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -27,9 +27,8 @@ void filesystem_get_uuid(filesystem fs, u8 *uuid);
 void create_filesystem(heap h,
                        u64 blocksize,
                        u64 size,
-                       block_io read,
-                       block_io write,
-                       block_flush flush,
+                       storage_req_handler req_handler,
+                       boolean ro,
                        const char *label,
                        filesystem_complete complete);
 void destroy_filesystem(filesystem fs);

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -44,9 +44,8 @@ typedef struct filesystem {
     closure_type(log, void, tuple);
     heap dma;
     void *zero_page;
-    block_io r;
-    block_io w;
-    block_flush flush;
+    storage_req_handler req_handler;
+    boolean ro; /* true for read-only filesystem */
     pagecache_volume pv;
     log tl;
     log temp_log;
@@ -82,7 +81,7 @@ typedef struct uninited_queued_op {
     sg_list sg;
     merge m;
     range blocks;
-    block_io op;
+    boolean write;
 } *uninited_queued_op;
 
 declare_closure_struct(2, 0, void, free_uninited,
@@ -124,7 +123,8 @@ void flush(filesystem fs, status_handler);
 u64 filesystem_allocate_storage(filesystem fs, u64 nblocks);
 boolean filesystem_reserve_storage(filesystem fs, range storage_blocks);
 boolean filesystem_free_storage(filesystem fs, range storage_blocks);
-void filesystem_storage_op(filesystem fs, sg_list sg, merge m, range blocks, block_io op);
+void filesystem_storage_op(filesystem fs, sg_list sg, range blocks, boolean write,
+                           status_handler completion);
     
 void filesystem_log_rebuild(filesystem fs, log new_tl, status_handler sh);
 void filesystem_log_rebuild_done(filesystem fs, log new_tl);

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -1094,7 +1094,7 @@ sysreturn io_uring_enter(int fd, unsigned int to_submit,
         rv = -EFAULT;
         goto out;
     }
-    closure_ref(iour_getevents_bh, bh);
+    closure_ref(iour_getevents_bh, bh) = 0;
     if (flags & IORING_ENTER_GETEVENTS) {
         contextual_closure_alloc(iour_getevents_bh, bh);
         if (bh == INVALID_ADDRESS) {

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -420,7 +420,7 @@ closure_function(9, 2, void, sendfile_bh,
     /* issue next write */
     assert(bound(cur_buf));
     void *buf = bound(cur_buf)->buf + bound(cur_buf)->offset;
-    u32 n = bound(cur_buf)->size - bound(cur_buf)->offset;
+    u32 n = sg_buf_len(bound(cur_buf));
     thread_log(t, "   writing %d bytes from %p", rv, n, buf);
     apply(bound(out)->write, buf, n, 0, t, true, (io_completion)closure_self());
     return;

--- a/src/vmware/vmware.h
+++ b/src/vmware/vmware.h
@@ -1,1 +1,2 @@
 void init_pvscsi(kernel_heaps kh, storage_attach a);
+void init_vmxnet3_network(kernel_heaps kh);

--- a/src/vmware/vmxnet3.h
+++ b/src/vmware/vmxnet3.h
@@ -1,1 +1,0 @@
-void init_vmxnet3_network(kernel_heaps kh);

--- a/src/vmware/vmxnet3_net.c
+++ b/src/vmware/vmxnet3_net.c
@@ -11,7 +11,7 @@
 #include "lwip/dhcp.h"
 #include <pci.h>
 #include "netif/ethernet.h"
-#include "vmxnet3.h"
+#include "vmware.h"
 #include "vmxnet3_queue.h"
 #include "vmxnet3_net.h"
 


### PR DESCRIPTION
This PR changes the interface between storage drivers and the rest of the kernel so that all storage requests are made via a single storage_req_handler closure, whose function takes a storage_req structure containing the parameters for the request being issued. Among these parameters there is an opcode indicating the request type; the STORAGE_OP_READSG and STORAGE_OP_WRITESG opcodes are used for scatter-gather I/O.
This PR implements scatter-gather I/O in the virtIO block and virtIO SCSI drivers, while the remaining storage drivers use a generic helper function that maps a given request to the existing read and write block_io closures.

With this change, average read speed values for a bulk read test program changed from 113 to 283 MB/s. Test conditions: reading 4 files large 128 MB each, with read requests of 128 KB each, running on qemu (virtio-scsi disk device), with file contents not cached in the guest RAM, but with the relevant parts of the img file cached in the host RAM.

The page cache code has been changed in order to minimize the number of filesystem read requests, by grouping adjacent pages in a single request. This allows taking advantage of scatter-gather I/O support in disk drivers.