### PR TITLE
Add lock profiling support

### DIFF
--- a/doc/lock-profiling.txt
+++ b/doc/lock-profiling.txt
@@ -1,0 +1,47 @@
+Nanos provides a simple lock profiling mechanism that can be optionally built into the
+kernel. The profile output is a list of frame traces for each lock or mutex acquired
+when profiling is enabled along with acquisition counts and time. A helper python
+script can be used on the profile output that groups backtraces together
+by lock address, making it easier to analyze which traces are accessing
+the same lock and their frequency of doing so.
+
+The compilation of lock profiling is controlled with the TRACE variable, like so:
+    make TRACE=lockstats
+This must be done with a clean output directory to ensure all support is properly
+built in. Lock profiling control is handled through a very simple http interface
+located on port 9090. Enabling and disabling profiling is done by accessing
+/lockstat/enable or /lockstat/disable, and the profile output is accessed via
+/lockstat/log, all by http get requests. Thus, tools like curl can be used to
+control lock profiling.
+    curl http://127.0.0.1:9090/lockstat/enable
+    ...[run test load]...
+    curl http://127.0.0.1:9090/lockstat/disable
+    curl http://127.0.0.1:9090/lockstat/log > locklog.txt
+
+The lock profile output has a line for each tuple of lock address and backtrace.
+The first field is the lock address first accessed by this backtrace. If a backtrace
+accesses a lock on transient data structures, only the first lock address is
+recorded, but profile data for other locks with the same backtrace are all accounted
+for in this line. The second field is the type of lock, spin or mutex. The next
+several fields are the statistics. This includes number of acquisitions, number
+of contended acquisitions, number of try locks that failed to acquire,
+spin count total, max, and min, held cycles total, max, and min, and then
+number of times the context was reschedule (sleeps, only for mutexes). Finally, the
+remainder of the line is the backtrace. The entire record is kept on a single line
+for ease of machine parsing rather than human readability.
+
+The python script tools/lockstat.py processes the profile log output and groups
+backtraces and statistics by lock address so that it is easy to see which
+backtraces access the same lock. Each line of the backtrace list starts with a
+percentage contribution that the backtrace makes towards the total. The python
+script can be run like this:
+    python tools/lockstat.py locklog.txt
+
+By default, the script sorts by descending contended acquisition count, but can
+be sorted by other fields by specifying a second argument with the field name
+shortcut. For example, to sort by total acquisition time:
+    python tools/lockstat.py locklog.txt spins
+
+Lock profiling support is currently only available for the x86_64 platform. Expect
+to see a decrease of 10-20% in performance with profiling enabled, including
+much greater variation in your test results.

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -179,17 +179,23 @@ CFLAGS+=-Wno-address # lwIP build sadness
 CFLAGS+=$(INCLUDES)
 
 # Enable tracing by specifying TRACE=ftrace on command line
-ifeq ($(TRACE),ftrace)
+ifneq (,$(findstring ftrace,$(TRACE)))
 CFLAGS+= -DCONFIG_FTRACE -pg
 SRCS-kernel.elf+= \
 	$(SRCDIR)/unix/ftrace.c \
 	$(ARCHDIR)/ftrace.s
 endif
 
-ifeq ($(TRACE),tracelog)
+ifneq (,$(findstring tracelog,$(TRACE)))
 CFLAGS+= -DCONFIG_TRACELOG
 SRCS-kernel.elf+= \
 	$(SRCDIR)/kernel/tracelog.c
+endif
+
+ifneq (,$(findstring lockstats,$(TRACE)))
+CFLAGS+= -DLOCK_STATS
+SRCS-kernel.elf+= \
+	$(SRCDIR)/kernel/lockstats.c
 endif
 
 ifeq ($(MANAGEMENT),telnet)

--- a/src/aarch64/interrupt.c
+++ b/src/aarch64/interrupt.c
@@ -40,28 +40,10 @@ static void print_far_if_valid(u32 iss)
     }
 }
 
-static void frame_trace(u64 *fp)
-{
-    for (unsigned int frame = 0; frame < FRAME_TRACE_DEPTH; frame ++) {
-        if (!validate_virtual(fp, sizeof(u64)) ||
-            !validate_virtual(fp + 1, sizeof(u64)))
-            break;
-
-        u64 n = fp[1];
-        if (n == 0)
-            break;
-        print_u64(u64_from_pointer(fp + 1));
-        rputs(":   ");
-        fp = pointer_from_u64(fp[0]);
-        print_u64_with_sym(n);
-        rputs("\n");
-    }
-}
-
 static void print_stack(context_frame c)
 {
     rputs("\nframe trace: \n");
-    frame_trace(pointer_from_u64(c[FRAME_X29]));
+    print_frame_trace(pointer_from_u64(c[FRAME_X29]));
 
     rputs("\nstack trace:\n");
     u64 *sp = pointer_from_u64(c[FRAME_SP]);
@@ -210,14 +192,6 @@ void dump_context(context ctx)
         rputs("\n");
     }
     print_stack(f);
-}
-
-void print_frame_trace_from_here(void)
-{
-    rputs("\nframe trace: \n");
-    u64 fp;
-    asm("mov %0, x29" : "=r" (fp));
-    frame_trace(pointer_from_u64(fp));
 }
 
 extern void (*syscall)(context f);

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -393,6 +393,29 @@ static inline void frame_reset_stack(context_frame f)
     f[FRAME_SP] = f[FRAME_STACK_TOP];
 }
 
