### PR TITLE
Page cache: add global lock

### DIFF
--- a/src/kernel/pagecache_internal.h
+++ b/src/kernel/pagecache_internal.h
@@ -37,6 +37,7 @@ typedef struct pagecache {
        alterations to page completion vecs */
 #ifdef KERNEL
     struct spinlock state_lock;
+    struct spinlock global_lock;
 #endif
     struct pagelist free;      /* see state descriptions */
     struct pagelist new;


### PR DESCRIPTION
This lock protects from concurrent access to the list of page cache volumes.