### PR TITLE
Unix fault handler: do not change CPU state

### DIFF
--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -264,18 +264,14 @@ define_closure_function(1, 1, context, unix_fault_handler,
         }
 
         if (handle_protection_fault(ctx, vaddr, vm)) {
-            if (!is_thread_context(ctx)) {
-                current_cpu()->state = cpu_kernel;
+            if (!is_thread_context(ctx))
                 return ctx;   /* direct return */
-            }
             schedule_thread(t);
             return 0;
         }
 
-        if (do_demand_page(t, ctx, fault_address(ctx->frame), vm)) {
-            current_cpu()->state = cpu_kernel;
+        if (do_demand_page(t, ctx, fault_address(ctx->frame), vm))
             return ctx;   /* direct return */
-        }
     }
     /* XXX arch dep */
 #ifdef __x86_64__


### PR DESCRIPTION
When the fault handler is invoked, the CPU state is the same as the state when the interrupt was triggered. Therefore, it is not necessary for the fault handler to set the state when returning the current context; in fact, this causes a wrong state to be set when a user thread generates a page fault that is resolved without blocking, which may cause any subsequent exception generated by the thread to be handled as if it was generated by the kernel.