### PR TITLE
fixes and new features for mmap(2) and mremap(2)

### DIFF
--- a/src/kernel/elf.c
+++ b/src/kernel/elf.c
@@ -179,9 +179,11 @@ void walk_elf(buffer elf, range_handler rh)
         if (p->p_type == PT_LOAD) {
             range r = irangel(p->p_vaddr & (~MASK(PAGELOG)),
                 pad(p->p_filesz + (p->p_vaddr & MASK(PAGELOG)), PAGESIZE));
-            apply(rh, r);
+            if (!apply(rh, r))
+                return;
             if (p->p_memsz > range_span(r))
-                apply(rh, irangel(r.end, pad(p->p_memsz - range_span(r), PAGESIZE)));
+                if (!apply(rh, irangel(r.end, pad(p->p_memsz - range_span(r), PAGESIZE))))
+                    return;
         }
     }
   out_elf_fail:

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -16,7 +16,7 @@ BSS_RO_AFTER_INIT static filesystem klib_fs;
 BSS_RO_AFTER_INIT static tuple klib_root;
 BSS_RO_AFTER_INIT static id_heap klib_heap;
 
-closure_function(1, 1, void, klib_elf_walk,
+closure_function(1, 1, boolean, klib_elf_walk,
                  klib, kl,
                  range, r)
 {
@@ -30,6 +30,7 @@ closure_function(1, 1, void, klib_elf_walk,
             kl->load_range.end = r.end;
     }
     klib_debug("%s: kl %s, r %R, load_range %R\n", __func__, kl->name, r, kl->load_range);
+    return true;
 }
 
 closure_function(1, 4, u64, klib_elf_map,
@@ -140,7 +141,7 @@ void load_klib(const char *name, klib_handler complete, status_handler sh)
     }
 }
 
-closure_function(1, 1, void, destruct_mapping,
+closure_function(1, 1, boolean, destruct_mapping,
                  klib, kl,
                  rmnode, n)
 {
@@ -148,6 +149,7 @@ closure_function(1, 1, void, destruct_mapping,
     klib_debug("   v %R, p 0x%lx, flags 0x%lx\n", km->n.r, km->phys, km->flags.w);
     unmap(km->n.r.start, range_span(km->n.r));
     deallocate(heap_locked(klib_kh), km, sizeof(struct klib_mapping));
+    return true;
 }
 
 void unload_klib(klib kl)

--- a/src/kernel/linear_backed_heap.c
+++ b/src/kernel/linear_backed_heap.c
@@ -90,7 +90,7 @@ static void add_linear_backed_page(linear_backed_heap hb, int index)
     }
 }
 
