### PR TITLE
select(2): allow blocking indefinitely with zero nfds

### DIFF
--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -760,9 +760,6 @@ static sysreturn select_internal(int nfds,
                                  timestamp timeout,
                                  const sigset_t * sigmask)
 {
-    if (nfds == 0 && timeout == infinity)
-        return 0;
-
     u64 set_bytes = pad(nfds, 64) / 8;
     if ((readfds && !validate_user_memory(readfds, set_bytes, true)) ||
         (writefds && !validate_user_memory(writefds, set_bytes, true)) ||
@@ -782,7 +779,7 @@ static sysreturn select_internal(int nfds,
     epoll_debug("nfds %d, readfds %p, writefds %p, exceptfds %p\n"
                 "   epoll_blocked %p, timeout %d\n", nfds, readfds, writefds, exceptfds,
                 wt, timeout);
-    if (nfds == 0)            /* timeout != infinity */
+    if (nfds == 0)
         goto check_timeout;
 
     wt->rset = readfds ? bitmap_wrap(e->h, readfds, nfds) : 0;


### PR DESCRIPTION
Our select implementation incorrectly assumed that a call with zero nfds
specified and an indefinite timeout should return immediately. Such a call may
legitimately be used to wait for signal reception, though, so
select_internal() has been changed here to enter an indefinite, interruptible
block whenever a NULL timeout is specified, regardless of the value of
nfds. The signal test now checks that such a call to select behaves in the
same manner as pause(2).