### PR TITLE
clone(2): fix check for attempts to create new process

### DIFF
--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -60,8 +60,8 @@ sysreturn clone(unsigned long flags, void *child_stack, int *ptid, unsigned long
     thread_log(current, "clone: flags %lx, child_stack %p, ptid %p, ctid %p, newtls %lx",
         flags, child_stack, ptid, ctid, newtls);
 
-    if (!child_stack) {   /* this is actually a fork() */
-        thread_log(current, "attempted to fork by passing null child stack, aborting.");
+    if (!(flags & CLONE_THREAD)) {
+        thread_log(current, "attempted to create new process, aborting.");
         return set_syscall_error(current, ENOSYS);
     }
 


### PR DESCRIPTION
The existing clone(2) syscall implementation was detecting whether the user program is trying to create a new process by checking the child_stack argument against a null value. This logic is based on the fact that the glibc fork() wrapper that is provided as part of the NPTL threading implementation invokes clone(2) with child_stack set to 0. However, it is possible to create a new process even if child_stack is non-zero: notably, the posix_spawn() implementation in glibc invokes clone() with a valid stack pointer, which is later unmapped by the parent process after the child starts executing the newly created process. The correct way for clone(2) to detect an attempt to create a new process is by checking for the CLONE_THREAD flag.