### PR TITLE
Add support for SIGILL and SIGTRAP; correct tid handling and sigframe overflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ test test-noaccel: image
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws inotify io_uring klibs mkdir mmap netlink netsock pipe readv rename sendfile signal socketpair syslog time unlink thread_test tlbshootdown tun unixsocket vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws inotify io_uring klibs mkdir mmap netlink netsock pipe readv rename sendfile signal sigoverflow socketpair syslog time unlink thread_test tlbshootdown tun unixsocket vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -150,6 +150,10 @@ void vm_exit(u8 code)
     if (root) {
         if (get(root, sym(reboot_on_exit)))
             triple_fault();
+        u64 expected_code;
+        if (get_u64(root, sym(expected_exit_code), &expected_code) &&
+                expected_code == code)
+            code = 0;
         if (get(root, sym(debug_exit)))
             goto debug_exit;
     }

--- a/src/aarch64/interrupt.c
+++ b/src/aarch64/interrupt.c
@@ -166,6 +166,9 @@ void dump_context(context ctx)
             rputs(str);
         }
         break;
+    case ESR_EC_BRK:
+        rputs(" brk");
+        break;
     default:
         rputs(" illegal ec: ");
         print_u64(esr_ec);

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -45,6 +45,7 @@
 #define ESR_EC_DATA_ABRT      0x25
 #define ESR_EC_SP_ALIGN_FAULT 0x26
 #define ESR_EC_SERROR_INT     0x2f
+#define ESR_EC_BRK            0x3c
 
 #define ESR_IL        U64_FROM_BIT(25)
 #define ESR_ISS_BITS  25
@@ -327,6 +328,24 @@ static inline boolean is_write_fault(context_frame f)
 static inline boolean is_div_by_zero(context_frame f)
 {
     return false; // XXX not on arm / fp only?
+}
+
+static inline boolean is_breakpoint(context_frame f)
+{
+    u64 esr = esr_from_frame(f);
+    u32 ec = field_from_u64(esr, ESR_EC);
+    if (ec == ESR_EC_BRK)
+        return true;
+    return false;
+}
+
+static inline boolean is_illegal_instruction(context_frame f)
+{
+    u64 esr = esr_from_frame(f);
+    u32 ec = field_from_u64(esr, ESR_EC);
+    if (ec == ESR_EC_UNKNOWN)
+        return true;
+    return false;
 }
 
 static inline boolean frame_is_full(context_frame f)

--- a/src/boot/uefi.c
+++ b/src/boot/uefi.c
@@ -89,7 +89,7 @@ u64 random_u64()
     }
 }
 
-void halt(char *format, ...)
+void halt_with_code(u8 code, char *format, ...)
 {
     vlist a;
     buffer b = little_stack_buffer(512);

--- a/src/kernel/kvm_platform.c
+++ b/src/kernel/kvm_platform.c
@@ -18,7 +18,7 @@
 #define KVM_MSR_SYSTEM_TIME 0x4b564d01
 #define KVM_MSR_WALL_CLOCK  0x4b564d00
 
-void halt(char *format, ...)
+void halt_with_code(u8 code, char *format, ...)
 {
     vlist a;
     buffer b = little_stack_buffer(512);
@@ -26,7 +26,7 @@ void halt(char *format, ...)
     vstart(a, format);
     vbprintf(b, alloca_wrap_cstring(format), &a);
     buffer_print(b);
-    kernel_shutdown(VM_EXIT_HALT);
+    kernel_shutdown(code);
 }
 
 static boolean probe_kvm_pvclock(kernel_heaps kh)

--- a/src/riscv64/kernel_machine.h
+++ b/src/riscv64/kernel_machine.h
@@ -237,6 +237,16 @@ static inline boolean is_div_by_zero(context_frame f)
     return false; // riscv has no div by zero exception, software must check
 }
 
