### PR TITLE
Reflect a volume's readonly status in /proc/mounts

### DIFF
--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -135,7 +135,7 @@ closure_function(1, 4, void, mounts_handler,
         push_u8(b, '/');
     }
 out:
-    buffer_write_cstring(b, " tfs rw 0 0\n");
+    bprintf(b, " tfs %s 0 0\n", filesystem_is_readonly(fs) ? "ro" : "rw");
 }
 
 static sysreturn mounts_read(file f, void *dest, u64 length, u64 offset)


### PR DESCRIPTION
The readonly status added in https://github.com/nanovms/nanos/pull/1728 should be shown in /proc/mounts:
```
root / tfs ro 0 0
testvol /test tfs rw 0 0
testvolro /testro tfs ro 0 0
```
