### PR TITLE
virtio-rng support

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -80,6 +80,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/virtio/virtio_mmio.c \
 	$(SRCDIR)/virtio/virtio_net.c \
 	$(SRCDIR)/virtio/virtio_pci.c \
+	$(SRCDIR)/virtio/virtio_rng.c \
 	$(SRCDIR)/virtio/virtio_storage.c \
 	$(SRCDIR)/virtio/virtio_scsi.c \
 	$(SRCDIR)/virtio/virtqueue.c \
@@ -408,6 +409,7 @@ endif
 ifneq ($(ENABLE_BALLOON),)
 QEMU_BALLOON=   -device virtio-balloon-pci
 endif
+QEMU_RNG=	-device virtio-rng-pci
 ifneq ($(ENABLE_QMP),)
 QEMU_QMP=	-qmp unix:$(ROOTDIR)/qmp-sock,server,nowait
 #QEMU_QMP=	-qmp tcp:localhost:4444,server,nowait
@@ -418,7 +420,7 @@ QEMU_FLAGS=
 #QEMU_FLAGS+=	-d int -D int.log
 #QEMU_FLAGS+=	-s -S
 
-QEMU_COMMON=	$(QEMU_MACHINE) $(QEMU_MEMORY) $(QEMU_BALLOON) $(QEMU_DISPLAY) $(QEMU_PCI) $(QEMU_SERIAL) $(QEMU_STORAGE) -device isa-debug-exit -no-reboot $(QEMU_FLAGS) $(QEMU_QMP)
+QEMU_COMMON=	$(QEMU_MACHINE) $(QEMU_MEMORY) $(QEMU_BALLOON) $(QEMU_DISPLAY) $(QEMU_PCI) $(QEMU_RNG) $(QEMU_SERIAL) $(QEMU_STORAGE) -device isa-debug-exit -no-reboot $(QEMU_FLAGS) $(QEMU_QMP)
 
 run: image
 	$(QEMU) $(QEMU_COMMON) $(QEMU_USERNET) $(QEMU_ACCEL) || exit $$(($$?>>1))

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -87,14 +87,14 @@ static boolean hw_seed(u64 * seed, boolean rdseed)
     return false;
 }
 
-u64 random_seed(void)
+u64 hw_get_seed(void)
 {
     u64 seed = 0;
     if (have_rdseed && hw_seed(&seed, true))
         return seed;
     if (have_rdrand && hw_seed(&seed, false))
         return seed;
-    return (u64)now(CLOCK_ID_MONOTONIC_RAW);
+    return (u64)now(CLOCK_ID_REALTIME);
 }
 
 static void init_hwrand(void)
@@ -579,4 +579,5 @@ void detect_devices(kernel_heaps kh, storage_attach sa)
     init_acpi(kh);
 
     init_virtio_balloon(kh);
+    init_virtio_rng(kh);
 }

--- a/platform/riscv-virt/Makefile
+++ b/platform/riscv-virt/Makefile
@@ -77,6 +77,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/virtio/virtio_mmio.c \
 	$(SRCDIR)/virtio/virtio_net.c \
 	$(SRCDIR)/virtio/virtio_pci.c \
+	$(SRCDIR)/virtio/virtio_rng.c \
 	$(SRCDIR)/virtio/virtio_scsi.c \
 	$(SRCDIR)/virtio/virtio_storage.c \
 	$(SRCDIR)/virtio/virtqueue.c \
@@ -333,6 +334,7 @@ QEMU_USERNET=	-device $(NETWORK)$(NETWORK_BUS),netdev=n0 -netdev user,id=n0,host
 ifneq ($(ENABLE_BALLOON),)
 QEMU_BALLOON=   -device virtio-balloon-pci
 endif
+QEMU_RNG=	-device virtio-rng-pci
 ifneq ($(ENABLE_QMP),)
 QEMU_QMP=	-qmp unix:$(ROOTDIR)/qmp-sock,server,nowait
 #QEMU_QMP=	-qmp tcp:localhost:4444,server,nowait
@@ -347,7 +349,7 @@ endif
 
 #QEMU_FLAGS+=	-monitor telnet:127.0.0.1:9999,server,nowait
 
