### PR TITLE
Miscellaneous changes to silence new gcc warnings

### DIFF
--- a/src/hyperv/utilities/vmbus_ic.c
+++ b/src/hyperv/utilities/vmbus_ic.c
@@ -99,6 +99,7 @@ vmbus_ic_negomsg(struct vmbus_ic_softc *sc, void *data, int *dlen0,
 	 * Fine the best match message version.
 	 */
 	has_msg_ver = false;
+	sel_msg_ver = 0;
 	for (i = nego->ic_fwver_cnt;
 	    i < nego->ic_fwver_cnt + nego->ic_msgver_cnt; ++i) {
 		if (VMBUS_ICVER_LE(nego->ic_ver[i], msg_ver)) {

--- a/test/runtime/thread_test.c
+++ b/test/runtime/thread_test.c
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
         locks[i] = create_pipelock(1);
     pthread_create(&term , 0, terminus, locks[npipes-1]);
     for (int i = 0; i < nthreads; i ++)  {
-        loopy_activation_record a = malloc(sizeof (loopy_activation_record));
+        loopy_activation_record a = malloc(sizeof (struct loopy_activation_record));
         a->p = locks+i;
         a->id = i;
         int r = pthread_create(threads + i , 0, loopy, a);


### PR DESCRIPTION
New versions of gcc cause two new static analysis warnings which cause build
failures. One is an error in allocation size and the other is an uninitialized
variable.