### PR TITLE
x86: add support for microvm Qemu machine type

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -360,19 +360,33 @@ endif
 
 QEMU=		qemu-system-x86_64
 QEMU_FLAGS=
+ifneq ($(MICROVM),)
+IOAPIC2=	$(shell $(QEMU) -machine microvm,help | grep -c ioapic2)
+ifneq ($(IOAPIC2),0)
+MACHINE_TYPE=	microvm,rtc=on,ioapic2=off
+else
+MACHINE_TYPE=	microvm,rtc=on
+endif
+KERNEL_BOOT=	1
+STORAGE=	virtio-mmio
+NETWORK=	virtio-net-device
+QEMU_FLAGS+=	-global virtio-mmio.force-legacy=false
+else
 MACHINE_TYPE=	q35
-QEMU_CPU=	-cpu max
-DISPLAY=	none
 STORAGE=	virtio-scsi
 STORAGE_BUS=	,bus=pci.2,addr=0x0
 NETWORK=	virtio-net
 NETWORK_BUS=	,bus=pci.3,addr=0x0
 NETWORK_BUS_2=  ,bus=pci.3,addr=0x1
-QEMU_MACHINE=	-machine $(MACHINE_TYPE)
-QEMU_MEMORY=	-m 2G
+QEMU_RNG=	-device virtio-rng-pci
 QEMU_PCI=	-device pcie-root-port,port=0x10,chassis=1,id=pci.1,bus=$(PCI_BUS),multifunction=on,addr=0x3 \
 		-device pcie-root-port,port=0x11,chassis=2,id=pci.2,bus=$(PCI_BUS),addr=0x3.0x1 \
 		-device pcie-root-port,port=0x12,chassis=3,id=pci.3,bus=$(PCI_BUS),addr=0x3.0x2
+endif
+QEMU_CPU=	-cpu max
+DISPLAY=	none
+QEMU_MACHINE=	-machine $(MACHINE_TYPE)
+QEMU_MEMORY=	-m 2G
 ifneq ($(KERNEL_BOOT),)
 QEMU_FLAGS+=	-kernel $(KERNEL)
 endif
@@ -392,6 +406,8 @@ else ifeq ($(STORAGE),pvscsi)
 QEMU_STORAGE+=	-device pvscsi$(STORAGE_BUS),id=scsi0 -device scsi-hd,bus=scsi0.0,drive=hd0
 else ifeq ($(STORAGE),virtio-blk)
 QEMU_STORAGE+=	-device virtio-blk-pci$(STORAGE_BUS),drive=hd0
+else ifeq ($(STORAGE),virtio-mmio)
+QEMU_STORAGE+=	-device virtio-blk-device,drive=hd0
 else ifeq ($(STORAGE),ide)
 MACHINE_TYPE=	pc # no AHCI support yet
 QEMU_STORAGE+=	-device ide-hd,bus=ide.0,drive=hd0
@@ -413,7 +429,6 @@ endif
 ifneq ($(ENABLE_BALLOON),)
 QEMU_BALLOON=   -device virtio-balloon-pci
 endif
-QEMU_RNG=	-device virtio-rng-pci
 ifneq ($(ENABLE_QMP),)
 QEMU_QMP=	-qmp unix:$(ROOTDIR)/qmp-sock,server,nowait
 #QEMU_QMP=	-qmp tcp:localhost:4444,server,nowait

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -359,6 +359,7 @@ endif
 .PHONY: run run-bridge run-nokvm
 
 QEMU=		qemu-system-x86_64
+QEMU_FLAGS=
 MACHINE_TYPE=	q35
 QEMU_CPU=	-cpu max
 DISPLAY=	none
