### PR TITLE
Volumes: add support for attachment points

### DIFF
--- a/src/drivers/ata-pci.c
+++ b/src/drivers/ata-pci.c
@@ -331,7 +331,7 @@ closure_function(3, 1, boolean, ata_pci_probe,
     register_interrupt(irq, (thunk)&dev->irq_handler, "ata pci");
     apply(bound(a),
           storage_init_req_handler(&dev->req_handler, (block_io)&dev->read, (block_io)&dev->write),
-          ata_get_capacity(dev->ata));
+          ata_get_capacity(dev->ata), 0);
     return true;
 }
 

--- a/src/hyperv/storvsc/storvsc.c
+++ b/src/hyperv/storvsc/storvsc.c
@@ -732,7 +732,7 @@ closure_function(5, 0, void, storvsc_read_capacity_done,
 
     block_io in = closure(s->general, storvsc_read, s);
     block_io out = closure(s->general, storvsc_write, s);
-    apply(bound(a), storage_init_req_handler(&s->req_handler, in, out), s->capacity);
+    apply(bound(a), storage_init_req_handler(&s->req_handler, in, out), s->capacity, -1);
   out:
     closure_finish();
 }

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -218,7 +218,7 @@ typedef closure_type(block_io, void, void *, range, status_handler);
 
 struct storage_req;
 typedef closure_type(storage_req_handler, void, struct storage_req *);
-typedef closure_type(storage_attach, void, storage_req_handler, u64);
+typedef closure_type(storage_attach, void, storage_req_handler, u64, int);
 
 #include <sg.h>
 

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -95,7 +95,7 @@ storage_req_handler storage_init_req_handler(closure_ref(storage_simple_req_hand
 void init_volumes(heap h);
 void storage_set_root_fs(struct filesystem *root_fs);
 void storage_set_mountpoints(tuple mounts);
-boolean volume_add(u8 *uuid, char *label, storage_req_handler req_handler, u64 size);
+boolean volume_add(u8 *uuid, char *label, storage_req_handler req_handler, u64 size, int attach_id);
 void storage_when_ready(status_handler complete);
 void storage_sync(status_handler sh);
 

--- a/src/virtio/virtio_scsi.c
+++ b/src/virtio/virtio_scsi.c
@@ -439,7 +439,7 @@ closure_function(2, 0, void, virtio_scsi_init_done,
     spin_lock(&s->lock);
     vector_push(s->disks, d);
     spin_unlock(&s->lock);
-    apply(bound(a), init_closure(&d->req_handler, virtio_scsi_req_handler), d->capacity);
+    apply(bound(a), init_closure(&d->req_handler, virtio_scsi_req_handler), d->capacity, -1);
     closure_finish();
 }
 

--- a/src/virtio/virtio_storage.c
+++ b/src/virtio/virtio_storage.c
@@ -282,7 +282,7 @@ static void virtio_blk_attach(heap general, storage_attach a, vtdev v)
     }
     vtdev_set_status(v, VIRTIO_CONFIG_STATUS_DRIVER_OK);
 
-    apply(a, init_closure(&s->req_handler, virtio_storage_req_handler), s->capacity);
+    apply(a, init_closure(&s->req_handler, virtio_storage_req_handler), s->capacity, -1);
 }
 
 closure_function(3, 1, boolean, vtpci_blk_probe,

--- a/src/vmware/pvscsi.c
+++ b/src/vmware/pvscsi.c
@@ -257,7 +257,7 @@ closure_function(5, 0, void, pvscsi_read_capacity_done,
 
     block_io in = closure(s->general, pvscsi_read, d);
     block_io out = closure(s->general, pvscsi_write, d);
-    apply(bound(a), storage_init_req_handler(&d->req_handler, in, out), d->capacity);
+    apply(bound(a), storage_init_req_handler(&d->req_handler, in, out), d->capacity, -1);
   out:
     closure_finish();
 }


### PR DESCRIPTION
This change adds detection of the "attachment point" of a storage device, expressed as an integer number; the attachment point, when known, identifies uniquely a given volume among all volumes attached to an instance. An unknown attachment point is indicated by the value -1, while 0 indicates the root volume.
The attachment point can be used in a volume mount directive alternatively to the volume ID: if the <volume_id> part of the <volume_id>:<mount_path> syntax has the format %<attach_id> (where <attach_id> is an integer number), then an attached volume whose attachment point equals <attach_id> matches the mount directive.
Detection of a volume attachment point is currently implemented in the xenblk and nvme disk drivers, which are used in AWS instances.

This functionality can be used in the `volume attach` Ops command by specifying a volume identifier argument with format %<attach_id>:<volume_name> instead of <volume_name>.