### PR TITLE
Fix load program limits and exit syscall

### DIFF
--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -36,8 +36,8 @@ static void build_exec_stack(process p, thread t, Elf64_Ehdr * e, void *start,
 {
     exec_debug("build_exec_stack start %p, tid %d, va 0x%lx\n", start, t->tid, va);
 
-    /* allocate process stack at top of first 2gb of address space */
-    u64 stack_start = 0x80000000 - PROCESS_STACK_SIZE;
+    /* allocate process stack at top of 32-bit address space */
+    u64 stack_start = 0x100000000 - PROCESS_STACK_SIZE;
     if (aslr)
         stack_start = (stack_start - PROCESS_STACK_ASLR_RANGE) +
             get_aslr_offset(PROCESS_STACK_ASLR_RANGE);
@@ -199,6 +199,10 @@ closure_function(3, 4, u64, exec_elf_map,
         assert(paddr != INVALID_PHYSICAL);
     }
     map(vaddr, paddr, size, pageflags_user(pageflags_minpage(flags)));
+#ifdef __x86_64__
+    if (vaddr < 0x100000000)
+        assert(id_heap_set_area(bound(p)->virtual32, vaddr, size, true, true));
+#endif
     if (is_bss)
         zero(pointer_from_u64(vaddr), size);
     return vaddr;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -38,7 +38,7 @@
 #define PROCESS_STACK_SIZE          (2 * MB)
 
 /* restrict the area in which ELF segments can be placed */
-#define PROCESS_ELF_LOAD_END        (GB) /* 1gb hard upper limit */
+#define PROCESS_ELF_LOAD_END        (3ull * GB) /* 3gb hard upper limit */
 
 /* range of variation for various ASLR mappings; kind of arbitrary at this point */
 #define PROCESS_PIE_LOAD_ASLR_RANGE (4 * MB)


### PR DESCRIPTION
An elf binary can ask for loading of a program segment above the current limit (1GB) causing a panic. The current
limit appears arbitrary, so it has been adjusted to 3GB, and the user stack allocation has been moved to just under
4GB so that it will not conflict with program segments.

Additionally, the exit syscall was not triggering a shutdown if called by the last thread of a program (in lieu of exit_group).
This has also been fixed.