### PR TITLE
Support mounting volumes read-only

### DIFF
--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -161,6 +161,8 @@ closure_function(6, 0, void, startup,
         rprintf("Debug http server started on port 9090\n");
     }
 #endif
+    if (get(root, sym(readonly_rootfs)))
+        filesystem_set_readonly(fs);
     value p = get(root, sym(program));
     assert(p);
     tuple pro = resolve_path(root, split(general, p, '/'));

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -82,7 +82,8 @@ typedef enum {
     FS_STATUS_LINKLOOP,
     FS_STATUS_NAMETOOLONG,
     FS_STATUS_XDEV,
-    FS_STATUS_FAULT
+    FS_STATUS_FAULT,
+    FS_STATUS_READONLY,
 } fs_status;
 
 const char *string_from_fs_status(fs_status s);
@@ -111,7 +112,7 @@ fs_status filesystem_get_node(filesystem *fs, inode cwd, const char *path, boole
 void filesystem_put_node(filesystem fs, tuple n);
 tuple filesystem_get_meta(filesystem fs, inode n);
 void filesystem_put_meta(filesystem fs, tuple n);
-fsfile filesystem_creat_unnamed(filesystem fs);
+fs_status filesystem_creat_unnamed(filesystem fs, fsfile *f);
 fs_status filesystem_symlink(filesystem fs, inode cwd, const char *path, const char *target);
 fs_status filesystem_delete(filesystem fs, inode cwd, const char *path, boolean directory);
 fs_status filesystem_rename(filesystem oldfs, inode oldwd, const char *oldpath,
@@ -128,6 +129,8 @@ fs_status filesystem_mount(filesystem parent, inode mount_dir, filesystem child)
 void filesystem_unmount(filesystem parent, inode mount_dir, filesystem child, thunk complete);
 
 tuple filesystem_getroot(filesystem fs);
+boolean filesystem_is_readonly(filesystem fs);
+void filesystem_set_readonly(filesystem fs);
 
 u64 fs_blocksize(filesystem fs);
 u64 fs_totalblocks(filesystem fs);

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -31,6 +31,8 @@ sysreturn sysreturn_from_fs_status(fs_status s)
         return -EXDEV;
     case FS_STATUS_FAULT:
         return -EFAULT;
+    case FS_STATUS_READONLY:
+        return -EROFS;
     default:
         return 0;
     }


### PR DESCRIPTION
Support mounting tfs volumes read-only by checking for a string ":ro" appended
to the path of a volume in the mounts tuple. While tfs already supported a flag
for a read-only filesystem, support had to be added for checking the flag and
returning an appropriate error that could be translated into EROFS for syscalls.

Additionally, the filesystem_creat_unnamed function needed to change to support
returning errors.