@@ -372,6 +373,9 @@ QEMU_MEMORY=	-m 2G
 QEMU_PCI=	-device pcie-root-port,port=0x10,chassis=1,id=pci.1,bus=$(PCI_BUS),multifunction=on,addr=0x3 \
 		-device pcie-root-port,port=0x11,chassis=2,id=pci.2,bus=$(PCI_BUS),addr=0x3.0x1 \
 		-device pcie-root-port,port=0x12,chassis=3,id=pci.3,bus=$(PCI_BUS),addr=0x3.0x2
+ifneq ($(KERNEL_BOOT),)
+QEMU_FLAGS+=	-kernel $(KERNEL)
+endif
 
 ifeq ($(DISPLAY),none)
 QEMU_DISPLAY=	-display none
@@ -415,7 +419,6 @@ QEMU_QMP=	-qmp unix:$(ROOTDIR)/qmp-sock,server,nowait
 #QEMU_QMP=	-qmp tcp:localhost:4444,server,nowait
 endif
 #QEMU_USERNET+=	-object filter-dump,id=filter0,netdev=n0,file=/tmp/nanos.pcap
-QEMU_FLAGS=
 #QEMU_FLAGS+=	-smp 4
 #QEMU_FLAGS+=	-d int -D int.log
 #QEMU_FLAGS+=	-s -S

--- a/platform/pc/boot/stage2.c
+++ b/platform/pc/boot/stage2.c
@@ -190,8 +190,6 @@ closure_function(0, 1, void, fail,
     halt("filesystem_read_entire failed: %v\n", s);
 }
 
-static region initial_pages_region;
-
 static void setup_page_tables()
 {
     stage2_debug("%s\n", __func__);
@@ -199,7 +197,7 @@ static void setup_page_tables()
     /* initial page tables, carried into stage3 init */
     stage2_debug("initial page tables at [0x%lx,  0x%lx)\n", initial_pages_base,
                  initial_pages_base + INITIAL_PAGES_SIZE);
-    initial_pages_region = create_region(initial_pages_base, INITIAL_PAGES_SIZE, REGION_INITIAL_PAGES);
+    create_region(initial_pages_base, INITIAL_PAGES_SIZE, REGION_INITIAL_PAGES);
     init_mmu(region_allocator(general, PAGESIZE, REGION_INITIAL_PAGES));
 
     /* initial map, page tables and stack */

--- a/platform/pc/linker_script
+++ b/platform/pc/linker_script
@@ -10,6 +10,7 @@ PHDRS
     rodata PT_LOAD FLAGS(4);        /* R */
     data PT_LOAD FLAGS(6);          /* RW */
     stack PT_GNU_STACK FLAGS(7);    /* RWE */
+    note PT_NOTE FLAGS(4);          /* R */
 }
 
 /* Note these are ordered such that sections are grouped together by write
@@ -22,6 +23,7 @@ SECTIONS
     /* Physical addresses are only relevant in case of direct stage3 load. */
     LOAD_OFFSET = START - 0x200000;     /* 0x200000 equals KERNEL_BASE_PHYS */
     _phys_start = _start - LOAD_OFFSET; /* entry point physical adddress */
+    _phys_pvh_start32 = pvh_start32 - LOAD_OFFSET;
 
     . = 0xffffffff80000000;
     START = .;
@@ -92,4 +94,9 @@ SECTIONS
     } :data
 
     END = .;
