### PR TITLE
unix_fault_handler: deliver SIGSEGV on user page faults from syscall context

### DIFF
--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -261,12 +261,12 @@ static inline boolean is_pte_error(context_frame f)
     return false;
 }
 
-static inline u64 frame_return_address(context_frame f)
+static inline u64 frame_fault_pc(context_frame f)
 {
-    return f[FRAME_X30];
+    return f[FRAME_ELR];
 }
 
-static inline u64 fault_address(context_frame f)
+static inline u64 frame_fault_address(context_frame f)
 {
     return f[FRAME_FAULT_ADDRESS];
 }

--- a/src/riscv64/kernel_machine.h
+++ b/src/riscv64/kernel_machine.h
@@ -193,12 +193,12 @@ static inline boolean is_pte_error(context_frame f)
     return false;
 }
 
-static inline u64 frame_return_address(context_frame f)
+static inline u64 frame_fault_pc(context_frame f)
 {
-    return f[FRAME_RA];
+    return f[FRAME_PC];
 }
 
-static inline u64 fault_address(context_frame f)
+static inline u64 frame_fault_address(context_frame f)
 {
     return f[FRAME_FAULT_ADDRESS];
 }

--- a/src/riscv64/page.c
+++ b/src/riscv64/page.c
@@ -22,7 +22,7 @@ boolean is_protection_fault(context_frame f)
        readonly page versus writing to a non-existant page? */
     pte e;
     // XXX this lookup is not locked but will need to be for smp
-    if (physical_and_pte_from_virtual(fault_address(f), &e) == INVALID_PHYSICAL)
+    if (physical_and_pte_from_virtual(frame_fault_address(f), &e) == INVALID_PHYSICAL)
         return false;
     u64 cause = SCAUSE_CODE(f[FRAME_CAUSE]);
     return (e & PAGE_VALID) && (cause == TRAP_E_SPAGE_FAULT);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -310,7 +310,8 @@ typedef struct thread {
     blockq blocked_on;
 
     /* set by syscall_return(); used to detect if blocking is necessary */
-    boolean syscall_complete; // XXX?
+    boolean syscall_complete;
+    boolean syscall_abandoned;
 
     /* for waiting on thread-specific conditions rather than a resource */
     blockq thread_bq;

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -165,7 +165,7 @@ void dump_context(context ctx)
 {
     context_frame f = ctx->frame;
     u64 v = f[FRAME_VECTOR];
-    rputs(" interrupt: ");
+    rputs("lastvector: ");
     print_u64(v);
     if (v < INTERRUPT_VECTOR_START) {
         rputs(" (");
@@ -262,7 +262,6 @@ void common_handler()
             context_schedule_return(ctx);
         }
     } else {
-        /* fault handlers may act on cpu state, so don't change it */
         fault_handler fh = ctx->fault_handler;
         if (fh) {
             context retctx = apply(fh, ctx);
@@ -270,6 +269,17 @@ void common_handler()
                 context_release_refcount(retctx);
                 frame_return(retctx->frame);
             }
+            if (is_syscall_context(ctx)) {
+                /* This indicates an unhandled fault on a user page from
+                   within a syscall. We need to abandon the syscall at this
+                   point and let the thread run so it may receive the
+                   appropriate signal. The frame is left full so that future
+                   context dumps will report the actual processor state when
+                   the exception occurred. */
+                context_release_refcount(ctx);
+                runloop();
+            }
+            assert(!is_kernel_context(ctx));
         } else {
             console("\nno fault handler\n");
             goto exit_fault;

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -370,12 +370,12 @@ static inline boolean is_pte_error(context_frame f)
     return (is_protection_fault(f) && (f[FRAME_ERROR_CODE] & FRAME_ERROR_PF_RSV));
 }
 
-static inline u64 frame_return_address(context_frame f)
+static inline u64 frame_fault_pc(context_frame f)
 {
     return f[FRAME_RIP];
 }
 
-static inline u64 fault_address(context_frame f)
+static inline u64 frame_fault_address(context_frame f)
 {
     return f[FRAME_CR2];
 }


### PR DESCRIPTION
This addresses a common problem whereby the kernel can panic on a user page
fault that occurs within a syscall context. Such faults are usually caused by
the user program supplying an invalid buffer address, and as such should be
treated as segmentation violations. This handles such cases by marking the
relevant thread's current syscall as having been "abandoned," thereafter
delivering SIGSEGV to the violating process - just as if the fault had
occurred from within user mode. The abandoned syscall is "cleaned up" in
thread_return() before returning control to the program (albeit not
completely; see the comment in that function).

This also addresses a few cosmetic issues with output that occurs after
terminal signal delivery. To aid the debugging of such violations, frames of
the the offending thread and syscall_context (if applicable) are dumped.

The second commit fixes the incorrect setting of the siginfo si_addr
(sifields.sigfault.addr) field for SIGFPE, SIGILL and SIGTRAP signals.
The signal test has been amended with a test that checks validity of
the reported address after a SIGILL, and also includes a test for a terminal
page fault from within a syscall.

Resolves #1705 