+static inline boolean is_breakpoint(context_frame f)
+{
+    return SCAUSE_CODE(f[FRAME_CAUSE]) == TRAP_E_BREAKPOINT;
+}
+
+static inline boolean is_illegal_instruction(context_frame f)
+{
+    return SCAUSE_CODE(f[FRAME_CAUSE]) == TRAP_E_ILLEGAL_INST;
+}
+
 static inline boolean frame_is_full(context_frame f)
 {
     return f[FRAME_FULL];

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -33,11 +33,13 @@ void console_write(const char *s, bytes count);
 
 void print_u64(u64 s);
 
+#define VM_EXIT_SIGNAL(x) (x)
 #define VM_EXIT_GDB 0x7d
 #define VM_EXIT_FAULT 0x7e
 #define VM_EXIT_HALT 0x7f
 
-void halt(char *format, ...) __attribute__((noreturn));
+#define halt(fmt, ...) halt_with_code(VM_EXIT_HALT, fmt, ##__VA_ARGS__)
+void halt_with_code(u8 code, char *format, ...) __attribute__((noreturn));
 void kernel_shutdown(int status) __attribute__((noreturn));
 void vm_exit(u8 code) __attribute__((noreturn));
 void print_frame_trace_from_here();

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -224,7 +224,7 @@ process exec_elf(buffer ex, process kp)
     tuple root = kp->process_root;
     filesystem fs = kp->root_fs;
     process proc = create_process(uh, root, fs);
-    thread t = create_thread(proc);
+    thread t = create_thread(proc, proc->pid);
     tuple interp = 0;
     Elf64_Ehdr *e = (Elf64_Ehdr *)buffer_ref(ex, 0);
     boolean aslr = get(root, sym(noaslr)) == 0;

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -1069,7 +1069,7 @@ static void default_signal_action(thread t, queued_signal qs)
     }
     dump_sig_info(t, qs);
     thread_log(t, fate);
