### PR TITLE
syscall_handler: do not bypass syscall context resume

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2444,14 +2444,6 @@ void syscall_handler(thread t)
     syscall_restart_arch_setup(f);
     set_syscall_return(t, -ENOSYS);
 
-    if (shutting_down)
-        goto out;
-
-    if (call >= sizeof(_linux_syscalls) / sizeof(_linux_syscalls[0])) {
-        thread_log(t, "invalid syscall %d", call);
-        goto out;
-    }
-
     syscall_context sc = (syscall_context)get_current_context(ci);
     assert(is_syscall_context(&sc->context));
     sc->t = t;
@@ -2463,6 +2455,14 @@ void syscall_handler(thread t)
     context_pause(&t->context);
     context_release(&t->context);
     context_resume(&sc->context);
+
+    if (shutting_down)
+        goto out;
+
+    if (call >= sizeof(_linux_syscalls) / sizeof(_linux_syscalls[0])) {
+        thread_log(t, "invalid syscall %d", call);
+        goto out;
+    }
 
     /* In the future, interrupt enable can go here. */
     if (do_syscall_stats) {


### PR DESCRIPTION
The syscall handler must resume the syscall context installed on low-level
entry, completing the context switch. syscall_handler() was previously exiting
on shutdown or an invalid syscall without performing this restore, causing an
assertion failure when the pause method for the context is called on the next
context switch. This materialized when the clone() wrapper in glibc 2.34
attempted to invoke the unimplemented clone3(2) syscall. With this fix, glibc
safely handles the -ENOSYS from the invalid syscall and falls back to using
clone(2).

https://github.com/nanovms/ops/issues/1321