+
+    .note :
+    {
+        KEEP(*(.note.*))
+    } :note
 }

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -620,6 +620,7 @@ void detect_devices(kernel_heaps kh, storage_attach sa)
             init_ata_pci(kh, sa); /* hvm ata fallback */
     } else {
         init_debug("hypervisor undetected or HVM platform; registering all PCI drivers...");
+        virtio_mmio_enum_devs(kh);
 
         /* net */
         init_virtio_network(kh);

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -465,8 +465,7 @@ void init_service(u64 rdi, u64 rsi)
         region_heap_init(&rh, PAGESIZE, REGION_PHYSICAL);
         u64 initial_pages_base = allocate_u64(&rh.h, INITIAL_PAGES_SIZE);
         assert(initial_pages_base != INVALID_PHYSICAL);
-        region initial_pages_region = create_region(initial_pages_base,
-            INITIAL_PAGES_SIZE, REGION_INITIAL_PAGES);
+        create_region(initial_pages_base, INITIAL_PAGES_SIZE, REGION_INITIAL_PAGES);
         heap pageheap = region_allocator(&rh.h, PAGESIZE, REGION_INITIAL_PAGES);
         void *pgdir = bootstrap_page_tables(pageheap);
 
@@ -480,7 +479,6 @@ void init_service(u64 rdi, u64 rsi)
         map(KERNEL_BASE, KERNEL_BASE_PHYS, roend_offset, roflags);
         map(KERNEL_BASE + roend_offset, KERNEL_BASE_PHYS + roend_offset,
                pad(kernel_size - roend_offset, PAGESIZE), flags);
-        initial_pages_region->length = INITIAL_PAGES_SIZE;
         mov_to_cr("cr3", pgdir);
         bootstrapping = false;
     }

--- a/src/drivers/acpi.h
+++ b/src/drivers/acpi.h
@@ -158,3 +158,13 @@ void init_acpi_tables(kernel_heaps kh);
 boolean acpi_walk_madt(madt_handler mh);
 boolean acpi_walk_mcfg(mcfg_handler mh);
 boolean acpi_parse_spcr(spcr_handler h);
+
+typedef struct acpi_mmio_dev {
+    u64 membase;
+    u64 memsize;
+    u32 irq;
+} *acpi_mmio_dev;
+
+typedef closure_type(acpi_mmio_handler, void, acpi_mmio_dev);
+
+void acpi_get_vtmmio_devs(acpi_mmio_handler handler);

--- a/src/kernel/region.h
+++ b/src/kernel/region.h
@@ -79,6 +79,11 @@ static inline heap region_allocator(heap h, u64 pagesize, int type)
     return (heap)rh;
 }
 
