### PR TITLE
Virtio SCSI / HyperV: add detection of volume attachment point

### DIFF
--- a/src/hyperv/storvsc/storvsc.c
+++ b/src/hyperv/storvsc/storvsc.c
@@ -732,7 +732,7 @@ closure_function(5, 0, void, storvsc_read_capacity_done,
 
     block_io in = closure(s->general, storvsc_read, s);
     block_io out = closure(s->general, storvsc_write, s);
-    apply(bound(a), storage_init_req_handler(&s->req_handler, in, out), s->capacity, -1);
+    apply(bound(a), storage_init_req_handler(&s->req_handler, in, out), s->capacity, lun);
   out:
     closure_finish();
 }

--- a/src/virtio/scsi.h
+++ b/src/virtio/scsi.h
@@ -241,6 +241,26 @@ struct scsi_res_inquiry
     u8 vendor_specific1[SID_VENDOR_SPECIFIC_1_SIZE];
 } __attribute__((packed));
 
+/* Vital Product Data page codes */
+#define SCSI_VPD_DEVID  0x83
+
+struct scsi_devid_desc
+{
+    u8 byte0;
+    u8 byte1;
+    u8 reserved;
+    u8 length;
+    char id[];
+} __attribute__((packed));
+
+struct scsi_res_inquiry_vpd_devid
+{
+    u8 device;
+    u8 page_code;
+    u16 length;
+    struct scsi_devid_desc desc[];
+} __attribute__((packed));
+
 struct scsi_cdb_readwrite_16
 {
     u8 opcode;


### PR DESCRIPTION
This change adds detection of a volume attachment point in the virtio SCSI and HyperV storage drivers.
With these changes, it is possible for GCP and Azure images to mount volumes by using mount directives that reference an attachment point alternatively to a volume name (see also https://github.com/nanovms/ops/pull/1301).