### PR TITLE
ACPI: add support for entering S3 sleeping state (VM suspend)

### DIFF
--- a/src/drivers/acpica.mk
+++ b/src/drivers/acpica.mk
@@ -59,11 +59,14 @@ ACPICA= \
 	$(ACPICA_SRCDIR)/executer/extrace.c \
 	$(ACPICA_SRCDIR)/executer/exutils.c \
 	$(ACPICA_SRCDIR)/hardware/hwacpi.c \
+	$(ACPICA_SRCDIR)/hardware/hwesleep.c \
 	$(ACPICA_SRCDIR)/hardware/hwgpe.c \
 	$(ACPICA_SRCDIR)/hardware/hwpci.c \
 	$(ACPICA_SRCDIR)/hardware/hwregs.c \
+	$(ACPICA_SRCDIR)/hardware/hwsleep.c \
 	$(ACPICA_SRCDIR)/hardware/hwvalid.c \
 	$(ACPICA_SRCDIR)/hardware/hwxface.c \
+	$(ACPICA_SRCDIR)/hardware/hwxfsleep.c \
 	$(ACPICA_SRCDIR)/namespace/nsaccess.c \
 	$(ACPICA_SRCDIR)/namespace/nsalloc.c \
 	$(ACPICA_SRCDIR)/namespace/nsarguments.c \


### PR DESCRIPTION
This change implements a handler for the ACPI sleep button event, which is triggered in a GCP instance during a VM suspend operation. This handler communicates with the ACPI firmware to put the system in the ACPI S3 state, at which point the VM is suspended; then, when a VM resume operation is requested, guest execution resumes from where it was suspended (at the call to AcpiEnterSleepState()), after which the sleep button handler indicates to the ACPI firmware that wakeup has completed and the VM resumes normal operation.