+static inline u64 *get_frame_ra_ptr(u64 *fp, u64 **nfp)
+{
+#ifdef LOCK_STATS
+    /* simple bounds check for performance and to avoid recursive pt locking */
+    if ((u64)fp < KMEM_BASE || (u64)fp > KERNEL_LIMIT)
+        return 0;
+#else
+    if (!validate_virtual(fp, sizeof(u64)) ||
+        !validate_virtual(fp + 1, sizeof(u64)))
+        return 0;
+#endif
+    u64 *rap = fp + 1;
+    *nfp = pointer_from_u64(fp[0]);
+    return rap;
+}
+
+static inline u64 *get_current_fp(void)
+{
+    u64 fp;
+    asm("mov %0, x29" : "=r" (fp));
+    return pointer_from_u64(fp);
+}
+
 #define _switch_stack_head(s, target)                                   \
     register u64 __s = u64_from_pointer(s);                             \
     register u64 __t = u64_from_pointer(target)

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -393,17 +393,16 @@ static inline void frame_reset_stack(context_frame f)
     f[FRAME_SP] = f[FRAME_STACK_TOP];
 }
 
-static inline u64 *get_frame_ra_ptr(u64 *fp, u64 **nfp)
+static inline boolean validate_frame_ptr(u64 *fp)
 {
-#ifdef LOCK_STATS
-    /* simple bounds check for performance and to avoid recursive pt locking */
-    if ((u64)fp < KMEM_BASE || (u64)fp > KERNEL_LIMIT)
-        return 0;
-#else
     if (!validate_virtual(fp, sizeof(u64)) ||
         !validate_virtual(fp + 1, sizeof(u64)))
-        return 0;
-#endif
+        return false;
+    return true;
+}
+
+static inline u64 *get_frame_ra_ptr(u64 *fp, u64 **nfp)
+{
     u64 *rap = fp + 1;
     *nfp = pointer_from_u64(fp[0]);
     return rap;

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -1,4 +1,5 @@
 #include <kernel.h>
+#include <symtab.h>
 
 const char *context_type_strings[CONTEXT_TYPE_MAX] = {
     "undefined",
@@ -30,6 +31,31 @@ void deallocate_stack(heap h, u64 size, void *stack)
 {
     u64 padsize = pad(size, h->pagesize);
     deallocate(h, u64_from_pointer(stack) - padsize + STACK_ALIGNMENT, padsize);
+}
+
+void print_frame_trace(u64 *fp)
+{
+    u64 *nfp;
+    u64 *rap;
+
+    for (int frame = 0; frame < FRAME_TRACE_DEPTH; frame++) {
+        if ((rap = get_frame_ra_ptr(fp, &nfp)) == 0)
+            break;
+
+        if (*rap == 0)
+            break;
+        print_u64(u64_from_pointer(rap));
+        rputs(":   ");
+        fp = nfp;
+        print_u64_with_sym(*rap);
+        rputs("\n");
+    }
+}
+
+void print_frame_trace_from_here(void)
+{
+    rputs("\nframe trace: \n");
+    print_frame_trace(get_current_fp());
 }
 
 define_closure_function(3, 0, void, free_kernel_context,

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -39,6 +39,8 @@ void print_frame_trace(u64 *fp)
     u64 *rap;
 
     for (int frame = 0; frame < FRAME_TRACE_DEPTH; frame++) {
+        if (!validate_frame_ptr(fp))
+            break;
         if ((rap = get_frame_ra_ptr(fp, &nfp)) == 0)
             break;
 

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -469,6 +469,9 @@ cpuinfo init_cpuinfo(heap backed, int cpu);
 void init_interrupts(kernel_heaps kh);
 void msi_map_vector(int slot, int msislot, int vector);
 
+void print_frame_trace(u64 *fp);
+void print_frame_trace_from_here(void);
+
 void syscall_enter(void);
 
 backed_heap mem_debug_backed(heap m, backed_heap bh, u64 padsize, boolean nohdr);

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -76,6 +76,11 @@ struct cpuinfo {
 #ifdef CONFIG_TRACELOG
     void *tracelog_buffer;
 #endif
+#ifdef LOCK_STATS
+    boolean lock_stats_disable;
+    table lock_stats_table;
+    heap lock_stats_heap;
+#endif
 };
 
 extern vector cpuinfos;
@@ -441,6 +446,13 @@ static inline void schedule_timer_service(void)
 {
     if (compare_and_swap_boolean(&kernel_timers->service_scheduled, false, true))
         enqueue(bhqueue, kernel_timers->service);
+}
+
+static inline boolean is_kernel_memory(void *a)
+{
+    if ((u64)a < KMEM_BASE || (u64)a > KERNEL_LIMIT)
+        return false;
+    return true;
 }
 #endif /* KERNEL */
 

--- a/src/kernel/lockstats.c
+++ b/src/kernel/lockstats.c
@@ -1,0 +1,319 @@
+#include <kernel.h>
+#include <net.h>
+#include <http.h>
+#include <symtab.h>
+
+#define LOCKSTATS_PORT               9090
+#define LOCKSTATS_URI                "lockstat"
+#define LOCKSTATS_HTTP_CHUNK_MAXSIZE (64*KB)
+#define LOCKSTATS_PREALLOC           2048
+
+static heap lockstats_heap;
+static http_listener lockstats_hl;
+
+boolean record_lock_stats = false;
+
+static u64 hash_lock_block(lock_block b)
+{
+    u64 hash = 0xcbf29ce484222325;
+    u64 fnv_prime = 1099511628211;
+    for (int i = 0; i < MAX_TRACE_DEPTH; i++) {
+        if (b->lock_trace[i] == 0)
+            break;
+        hash ^= b->lock_trace[i];
+        hash *= fnv_prime;
+    }
+    return hash;
+}
+
+static inline void save_frame_trace(u64 *trace)
+{
+    int i;
+    u64 *fp = get_current_fp();
+
+    for (i = 0; i < MAX_TRACE_DEPTH; i++) {
+        /* simple bounds check for performance and to avoid recursive pt locking */
+        if (!is_kernel_memory(fp))
+            break;
+        u64 *rap = get_frame_ra_ptr(fp, &fp);
+        if (rap == 0)
+            break;
+        trace[i] = *rap;
+        if (*rap == 0)
+            return;
+    }
+    if (i < MAX_TRACE_DEPTH)
+        trace[i] = 0;
+}
+
+lock_stats get_lockstats_block(lockstats_lock l, boolean islocking)
+{
+    struct lock_block lookup;
+    cpuinfo ci = current_cpu();
+
+    if (ci->lock_stats_disable)
+        return 0;
+    ci->lock_stats_disable = true;
+
+    u64 trace_hash = 0;
+    lock_stats stats = 0;
+    table t = ci->lock_stats_table;
+    if (islocking) {
+        lookup.lock_address = u64_from_pointer(l);
+        save_frame_trace(lookup.lock_trace);
+        trace_hash = hash_lock_block(&lookup);
+        stats = table_find(t, (void *)trace_hash);
+        if (stats)
+            goto out;
+        stats = allocate_zero(ci->lock_stats_heap, sizeof(struct lock_stats));
+        assert(stats != INVALID_ADDRESS);
+        runtime_memcpy(&stats->lock, &lookup, sizeof(struct lock_block));
+        stats->lock.type = l->type;
+        stats->lock.hash = trace_hash;
+        stats->spins_min = -1u;
+        stats->hold_time_min = -1u;
+        table_set(t, (void *)trace_hash, stats);
+    } else if (l->trace_hash) {
+        stats = table_find(t, (void *)l->trace_hash);
+    }
+out:
+    ci->lock_stats_disable = false;
+    return stats;
+}
+
+boolean lockstats_print_u64_with_sym(buffer b, u64 n)
+{
+    char * name;
+    u64 offset, len;
+
+    name = find_elf_sym(n, &offset, &len);
+    bprintf(b, "%p [%s+0x%x]", n, name ? name : "", name ? offset : 0);
+    return name != 0;
+}
+
+static boolean stat_sort_reverse(void *a, void *b)
+{
+    lock_stats sa = a;
+    lock_stats sb = b;
+    if (sa->cont > sb->cont)
+        return false;
+    return true;
+}
+
+static pqueue log_collate_and_sort(void)
+{
+    cpuinfo ci;
+    pqueue pq = INVALID_ADDRESS;
+    boolean record_state = record_lock_stats;
+    record_lock_stats = 0;
+    table collated = allocate_table(lockstats_heap, identity_key, pointer_equal);
+    if (collated == INVALID_ADDRESS)
+        goto out;
+    vector_foreach(cpuinfos, ci) {
+        table_foreach(ci->lock_stats_table, k, v) {
+            lock_stats stats = table_find(collated, k);
+            if (!stats) {
+                stats = allocate_zero(lockstats_heap, sizeof(struct lock_stats));
+                assert(stats != INVALID_ADDRESS);
+                runtime_memcpy(stats, v, sizeof(struct lock_stats));
+                table_set(collated, k, stats);
+                continue;
+            }
+            lock_stats s = v;
+            stats->acq += s->acq;
+            stats->cont += s->cont;
+            stats->tries += s->tries;
+            stats->spins_total += s->spins_total;
+            if (s->cont) {
+                if (s->spins_max > stats->spins_max)
+                    stats->spins_max = s->spins_max;
+                if (s->spins_min < stats->spins_min)
+                    stats->spins_min = s->spins_min;
+            }
+        }
+    }
+    pq = allocate_pqueue(lockstats_heap, stat_sort_reverse);
+    if (pq == INVALID_ADDRESS)
+        goto out;
+    table_foreach(collated, k, v) {
+        (void)k;
+        /* Only print locks with contended acquisitions */
+        if (((lock_stats)v)->cont == 0)
+            continue;
+        pqueue_insert(pq, v);
+    }
+    deallocate_table(collated);
+out:
+    record_lock_stats = record_state;
+    return pq;
+}
+
+static boolean log_output(pqueue pq, buffer b)
+{
+    lock_stats s;
+    buffer tb = little_stack_buffer(4*KB);
+
+    if (pqueue_peek(pq) == INVALID_ADDRESS)
+        return false;
+
+    while ((s = pqueue_peek(pq)) != INVALID_ADDRESS) {
+        buffer_clear(tb);
+        bprintf(tb, "%p %s %ld %ld %ld %ld %ld %ld %ld %ld %ld %ld ", s->lock.lock_address,
+            s->lock.type == 0 ? "spin" : "mutex", s->acq,
+            s->cont, s->tries, s->spins_total,
+            s->spins_min, s->spins_max, s->hold_time_total,
+            s->hold_time_min, s->hold_time_max, s->sleep_time_total);
+        for (int i = 0; i < MAX_TRACE_DEPTH; i++) {
+            if (s->lock.lock_trace[i] == 0)
+                break;
+            if (!lockstats_print_u64_with_sym(tb, s->lock.lock_trace[i]))
+                break;
+            bprintf(tb, " ");
+        }
+        bprintf(tb, "\n");
+        if (buffer_length(tb) > buffer_space(b))
+            break;
+        push_buffer(b, tb);
+        s = pqueue_pop(pq);
+        deallocate(lockstats_heap, s, sizeof(struct lock_stats));
+    }
+    return true;
+}
+
+#define catch_err(s) do {if (!is_ok(s)) msg_err("lockstat: failed to send HTTP response: %v\n", (s));} while(0)
+
+static void
+lockstats_send_http_response(buffer_handler handler, buffer b)
+{
+    catch_err(send_http_response(handler, timm("ContentType", "text/html"), b));
+}
+
+static inline void lockstats_send_http_chunked_response(buffer_handler handler)
+{
+    catch_err(send_http_chunked_response(handler, timm("ContentType", "text/html")));
+}
+
+static inline void lockstats_send_http_error(buffer_handler handler, const char *status, const char *msg)
+{
+    buffer b = aprintf(lockstats_heap, "<html><head><title>%s %s</title></head>"
+                       "<body><h1>%s</h1></body></html>\r\n", status, msg, msg);
+    catch_err(send_http_response(handler, timm("status", "%s %s", status, msg), b));
+}
+
+static void
+lockstats_send_http_uri_not_found(buffer_handler handler)
+{
+    lockstats_send_http_error(handler, "404", "Not Found");
+}
+
+static void
+lockstats_send_http_no_method(buffer_handler handler, http_method method)
+{
+    lockstats_send_http_error(handler, "501", "Not Implemented");
+}
+
+static void
+lockstats_send_http_internal_error(buffer_handler handler, http_method method)
+{
+    lockstats_send_http_error(handler, "500", "Internal Server Error");
+}
+
+static void
+lockstats_do_http_get_log_chunked(buffer_handler out)
+{
+    pqueue pq = log_collate_and_sort();
+    if (pq == INVALID_ADDRESS) {
+        lockstats_send_http_internal_error(out, 0);
+        return;
+    }
+    while (true) {
+        buffer b = allocate_buffer(lockstats_heap, LOCKSTATS_HTTP_CHUNK_MAXSIZE);
+        assert(b != INVALID_ADDRESS);
+        if (!log_output(pq, b)) {
+            deallocate_buffer(b);
+            break;
+        }
+        send_http_chunk(out, b);
+    }
+    deallocate_pqueue(pq);
+    send_http_chunk(out, 0);
+}
+
+closure_function(0, 3, void, lockstats_http_request,
+                 http_method, method, buffer_handler, handler, value, val)
+{
+    string relative_uri;
+    relative_uri = get_string(val, sym(relative_uri));
+    if (relative_uri == 0) {
+        lockstats_send_http_internal_error(handler, method);
+        return;
+    }
+
+    if (method != HTTP_REQUEST_METHOD_GET) {
+        lockstats_send_http_no_method(handler, method);
+        return;
+    }
+    if (buffer_compare_with_cstring(relative_uri, "log")) {
+        lockstats_send_http_chunked_response(handler);
+        lockstats_do_http_get_log_chunked(handler);
+    } else if (buffer_compare_with_cstring(relative_uri, "enable")) {
+        lockstats_send_http_response(handler,
+               aprintf(lockstats_heap, "lock profiling enabled\n"));
+        record_lock_stats = true;
+    } else if (buffer_compare_with_cstring(relative_uri, "disable")) {
+        record_lock_stats = false;
+        lockstats_send_http_response(handler,
+               aprintf(lockstats_heap, "lock profiling disabled\n"));
+    } else {
+        lockstats_send_http_uri_not_found(handler);
+    }
+}
+
+static int
+init_http_listener(void)
+{
+    status s;
+
+    lockstats_hl = allocate_http_listener(lockstats_heap, LOCKSTATS_PORT);
+    if (lockstats_hl == INVALID_ADDRESS) {
+        msg_err("could not allocate lock stat HTTP listener\n");
+        return -1;
+    }
+
+    http_register_uri_handler(
+        lockstats_hl,
+        LOCKSTATS_URI,
+        closure(lockstats_heap, lockstats_http_request)
+    );
+
+    s = listen_port(lockstats_heap, LOCKSTATS_PORT,
+        connection_handler_from_http_listener(lockstats_hl)
+    );
+    if (!is_ok(s)) {
+        msg_err("listen_port(port=%d) failed for lockstat HTTP listener\n",
+            LOCKSTATS_PORT
+        );
+        deallocate_http_listener(lockstats_heap, lockstats_hl);
+        return -1;
+    }
+
+    rprintf("started lockstat http listener on port %d\n", LOCKSTATS_PORT);
+
+    return 0;
+}
+
+void lockstats_init(kernel_heaps kh)
+{
+    heap h = heap_general(kh);
+    heap backed = (heap)heap_linear_backed(kh);
+    lockstats_heap = h;
+    cpuinfo ci;
+    vector_foreach(cpuinfos, ci) {
+        ci->lock_stats_table = allocate_table_preallocated(h, backed, identity_key, pointer_equal, LOCKSTATS_PREALLOC);
+        ci->lock_stats_heap = allocate_objcache_preallocated(h, backed,
+            sizeof(struct lock_stats), PAGESIZE, LOCKSTATS_PREALLOC, true);
+    }
+    int ret = init_http_listener();
+    if (ret != 0)
+        rprintf("%s: failed to start http listener\n", __func__);
+}

--- a/src/kernel/lockstats.h
+++ b/src/kernel/lockstats.h
@@ -1,0 +1,98 @@
+#define MAX_TRACE_DEPTH 8
+#define LOCK_TYPE_SPIN 0
+#define LOCK_TYPE_MUTEX 1
+
+typedef struct lock_block {
+    u64 lock_trace[MAX_TRACE_DEPTH];
+    u64 lock_address;
+    int type;               /* lock type */
+    u64 hash;
+} *lock_block;
+
+typedef struct lock_stats {
+    struct lock_block lock; /* lock information */
+    u64 acq;                /* number of acquisitions */
+    u64 cont;               /* number of contended acquisitions */
+    u64 tries;              /* number of lock tries when not acquired */
+    u64 spins_total;        /* number of spins to acquire (when waiting) */
+    u64 spins_max;          /* max spins to acquire (when waiting) */
+    u64 spins_min;          /* min spins to acquire (when waiting) */
+    u64 hold_time_total;    /* total time (cycles) holding lock */
+    u64 hold_time_max;      /* max time holding lock */
+    u64 hold_time_min;      /* min time holding lock */
+    u64 sleep_time_total;   /* time spent sleeping for lock */
+
+} *lock_stats;
+
+void lockstats_init(kernel_heaps kh);
+
+#ifdef __x86_64__
+static inline u64 lockstats_rdtscp(void)
+{
+    u32 a, d;
+    if (platform_has_precise_clocksource())
+        asm volatile("rdtscp" : "=a" (a), "=d" (d) :: "%rcx");
+    else
+        asm volatile("rdtsc" : "=a" (a), "=d" (d) :: "%rcx");
+    return (((u64)a) | (((u64)d) << 32));
+}
+
+#define lockstats_timestamp() lockstats_rdtscp()
+#else
+#define lockstats_timestamp() (nsec_from_timestamp(now(CLOCK_ID_MONOTONIC)))
+#endif
+
+#define LOCKSTATS_RECORD_LOCK(L, A, N, S)                       \
+            if (record_lock_stats) {                               \
+                if (A) L.acq_time = lockstats_timestamp();         \
+                lockstats_record(&L, A, N, S);     \
+            }
+
+#define LOCKSTATS_RECORD_UNLOCK(L) \
+    if (record_lock_stats) { lockstats_record_unlock(&L, lockstats_timestamp() - L.acq_time); }
+
+extern boolean record_lock_stats;
+
+lock_stats get_lockstats_block(lockstats_lock ll, boolean islocking);
+
+static inline void lockstats_record(lockstats_lock ll, boolean acq, u64 spins, u64 sleeps)
+{
+    if (!record_lock_stats)
+        return;
+    lock_stats stats = get_lockstats_block(ll, true);
+    if (!stats)
+        return;
+    if (!acq) {
+        stats->tries++;
+        return;
+    }
+    stats->acq++;
+    if (spins > 0) {
+        stats->spins_total += spins;
+        if (spins > stats->spins_max)
+            stats->spins_max = spins;
+        if (spins < stats->spins_min)
+            stats->spins_min = spins;
+        stats->sleep_time_total += sleeps;
+        stats->cont++;
+    }
+    ll->trace_hash = stats->lock.hash;
+}
+
+static inline void lockstats_record_unlock(lockstats_lock ll, u64 holdtm)
+{
+    lock_stats stats = get_lockstats_block(ll, false);
+    /* XXX unlocks on a cpu that has never first locked this hash will be dropped */
+    if (!stats)
+        return;
+
+    ll->trace_hash = 0;
+    /* discard giant hold times resulting from enabling profiling while lock was being held */
+    if (holdtm > 10*BILLION)
+        return;
+    stats->hold_time_total += holdtm;
+    if (holdtm > stats->hold_time_max)
+        stats->hold_time_max = holdtm;
+    if (holdtm < stats->hold_time_min)
+        stats->hold_time_min = holdtm;
+}

--- a/src/kernel/lockstats_struct.h
+++ b/src/kernel/lockstats_struct.h
@@ -1,0 +1,5 @@
+typedef struct lockstats_lock {
+    int type;
+    u64 acq_time;
+    u64 trace_hash;
+} *lockstats_lock;

--- a/src/kernel/mutex.h
+++ b/src/kernel/mutex.h
@@ -6,6 +6,9 @@ typedef struct mutex {
     struct list waiters;
     u64 mcs_spinouts;           /* stats */
     u64 acquire_spinouts;
+#ifdef LOCK_STATS
+    struct lockstats_lock s;
+#endif
 } *mutex;
 
 boolean mutex_try_lock(mutex ql);

--- a/src/riscv64/interrupt.c
+++ b/src/riscv64/interrupt.c
@@ -74,36 +74,10 @@ static struct list *handlers;
 
 static heap int_general;
 
-void frame_trace(u64 *fp)
-{
-    for (unsigned int frame = 0; frame < FRAME_TRACE_DEPTH; frame ++) {
-        if (!validate_virtual(fp - 1 , sizeof(u64)) ||
-            !validate_virtual(fp - 2, sizeof(u64)))
-            break;
-
-        u64 n = fp[-1];
-        if (n == 0)
-            break;
-        print_u64(u64_from_pointer(fp - 1));
-        rputs(":   ");
-        fp = pointer_from_u64(fp[-2]);
-        print_u64_with_sym(n);
-        rputs("\n");
-    }
-}
-
-void print_frame_trace_from_here(void)
-{
-    rputs("\nframe trace: \n");
-    u64 fp;
-    asm("mv %0, fp" : "=r" (fp));
-    frame_trace(pointer_from_u64(fp));
-}
-
 void print_stack(context_frame c)
 {
     rputs("\nframe trace: \n");
-    frame_trace(pointer_from_u64(c[FRAME_FP]));
+    print_frame_trace(pointer_from_u64(c[FRAME_FP]));
 
     rputs("\nstack trace:\n");
     u64 *sp = pointer_from_u64(c[FRAME_SP]);

--- a/src/riscv64/kernel_machine.h
+++ b/src/riscv64/kernel_machine.h
@@ -292,6 +292,29 @@ static inline void frame_reset_stack(context_frame f)
     f[FRAME_SP] = f[FRAME_STACK_TOP];
 }
 
+static inline u64 *get_frame_ra_ptr(u64 *fp, u64 **nfp)
+{
+#ifdef LOCK_STATS
+    /* simple bounds check for performance and to avoid recursive pt locking */
+    if ((u64)(fp - 1) < KMEM_BASE || (u64)(fp - 1) > KERNEL_LIMIT)
+        return 0;
+#else
+    if (!validate_virtual(fp - 1, sizeof(u64)) ||
+        !validate_virtual(fp - 2, sizeof(u64)))
+        return 0;
+#endif
+    u64 *rap = fp - 1;
+    *nfp = pointer_from_u64(fp[-2]);
+    return rap;
+}
+
+static inline u64 *get_current_fp(void)
+{
+    u64 fp;
+    asm("mv %0, fp" : "=r" (fp));
+    return pointer_from_u64(fp);
+}
+
 #define _switch_stack_head(s, target)                                   \
     register u64 __s = u64_from_pointer(s);                             \
     register u64 __t = u64_from_pointer(target)

--- a/src/riscv64/kernel_machine.h
+++ b/src/riscv64/kernel_machine.h
@@ -292,17 +292,16 @@ static inline void frame_reset_stack(context_frame f)
     f[FRAME_SP] = f[FRAME_STACK_TOP];
 }
 
-static inline u64 *get_frame_ra_ptr(u64 *fp, u64 **nfp)
+static inline boolean validate_frame_ptr(u64 *fp)
 {
-#ifdef LOCK_STATS
-    /* simple bounds check for performance and to avoid recursive pt locking */
-    if ((u64)(fp - 1) < KMEM_BASE || (u64)(fp - 1) > KERNEL_LIMIT)
-        return 0;
-#else
     if (!validate_virtual(fp - 1, sizeof(u64)) ||
         !validate_virtual(fp - 2, sizeof(u64)))
-        return 0;
-#endif
+        return false;
+    return true;
+}
+
+static inline u64 *get_frame_ra_ptr(u64 *fp, u64 **nfp)
+{
     u64 *rap = fp - 1;
     *nfp = pointer_from_u64(fp[-2]);
     return rap;

--- a/src/runtime/heap/heap.h
+++ b/src/runtime/heap/heap.h
@@ -46,6 +46,7 @@ static inline value heap_management(heap h)
 heap wrap_freelist(heap meta, heap parent, bytes size);
 heap allocate_objcache(heap meta, heap parent, bytes objsize, bytes pagesize);
 heap allocate_wrapped_objcache(heap meta, heap parent, bytes objsize, bytes pagesize, heap wrapper);
+heap allocate_objcache_preallocated(heap meta, heap parent, bytes objsize, bytes pagesize, u64 prealloc_count, boolean prealloc_only);
 boolean objcache_validate(heap h);
 heap objcache_from_object(u64 obj, bytes parent_pagesize);
 heap allocate_mcache(heap meta, heap parent, int min_order, int max_order, bytes pagesize);

--- a/src/runtime/range.c
+++ b/src/runtime/range.c
@@ -144,7 +144,7 @@ boolean rangemap_range_find_gaps(rangemap rm, range q, range_handler gap_handler
     return rangemap_range_lookup_internal(rm, q, 0, gap_handler);
 }
 
-closure_function(0, 2, int, rmnode_compare,
+define_closure_function(0, 2, int, rmnode_compare,
                  rbnode, a, rbnode, b)
 {
     u64 sa = ((rmnode)a)->r.start;
@@ -152,7 +152,7 @@ closure_function(0, 2, int, rmnode_compare,
     return sa == sb ? 0 : (sa < sb ? -1 : 1);
 }
 
-closure_function(0, 1, boolean, print_key,
+define_closure_function(0, 1, boolean, print_key,
                  rbnode, n)
 {
     rprintf(" %R", ((rmnode)n)->r);
@@ -165,7 +165,7 @@ rangemap allocate_rangemap(heap h)
     if (rm == INVALID_ADDRESS)
         return rm;
     rm->h = h;
-    init_rbtree(&rm->t, closure(h, rmnode_compare), closure(h, print_key));
+    init_rbtree(&rm->t, init_closure(&rm->compare, rmnode_compare), init_closure(&rm->print, print_key));
     return rm;
 }
 

--- a/src/runtime/range.h
+++ b/src/runtime/range.h
@@ -1,6 +1,13 @@
+
+declare_closure_struct(0, 2, int, rmnode_compare,
+                 rbnode, a, rbnode, b);
+declare_closure_struct(0, 1, boolean, print_key,
+                 rbnode, n);
 typedef struct rangemap {
     heap h;
     struct rbtree t;
+    closure_struct(rmnode_compare, compare);
+    closure_struct(print_key, print);
 } *rangemap;
 
 // [start, end)

--- a/src/runtime/table.h
+++ b/src/runtime/table.h
@@ -11,6 +11,7 @@ typedef struct entry {
 
 struct table {
     heap h;
+    heap eh;
     int buckets;
     int count;
     entry *entries;
@@ -19,6 +20,7 @@ struct table {
 };
 
 table allocate_table(heap h, key (*key_function)(void *x), boolean (*equal_function)(void *x, void *y));
+table allocate_table_preallocated(heap h, heap entry_parent, key (*key_function)(void *x), boolean (*equal_function)(void *x, void *y), u64 prealloc_count);
 void deallocate_table(table t);
 void table_validate(table t, char *n);
 int table_elements(table t);

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -280,7 +280,7 @@ int blockq_transfer_waiters(blockq dest, blockq src, int n, blockq_action_handle
         assert(t->blocked_on == src);
         boolean timer_pending = t->bq_timer_pending;
         timestamp remain;
-        clock_id id;
+        clock_id id = 0;
         if (timer_pending) {
             id = t->bq_timer.id;
             if (!remove_timer(kernel_timers, &t->bq_timer, &remain)) {

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -510,6 +510,9 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
         goto alloc_fail;
     if (ftrace_init(uh, fs))
 	goto alloc_fail;
+#ifdef LOCK_STATS
+    lockstats_init(kh);
+#endif
 #ifdef NET
     if (!netsyscall_init(uh, root))
         goto alloc_fail;

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -119,35 +119,11 @@ BSS_RO_AFTER_INIT u32 spurious_int_vector;
 
 extern void *text_start;
 extern void *text_end;
-void frame_trace(u64 *fp)
-{
-    for (unsigned int frame = 0; frame < FRAME_TRACE_DEPTH; frame++) {
-        if (!validate_virtual(fp, sizeof(u64)) ||
-            !validate_virtual(fp + 1, sizeof(u64)))
-            break;
-
-        u64 n = fp[1];
-        if (n == 0)
-            break;
-        print_u64(u64_from_pointer(fp + 1));
-        rputs(":   ");
-        fp = pointer_from_u64(fp[0]);
-        print_u64_with_sym(n);
-        rputs("\n");
-    }
-}
-
-void print_frame_trace_from_here(void)
-{
-    u64 rbp;
-    asm("movq %%rbp, %0" : "=r" (rbp));
-    frame_trace(pointer_from_u64(rbp));
-}
 
 static void print_stack(context_frame c)
 {
     rputs("\nframe trace:\n");
-    frame_trace(pointer_from_u64(c[FRAME_RBP]));
+    print_frame_trace(pointer_from_u64(c[FRAME_RBP]));
 
     rputs("\nstack trace:\n");
     u64 *sp = pointer_from_u64(c[FRAME_RSP]);

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -425,17 +425,16 @@ static inline void frame_reset_stack(context_frame f)
     f[FRAME_RSP] = f[FRAME_STACK_TOP];
 }
 
-static inline u64 *get_frame_ra_ptr(u64 *fp, u64 **nfp)
+static inline boolean validate_frame_ptr(u64 *fp)
 {
-#ifdef LOCK_STATS
-    /* simple bounds check for performance and to avoid recursive pt locking */
-    if ((u64)fp < KMEM_BASE || (u64)fp > KERNEL_LIMIT)
-        return 0;
-#else
     if (!validate_virtual(fp, sizeof(u64)) ||
         !validate_virtual(fp + 1, sizeof(u64)))
-        return 0;
-#endif
+        return false;
+    return true;
+}
+
+static inline u64 *get_frame_ra_ptr(u64 *fp, u64 **nfp)
+{
     u64 *rap = fp + 1;
     *nfp = pointer_from_u64(fp[0]);
     return rap;

--- a/src/x86_64/lock.h
+++ b/src/x86_64/lock.h
@@ -1,20 +1,39 @@
 /* struct spinlock defined in machine.h */
 
 #if defined(KERNEL) && defined(SMP_ENABLE)
+
+#ifdef LOCK_STATS
+#include <lockstats.h>
+#endif
+
 static inline boolean spin_try(spinlock l) {
     u64 tmp = 1;
     /* Is it worth the compare and branch to skip a pause? */
     asm volatile("lock xchg %0, %1; cmp $1, %1; jne 1f; pause; 1:" : "+m"(*&l->w), "+r"(tmp) :: "memory");
+
+#ifdef LOCK_STATS
+    LOCKSTATS_RECORD_LOCK(l->s, tmp == 0, 0, 0);
+#endif
     return tmp == 0 ? true:false;
 }
 
 static inline void spin_lock(spinlock l) {
     u64 tmp = 1;
+#ifdef LOCK_STATS
+    u64 spins = 0;
+    asm volatile("1: cmp %0, %1; jne 2f; pause; inc %2; jmp 1b; 2: lock xchg %0, %1; cmp $1, %1; je 1b" :
+                 "+m"(*&l->w), "+r"(tmp), "+r"(spins) :: "memory");
+    LOCKSTATS_RECORD_LOCK(l->s, true, spins, 0);
+#else
     asm volatile("1: cmp %0, %1; jne 2f; pause; jmp 1b; 2: lock xchg %0, %1; cmp $1, %1; je 1b" :
                  "+m"(*&l->w), "+r"(tmp) :: "memory");
+#endif
 }
 
 static inline void spin_unlock(spinlock l) {
+#ifdef LOCK_STATS
+    LOCKSTATS_RECORD_UNLOCK(l->s);
+#endif
     compiler_barrier();
     *(volatile u64 *)&l->w = 0;
 }
@@ -165,6 +184,11 @@ static inline void spin_runlock_irq(rw_spinlock l, u64 flags)
 static inline void spin_lock_init(spinlock l)
 {
     l->w = 0;
+#ifdef LOCK_STATS
+    l->s.type = LOCK_TYPE_SPIN;
+    l->s.acq_time = 0;
+    l->s.trace_hash = 0;
+#endif
 }
 
 static inline void spin_rw_lock_init(rw_spinlock l)

--- a/src/x86_64/machine.h
+++ b/src/x86_64/machine.h
@@ -42,8 +42,15 @@ static inline u8 tagof(void *v)
 
 #endif
 
+#ifdef LOCK_STATS
+#include <lockstats_struct.h>
+#endif
+
 typedef struct spinlock {
     word w;
+#ifdef LOCK_STATS
+    struct lockstats_lock s;
+#endif
 } *spinlock;
 
 typedef struct rw_spinlock {

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -96,7 +96,8 @@ SRCS-rbtree_test= \
 SRCS-table_test= \
 	$(CURDIR)/table_test.c \
 	$(RUNTIME)\
-	$(SRCDIR)/unix_process/unix_process_runtime.c
+	$(SRCDIR)/unix_process/unix_process_runtime.c \
+	$(SRCDIR)/unix_process/mmap_heap.c
 
 SRCS-tuple_test= \
 	$(CURDIR)/tuple_test.c \

--- a/tools/lockstat.py
+++ b/tools/lockstat.py
@@ -1,0 +1,100 @@
+from __future__ import print_function
+import copy
+import sys
+
+sortkeys = {'acq', 'cont', 'spins', 'spins_avg', 'spins_min', 'spins_max', 'hold_time', 'hold_avg', 'hold_min', 'hold_max', 'sleeps'}
+num_stat_fields = 12
+
+def fields_to_dict(f):
+    d = dict()
+    d['type'] = f[1]
+    d['acq'] = int(f[2])
+    d['cont'] = int(f[3])
+    d['tries'] = int(f[4])
+    d['spins'] = int(f[5])
+    d['spins_avg'] = d['spins'] / d['cont'] if d['cont'] != 0 else 0
+    d['spins_min'] = int(f[6])
+    d['spins_max'] = int(f[7])
+    d['hold_time'] = int(f[8])
+    d['hold_avg'] = d['hold_time'] / d['acq']
+    d['hold_min'] = int(f[9])
+    d['hold_max'] = int(f[10])
+    d['sleeps'] = int(f[11])
+    return d
+
+def process_file(inf):
+    locks = dict()
+    ln = inf.readline()
+    while ln:
+        f = ln.split()
+        if len(f) < num_stat_fields:
+            break
+        d = fields_to_dict(f)
+        if f[0] in locks:
+            locks[f[0]]['acq'] += d['acq']
+            locks[f[0]]['cont'] += d['cont']
+            locks[f[0]]['tries'] += d['tries']
+            locks[f[0]]['spins'] += d['spins']
+            if d['spins_min'] > 0 and d['spins_min'] < locks[f[0]]['spins_min']:
+                locks[f[0]]['spins_min'] = d['spins_min']
+            if d['spins_max'] > locks[f[0]]['spins_max']:
+                locks[f[0]]['spins_max'] = d['spins_max']
+            locks[f[0]]['hold_time'] += d['hold_time']
+            if d['hold_min'] < locks[f[0]]['hold_min']:
+                locks[f[0]]['hold_min'] = d['hold_min']
+            if d['hold_max'] > locks[f[0]]['hold_max']:
+                locks[f[0]]['hold_max'] = d['hold_max']
+            locks[f[0]]['sleeps'] += d['sleeps']
+            locks[f[0]]['call_traces'].append((d, f[num_stat_fields:]))
+        else:
+            locks[f[0]] = d.copy()
+            locks[f[0]]['call_traces'] = [(d, f[num_stat_fields:])]
+
+        ln = inf.readline()
+
+    for v in locks.items():
+        v[1]['spins_avg'] = v[1]['spins']/v[1]['cont'] if v[1]['cont'] != 0 else 0
+        v[1]['hold_avg'] = v[1]['hold_time']/v[1]['acq']
+
+    return locks
+
+def print_locks(locks, sortcol):
+    print('%-18s %5s %7s %7s %12s %7s %7s %10s %12s %7s %7s %10s %10s' %
+            ('Lock Address', 'Type', 'Acquire', 'Contend',
+                'Tot Spins', 'Min', 'Avg', 'Max', 'Hld Cycles', 'Min',
+                'Avg', 'Max', 'Sleeps'))
+    for k in sorted(locks.items(), key=lambda v: v[1][sortcol], reverse=True):
+        print('%s %5s %7d %7d %12d %7d %7d %10d %12d %7d %7d %10d %10d' %
+               (k[0], k[1]['type'], k[1]['acq'], k[1]['cont'],
+                   k[1]['spins'], k[1]['spins_min'],
+                   k[1]['spins_avg'], k[1]['spins_max'], k[1]['hold_time'],
+                   k[1]['hold_min'], k[1]['hold_avg'], k[1]['hold_max'],
+                   k[1]['sleeps']))
+        traces = k[1]['call_traces']
+        for t in sorted(traces, key=lambda tv: tv[0][sortcol], reverse=True):
+            print('  %2d%% ' % (t[0][sortcol]*100 / k[1][sortcol]), end='')
+            #print('(%d/%d)' % (t[0][sortcol], k[1][sortcol]), end='')
+            for i in range(0, len(t[1]), 2):
+                print('%s' % (t[1][i+1]), end='')
+            print('')
+        print('')
+
+def main():
+    args = sys.argv[1:]
+    inf = sys.stdin
+    if len(args) != 0:
+        inf = open(args[0])
+    locks = process_file(inf)
+    sortcol = 'cont'
+    if len(args) > 1:
+        if args[1] in sortkeys:
+            sortcol = args[1]
+        else:
+            print('bad sort key!')
+
+    print_locks(locks, sortcol)
+    inf.close()
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
This PR introduces optional lock profiling support to be built into the kernel. Lock profiling is controlled
by a simple http interface allowing you to turn it on, off, or download the statistics. The statistics gathered
are for acquisition/contended acquisition counts and times for each backtrace accessing a lock. Statistics
are gathered per cpu and collated together when fetching the output. A new python script is added to help
with analysis of the lock output and show which backtraces access the same lock.

Gathering these lock statistics required some supporting changes including generating a frame trace
and adding versions of the objcache and table data structures that can be preallocated to avoid
any runtime allocations and deadlocks when accessing the shared heap.