+static inline void region_resize(region r, s64 delta)
+{
+    r->base -= delta;
+    r->length += delta;
+}
 
 static inline void print_regions()
 {

--- a/src/virtio/virtio.h
+++ b/src/virtio/virtio.h
@@ -5,3 +5,4 @@ void init_virtio_rng(kernel_heaps kh);
 void init_virtio_scsi(kernel_heaps kh, storage_attach a);
 
 void virtio_mmio_parse(kernel_heaps kh, const char *str, int len);
+void virtio_mmio_enum_devs(kernel_heaps kh);

--- a/src/x86_64/crt0.s
+++ b/src/x86_64/crt0.s
@@ -381,3 +381,84 @@ align 4096
 global hypercall_page
 hypercall_page:
         times 4096 db 0
+
+%include "../../platform/pc/boot/longmode.inc"
+
+global pvh_start32
+extern _phys_pvh_start32
+extern pvh_start
+
+pvh_start32:
+bits 32
+        PREPARE_LONG_MODE eax
+        ; set up minimal mapping to be able to run in 64-bit mode, carving page
+        ; tables from memory just below kernel code
+        mov eax, 0x200000 - 0x1000 ; PML4
+        ; PDPT
+        mov ecx, eax
+        sub ecx, 0x1000
+        mov [eax], ecx
+        or dword [eax], 0x3
+        mov dword [eax + 4], 0
+        ; PDT
+        mov edx, ecx
+        sub edx, 0x1000
+        mov [ecx], edx
+        or dword [ecx], 0x3
+        mov dword [ecx + 4], 0
+        ; map start info data (whose address is in the ebx register)
+        mov ecx, ebx
+        and ecx, 0xffe00000
+        mov esi, ecx
+        shr esi, 18
+        mov dword [edx + esi], ecx
+        or dword [edx + esi], 0x83
+        mov dword [edx + esi + 4], 0
+        ; map kernel code
+        mov dword [edx + 8], 0x200000 | 0x83
+        mov dword [edx + 12], 0
+        mov cr3, eax
+        ENTER_LONG_MODE eax
+        lgdt [pvh_gdt.Pointer + _phys_pvh_start32 - pvh_start32]
+        jmp pvh_gdt.Code:(long_mode + _phys_pvh_start32 - pvh_start32)
+
+bits 64
+long_mode:
+        mov edi, ebx ; retrieve start info address from ebx register
+        jmp pvh_start
+
+%include "segment.inc"
+
+align 16
+pvh_gdt:
+        .Null: equ $ - pvh_gdt
+        dd 0
+        dd 0
+        .Code: equ $ - pvh_gdt
+        dd 0
+        dd KERN_CODE_SEG_DESC
+        .Data: equ $ - pvh_gdt
+        dd 0
+        dd KERN_DATA_SEG_DESC
+        .UserCode: equ $ - pvh_gdt
+        dd 0
+        dd 0
+        .UserData: equ $ - pvh_gdt
+        dd 0
+        dd USER_DATA_SEG_DESC
+        .UserCode64: equ $ - pvh_gdt
+        dd 0
+        dd USER_CODE_SEG_DESC
+        .Pointer:
+        dw $ - pvh_gdt - 1                             ; Limit.
+        dq (pvh_gdt + _phys_pvh_start32 - pvh_start32) ; 64 bit Base
+
+section .note.Xen noalloc
+align 4
+        dd 4 ; name size
+        dd 4 ; data size
+        dd 18 ; type (XEN_ELFNOTE_PHYS32_ENTRY)
+align 4
+        db 'Xen',0x00 ; name
+align 4
+        dd _phys_pvh_start32 ; data

--- a/src/x86_64/uefi.c
+++ b/src/x86_64/uefi.c
@@ -12,7 +12,6 @@
 #define START_FUNC_SIZE 0x20
 
 static heap uefi_heap;
-static region initial_pages_region;
 static void *pgdir; /* page directory (PML4) */
 static rangemap rsvd_mem;
 
@@ -54,7 +53,7 @@ void uefi_arch_setup(heap general, heap aligned, uefi_arch_options options)
     assert(rsvd_mem != INVALID_ADDRESS);
     u64 initial_pages = allocate_u64(aligned, INITIAL_PAGES_SIZE);
     assert(initial_pages != INVALID_PHYSICAL);
-    initial_pages_region = create_region(initial_pages, INITIAL_PAGES_SIZE, REGION_INITIAL_PAGES);
+    create_region(initial_pages, INITIAL_PAGES_SIZE, REGION_INITIAL_PAGES);
     rsvd_mem_add(irangel(initial_pages, INITIAL_PAGES_SIZE));
     pgdir = bootstrap_page_tables(region_allocator(general, PAGESIZE, REGION_INITIAL_PAGES));
     map(0, 0, INITIAL_MAP_SIZE, pageflags_writable(pageflags_exec(pageflags_memory())));
@@ -108,6 +107,5 @@ void uefi_start_kernel(void *image_handle, efi_system_table system_table, buffer
             break;
         }
     }
-    initial_pages_region->length = INITIAL_PAGES_SIZE;
     start_kernel(kern_entry + KERNEL_BASE - KERNEL_BASE_PHYS);
 }


### PR DESCRIPTION
With this change set, the kernel supports booting via the HVM direct boot protocol and running on the microvm Qemu
machine type.
The first 2 commits are fixes for issues in the initialization code run when the kernel is not loaded by the stage2 bootloader.
`make run KERNEL_BOOT=1` runs an image with direct kernel boot (while using the default q35 Qemu machine type); direct kernel boot results in faster boot times compared to bootloader boot.
`make run MICROVM=1` runs an image by using the microvm Qemu machine type; this setting automatically enables direct kernel boot; using microvm results in faster boot times and less memory consumption compared to using the q35 machine type (either with or without direct kernel boot).