### PR TITLE
support SO_KEEPALIVE and SO_BROADCAST sockopts, socket_write_udp(): fail on sending to an unconnected socket

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -682,8 +682,12 @@ static sysreturn socket_write_udp(netsock s, void *source, u64 length,
     err_t err = ERR_OK;
 
     /* XXX check how much we can queue, maybe make udp bh */
-    /* XXX check if remote endpoint set? let LWIP check? */
     lwip_lock();
+    if (!dest_addr && !udp_is_flag_set(s->info.udp.lw, UDP_FLAGS_CONNECTED)) {
+        lwip_unlock();
+        return -EDESTADDRREQ;
+    }
+
     struct pbuf * pbuf = pbuf_alloc(PBUF_TRANSPORT, length, PBUF_RAM);
     if (!pbuf) {
         lwip_unlock();

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -2125,21 +2125,25 @@ sysreturn setsockopt(int sockfd,
     case SOL_SOCKET:
         switch (optname) {
         case SO_REUSEADDR:
+        case SO_KEEPALIVE:
+        case SO_BROADCAST:
             if (optlen != sizeof(int)) {
                 rv = -EINVAL;
                 goto out;
             }
+            u8 so_option = (optname == SO_REUSEADDR ? SOF_REUSEADDR :
+                            (optname == SO_KEEPALIVE ? SOF_KEEPALIVE : SOF_BROADCAST));
             lwip_lock();
             if ((s->sock.type == SOCK_STREAM) && s->info.tcp.lw) {
                 if (*((int *)optval))
-                    ip_set_option(s->info.tcp.lw, SOF_REUSEADDR);
+                    ip_set_option(s->info.tcp.lw, so_option);
                 else
-                    ip_reset_option(s->info.tcp.lw, SOF_REUSEADDR);
-            } else if (s->sock.type == SOCK_DGRAM){
+                    ip_reset_option(s->info.tcp.lw, so_option);
+            } else if (s->sock.type == SOCK_DGRAM) {
                 if (*((int *)optval))
-                    ip_set_option(s->info.udp.lw, SOF_REUSEADDR);
+                    ip_set_option(s->info.udp.lw, so_option);
                 else
-                    ip_reset_option(s->info.udp.lw, SOF_REUSEADDR);
+                    ip_reset_option(s->info.udp.lw, so_option);
             } else {
                 lwip_unlock();
                 rv = -EINVAL;
@@ -2247,11 +2251,15 @@ sysreturn getsockopt(int sockfd, int level, int optname, void *optval, socklen_t
             ret_optlen = sizeof(ret_optval.val);
             break;
         case SO_REUSEADDR:
+        case SO_KEEPALIVE:
+        case SO_BROADCAST: {
+            u8 so_option = (optname == SO_REUSEADDR ? SOF_REUSEADDR :
+                            (optname == SO_KEEPALIVE ? SOF_KEEPALIVE : SOF_BROADCAST));
             lwip_lock();
             if ((s->sock.type == SOCK_STREAM) && s->info.tcp.lw) {
-                ret_optval.val = !!ip_get_option(s->info.tcp.lw, SOF_REUSEADDR);
-            } else if (s->sock.type == SOCK_DGRAM){
-                ret_optval.val = !!ip_get_option(s->info.udp.lw, SOF_REUSEADDR);
+                ret_optval.val = !!ip_get_option(s->info.tcp.lw, so_option);
+            } else if (s->sock.type == SOCK_DGRAM) {
+                ret_optval.val = !!ip_get_option(s->info.udp.lw, so_option);
             } else {
                 lwip_unlock();
                 rv = -EINVAL;
@@ -2260,6 +2268,7 @@ sysreturn getsockopt(int sockfd, int level, int optname, void *optval, socklen_t
             ret_optlen = sizeof(ret_optval.val);
             lwip_unlock();
             break;
+        }
         case SO_REUSEPORT:
             ret_optval.val = 0;
             ret_optlen = sizeof(ret_optval.val);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -752,8 +752,10 @@ struct io_uring_params {
 #define SO_REUSEADDR    2
 #define SO_TYPE         3
 #define SO_ERROR        4
+#define SO_BROADCAST    6
 #define SO_SNDBUF       7
 #define SO_RCVBUF       8
+#define SO_KEEPALIVE    9
 #define SO_PRIORITY     12
 #define SO_LINGER       13
 #define SO_REUSEPORT    15

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -59,6 +59,16 @@ static void *netsock_test_basic_thread(void *arg)
     return NULL;
 }
 
+static inline void netsock_toggle_and_check_sockopt(int fd, int level, int optname, int val)
+{
+    int v;
+    socklen_t len = sizeof(v);
+    test_assert(getsockopt(fd, level, optname, &v, &len) == 0 && v == !val);
+    v = val;
+    test_assert(setsockopt(fd, level, optname, &v, len) == 0);
+    test_assert(getsockopt(fd, level, optname, &v, &len) == 0 && v == val);
+}
+
 static void netsock_test_basic(int sock_type)
 {
     int fd, tx_fd;
@@ -87,6 +97,8 @@ static void netsock_test_basic(int sock_type)
         int val;
         socklen_t len = sizeof(val);
         test_assert(getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &val, &len) == 0 && val == 0);
+        netsock_toggle_and_check_sockopt(fd, SOL_SOCKET, SO_REUSEADDR, 1);
+        netsock_toggle_and_check_sockopt(fd, SOL_SOCKET, SO_KEEPALIVE, 1);
         test_assert(listen(fd, 1) == 0);
         test_assert(listen(fd, 1) == 0);    /* test listen() call on already listening socket */
         test_assert(getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &val, &len) == 0 && val == 1);
@@ -95,18 +107,23 @@ static void netsock_test_basic(int sock_type)
 
         /* Change a TCP option on the listening socket and verify that the option is inherited by
          * the accepted socket. */
-        test_assert(getsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &val, &len) == 0 && val == 0);
-        val = 1;
-        test_assert(setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &val, len) == 0);
+        netsock_toggle_and_check_sockopt(fd, IPPROTO_TCP, TCP_NODELAY, 1);
         tx_fd = accept(fd, NULL, NULL);
         test_assert(tx_fd > 0);
         test_assert(getsockopt(tx_fd, IPPROTO_TCP, TCP_NODELAY, &val, &len) == 0 && val == 1);
+
+        /* Also validate that SO_REUSEADDR and SO_KEEPALIVE are inherited. Linux follows this
+         * behavior, and it is explicitly supported by lwIP (see SOF_INHERITED). */
+        test_assert(getsockopt(tx_fd, SOL_SOCKET, SO_REUSEADDR, &val, &len) == 0 && val == 1);
+        test_assert(getsockopt(tx_fd, SOL_SOCKET, SO_KEEPALIVE, &val, &len) == 0 && val == 1);
         val = 0;
         test_assert(setsockopt(tx_fd, IPPROTO_TCP, TCP_NODELAY, &val, len) == 0);
 
         test_assert(getsockopt(tx_fd, SOL_SOCKET, SO_ACCEPTCONN, &val, &len) == 0 && val == 0);
         test_assert(close(fd) == 0);
     } else {
+        netsock_toggle_and_check_sockopt(fd, SOL_SOCKET, SO_BROADCAST, 1);
+        netsock_toggle_and_check_sockopt(fd, SOL_SOCKET, SO_BROADCAST, 0);
         tx_fd = fd;
     }
     test_assert((recv(tx_fd, tx_buf, sizeof(tx_buf), MSG_DONTWAIT) == -1) && (errno == EAGAIN));

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -125,6 +125,9 @@ static void netsock_test_basic(int sock_type)
         netsock_toggle_and_check_sockopt(fd, SOL_SOCKET, SO_BROADCAST, 1);
         netsock_toggle_and_check_sockopt(fd, SOL_SOCKET, SO_BROADCAST, 0);
         tx_fd = fd;
+        /* Test that writing to an unconnected datagram socket gives an error. */
+        test_assert(write(tx_fd, &ret, sizeof(ret)) < 0 && errno == EDESTADDRREQ);
+        test_assert(connect(tx_fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
     }
     test_assert((recv(tx_fd, tx_buf, sizeof(tx_buf), MSG_DONTWAIT) == -1) && (errno == EAGAIN));
     test_assert(clock_gettime(CLOCK_MONOTONIC, &start) == 0);


### PR DESCRIPTION
This adds support for SO_KEEPALIVE and SO_BROADCAST socket options under the
SOL_SOCKET protocol level. The netsock test has been modified to check that
these options, if set on a listening socket, are inherited by accepted
sockets.

Also, the netsock test was previously failing under Linux, with the write() in
netsock_test_basic() failing with the errno EDESTADDRREQ (89). This was a
result of a missing connect() on the datagram socket, a condition that was
silently being ignored by Nanos. socket_write_udp() has been updated to report
this error when attempting to send to an unconnected udp socket, and a test
for this condition, as well as the required call to connect(), have been added
to the netsock test.