### PR TITLE
ARM and RISC-V build improvements

### DIFF
--- a/platform/riscv-virt/Makefile
+++ b/platform/riscv-virt/Makefile
@@ -207,6 +207,14 @@ cmd_xxd_r=	$(XXD) -r $< $@
 
 include ../../rules.mk
 
+# check riscv64 gcc version for 9.3.0, lowest known working version (from Ubuntu 20)
+GCCRAWVER= $(shell $(CC) -dumpfullversion -dumpversion)
+GCCVER= $(shell echo $(GCCRAWVER) | awk -F'.' '{ printf "%02d%02d%02d", $$1, $$2, $$3 }')
+GCCOK= $(shell expr $(GCCVER) \>= 090300)
+ifeq ($(GCCOK), 0)
+$(error gcc version 9.3.0 or higher required to build RISC-V: $(CC) is only $(GCCRAWVER))
+endif
+
 MKFS=		$(TOOLDIR)/mkfs
 BOOTIMG=	$(OBJDIR)/boot-stub.img
 KERNEL=		$(OBJDIR)/bin/kernel.img

--- a/rules.mk
+++ b/rules.mk
@@ -117,6 +117,14 @@ ifeq ($(ARCH),x86_64)
 KERNCFLAGS+=    -mno-sse \
 		-mno-sse2
 endif
+
+ifeq ($(ARCH),aarch64)
+OUTLINE_ATOMICS=	$(shell $(CC) --help=target | grep -c outline-atomics)
+ifneq ($(OUTLINE_ATOMICS),0)
+KERNCFLAGS+=	-mno-outline-atomics
+endif
+endif
+
 KERNCFLAGS+=	-fno-omit-frame-pointer
 KERNLDFLAGS=	--gc-sections -z max-page-size=4096 -L $(OUTDIR)/klib
 

--- a/src/aarch64/clock.c
+++ b/src/aarch64/clock.c
@@ -36,10 +36,9 @@ BSS_RO_AFTER_INIT closure_struct(arm_timer_percpu_init, _timer_percpu_init);
 
 void init_clock(void)
 {
-    __vdso_dat->clock_src = VDSO_CLOCK_SYSCALL;
     __vdso_dat->platform_has_rdtscp = 0;
 
-    register_platform_clock_now(init_closure(&_clock_now, arm_clock_now), VDSO_CLOCK_PVCLOCK);
+    register_platform_clock_now(init_closure(&_clock_now, arm_clock_now), VDSO_CLOCK_SYSCALL);
     register_platform_clock_timer(init_closure(&_deadline_timer, arm_deadline_timer),
                                   init_closure(&_timer_percpu_init, arm_timer_percpu_init));
 }

--- a/src/riscv64/clock.c
+++ b/src/riscv64/clock.c
@@ -57,9 +57,8 @@ closure_struct(riscv_timer_percpu_init, _timer_percpu_init);
 
 void init_clock(void)
 {
-    __vdso_dat->clock_src = VDSO_CLOCK_SYSCALL;
     __vdso_dat->platform_has_rdtscp = 0;
-    register_platform_clock_now(init_closure(&_clock_now, riscv_clock_now), VDSO_CLOCK_PVCLOCK);
+    register_platform_clock_now(init_closure(&_clock_now, riscv_clock_now), VDSO_CLOCK_SYSCALL);
     register_platform_clock_timer(init_closure(&_deadline_timer, riscv_deadline_timer),
                                   init_closure(&_timer_percpu_init, riscv_timer_percpu_init));
 }

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -317,8 +317,8 @@ dummy:
 include ../../rules.mk
 
 ifneq ($(CROSS_COMPILE),)
-CFLAGS+=	--sysroot $(TARGET_ROOT) -I$(TARGET_ROOT)/usr/include
-LDFLAGS+=	--sysroot=$(TARGET_ROOT) -L$(TARGET_ROOT)/usr/lib/$(ARCH)-linux-gnu
+CFLAGS+=	--sysroot $(TARGET_ROOT) -isystem $(TARGET_ROOT)/usr/include -isystem $(TARGET_ROOT)/usr/include/$(ARCH)-linux-gnu
+LDFLAGS+=	--sysroot=$(TARGET_ROOT) -B$(TARGET_ROOT)/usr/lib/$(ARCH)-linux-gnu
 ifeq ($(ARCH),riscv64)
 LDFLAGS+=	-Wl,--eh-frame-hdr
 endif


### PR DESCRIPTION
This PR adds a number of improvements for building alternate architectures, including:
* generate error if RISC-V compiler is too old to support current RISC-V ISA
* add -mno-outline-atomics to ARM builds if the compiler supports it to eliminate linking errors
* use more appropriate flags for specifying system includes and libraries for runtime tests
* fix clock type bug for ARM and RISC-V
