### PR TITLE
Use readv/writev in tools for broader compatibility

### DIFF
--- a/tools/dump.c
+++ b/tools/dump.c
@@ -34,6 +34,7 @@ closure_function(2, 1, void, bread,
     struct iovec iov[IOV_MAX];
     int iov_count;
     ssize_t xfer;
+    lseek(bound(d), offset, SEEK_SET);
     while (total > 0) {
         iov_count = 0;
         xfer = 0;
@@ -44,7 +45,7 @@ closure_function(2, 1, void, bread,
             if ((++iov_count == IOV_MAX) || (xfer == total))
                 break;
         }
-        xfer = preadv(bound(d), iov, iov_count, offset);
+        xfer = readv(bound(d), iov, iov_count);
         if (xfer < 0 && errno != EINTR) {
             apply(req->completion, timm("result", "read error", "error", "%s", strerror(errno)));
             return;
@@ -54,7 +55,6 @@ closure_function(2, 1, void, bread,
             return;
         }
         sg_consume(sg, xfer);
-        offset += xfer;
         total -= xfer;
     }
     apply(req->completion, STATUS_OK);

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -270,6 +270,7 @@ closure_function(2, 1, void, bwrite,
     struct iovec iov[IOV_MAX];
     int iov_count;
     ssize_t xfer;
+    lseek(bound(d), offset, SEEK_SET);
     while (total > 0) {
         iov_count = 0;
         xfer = 0;
@@ -280,13 +281,12 @@ closure_function(2, 1, void, bwrite,
             if ((++iov_count == IOV_MAX) || (xfer == total))
                 break;
         }
-        xfer = pwritev(bound(d), iov, iov_count, offset);
+        xfer = writev(bound(d), iov, iov_count);
         if (xfer < 0 && errno != EINTR) {
             apply(req->completion, timm("result", "write error", "error", "%s", strerror(errno)));
             return;
         }
         sg_consume(sg, xfer);
-        offset += xfer;
         total -= xfer;
     }
     apply(req->completion, STATUS_OK);

--- a/tools/tfs-fuse.c
+++ b/tools/tfs-fuse.c
@@ -210,6 +210,7 @@ closure_function(2, 1, void, req_handle,
         sg = req->data;
         offset = bound(fs_offset) + (req->blocks.start << SECTOR_OFFSET);
         total = range_span(req->blocks) << SECTOR_OFFSET;
+        lseek(bound(d), offset, SEEK_SET);
         while (total > 0) {
             iov_count = 0;
             xfer = 0;
@@ -221,14 +222,14 @@ closure_function(2, 1, void, req_handle,
                     break;
             }
             if (write) {
-                xfer = pwritev(bound(d), iov, iov_count, offset);
+                xfer = writev(bound(d), iov, iov_count);
                 if (xfer < 0 && errno != EINTR) {
                     apply(req->completion,
                           timm("result", "write error", "error", "%s", strerror(errno)));
                     return;
                 }
             } else {
-                xfer = preadv(bound(d), iov, iov_count, offset);
+                xfer = readv(bound(d), iov, iov_count);
                 if (xfer < 0 && errno != EINTR) {
                     apply(req->completion,
                           timm("result", "read error", "error", "%s", strerror(errno)));


### PR DESCRIPTION
Some versions of OS X and BSD do not have support for preadv and pwritev, so
use lseek and readv/writev instead for the tools.