### PR TITLE
x86: add support for FSGSBASE instructions

### DIFF
--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -123,6 +123,9 @@ static void build_exec_stack(process p, thread t, Elf64_Ehdr * e, void *start,
         /* This is aarch64 specific because it's needed for arm .so search paths */
         {AT_HWCAP, get_cpu_capabilities()},
 #endif
+#if defined(__x86_64__)
+        {AT_HWCAP2, get_hwcap2()},
+#endif
         {AT_SYSINFO_EHDR, p->vdso_base}
     };
     for (int i = 0; i < sizeof(auxp) / sizeof(auxp[0]); i++) {

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -152,6 +152,7 @@ struct flock {
 #define AT_HWCAP        16              /* Arch specific CPU capabilities */
 #define AT_CLKTCK       17              /* Frequency of times() */
 #define AT_RANDOM       25   
+#define AT_HWCAP2       26              /* Extension of AT_HWCAP */
 #define AT_SYSINFO_EHDR 33              /* Location of VDSO mapping */
 #define AT_FDCWD        -100            /* openat should use the current working directory.*/
 

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -57,6 +57,7 @@
 #define CR4_OSFXSR      (1 << 9)
 #define CR4_OSXMMEXCPT  (1 << 10)
 #define CR4_UMIP        (1 << 11)
+#define CR4_FSGSBASE    (1 << 16)
 #define CR4_OSXSAVE     (1 << 18)
 #define CR4_SMEP        (1 << 20)
 
@@ -204,6 +205,9 @@ extern void write_xmsr(u64, u64);
 
 #define mov_to_cr(__x, __y) asm volatile("mov %0,%%"__x : : "a"(__y) : "memory");
 #define mov_from_cr(__x, __y) asm volatile("mov %%"__x", %0" : "=a"(__y) : : "memory");
+
+/* CPUID level 7 (EBX) */
+#define CPUID_FSGSBASE  (1 << 0)
 
 static inline void cpuid(u32 fn, u32 ecx, u32 * v)
 {

--- a/src/x86_64/mp.c
+++ b/src/x86_64/mp.c
@@ -52,6 +52,8 @@ void init_cpu_features()
     if (use_xsave)
         cr |= CR4_OSXSAVE;
     cpuid(7, 0, v);
+    if (v[1] & CPUID_FSGSBASE)
+        cr |= CR4_FSGSBASE;
     if (v[1] & CPUID_SMEP)
         cr |= CR4_SMEP;
     if (v[2] & CPUID_UMIP)

--- a/src/x86_64/unix_machine.h
+++ b/src/x86_64/unix_machine.h
@@ -226,3 +226,15 @@ static inline void syscall_restart_arch_fixup(context_frame f)
 /* ignore these unless moving fs/gs save out of entry */
 #define thread_frame_save_tls(f) ((void)f)
 #define thread_frame_restore_tls(f) ((void)f)
+
+#define HWCAP2_FSGSBASE     U64_FROM_BIT(1)
+
+static inline u64 get_hwcap2(void)
+{
+    u64 hwcap2 = 0;
+    u32 v[4];
+    cpuid(7, 0, v);
+    if (v[1] & CPUID_FSGSBASE)
+        hwcap2 |= HWCAP2_FSGSBASE;
+    return hwcap2;
+}


### PR DESCRIPTION
The FSGSBASE instructions allow reading and writing the FS and GS registers with dedicated CPU instructions, avoiding the need for the arch_prctl syscall and therefore providing performance benefits.
This change adds detection of the FSGSBASE capability from the CPU; if this capability is detected, the FSGSBASE instructions are enabled and their support is reported to userspace in the auxiliary vector.