### PR TITLE
SMP optimization

### DIFF
--- a/src/aarch64/uefi.c
+++ b/src/aarch64/uefi.c
@@ -29,9 +29,10 @@ void uefi_start_kernel(void *image_handle, efi_system_table system_table, buffer
     start(0, u64_from_pointer(&boot_params));
 }
 
-void map_with_complete(u64 v, physical p, u64 length, pageflags flags, status_handler complete)
+physical map_with_complete(u64 v, physical p, u64 length, pageflags flags, status_handler complete)
 {
     /* Mapping is not needed, since the MMU is disabled before starting the kernel. */
     if (complete)
         apply(complete, STATUS_OK);
+    return p;
 }

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -245,10 +245,11 @@ static inline void __attribute__((always_inline)) context_acquire(context ctx, c
     context_debug("%s: ctx %p, cpu %d\n", __func__, ctx, ci->id);
     assert(ctx->active_cpu != ci->id);
     u64 remain = CONTEXT_RESUME_SPIN_LIMIT;
-    while (!compare_and_swap_32(&ctx->active_cpu, -1u, ci->id)) {
+    while (ctx->active_cpu != -1u) {
         kern_pause();
         assert(remain-- > 0);
     }
+    ctx->active_cpu = ci->id;
     context_debug("%s: ctx %p, cpu %d acquired\n", __func__, ctx, ci->id);
 }
 

--- a/src/kernel/page.h
+++ b/src/kernel/page.h
@@ -19,7 +19,7 @@ void page_invalidate_sync(flush_entry f, status_handler completion);
 void page_invalidate_flush();
 
 /* mapping and flag update */
-void map_with_complete(u64 virtual, physical p, u64 length, pageflags flags, status_handler complete);
+physical map_with_complete(u64 v, physical p, u64 length, pageflags flags, status_handler complete);
 
 static inline void map(u64 v, physical p, u64 length, pageflags flags)
 {

--- a/src/x86_64/flush.c
+++ b/src/x86_64/flush.c
@@ -90,7 +90,7 @@ void page_invalidate_flush(void)
 
 void page_invalidate(flush_entry f, u64 p)
 {
-    if (initialized) {
+    if (f && initialized) {
         if (f->flush)
             return;
         f->pages[f->npages++] = p;

--- a/src/x86_64/lock.h
+++ b/src/x86_64/lock.h
@@ -10,7 +10,8 @@ static inline boolean spin_try(spinlock l) {
 
 static inline void spin_lock(spinlock l) {
     u64 tmp = 1;
-    asm volatile("1: lock xchg %0, %1; cmp $1, %1; jne 2f; pause; jmp 1b; 2:" : "+m"(*&l->w), "+r"(tmp) :: "memory");
+    asm volatile("1: cmp %0, %1; jne 2f; pause; jmp 1b; 2: lock xchg %0, %1; cmp $1, %1; je 1b" :
+                 "+m"(*&l->w), "+r"(tmp) :: "memory");
 }
 
 static inline void spin_unlock(spinlock l) {


### PR DESCRIPTION
This PR contains a few changes to improve kernel performance when running on instances with a high vCPU count:
- avoid repeated execution of atomic instructions
- avoid unneeded TLB shootdowns