### PR TITLE
Add support for UBSan (undefined behavior sanitizer)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run: gsutil setmeta -h "Custom-Time:`date -Iseconds`" gs://nanos/release/${COMMIT_ID}/*
       - run: gsutil acl ch -u AllUsers:R gs://nanos/release/${COMMIT_ID}/*
 
-  build-pc-memdebug:
+  build-pc-debug:
     docker:
       # specify the version
       - image: cimg/go:1.16
@@ -45,13 +45,13 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install nasm qemu-system-x86 ent ruby rustc
       - run: cd .. && git clone git@github.com:nanovms/ops.git
-      - run: make MEMDEBUG=all
+      - run: make MEMDEBUG=all UBSAN=1
       - run: curl https://ops.city/get.sh -sSfL | sh
       - run:
           command: |
             OPS_DIR=$HOME/.ops
             PATH=$HOME/.ops/bin:$PATH
-            make MEMDEBUG=all test-noaccel
+            make MEMDEBUG=all UBSAN=1 test-noaccel
 
   nightly-build:
     docker:
@@ -209,7 +209,7 @@ workflows:
     jobs:
       - build-pc
       - build-virt
-      - build-pc-memdebug
+      - build-pc-debug
       - build-riscv
   nightly:
     triggers:

--- a/rules.mk
+++ b/rules.mk
@@ -128,6 +128,10 @@ endif
 KERNCFLAGS+=	-fno-omit-frame-pointer
 KERNLDFLAGS=	--gc-sections -z max-page-size=4096 -L $(OUTDIR)/klib
 
+ifneq ($(UBSAN),)
+KERNCFLAGS+= -fsanitize=undefined -fno-sanitize=alignment,null -fsanitize-undefined-trap-on-error
+endif
+
 ifeq ($(MEMDEBUG),mcache)
 CFLAGS+= -DMEMDEBUG_MCACHE
 else ifeq ($(MEMDEBUG),backed)

--- a/src/aarch64/clock.c
+++ b/src/aarch64/clock.c
@@ -35,8 +35,6 @@ BSS_RO_AFTER_INIT closure_struct(arm_timer_percpu_init, _timer_percpu_init);
 
 void init_clock(void)
 {
-    __vdso_dat->platform_has_rdtscp = 0;
-
     register_platform_clock_now(init_closure(&_clock_now, arm_clock_now), VDSO_CLOCK_SYSCALL);
     register_platform_clock_timer(init_closure(&_deadline_timer, arm_deadline_timer),
                                   init_closure(&_timer_percpu_init, arm_timer_percpu_init));

--- a/src/aarch64/machine.h
+++ b/src/aarch64/machine.h
@@ -248,6 +248,9 @@ static inline __attribute__((always_inline)) void kern_pause(void)
 
 /* XXX make names generic */
 #if defined(KERNEL) || defined(BUILD_VDSO)
+struct arch_vdso_dat {
+};
+
 static inline __attribute__((always_inline)) u64 rdtsc(void)
 {
     // XXX vdso

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -30,7 +30,7 @@ static u64 bootstrap_alloc(heap h, bytes length)
         rputs("*** bootstrap heap overflow! ***\n");
         return INVALID_PHYSICAL;
     }
-    bootstrap_base += length;
+    bootstrap_base += pad(length, 8);   /* ensure 8-byte alignment for the next allocation */
     return result;
 }
 

