### PR TITLE
Free status tuple when file write fails

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -607,6 +607,7 @@ static void file_write_complete_internal(thread t, file f, u64 len,
         rv = len;
     } else {
         rv = sysreturn_from_fs_status_value(s);
+        timm_dealloc(s);
     }
     apply(completion, t, rv);
 }


### PR DESCRIPTION
Thousands of failed write syscalls can eventually exhaust memory if the status tuple is not freed.