### PR TITLE
Syscall stat fixes

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2380,7 +2380,6 @@ void count_syscall(thread t, sysreturn rv)
     else
         us = t->syscall_time;
     fetch_and_add(&ss->usecs, us);
-    t->syscall_time = 0;
 }
 
 static boolean debugsyscalls;
@@ -2515,6 +2514,7 @@ void syscall_handler(thread t)
         assert(t->last_syscall == -1);
         t->last_syscall = call;
         t->syscall_enter_ts = now(CLOCK_ID_MONOTONIC_RAW);
+        t->syscall_time = 0;
     }
     struct syscall *s = t->p->syscalls + call;
     if (debugsyscalls) {

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -790,7 +790,7 @@ void count_syscall(thread t, sysreturn rv);
 extern boolean do_syscall_stats;
 static inline void count_syscall_save(thread t)
 {
-    if (do_syscall_stats && !t->syscall_complete) {
+    if (do_syscall_stats && !t->syscall_complete && t->syscall_enter_ts) {
         t->syscall_time += usec_from_timestamp(now(CLOCK_ID_MONOTONIC_RAW) - t->syscall_enter_ts);
         t->syscall_enter_ts = 0;
     }


### PR DESCRIPTION
This changeset fixes two issues found in the code that computes syscall execution statistics:
- the syscall_time field of the thread struct was not being initialized at syscall entry
- the count_syscall_save() function was not handling properly multiple consecutive calls without count_syscall_resume() being called in-between