-QEMU_COMMON=	$(QEMU_MACHINE) $(QEMU_MEMORY) $(QEMU_BALLOON) $(QEMU_KERNEL) $(QEMU_DISPLAY) $(QEMU_PCI) $(QEMU_SERIAL) $(QEMU_STORAGE) -no-reboot $(QEMU_FLAGS) $(QEMU_QMP)
+QEMU_COMMON=	$(QEMU_MACHINE) $(QEMU_MEMORY) $(QEMU_BALLOON) $(QEMU_KERNEL) $(QEMU_DISPLAY) $(QEMU_PCI) $(QEMU_RNG) $(QEMU_SERIAL) $(QEMU_STORAGE) -no-reboot $(QEMU_FLAGS) $(QEMU_QMP)
 
 run: image
 	$(QEMU) $(QEMU_COMMON) $(QEMU_USERNET) $(QEMU_ACCEL)

--- a/platform/riscv-virt/service.c
+++ b/platform/riscv-virt/service.c
@@ -17,10 +17,9 @@
 #define init_dump(p, len)
 #endif
 
-u64 random_seed(void)
+u64 hw_get_seed(void)
 {
-    // XXX add qemu random device? virtio-rng-device?
-    return rdtsc();
+    return (u64)now(CLOCK_ID_REALTIME);
 }
 
 extern void *START, *END;
@@ -199,4 +198,5 @@ void detect_devices(kernel_heaps kh, storage_attach sa)
     init_virtio_blk(kh, sa);
     init_virtio_scsi(kh, sa);
     init_virtio_balloon(kh);
+    init_virtio_rng(kh);
 }

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -88,6 +88,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/virtio/virtio_mmio.c \
 	$(SRCDIR)/virtio/virtio_net.c \
 	$(SRCDIR)/virtio/virtio_pci.c \
+	$(SRCDIR)/virtio/virtio_rng.c \
 	$(SRCDIR)/virtio/virtio_scsi.c \
 	$(SRCDIR)/virtio/virtio_storage.c \
 	$(SRCDIR)/virtio/virtqueue.c \
@@ -402,6 +403,7 @@ QEMU_USERNET=	-device $(NETWORK)$(NETWORK_BUS),netdev=n0 -netdev user,id=n0,host
 ifneq ($(ENABLE_BALLOON),)
 QEMU_BALLOON=   -device virtio-balloon-pci
 endif
+QEMU_RNG=	-device virtio-rng-pci
 ifneq ($(ENABLE_QMP),)
 QEMU_QMP=	-qmp unix:$(ROOTDIR)/qmp-sock,server,nowait
 #QEMU_QMP=	-qmp tcp:localhost:4444,server,nowait
@@ -419,7 +421,7 @@ QEMU_FLAGS+=	-semihosting
 
 #QEMU_FLAGS+=	-monitor telnet:127.0.0.1:9999,server,nowait
 
-QEMU_COMMON=	$(QEMU_MACHINE) $(QEMU_MEMORY) $(QEMU_BALLOON) $(QEMU_KERNEL) $(QEMU_DISPLAY) $(QEMU_PCI) $(QEMU_SERIAL) $(QEMU_STORAGE) -no-reboot $(QEMU_FLAGS) $(QEMU_QMP)
+QEMU_COMMON=	$(QEMU_MACHINE) $(QEMU_MEMORY) $(QEMU_BALLOON) $(QEMU_KERNEL) $(QEMU_DISPLAY) $(QEMU_PCI) $(QEMU_RNG) $(QEMU_SERIAL) $(QEMU_STORAGE) -no-reboot $(QEMU_FLAGS) $(QEMU_QMP)
 
 run: image
 	$(QEMU) $(QEMU_COMMON) $(QEMU_USERNET) $(QEMU_ACCEL)

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -29,7 +29,7 @@
 
 BSS_RO_AFTER_INIT struct uefi_boot_params boot_params;
 
-u64 random_seed(void)
+u64 hw_get_seed(void)
 {
 #if 0 // gcc not taking +rng feature modifier...encode manually?
     if (field_from_u64(read_psr(ID_AA64ISAR0_EL1), ID_AA64ISAR0_EL1_RNDR)
@@ -38,7 +38,7 @@ u64 random_seed(void)
     }
 #endif
     /* likely not a good fallback - look for another */
-    return rdtsc();
+    return (u64)now(CLOCK_ID_REALTIME);
 }
 
 static void uefi_mem_map_iterate(uefi_mem_map mem_map, range_handler h)
@@ -378,4 +378,5 @@ void detect_devices(kernel_heaps kh, storage_attach sa)
     init_virtio_scsi(kh, sa);
     init_nvme(kh, sa);
     init_virtio_balloon(kh);
+    init_virtio_rng(kh);
 }

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -356,7 +356,7 @@ void kernel_runtime_init(kernel_heaps kh)
 
     /* RNG, stack canaries */
     init_debug("RNG");