-closure_function(1, 1, void, physmem_range_handler,
+closure_function(1, 1, boolean, physmem_range_handler,
                  linear_backed_heap, hb,
                  range, r)
 {
@@ -112,6 +112,7 @@ closure_function(1, 1, void, physmem_range_handler,
 #endif
     for (int i = r.start; i <= r.end; i++)
         add_linear_backed_page(bound(hb), i);
+    return true;
 }
 
 static void linear_backed_init_maps(linear_backed_heap hb)

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1107,7 +1107,7 @@ void pagecache_node_add_shared_map(pagecache_node pn, range q /* bytes */, u64 n
     pagecache_unlock_state(pc);
 }
 
-closure_function(3, 1, void, close_shared_pages_intersection,
+closure_function(3, 1, boolean, close_shared_pages_intersection,
                  pagecache_node, pn, range, q, flush_entry, fe,
                  rmnode, n)
 {
@@ -1142,6 +1142,7 @@ closure_function(3, 1, void, close_shared_pages_intersection,
         assert(rangemap_reinsert(pn->shared_maps, n, irange(ri.end, rn.end)));
         sm->node_offset += ri.end - rn.start;
     }
+    return true;
 }
 
 void pagecache_node_close_shared_pages(pagecache_node pn, range q /* bytes */, flush_entry fe)
@@ -1151,7 +1152,7 @@ void pagecache_node_close_shared_pages(pagecache_node pn, range q /* bytes */, f
                           stack_closure(close_shared_pages_intersection, pn, q, fe));
 }
 
-closure_function(2, 1, void, scan_shared_pages_intersection,
+closure_function(2, 1, boolean, scan_shared_pages_intersection,
                  pagecache, pc, flush_entry, fe,
                  rmnode, n)
 {
@@ -1160,6 +1161,7 @@ closure_function(2, 1, void, scan_shared_pages_intersection,
     pagecache_shared_map sm = (pagecache_shared_map)n;
     pagecache_debug("   map %p\n", sm);
     pagecache_scan_shared_map(bound(pc), sm, bound(fe));
+    return true;
 }
 
 void pagecache_node_scan_and_commit_shared_pages(pagecache_node pn, range q /* bytes */)
@@ -1339,11 +1341,12 @@ closure_function(0, 1, boolean, pagecache_page_release,
     return true;
 }
 
-closure_function(0, 1, void, pagecache_node_assert,
+closure_function(0, 1, boolean, pagecache_node_assert,
                  rmnode, n)
 {
     /* A pagecache node being deallocated must not have any shared maps. */
     assert(0);
+    return false;
 }
 
 define_closure_function(1, 0, void, pagecache_node_free,

--- a/src/kernel/symtab.c
+++ b/src/kernel/symtab.c
@@ -58,12 +58,13 @@ closure_function(1, 4, void, elf_symtable_add,
     }
 }
 
-closure_function(0, 1, void, symtab_remove_sym,
+closure_function(0, 1, boolean, symtab_remove_sym,
                  rmnode, n)
 {
     elfsym sym = struct_from_field(n, elfsym, node);
     rangemap_remove_node(elf_symtable, n);
     deallocate_elfsym(sym);
+    return true;
 }
 
 char * find_elf_sym(u64 a, u64 *offset, u64 *len)

--- a/src/runtime/range.h
+++ b/src/runtime/range.h
@@ -24,9 +24,8 @@ typedef struct rmnode {
 #define irangel(__s, __l) (range){__s, (__s) + (__l)}
 #define point_in_range(__r, __p) ((__p >= __r.start) && (__p < __r.end))
 
-/* XXX might want to add a boolean return to abort op */
-typedef closure_type(rmnode_handler, void, rmnode);
-typedef closure_type(range_handler, void, range);
+typedef closure_type(rmnode_handler, boolean, rmnode);
+typedef closure_type(range_handler, boolean, range);
 
 boolean rangemap_insert(rangemap rm, rmnode n);
 boolean rangemap_reinsert(rangemap rm, rmnode n, range k);
@@ -35,10 +34,15 @@ void rangemap_remove_range(rangemap rm, rmnode n);
 rmnode rangemap_lookup(rangemap rm, u64 point);
 rmnode rangemap_lookup_at_or_next(rangemap rm, u64 point);
 boolean rangemap_range_intersects(rangemap rm, range q);
-boolean rangemap_range_lookup(rangemap rm, range q, rmnode_handler node_handler);
-boolean rangemap_range_lookup_with_gaps(rangemap rm, range q, rmnode_handler node_handler,
-                                        range_handler gap_handler);
-boolean rangemap_range_find_gaps(rangemap rm, range q, range_handler gap_handler);
+
+#define RM_NOMATCH -1           /* no handler invoked */
+#define RM_ABORT   0            /* a handler returned false, aborting traversal */
+#define RM_MATCH   1            /* success on all nodes/gaps handled */
+
+int rangemap_range_lookup(rangemap rm, range q, rmnode_handler node_handler);
+int rangemap_range_lookup_with_gaps(rangemap rm, range q, rmnode_handler node_handler,
+                                    range_handler gap_handler);
+int rangemap_range_find_gaps(rangemap rm, range q, range_handler gap_handler);
 
 rangemap allocate_rangemap(heap h);
 void init_rangemap(rangemap rm, heap h);

--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -194,11 +194,12 @@ static void close_log_extension(log_ext ext)
 
 #ifndef TLOG_READ_ONLY
 
-closure_function(1, 1, void, log_dealloc_ext_node,
+closure_function(1, 1, boolean, log_dealloc_ext_node,
                  log, tl,
                  rmnode, n)
 {
     deallocate(bound(tl)->h, n, sizeof(*n));
+    return true;
 }
 
 define_closure_function(1, 0, void, log_free,

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -42,7 +42,7 @@ static void build_exec_stack(process p, thread t, Elf64_Ehdr * e, void *start,
         stack_start = (stack_start - PROCESS_STACK_ASLR_RANGE) +
             get_aslr_offset(PROCESS_STACK_ASLR_RANGE);
 
-    p->stack_map = allocate_vmap(p->vmaps, irangel(stack_start, PROCESS_STACK_SIZE),
+    p->stack_map = allocate_vmap(p, irangel(stack_start, PROCESS_STACK_SIZE),
                                  ivmap(VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE, 0, 0, 0));
     assert(p->stack_map != INVALID_ADDRESS);
 
@@ -188,8 +188,8 @@ closure_function(3, 4, u64, exec_elf_map,
     boolean is_bss = paddr == INVALID_PHYSICAL;
     exec_debug("%s: add to vmap: %R vmflags 0x%lx%s\n",
                __func__, r, vmflags, is_bss ? " bss" : "");
-    assert(allocate_vmap(bound(p)->vmaps, r, ivmap(vmflags, bound(allowed_flags), 0, 0)) !=
-            INVALID_ADDRESS);
+    assert(allocate_vmap(bound(p), r, ivmap(vmflags, bound(allowed_flags), 0, 0)) !=
+           INVALID_ADDRESS);
     if (is_bss) {
         /* bss */
         paddr = allocate_u64((heap)heap_physical(kh), size);
@@ -290,8 +290,8 @@ process exec_elf(buffer ex, process kp)
     u64 brk = pad(load_range.end, PAGESIZE) + brk_offset;
     proc->brk = pointer_from_u64(brk);
     proc->heap_base = brk;
-    proc->heap_map = allocate_vmap(proc->vmaps, irange(brk, brk),
-        ivmap(VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE, 0, 0, 0));
+    proc->heap_map = allocate_vmap(proc, irange(brk, brk),
+                                   ivmap(VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE, 0, 0, 0));
     assert(proc->heap_map != INVALID_ADDRESS);
     exec_debug("entry %p, brk %p (offset 0x%lx)\n", entry, proc->brk, brk_offset);
 

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -169,6 +169,12 @@ struct flock {
 #define MAP_FIXED           0x10
 #define MAP_ANONYMOUS       0x20
 
+#define MAP_GROWSDOWN       0x100
+#define MAP_DENYWRITE       0x800
+#define MAP_EXECUTABLE      0x1000
+#define MAP_LOCKED          0x2000
+#define MAP_NORESERVE       0x4000
+
 #define MAP_POPULATE        0x08000
 #define MAP_NONBLOCK        0x10000
 #define MAP_STACK           0x20000
@@ -177,9 +183,11 @@ struct flock {
 #define MAP_FIXED_NOREPLACE 0x100000
 #define MAP_UNINITIALIZED   0x4000000
 
+#define HUGETLB_FLAG_ENCODE_SHIFT 26
+#define HUGETLB_FLAG_ENCODE_MASK  0x3ful
+
 #define MREMAP_MAYMOVE      1
 #define MREMAP_FIXED        2
-#define MAP_STACK           0x20000
 
 #define PROT_READ       0x1
 #define PROT_WRITE      0x2

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -168,6 +168,15 @@ struct flock {
 #define MAP_TYPE_MASK       0x0f
 #define MAP_FIXED           0x10
 #define MAP_ANONYMOUS       0x20
+
+#define MAP_POPULATE        0x08000
+#define MAP_NONBLOCK        0x10000
+#define MAP_STACK           0x20000
+#define MAP_HUGETLB         0x40000
+#define MAP_SYNC            0x80000
+#define MAP_FIXED_NOREPLACE 0x100000
+#define MAP_UNINITIALIZED   0x4000000
+
 #define MREMAP_MAYMOVE      1
 #define MREMAP_FIXED        2
 #define MAP_STACK           0x20000

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -842,7 +842,7 @@ u64 new_zeroed_pages(u64 v, u64 length, pageflags flags, status_handler complete
 boolean do_demand_page(thread t, context ctx, u64 vaddr, vmap vm);
 vmap vmap_from_vaddr(process p, u64 vaddr);
 void vmap_iterator(process p, vmap_handler vmh);
-boolean vmap_validate_range(process p, range q);
+boolean vmap_validate_range(process p, range q, u32 flags);
 void truncate_file_maps(process p, fsfile f, u64 new_length);
 const char *string_from_mmap_type(int type);
 
@@ -855,12 +855,9 @@ void thread_yield(void) __attribute__((noreturn));
 void thread_wakeup(thread);
 boolean thread_attempt_interrupt(thread t);
 
-/* XXX This should eventually be rolled into validate_user_memory */
 static inline boolean validate_process_memory(process p, const void *a, bytes length, boolean write)
 {
-    u64 v = u64_from_pointer(a);
-
-    return vmap_validate_range(p, irange(v, v + length));
+    return vmap_validate_range(p, irangel(u64_from_pointer(a), length), write ? VMAP_FLAG_WRITABLE : 0);
 }
 
 static inline boolean thread_in_interruptible_sleep(thread t)

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -34,6 +34,8 @@
 #define PROCESS_VIRTUAL_HEAP_START  0x000100000000ull
 #define PROCESS_VIRTUAL_HEAP_LIMIT  USER_LIMIT
 #define PROCESS_VIRTUAL_HEAP_LENGTH (PROCESS_VIRTUAL_HEAP_LIMIT - PROCESS_VIRTUAL_HEAP_START)
+#define PROCESS_VIRTUAL_MMAP_RANGE  (irange(PROCESS_VIRTUAL_HEAP_START, PROCESS_VIRTUAL_HEAP_LIMIT))
+#define PROCESS_VIRTUAL_32BIT_RANGE (irange(2ull * GB, 4ull * GB))
 
 #define PROCESS_STACK_SIZE          (2 * MB)
 
@@ -415,12 +417,6 @@ typedef struct vmap {
     fsfile fsf;
 } *vmap;
 
-typedef struct varea {
-    struct rmnode node;
-    id_heap h;
-    boolean allow_fixed;
-} *varea;
-
 #define ivmap(__f, __af, __o, __fsf) (struct vmap) {        \
     .flags = __f,                                   \
     .allowed_flags = __f | __af,                    \
@@ -459,7 +455,7 @@ static inline sysreturn blockq_block_required(thread t, u64 bq_flags)
 vmap allocate_vmap(rangemap rm, range r, struct vmap q);
 boolean adjust_process_heap(process p, range new);
 
-u64 process_get_virt_range(process p, u64 size);
+u64 process_get_virt_range(process p, u64 size, range region);
 void *process_map_physical(process p, u64 phys_addr, u64 size, u64 vmflags);
 
 typedef struct file *file;
@@ -473,9 +469,6 @@ typedef struct process {
     u64               heap_base;
     u64               vdso_base;
     heap              virtual; /* pagesized, default for mmaps */
-#ifdef __x86_64__
-    id_heap           virtual32; /* for tracking low 32-bit space and MAP_32BIT maps */
-#endif
     id_heap           fdallocator;
     filesystem        root_fs;
     filesystem        cwd_fs;
@@ -487,7 +480,7 @@ typedef struct process {
     struct spinlock   threads_lock;
     struct syscall   *syscalls;
     vector            files;
-    rangemap          vareas;   /* available address space */
+    u64               mmap_min_addr;
     struct spinlock   vmap_lock;
     rangemap          vmaps;    /* process mappings */
     vmap              stack_map;
@@ -673,7 +666,7 @@ boolean validate_user_memory_permissions(process p, const void *buf, bytes lengt
 boolean fault_in_user_memory(const void *buf, bytes length,
                              u64 required_flags, u64 disallowed_flags);
 
-void mmap_process_init(process p, boolean aslr);
+void mmap_process_init(process p, tuple root);
 
 /* This "validation" is just a simple limit check right now, but this
    could optionally expand to do more rigorous validation (e.g. vmap
@@ -685,8 +678,7 @@ static inline boolean validate_user_memory(const void *p, bytes length, boolean 
 {
     u64 v = u64_from_pointer(p);
 
-    /* no zero page access */
-    if (v < PAGESIZE)
+    if (v < MIN(PAGESIZE, current->p->mmap_min_addr))
         return false;
 
     if (length >= USER_LIMIT)

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -452,7 +452,7 @@ static inline sysreturn blockq_block_required(thread t, u64 bq_flags)
     return BLOCKQ_BLOCK_REQUIRED;
 }
 
-vmap allocate_vmap(rangemap rm, range r, struct vmap q);
+vmap allocate_vmap(process p, range r, struct vmap q);
 boolean adjust_process_heap(process p, range new);
 
 u64 process_get_virt_range(process p, u64 size, range region);

--- a/src/x86_64/uefi.c
+++ b/src/x86_64/uefi.c
@@ -62,7 +62,7 @@ void uefi_arch_setup(heap general, heap aligned, uefi_arch_options options)
     options->load_to_physical = false;
 }
 
-closure_function(1, 1, void, uefi_add_mem,
+closure_function(1, 1, boolean, uefi_add_mem,
                  region, last_region,
                  range, r)
 {
@@ -72,6 +72,7 @@ closure_function(1, 1, void, uefi_add_mem,
         last_region->length += range_span(r);
     else
         bound(last_region) = create_region(r.start, range_span(r), REGION_PHYSICAL);
+    return true;
 }
 
 void uefi_start_kernel(void *image_handle, efi_system_table system_table, buffer kern_elf,

--- a/test/runtime/mmap.manifest
+++ b/test/runtime/mmap.manifest
@@ -15,7 +15,7 @@
 #    futex_trace:t
 #    mmap_min_addr:0
     fault:t
-    arguments:[/mmap, basic]
+    arguments:[/mmap] # intensive, zeropage, exec
     environment:(USER:bobby PWD:/)
     exec_protection:t
     imagesize:30M

--- a/test/runtime/mmap.manifest
+++ b/test/runtime/mmap.manifest
@@ -13,6 +13,7 @@
 #    trace:t
 #    debugsyscalls:t
 #    futex_trace:t
+#    mmap_min_addr:0
     fault:t
     arguments:[/mmap, basic]
     environment:(USER:bobby PWD:/)

--- a/test/unit/range_test.c
+++ b/test/unit/range_test.c
@@ -21,7 +21,7 @@ typedef struct test_node {
     int val;
 } *test_node;
 
-closure_function(0, 1, void, basic_test_validate,
+closure_function(0, 1, boolean, basic_test_validate,
                  rmnode, node)
 {
     static int count = 0;
@@ -38,6 +38,7 @@ closure_function(0, 1, void, basic_test_validate,
         exit(EXIT_FAILURE);
     }
     count++;
+    return true;
 }
 
 static test_node allocate_test_node(heap h, range r, int val)
@@ -52,11 +53,12 @@ static test_node allocate_test_node(heap h, range r, int val)
     return tn;
 }
 
-closure_function(1, 1, void, dealloc_test_node,
+closure_function(1, 1, boolean, dealloc_test_node,
                  heap, h,
                  rmnode, n)
 {
     deallocate(bound(h), n, sizeof(struct test_node));
+    return true;
 }
 
 boolean basic_test(heap h)
@@ -193,11 +195,12 @@ static void rangemap_verify_ranges(rangemap rm, int expected_count, u64 expected
     }
 }
 
-closure_function(1, 1, void, rangemap_merge_destructor,
+closure_function(1, 1, boolean, rangemap_merge_destructor,
                  heap, h,
                  rmnode, n)
 {
     deallocate(bound(h), n, sizeof(*n));
+    return true;
 }
 
 static boolean rangemap_merge_test(heap h)


### PR DESCRIPTION
This merge covers a range of bug fixes and new features in the mmap code, as
summarized below:

- The mmap(2) implementation was insufficiently checking the flags parameter,
  selecting for implemented flags and ignoring all others. This change
  explicitly checks for known options and validates that unknown options are
  not blindly accepted.

- This fixes a flaw in the mmap(2) implementation whereby a vmap would be
  allocated for a new mapping, only to be immediately removed and replaced
  with an identical one.

- The p->virtual32 heap has been removed in place of making range allocations
  of address space, which is made possible by the rangemap-based allocation of
  vmaps.

- Since moving away from using an id heap to allocate process address space,
  "vareas" no longer serve a useful function. They have been removed and
  replaced with appropriate range checks.

- If the map type is not MAP_SHARED or MAP_SHARED_VALIDATE, check that it is
  set to MAP_PRIVATE.

- Implement MAP_FIXED_NOREPLACE and MAP_POPULATE

- mmap was previously ignoring hints, honoring a specified address only for a
  fixed mapping and allocating otherwise. With this change, mmap will attempt
  to make use of a hint address if provided.

- Nanos was strictly forbidding userspace access to the zero page. However,
  there are some applications which require zero page access. Create the
  "mmap_min_addr" manifest option which, if set to zero, will allow zero-page
  mappings to occur. (This is analogous to /proc/sys/vm/mmap_min_addr in
  Linux.)

- Support for MAP_POPULATE has been added, and the mmap
  test now checks the handling of unaligned hint and fixed addresses.

- The behavior of allocate_vmap() is changed here to merge adjacent vmaps when
  possible, thus reducing entries and lookup times. It also simplifies logic
  for operations like mremap, which no longer would need to handle multiple,
  adjacent vmaps with equivalent properties when considering a contiguous
  range of mapped space. In addition, a VMAP_DEBUG option and relevant debugs
  have been added for tracing changes to process vmaps, and the kernel may be
  built with VMAP_PARANOIA to validate the integrity of process vmaps after
  each transaction that modifies user address space.

- allocate_vmap() is the external interface for allocating user address space,
  and as such takes the vmap lock before calling allocate_vmap_locked().

- The mremap(2) implementation contained a flaw whereby the remapping of a
  portion of a vmap would lead to the entire vmap being removed rather than
  edited to exclude the relevant portion. In the process of fixing this,
  mremap has been extended to support MREMAP_FIXED and the extending of
  mappings (as well as support for MREMAP_MAYMOVE not being selected, which
  will cause mmap to return with -ENOMEM if a mapping could not be
  extended). The mmap runtime test includes checks for these additional
  features.

- This updates the interface for rangemap lookup functions by allowing rmnode
  and range handlers to abort lookups by returning false. The lookup functions
  return a code that indicates whether a handler abort occurred, no matches
  occurred (no handlers invoked), or one or more matches succeeded. This helps
  avoid unnecessary traversal after a desired condition is already met, and
  also helps avoid closing over boolean flags just to detect a gap or other
  error condition.

- The mmap test has been expanded to test flag validation, address hints,
  fixed mappings and map extension with mremap(2) and the splitting and
  merging of vmaps. While the test cannot directly check that correct
  transformations have been made on process vmaps, such transformations may be
  manually observed and validated by building with VMAP_DEBUG and
  VMAP_PARANOIA. Other additions to the mmap test include a test for hints
  (address specified for non-fixed mmap) as well as making the zeropage and
  exec protection tests optional - for testing the lowering of mmap_min_addr
  to 0 and running without exec protection enabled (or running on Linux). With
  these changes, the mmap test may now be run on Linux (with the exec option)
  as a parity check.

Resolves #986 
