### PR TITLE
Syscalls: add timer_settime and settimeofday

### DIFF
--- a/src/aarch64/unix_machine.c
+++ b/src/aarch64/unix_machine.c
@@ -216,7 +216,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, adjtimex, 0, 0);
     register_syscall(map, chroot, 0, 0);
     register_syscall(map, acct, 0, 0);
-    register_syscall(map, settimeofday, 0, 0);
     register_syscall(map, mount, 0, 0);
     register_syscall(map, umount2, 0, 0);
     register_syscall(map, swapon, 0, 0);
@@ -246,7 +245,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, remap_file_pages, 0, 0);
     register_syscall(map, restart_syscall, 0, 0);
     register_syscall(map, semtimedop, 0, 0);
-    register_syscall(map, clock_settime, 0, 0);
     register_syscall(map, mbind, 0, 0);
     register_syscall(map, set_mempolicy, 0, 0);
     register_syscall(map, get_mempolicy, 0, 0);

--- a/src/kernel/clock.c
+++ b/src/kernel/clock.c
@@ -57,7 +57,7 @@ void clock_reset_rtc(timestamp wallclock_now)
                 __func__, now(CLOCK_ID_REALTIME), wallclock_now);
     timestamp n = now(CLOCK_ID_REALTIME);
     rtc_settimeofday(sec_from_timestamp(wallclock_now));
-    pqueue_walk(kernel_timers->pq, stack_closure(timer_adjust_handler, wallclock_now - n));
-    timer_reorder(kernel_timers);
+    timer_adjust_begin(kernel_timers);
     reset_clock_vdso_dat();
+    timer_adjust_end(kernel_timers, stack_closure(timer_adjust_handler, wallclock_now - n));
 }

--- a/src/kernel/clock.c
+++ b/src/kernel/clock.c
@@ -7,6 +7,8 @@
 #define clock_debug(x, ...)
 #endif
 
+extern void notify_unix_timers_of_rtc_change(void);
+
 void kernel_delay(timestamp delta)
 {
     timestamp end = now(CLOCK_ID_MONOTONIC) + delta;
@@ -59,6 +61,7 @@ void clock_reset_rtc(timestamp wallclock_now)
                 __func__, now(CLOCK_ID_REALTIME), wallclock_now);
     timestamp n = now(CLOCK_ID_REALTIME);
     rtc_settimeofday(sec_from_timestamp(wallclock_now));
+    notify_unix_timers_of_rtc_change();
     timer_adjust_begin(kernel_timers);
     reset_clock_vdso_dat();
     timer_adjust_end(kernel_timers, stack_closure(timer_adjust_handler, wallclock_now - n));

--- a/src/kernel/clock.c
+++ b/src/kernel/clock.c
@@ -39,6 +39,8 @@ closure_function(1, 1, boolean, timer_adjust_handler,
                 void *, v)
 {
     timer t = v;
+    if (t->absolute)
+        return true;
     switch (t->id) {
     case CLOCK_ID_REALTIME:
     case CLOCK_ID_REALTIME_COARSE:

--- a/src/riscv64/unix_machine.c
+++ b/src/riscv64/unix_machine.c
@@ -161,7 +161,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, adjtimex, 0, 0);
     register_syscall(map, chroot, 0, 0);
     register_syscall(map, acct, 0, 0);
-    register_syscall(map, settimeofday, 0, 0);
     register_syscall(map, mount, 0, 0);
     register_syscall(map, umount2, 0, 0);
     register_syscall(map, swapon, 0, 0);
@@ -191,7 +190,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, remap_file_pages, 0, 0);
     register_syscall(map, restart_syscall, 0, 0);
     register_syscall(map, semtimedop, 0, 0);
-    register_syscall(map, clock_settime, 0, 0);
     register_syscall(map, mbind, 0, 0);
     register_syscall(map, set_mempolicy, 0, 0);
     register_syscall(map, get_mempolicy, 0, 0);

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -31,6 +31,7 @@ void register_timer(timerqueue tq, timer t, clock_id id,
     t->id = id;
     t->expiry = absolute ? val : now(id) + val;
     t->interval = interval;
+    t->absolute = absolute;
     assert(!t->queued);
     t->active = true;
     t->queued = true;

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -133,6 +133,18 @@ void timer_reorder(timerqueue tq)
     timer_unlock(tq);
 }
 
+void timer_adjust_begin(timerqueue tq)
+{
+    timer_lock(tq);
+}
+
+void timer_adjust_end(timerqueue tq, pqueue_element_handler h)
+{
+    pqueue_walk(tq->pq, h);
+    pqueue_reorder(tq->pq);
+    timer_unlock(tq);
+}
+
 timerqueue allocate_timerqueue(heap h, const char *name)
 {
     timerqueue tq = allocate(h, sizeof(struct timerqueue));

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -45,6 +45,7 @@ struct timer {
     clock_id id;
     timestamp expiry;
     timestamp interval;
+    boolean absolute;
     boolean active;
     boolean queued;
     timer_handler handler;

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -144,4 +144,7 @@ timerqueue allocate_timerqueue(heap h, const char *name);
 void timer_service(timerqueue tq, timestamp here);
 void timer_reorder(timerqueue tq);
 
+void timer_adjust_begin(timerqueue tq);
+void timer_adjust_end(timerqueue tq, pqueue_element_handler h);
+
 s64 rtime(s64 *result);

--- a/src/x86_64/unix_machine.c
+++ b/src/x86_64/unix_machine.c
@@ -313,7 +313,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, adjtimex, 0, 0);
     register_syscall(map, chroot, 0, 0);
     register_syscall(map, acct, 0, 0);
-    register_syscall(map, settimeofday, 0, 0);
     register_syscall(map, mount, 0, 0);
     register_syscall(map, umount2, 0, 0);
     register_syscall(map, swapon, 0, 0);
@@ -357,7 +356,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, remap_file_pages, 0, 0);
     register_syscall(map, restart_syscall, 0, 0);
     register_syscall(map, semtimedop, 0, 0);
-    register_syscall(map, clock_settime, 0, 0);
     register_syscall(map, vserver, 0, 0);
     register_syscall(map, mbind, 0, 0);
     register_syscall(map, set_mempolicy, 0, 0);

--- a/test/runtime/time.manifest
+++ b/test/runtime/time.manifest
@@ -9,6 +9,6 @@
 #    debugsyscalls:t
 #    futex_trace:t
 #    fault:t
-    arguments:[webg poppy]
+    arguments:[time -s]
     environment:(USER:bobby PWD:/)
 )


### PR DESCRIPTION
These syscalls allow changing the system (wall clock) time.
In addition, a few fixes are being applied to the existing timer code:
- use the monotonic clock in all itimer types
- implement proper locking in order to safely change the real-time clock from multiple sources, such as syscalls and NTP, and safely access the timerqueue during a real-time clock change in SMP systems
- move resetting of RTC offset value in the VDSO structure so that timer reordering uses the updated offset
- properly adjust expiry time for absolute timers based on real-time clock

The TFD_TIMER_CANCEL_ON_SET option is now implemented.
A set of test cases is being added to the runtime tests to exercise the new syscalls and test the behavior of active timers when the real-time clock undergoes a discontinuous change.