-    init_random();
+    init_random(locked);
     __stack_chk_guard_init();
 
     /* networking */

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -236,10 +236,15 @@ parser tuple_parser(heap h, parse_finish c, parse_error err);
 parser value_parser(heap h, parse_finish c, parse_error err);
 parser parser_feed (parser p, buffer b);
 
-// RNG
-void init_random();
-u64 random_u64();
+/* RNG */
+void init_random(heap h);
+u64 hw_get_seed(void);
+extern bytes (*preferred_get_seed)(void *seed, bytes len);
+void get_seed_complete(void *seed, bytes len);
+
+u64 random_u64(void);
 u64 random_buffer(buffer b);
+void random_reseed(void);
 
 typedef struct signature {
     u64 s[4];

--- a/src/unix_process/unix_process_runtime.c
+++ b/src/unix_process/unix_process_runtime.c
@@ -36,7 +36,7 @@ clock_now platform_monotonic_now;
 void *malloc(size_t size);
 void free(void *ptr);
 
-u64 random_seed()
+u64 hw_get_seed()
 {
     return random();
 }
@@ -178,7 +178,7 @@ heap init_process_runtime()
 {
     heap h = malloc_allocator();
     platform_monotonic_now = closure(h, unix_now);
-    init_random();
+    init_random(h);
     init_runtime(h, h);
     init_tuples(allocate_tagged_region(h, tag_table_tuple));
     init_symbols(allocate_tagged_region(h, tag_symbol), h);

--- a/src/virtio/virtio.h
+++ b/src/virtio/virtio.h
@@ -1,6 +1,7 @@
 void init_virtio_balloon(kernel_heaps kh);
 void init_virtio_blk(kernel_heaps kh, storage_attach a);
 void init_virtio_network(kernel_heaps kh);
+void init_virtio_rng(kernel_heaps kh);
 void init_virtio_scsi(kernel_heaps kh, storage_attach a);
 
 void virtio_mmio_parse(kernel_heaps kh, const char *str, int len);

--- a/src/virtio/virtio_rng.c
+++ b/src/virtio/virtio_rng.c
@@ -1,0 +1,147 @@
+#include <kernel.h>
+
+//#define VIRTIO_RNG_DEBUG
+#ifdef VIRTIO_RNG_DEBUG
+#define virtio_rng_debug(x, ...) do {tprintf(sym(vtrng), 0, x, ##__VA_ARGS__);} while(0)
+#else
+#define virtio_rng_debug(x, ...)
+#endif
+
+#include "virtio_internal.h"
+#include "virtio_mmio.h"
+#include "virtio_pci.h"
+
+#define VIRTIO_RNG_BUFSIZE 32768
+
+struct entropy_buf;
+
+declare_closure_struct(1, 1, void, ebuf_fill_complete,
+                       struct entropy_buf *, ebuf,
+                       u64, len);
+
+typedef struct entropy_buf {
+    void *buf;
+    u64 phys;
+    closure_struct(ebuf_fill_complete, fill_complete);
+    int offset;
+    int len;
+    boolean filling;
+} *entropy_buf;
+
+struct virtio_rng {
+    heap general;
+    backed_heap backed;
+    vtdev dev;
+    virtqueue requestq;
+    struct entropy_buf ebufs[2];
+    u8 ebuf_idx;
+    boolean initialized;
+} virtio_rng;
+
+/* no lock, single consumer thanks to rng mutex */
+
+static inline entropy_buf current_ebuf(void)
+{
+    return &virtio_rng.ebufs[virtio_rng.ebuf_idx];
+}
+
+static void virtio_rng_fill(entropy_buf ebuf)
+{
+    virtio_rng_debug("%s: ebuf %p\n", __func__, ebuf);
+    virtqueue vq = virtio_rng.requestq;
+    vqmsg m = allocate_vqmsg(vq);
+    assert(m != INVALID_ADDRESS);
+    ebuf->filling = true;
+    vqmsg_push(vq, m, ebuf->phys, VIRTIO_RNG_BUFSIZE, true);
+    vqmsg_commit(vq, m, (vqfinish)&ebuf->fill_complete);
+}
+
+define_closure_function(1, 1, void, ebuf_fill_complete,
+                        entropy_buf, ebuf,
+                        u64, len)
+{
+    virtio_rng_debug("%s: len %ld\n", __func__, len);
+    assert(len <= VIRTIO_RNG_BUFSIZE);
+    bound(ebuf)->offset = 0;
+    bound(ebuf)->len = len;
+    bound(ebuf)->filling = false;
+    if (compare_and_swap_boolean(&virtio_rng.initialized, false, true)) {
+        random_reseed();
+    }
+}
+
+static void virtio_init_ebufs(void)
+{
+    virtio_rng_debug("%s\n", __func__);
+    for (int i = 0; i < 2; i++) {
+        entropy_buf ebuf = &virtio_rng.ebufs[i];
+        ebuf->buf = alloc_map(virtio_rng.backed, VIRTIO_RNG_BUFSIZE, &ebuf->phys);
+        assert(ebuf->buf != INVALID_ADDRESS);
+        init_closure(&ebuf->fill_complete, ebuf_fill_complete, ebuf);
+        ebuf->offset = ebuf->len = 0;
+        virtio_rng_fill(ebuf);
+    }
+    virtio_rng.ebuf_idx = 0;
+}
+
+static bytes virtio_rng_get_seed(void *seed, bytes len)
+{
+    bytes filled = 0;
+    while (len - filled > 0) {
+        entropy_buf ebuf = current_ebuf();
+        if (ebuf->filling)
+            break;
+        bytes n = MIN(len - filled, ebuf->len - ebuf->offset);
+        runtime_memcpy(seed + filled, ebuf->buf + ebuf->offset, n);
+        filled += n;
+        ebuf->offset += n;
+        if (ebuf->offset >= ebuf->len) {
+            virtio_rng.ebuf_idx ^= 1;
+            virtio_rng_fill(ebuf);
+        }
+    }
+    virtio_rng_debug("%s: filled %ld\n", __func__, filled);
+    return filled;
+}
+
+static boolean virtio_rng_attach(heap general, backed_heap backed, vtdev v)
+{
+    virtio_rng_debug("   dev_features 0x%lx, features 0x%lx\n", v->dev_features, v->features);
+    virtio_rng.general = general;
+    virtio_rng.backed = backed;
+    virtio_rng.dev = v;
+    virtio_rng.initialized = false;
+
+    status s = virtio_alloc_virtqueue(v, "virtio rng requestq", 0, &virtio_rng.requestq);
+    if (!is_ok(s))
+        goto fail;
+
+    virtio_rng_debug("   virtqueues allocated, setting driver status OK\n");
+    vtdev_set_status(v, VIRTIO_CONFIG_STATUS_DRIVER_OK);
+    virtio_init_ebufs();
+    preferred_get_seed = virtio_rng_get_seed;
+    return true;
+  fail:
+    rprintf("%s: failed to attach: %v\n", __func__, s);
+    return false;
+}
+
+closure_function(3, 1, boolean, vtpci_rng_probe,
+                 heap, general, backed_heap, backed, id_heap, physical,
+                 pci_dev, d)
+{
+    virtio_rng_debug("%s\n", __func__);
+    if (!vtpci_probe(d, VIRTIO_ID_ENTROPY))
+        return false;
+
+    virtio_rng_debug("   attaching\n", __func__);
+    vtdev v = (vtdev)attach_vtpci(bound(general), bound(backed), d, 0);
+    return virtio_rng_attach(bound(general), bound(backed), v);
+}
+
+void init_virtio_rng(kernel_heaps kh)
+{
+    virtio_rng_debug("%s\n", __func__);
+    heap h = heap_locked(kh);
+    register_pci_driver(closure(h, vtpci_rng_probe, h, heap_linear_backed(kh), heap_physical(kh)), 0);
+}

--- a/test/runtime/getrandom.c
+++ b/test/runtime/getrandom.c
@@ -7,13 +7,12 @@
 #include <errno.h>
 #include <math.h>
 
-#define BUF_LEN 128
+#define BUF_LEN (4ull << 20)
 
 static int hash[256];
 
- void *malloc(size_t size);
-       void free(void *ptr);
-
+void *malloc(size_t size);
+void free(void *ptr);
 
 int
 __getrandom(void *buf, int i, int f)
@@ -31,7 +30,7 @@ int main(int argc, char **argvp)
     }
 
     r = __getrandom(buffer, BUF_LEN, 0);
-    if (r != 128) {
+    if (r != BUF_LEN) {
         printf("didn't get enough bytes: r = %d, errno = %d\n", r, errno);
         return 2;
     }


### PR DESCRIPTION
This introduces support for the virtio entropy device. When available, this
device will serve as the main source of entropy for the random number
generator. A hardware entropy source (e.g. rdseed and rdrand on x86-64) serves
as a fallback option when a virtio entropy device is not found.

Entropy data is stored in a double-buffered fashion with the intent to keep
entropy available for randomize functions without the need to block. Should an
underrun in entropy data occur, the aforementioned fallback option is used to
fulfill the request.

Other changes include adding a mutex to guard chacha20 usage and splitting
large getrandom(2) requests into smaller chunks to avoid starving other work.

Resolves #1440 
