### PR TITLE
implement SIOCGIFNAME socket ioctl, handle netdevice ioctls for any socket type

### DIFF
--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -120,11 +120,7 @@ static inline void socket_flush_q(struct sock *s)
     blockq_flush(s->txbq);
 }
 
-static inline sysreturn socket_ioctl(struct sock *s, unsigned long request,
-        vlist ap)
-{
-    return ioctl_generic(&s->f, request, ap);
-}
+sysreturn socket_ioctl(struct sock *s, unsigned long request, vlist ap);
 
 static inline boolean validate_msghdr(const struct msghdr *mh, boolean write)
 {

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -1,5 +1,6 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <net/if.h>
 #include <poll.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -472,6 +473,21 @@ static void netsock_test_rcvbuf(void)
     test_assert((close(tx_fd) == 0) && (close(rx_fd) == 0));
 }
 
+static void netsock_test_netconf(void)
+{
+    /* SIOC?IF* ioctls aren't netsock-specific - in fact, netdevice(7)
+       declares that they may be performed on any socket "regardless of the
+       family or type" (and we'll use AF_UNIX here just to test this
+       assertion) - but here is as good a place as any to stash tests for
+       them. */
+    struct ifreq ifr;
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    test_assert(fd > 0);
+    memset(&ifr, 0, sizeof(ifr));
+    ifr.ifr_ifindex = 1;
+    test_assert(ioctl(fd, SIOCGIFNAME, &ifr) == 0);
+}
+
 int main(int argc, char **argv)
 {
     setbuf(stdout, NULL);
@@ -483,6 +499,7 @@ int main(int argc, char **argv)
     netsock_test_nonblocking_connect();
     netsock_test_peek();
     netsock_test_rcvbuf();
+    netsock_test_netconf();
     printf("Network socket tests OK\n");
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This change implements the SIOCGIFNAME ioctl for getting an interface name by
index. It also moves the various SIOC?* netdevice-related ioctls from
netsock_ioctl() to socket_ioctl(), as they are valid for any type of socket,
regardless of family or type (as stated in netdevice(7)). These changes are
required for if_indextoname(3) to work properly.