### PR TITLE
id_heap dealloc_from_range(): only update next bit to a lower value

### DIFF
--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -180,12 +180,14 @@ closure_function(2, 1, void, dealloc_from_range,
 
     int bit = ri.start - n->r.start;
     u64 pages = range_span(ri);
+    int order = find_order(pages);
     if (!bitmap_dealloc(r->b, bit, pages)) {
         msg_err("heap %p: bitmap dealloc for range %R failed; leaking\n", i, q);
         return;
     }
 
-    set_next_bit(r, find_order(pages), bit);
+    if (bit < get_next_bit(r, order))
+        set_next_bit(r, order, bit);
     u64 deallocated = pages << page_order(i);
     assert(i->allocated >= deallocated);
     i->allocated -= deallocated;


### PR DESCRIPTION
An id heap deallocation would unconditionally update the next bit for a given
allocation size. This behavior would unnecessarily waste space in the heap if
the next bit was being replaced by a larger value. This effect materialized in
one case where file descriptors were continually increasing through many
cycles of opening and closing files, eventually exhausting the fd_set size
limit (FD_SETSIZE) being used for select(2).

This change prevents such behavior by only updating the next bit for an
allocation size with one of a lesser value.