--- a/src/kernel/vdso-now.c
+++ b/src/kernel/vdso-now.c
@@ -13,7 +13,6 @@
 
 #ifndef BUILD_VDSO
 VVAR_DEF(struct vdso_dat_struct, vdso_dat) = {
-    .platform_has_rdtscp = 0,
     .rtc_offset = 0,
     .pvclock_offset = 0,
     .clock_src = VDSO_CLOCK_SYSCALL
@@ -110,7 +109,7 @@ vdso_now(clock_id id)
 VDSO int
 vdso_getcpu(unsigned *cpu, unsigned *node)
 {
-    if (__vdso_dat->platform_has_rdtscp) {
+    if (__vdso_dat->machine.platform_has_rdtscp) {
         if (cpu)
             asm volatile("rdtscp" : "=c" (*cpu) :: "eax", "edx");
         if (node)

--- a/src/kernel/vdso.h
+++ b/src/kernel/vdso.h
@@ -16,8 +16,8 @@ struct vdso_dat_struct {
     s64 cal;    /* calibration value (from monotonic raw to monotonic); 0 means no drift */
     s64 last_drift; /* last calculated drift from monotonic raw to monotonic */
     timestamp last_raw; /* time at which last_drift has been calculated */
-    u8 platform_has_rdtscp;
-} __attribute((packed));
+    struct arch_vdso_dat machine;
+};
 
 /* VDSO accessible variables */
 VVAR_DECL(struct vdso_dat_struct, vdso_dat);

--- a/src/riscv64/clock.c
+++ b/src/riscv64/clock.c
@@ -56,7 +56,6 @@ closure_struct(riscv_timer_percpu_init, _timer_percpu_init);
 
 void init_clock(void)
 {
-    __vdso_dat->platform_has_rdtscp = 0;
     register_platform_clock_now(init_closure(&_clock_now, riscv_clock_now), VDSO_CLOCK_SYSCALL);
     register_platform_clock_timer(init_closure(&_deadline_timer, riscv_deadline_timer),
                                   init_closure(&_timer_percpu_init, riscv_timer_percpu_init));

--- a/src/riscv64/machine.h
+++ b/src/riscv64/machine.h
@@ -248,6 +248,9 @@ static inline __attribute__((always_inline)) void kern_pause(void)
 /* XXX used in vdso, but is rdcycle right for that? */
 /* XXX make names generic */
 #if defined(KERNEL) || defined(BUILD_VDSO)
+struct arch_vdso_dat {
+};
+
 static inline __attribute__((always_inline)) u64 rdtsc(void)
 {
     // XXX vdso

--- a/src/riscv64/serial.c
+++ b/src/riscv64/serial.c
@@ -18,6 +18,6 @@ void serial_putchar(char c)
 
 void serial_set_devbase(u64 devbase)
 {
-    UART0_BASE = ((void*)UART0_BASE) + devbase;
+    UART0_BASE = pointer_from_u64(u64_from_pointer(UART0_BASE) + devbase);
 }
 

--- a/src/runtime/bitmap.c
+++ b/src/runtime/bitmap.c
@@ -129,7 +129,7 @@ static inline u64 bitmap_alloc_internal(bitmap b, u64 nbits, u64 startbit, u64 e
 
     endbit -= nbits;
 
-    if (nbits >= 64) {
+    if (stride >= 64) {
         /* multi-word */
         while (bit <= endbit) {
             if (bitmap_extend(b, bit + nbits))

--- a/src/runtime/clock.h
+++ b/src/runtime/clock.h
@@ -90,15 +90,6 @@ static inline timestamp now(clock_id id)
     return t;
 }
 
-static inline boolean platform_has_precise_clocksource(void)
-{
-#if defined(KERNEL) || defined(BUILD_VDSO)
-    return __vdso_dat->platform_has_rdtscp;
-#else
-    return false;
-#endif
-}
-
 static inline timestamp uptime(void)
 {
     return now(CLOCK_ID_BOOTTIME);

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -206,7 +206,7 @@ typedef struct iour_timer {
  *   - array of struct io_uring_sqe (sq_entries)
  */
 #define IOUR_REGION1_SIZE(iour) \
-        pad(sizeof(struct io_rings) + (iour)->sq_entries * sizeof(u32) + \
+        pad(sizeof(struct io_rings) + pad((iour)->sq_entries * sizeof(u32), 8) + \
         (iour)->cq_entries * sizeof(struct io_uring_cqe), PAGESIZE)
 #define IOUR_REGION2_SIZE(iour) \
         pad((iour)->sq_entries * sizeof(struct io_uring_sqe), PAGESIZE)
@@ -394,7 +394,7 @@ sysreturn io_uring_setup(unsigned int entries, struct io_uring_params *params)
     }
     iour->sq_array = (u32 *)((u8 *)iour->rings + sizeof(struct io_rings));
     iour->cqes = (struct io_uring_cqe *)((u8 *)iour->sq_array +
-            iour->sq_entries * sizeof(u32));
+            pad(iour->sq_entries * sizeof(u32), 8));
     iour->sqes = (struct io_uring_sqe *)((u8 *)iour->rings +
             IOUR_REGION1_SIZE(iour));
     iour_debug("rings %p, SQ array %p, CQEs %p, SQEs %p", iour->rings,

--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -291,7 +291,8 @@ static void virtio_net_attach(vtdev dev)
     vn->net_header_len = (dev->features & VIRTIO_F_VERSION_1) ||
         (dev->features & VIRTIO_NET_F_MRG_RXBUF) != 0 ?
         sizeof(struct virtio_net_hdr_mrg_rxbuf) : sizeof(struct virtio_net_hdr);
-    vn->rxbuflen = vn->net_header_len + sizeof(struct eth_hdr) + sizeof(struct eth_vlan_hdr) + 1500;
+    vn->rxbuflen = pad(vn->net_header_len + sizeof(struct eth_hdr) + sizeof(struct eth_vlan_hdr) +
+                       1500, 8);    /* padding to make xpbuf structures aligned to 8 bytes */
     virtio_net_debug("%s: net_header_len %d, rxbuflen %d\n", __func__, vn->net_header_len, vn->rxbuflen);
     vn->rxbuffers = locking_heap_wrapper(h, allocate_objcache(h, (heap)contiguous,
 				      vn->rxbuflen + sizeof(struct xpbuf), PAGESIZE_2M));

--- a/src/x86_64/apic.c
+++ b/src/x86_64/apic.c
@@ -96,7 +96,7 @@ void msi_format(u32 *address, u32 *data, int vector)
     u32 dm = 0;             // destination mode: ignored if rh == 0
     u32 rh = 0;             // redirection hint: 0 - disabled
     u32 destination = 0;    // destination APIC
-    *address = (0xfee << 20) | (destination << 12) | (rh << 3) | (dm << 2);
+    *address = (0xfeeu << 20) | (destination << 12) | (rh << 3) | (dm << 2);
 
     u32 mode = 0;           // delivery mode: 000 fixed, 001 lowest, 010 smi, 100 nmi, 101 init, 111 extint
     u32 level = 0;          // trigger level: 0 - deassert, 1 - assert

--- a/src/x86_64/clock.c
+++ b/src/x86_64/clock.c
@@ -16,7 +16,7 @@ void init_clock(void)
     u32 regs[4];
     cpuid(0x80000001, 0, regs);
     __vdso_dat->clock_src = VDSO_CLOCK_SYSCALL;
-    __vdso_dat->platform_has_rdtscp = (regs[3] & U64_FROM_BIT(27)) != 0;
+    __vdso_dat->machine.platform_has_rdtscp = (regs[3] & U64_FROM_BIT(27)) != 0;
 }
 
 /* error refers to the time (expressed in TSC cycles) it takes to read the PIT counter value. */

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -497,6 +497,16 @@ static inline u64 *get_current_fp(void)
 })
 
 /* clocksource */
+
+static inline boolean platform_has_precise_clocksource(void)
+{
+#if defined(KERNEL) || defined(BUILD_VDSO)
+    return __vdso_dat->machine.platform_has_rdtscp;
+#else
+    return false;
+#endif
+}
+
 static inline u64
 _rdtscp(void)
 {

--- a/src/x86_64/machine.h
+++ b/src/x86_64/machine.h
@@ -133,3 +133,7 @@ static inline __attribute__((always_inline)) void kern_pause(void)
 {
     asm volatile("pause");
 }
+
+struct arch_vdso_dat {
+    u8 platform_has_rdtscp;
+};

--- a/src/x86_64/mp.c
+++ b/src/x86_64/mp.c
@@ -77,7 +77,7 @@ void cpu_init(int cpu)
     u64 addr = u64_from_pointer(cpuinfo_from_id(cpu));
     write_msr(KERNEL_GS_MSR, 0); /* clear user GS */
     write_msr(GS_MSR, addr);
-    if (VVAR_REF(vdso_dat).platform_has_rdtscp)
+    if (VVAR_REF(vdso_dat).machine.platform_has_rdtscp)
         write_msr(TSC_AUX_MSR, cpu);    /* used by vdso_getcpu() */
     init_syscall_handler();
 }


### PR DESCRIPTION
This change allows specifying an `UBSAN` Makefile variable that enables instrumenting the compiler-generated code with instructions to catch bugs that can result in undefined behavior. When UBSan detects an error, it generates a software trap (on x86-64, an "invalid opcode (UD2)" exception; on aarch64, a "brk" exception that results in an ESR value of 0xf20003e8; on risc-v, a breakpoint exception), which triggers a crash dump in the kernel.
UBSan checks for unaligned accesses and null pointers are being disabled because the kernel contains legitimate uses of unaligned accesses (mainly in third-party code such as acpica and lwIP) and null pointers (in the x86-64 code for secondary CPU bringup).
`UBSAN=1` is being added to the make command line in the build-pc-memdebug CircleCI job (now renamed to build-pc-debug) so that UBSan is enabled as part of the CI checks.

The `-fsanitize-undefined-trap-on-error` compiler flag is being used so that UBSan generates a software trap instead of calling an error handler function, because instrumenting the entire kernel code with calls to error handlers would result in a kernel binary file significantly larger (mainly because source file and line number information needs to be kept for each error path), which cannot be loaded by the stage2 bootloader. If more information is needed to find the cause of an UBSan error, the kernel can be rebuilt by omitting the `-fsanitize-undefined-trap-on-error` compiler flag for the source file where the error happens (which can be identified from the kernel crash dump via the instruction that caused the exception), and the error handler functions need to be included in the kernel binary. The following code provides an implementation of the error handler functions:
```
#include "kernel.h"

struct source_location {
    const char *file_name;
    u32 line;
    u32 column;
};

enum {
   type_kind_integer = 0x000,
   type_kind_float = 0x0001,
   type_kind_unkown = 0xffff,
};

struct type_descriptor {
    u16 kind;
    u16 info;
    char name[1];
};

struct out_of_bounds_data {
    struct source_location loc;
    struct type_descriptor *array_type;
    struct type_descriptor *index_type;
};

struct shift_out_of_bounds_data {
    struct source_location loc;
    struct type_descriptor *lhs_type;
    struct type_descriptor *rhs_type;
};

struct type_mismatch_data {
    struct source_location loc;
    struct type_descriptor *type;
    u8 log_alignment;
    u8 type_check_kind;
};

struct pointer_overflow_data {
    struct source_location loc;
};

struct overflow_data {
    struct source_location loc;
    struct type_descriptor *type;
};

static void ubsan_prologue(struct source_location *loc)
{
    rprintf("UBSan detected error at %s:%d:%d\n",loc->file_name, loc->line, loc->column);
}

static void ubsan_epilogue(void)
{
    dump_context(get_current_context(current_cpu()));
    vm_exit(VM_EXIT_FAULT);
}

void __ubsan_handle_out_of_bounds(struct out_of_bounds_data *data, u64 index)
{
    ubsan_prologue(&data->loc);
    rprintf("out of bounds: index %ld, array type %s, index type %s\n", index,
            data->array_type->name, data->index_type->name);
    ubsan_epilogue();
}

void __ubsan_handle_shift_out_of_bounds(struct shift_out_of_bounds_data *data, long lhs, long rhs)
{
    ubsan_prologue(&data->loc);
    rprintf("shift out of bounds: LHS %ld (%s), RHS %ld (%s)\n", lhs, data->lhs_type->name,
            rhs, data->rhs_type->name);
    ubsan_epilogue();
}

void __ubsan_handle_type_mismatch_v1(struct type_mismatch_data *data, void *pointer)
{
    ubsan_prologue(&data->loc);
    rprintf("type mismatch: type %s, alignment %d, pointer %p\n", data->type->name,
            1 << data->log_alignment, pointer);
    ubsan_epilogue();
}

void __ubsan_handle_pointer_overflow(struct pointer_overflow_data *data, void *base, void *result)
{
    ubsan_prologue(&data->loc);
    rprintf("pointer overflow: base %p, result %p\n", base, result);
    ubsan_epilogue();
}

void __ubsan_handle_negate_overflow(struct overflow_data *data, long old_val)
{
    ubsan_prologue(&data->loc);
    rprintf("negate overflow: type %s, old value 0x%lx\n", data->type->name, old_val);
    ubsan_epilogue();
}

#define UBSAN_OVERFLOW_HANDLER(op)                                                              \
    void __ubsan_handle_##op##_overflow(struct overflow_data *data, void *lhs, void *rhs)       \
    {                                                                                           \
        ubsan_prologue(&data->loc);                                                             \
        rprintf(#op " overflow: type %s, LHS 0x%lx, RHS 0x%lx\n", data->type->name, lhs, rhs);  \
        ubsan_epilogue();                                                                       \
    }

UBSAN_OVERFLOW_HANDLER(add)
UBSAN_OVERFLOW_HANDLER(sub)
UBSAN_OVERFLOW_HANDLER(mul)
UBSAN_OVERFLOW_HANDLER(divrem)
```