### PR TITLE
x2apic_ipi, xapic_ipi: target comparison requires explicit cast

### DIFF
--- a/src/x86_64/x2apic.c
+++ b/src/x86_64/x2apic.c
@@ -48,7 +48,7 @@ static void x2apic_ipi(apic_iface i, u32 target, u64 flags, u8 vector)
     u64 w;
     u64 icr = (flags & ~0xff) | vector;
     
-    if (target == TARGET_EXCLUSIVE_BROADCAST) {
+    if (target == (u32)TARGET_EXCLUSIVE_BROADCAST) {
         w = icr | ICR_DEST_ALL_EXC_SELF;
     } else {
         w = icr | (((u64)target) << 32);

--- a/src/x86_64/xapic.c
+++ b/src/x86_64/xapic.c
@@ -50,7 +50,7 @@ static void xapic_ipi(apic_iface i, u32 target, u64 flags, u8 vector)
     u64 w;
     u64 icr = (flags & ~0xff) | vector;
     
-    if (target == TARGET_EXCLUSIVE_BROADCAST) {
+    if (target == (u32)TARGET_EXCLUSIVE_BROADCAST) {
         w = icr | ICR_DEST_ALL_EXC_SELF;
     } else {
         w = icr | (((u64)target) << 56);


### PR DESCRIPTION
This resolves errors in the macOS build.