-    halt(fate);
+    halt_with_code(VM_EXIT_SIGNAL(signum), fate);
 }
 
 boolean dispatch_signals(thread t)

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -282,12 +282,13 @@ void deliver_signal_to_thread(thread t, struct siginfo *info)
 {
     int sig = info->si_signo;
     sig_debug("tid %d, sig %d\n", t->tid, sig);
-    if ((sig != SIGSEGV && sig != SIGKILL && sig != SIGSTOP && sig != SIGFPE) &&
+    if ((sig != SIGSEGV && sig != SIGKILL && sig != SIGSTOP && sig != SIGFPE && sig != SIGILL) &&
         sig_is_ignored(t->p, sig)) {
         sig_debug("signal ignored; no queue\n");
         return;
     }
 
+    assert(t && t != INVALID_ADDRESS);
     /* queue to thread for delivery */
     deliver_signal(&t->signals, info);
     sig_debug("... pending now 0x%lx\n", sigstate_get_pending(&t->signals));
@@ -335,6 +336,7 @@ void deliver_signal_to_process(process p, struct siginfo *info)
 {
     int sig = info->si_signo;
     u64 sigword = mask_from_sig(sig);
+    assert(p && p != INVALID_ADDRESS);
     sig_debug("pid %d, sig %d\n", p->pid, sig);
     if (sig_is_ignored(p, sig)) {
         sig_debug("signal ignored; no queue\n");

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -377,6 +377,24 @@ struct rusage {
 #define FPE_FLTSUB 8 /* Subscript out of range */
 #define NSIGFPE 8
 
+/*
+ * SIGILL si_codes
+ */
+#define ILL_ILLOPC 1 /* Illegal opcode */
+#define ILL_ILLOPN 2 /* Illegal operand */
+#define ILL_ILLADR 3 /* Illegal addressing mode */
+#define ILL_ILLTRP 4 /* Illegal trap */
+#define ILL_PRVOPC 5 /* Privileged opcode */
+#define ILL_PRVREG 6 /* Privileged register */
+#define ILL_COPROC 7 /* Coprocessor error */
+#define ILL_BADSTK 8 /* Internal stack error */
+
+/*
+ * SIGTRAP si_codes
+ */
+#define TRAP_BRKPT 1 /* Process breakpoint */
+#define TRAP_TRACE 2 /* Process trace trap */
+
 typedef union sigval {
     s32 sival_int;
     void * sival_ptr;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -472,7 +472,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
 
     u_heap = uh;
     uh->kh = *kh;
-    uh->processes = create_id_heap(h, h, 1, 65535, 1, false);
+    uh->processes = locking_heap_wrapper(h, (heap)create_id_heap(h, h, 1, 65535, 1, false));
     uh->file_cache = locking_heap_wrapper(h,
         allocate_objcache(h, (heap)heap_linear_backed(kh), sizeof(struct file), PAGESIZE));
     if (uh->file_cache == INVALID_ADDRESS)
@@ -490,7 +490,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
         goto alloc_fail;
 #endif
     process kernel_process = create_process(uh, root, fs);
-    dummy_thread = create_thread(kernel_process);
+    dummy_thread = create_thread(kernel_process, kernel_process->pid);
     runtime_memcpy(dummy_thread->name, "dummy_thread",
         sizeof(dummy_thread->name));
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -109,7 +109,6 @@ void deliver_fault_signal(u32 signo, thread t, u64 vaddr, s32 si_code)
     };
 
     char *signame = "SIGSEGV";
-    assert(signo == SIGSEGV || signo == SIGBUS || signo == SIGFPE);
     switch (signo) {
     case SIGSEGV:
         signame = "SIGSEGV";
@@ -120,6 +119,14 @@ void deliver_fault_signal(u32 signo, thread t, u64 vaddr, s32 si_code)
     case SIGFPE:
         signame = "SIGFPE";
         break;
+    case SIGILL:
+        signame = "SIGILL";
+        break;
+    case SIGTRAP:
+        signame = "SIGTRAP";
+        break;
+    default:
+        halt("%s: unexpected signal number %d\n", __func__, signo);
     }
     pf_debug("delivering %s to thread %d; vaddr 0x%lx si_code %d", signame,
         t->tid, vaddr, si_code);
@@ -200,6 +207,26 @@ define_closure_function(1, 1, context, unix_fault_handler,
             return 0;
         } else {
             errmsg = "Divide by zero occurs in kernel mode";
+            goto bug;
+        }
+    } else if (is_illegal_instruction(ctx->frame)) {
+        if (current_cpu()->state == cpu_user) {
+            pf_debug("invalid opcode fault in user mode, rip 0x%lx", ctx->frame[SYSCALL_FRAME_PC]);
+            deliver_fault_signal(SIGILL, t, vaddr, ILL_ILLOPC);
+            schedule_thread(t);
+            return 0;
+        } else {
+            errmsg = "Illegal instruction in kernel mode";
+            goto bug;
+        }
+    } else if (is_breakpoint(ctx->frame)) {
+        if (current_cpu()->state == cpu_user) {
+            pf_debug("breakpoint in user mode, rip 0x%lx", ctx->frame[SYSCALL_FRAME_PC]);
+            deliver_fault_signal(SIGTRAP, t, vaddr, TRAP_BRKPT);
+            schedule_thread(t);
+            return 0;
+        } else {
+            errmsg = "Breakpoint in kernel mode";
             goto bug;
         }
     } else if (is_page_fault(ctx->frame)) {

--- a/src/unix/unix.h
+++ b/src/unix/unix.h
@@ -6,7 +6,7 @@ typedef struct thread *thread;
 process init_unix(kernel_heaps kh, tuple root, filesystem fs);
 process create_process(unix_heaps uh, tuple root, filesystem fs);
 void process_get_cwd(process p, filesystem *cwd_fs, inode *cwd);
-thread create_thread(process p);
+thread create_thread(process p, u64 tid);
 process exec_elf(buffer ex, process kernel_process);
 
 void dump_mem_stats(buffer b);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -685,6 +685,13 @@ static inline boolean validate_user_memory(const void *p, bytes length, boolean 
     return v < USER_LIMIT - length;
 }
 
+static inline u64 grow_and_validate_stack(thread t, u64 sp, u64 size)
+{
+    if (!validate_user_memory_permissions(t->p, pointer_from_u64(sp - size), size, VMAP_FLAG_WRITABLE, 0))
+        return INVALID_PHYSICAL;
+    return sp - size;
+}
+
 static inline u64 get_aslr_offset(u64 range)
 {
     assert((range & (range - 1)) == 0);
@@ -758,7 +765,7 @@ void threads_to_vector(process p, vector v);
 
 /* machine-specific signal dispatch */
 struct rt_sigframe *get_rt_sigframe(thread t);
-void setup_sigframe(thread t, int signum, struct siginfo *si);
+boolean setup_sigframe(thread t, int signum, struct siginfo *si);
 void restore_ucontext(struct ucontext * uctx, thread t);
 
 void _register_syscall(struct syscall *m, int n, sysreturn (*f)(), const char *name);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -60,7 +60,7 @@ boolean netsyscall_init(unix_heaps uh, tuple cfg);
 typedef struct process *process;
 typedef struct thread *thread;
 
-thread create_thread(process);
+thread create_thread(process, u64 tid);
 void exit_thread(thread);
 
 declare_closure_struct(3, 0, void, free_syscall_context,
@@ -145,7 +145,7 @@ typedef struct unix_heaps {
 #endif
 
     /* id heaps */
-    id_heap processes;
+    heap processes;
 } *unix_heaps;
 
 #define BLOCKQ_ACTION_BLOCKED  1

--- a/src/unix_process/unix_process_runtime.c
+++ b/src/unix_process/unix_process_runtime.c
@@ -100,7 +100,7 @@ heap malloc_allocator()
     return h;
 }
 
-void halt(char *format, ...)
+void halt_with_code(u8 code, char *format, ...)
 {
     buffer z = little_stack_buffer(500);
     vlist a;

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -107,6 +107,8 @@ static void __attribute__((noinline)) write_idt(int interrupt, u64 offset, u64 i
     u64 type_attr = 0x8e;
     u64 *target = idt_from_interrupt(interrupt);
 
+    if (interrupt == 3)
+        type_attr = 0xee; /* allow int3 from cpl 3 */
     target[0] = ((selector << 16) | (offset & MASK(16)) | /* 31 - 0 */
                  (((offset >> 16) & MASK(16)) << 48) | (type_attr << 40) | (ist << 32)); /* 63 - 32 */
     target[1] = offset >> 32;   /*  95 - 64 */

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -390,6 +390,16 @@ static inline boolean is_div_by_zero(context_frame f)
     return f[FRAME_VECTOR] == 0; // XXX defined somewhere?
 }
 
+static inline boolean is_breakpoint(context_frame f)
+{
+    return f[FRAME_VECTOR] == 3;
+}
+
+static inline boolean is_illegal_instruction(context_frame f)
+{
+    return f[FRAME_VECTOR] == 6;
+}
+
 static inline void *frame_get_stack(context_frame f)
 {
     return pointer_from_u64(f[FRAME_RSP]);

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -31,6 +31,7 @@ PROGRAMS= \
 	readv \
 	rename \
 	sendfile \
+	sigoverflow \
 	signal \
 	socketpair \
 	symlink \
@@ -188,6 +189,13 @@ LDFLAGS-rename=		-static
 
 SRCS-sendfile=		$(CURDIR)/sendfile.c
 LDFLAGS-sendfile=	-static
+
+SRCS-sigoverflow= \
+	$(CURDIR)/sigoverflow.c \
+	$(SRCDIR)/unix_process/unix_process_runtime.c \
+	$(RUNTIME)
+LDFLAGS-sigoverflow=	-static
+LIBS-sigoverflow=	-lpthread
 
 SRCS-signal= \
 	$(CURDIR)/signal.c \

--- a/test/runtime/sigoverflow.c
+++ b/test/runtime/sigoverflow.c
@@ -1,0 +1,42 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <signal.h>
+#include <assert.h>
+#include <pthread.h>
+
+void handler(int signo)
+{
+    switch (signo) {
+    case SIGUSR1:
+        break;
+    case SIGABRT:
+        break;
+    default:
+        break;
+    }
+    abort();
+}
+
+void *thread(void *a)
+{
+    usleep(1000*1000);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    pthread_t pt;
+
+    setbuf(stdout, NULL);
+    printf("expecting signal stack overflow to segfault...\n");
+    pid_t pid = getpid();
+    pthread_create(&pt, NULL, thread, 0);
+    assert(signal(SIGUSR1, handler) != SIG_ERR);
+    assert(signal(SIGABRT, handler) != SIG_ERR);
+    kill(pid, SIGUSR1);
+    pthread_join(pt, 0);
+    return 0;
+}
+

--- a/test/runtime/sigoverflow.manifest
+++ b/test/runtime/sigoverflow.manifest
@@ -1,0 +1,16 @@
+(
+    children:(
+              #user program
+	      sigoverflow:(contents:(host:output/test/runtime/bin/sigoverflow))
+	      )
+    # filesystem path to elf for kernel to run
+    program:/sigoverflow
+#    trace:t
+#    debugsyscalls:t
+#    futex_trace:t
+#    fault:t
+    arguments:[test]
+    environment:(USER:bobby PWD:/)
+    # expect to segfault
+    expected_exit_code:11
+)


### PR DESCRIPTION
This PR adds detection and handling for signal frame overflow and also corrects tid handling, which should
share the same namespace as pids. The first thread in a process should have its id match the pid.
This also adds support for the SIGILL and SIGTRAP signals which can be used in exception handling
in user programs. Runtime tests have also been added for the new signals and for the signal frame
overflow.