### PR TITLE
move scheduling of thunks to async_apply() and async_apply_bh()

### DIFF
--- a/src/aws/ena/ena.c
+++ b/src/aws/ena/ena.c
@@ -873,7 +873,7 @@ static void ena_handle_msix(void *arg)
     struct netif *netif = &adapter->ifp;
 
     if (likely(netif_is_flag_set(netif, NETIF_FLAG_UP)))
-        enqueue(runqueue, &queue->cleanup_task);
+        async_apply_bh((thunk)&queue->cleanup_task);
 }
 
 static int ena_enable_msix(struct ena_adapter *adapter)
@@ -1310,7 +1310,7 @@ static void check_for_empty_rx_ring(struct ena_adapter *adapter)
 
                 device_printf(adapter->pdev, "trigger refill for ring %d\n", i);
 
-                enqueue_irqsafe(runqueue, &rx_ring->que->cleanup_task);
+                async_apply((thunk)&rx_ring->que->cleanup_task);
                 rx_ring->empty_rx_queue = 0;
             }
         }
@@ -1339,7 +1339,7 @@ define_closure_function(1, 2, void, ena_timer_task,
 
     if (unlikely(ENA_FLAG_ISSET (ENA_FLAG_TRIGGER_RESET, adapter))) {
         device_printf(adapter->pdev, "Trigger reset is on\n");
-        enqueue_irqsafe(runqueue, &adapter->reset_task);
+        async_apply((thunk)&adapter->reset_task);
     }
 }
 
@@ -2189,10 +2189,10 @@ static void ena_update_on_link_change(void *adapter_data, struct ena_admin_aenq_
 
     if (status != 0) {
         ena_trace(NULL, ENA_INFO, "link UP interrupt\n");
-        enqueue(runqueue, &adapter->link_up_task);
+        async_apply_bh((thunk)&adapter->link_up_task);
     } else {
         ena_trace(NULL, ENA_INFO, "link DOWN interrupt\n");
-        enqueue(runqueue, &adapter->link_down_task);
+        async_apply_bh((thunk)&adapter->link_down_task);
     }
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -33,6 +33,11 @@
 /* per-cpu queue */
 #define CPU_QUEUE_SIZE 512
 
+/* general scheduling queues */
+#define BHQUEUE_SIZE       8192
+#define RUNQUEUE_SIZE      8192
+#define ASYNC_QUEUE_1_SIZE 65536
+
 /* locking */
 #define MUTEX_ACQUIRE_SPIN_LIMIT (1ull << 20)
 

--- a/src/drivers/acpi.c
+++ b/src/drivers/acpi.c
@@ -595,10 +595,7 @@ ACPI_STATUS AcpiOsExecute(ACPI_EXECUTE_TYPE type, ACPI_OSD_EXEC_CALLBACK functio
     thunk t = closure(acpi_heap, acpi_async_func, function, context);
     if (t == INVALID_ADDRESS)
         return AE_NO_MEMORY;
-    if (!enqueue_irqsafe(runqueue, t)) {
-        deallocate_closure(t);
-        return AE_NO_MEMORY;
-    }
+    async_apply_bh(t);
     return AE_OK;
 }
 

--- a/src/drivers/ata-pci.c
+++ b/src/drivers/ata-pci.c
@@ -275,7 +275,7 @@ define_closure_function(1, 0, void, ata_pci_irq,
                 ata_pci_req, l);
             req->s = timm("result", "I/O error");
         }
-        enqueue(bhqueue, &apci->service);
+        async_apply_bh((thunk)&apci->service);
     }
     spin_unlock_irq(&apci->lock, irqflags);
 }

--- a/src/drivers/nvme.c
+++ b/src/drivers/nvme.c
@@ -431,7 +431,7 @@ define_closure_function(1, 0, void, nvme_io_irq,
     nvme_cq_doorbell(n, NVME_IOQ_IDX, &n->iocq);
     nvme_service_pending(n, false);
     if (done_empty && !list_empty(&n->done_reqs))
-        enqueue(bhqueue, &n->bh_service);
+        async_apply_bh((thunk)&n->bh_service);
     spin_unlock(&n->lock);
 }
 
@@ -500,7 +500,7 @@ static void nvme_ns_resp_parse(nvme n, u32 ns_id, void *ns_resp,
     if (ns_attach == INVALID_ADDRESS)
         msg_err("failed to allocate NS attach closure\n");
     else
-        enqueue(runqueue, ns_attach);
+        async_apply_bh(ns_attach);
 }
 
 static void nvme_ns_query(nvme n, u32 ns_id, void *ns_resp)

--- a/src/gdb/gdbutil.c
+++ b/src/gdb/gdbutil.c
@@ -81,7 +81,7 @@ void putpacket_deferred(gdb g, string b)
     }
     g->sending = true;
     put_sendstring(g, b);
-    assert(enqueue(runqueue, closure(g->h, gdb_deferred_tx, g)));
+    async_apply_bh(closure(g->h, gdb_deferred_tx, g));
     spin_unlock_irq(&g->send_lock, flags);
 }
 

--- a/src/hyperv/vmbus/vmbus.c
+++ b/src/hyperv/vmbus/vmbus.c
@@ -95,7 +95,7 @@ vmbus_handle_intr1(vmbus_dev sc, int cpu)
     msg = msg_base + VMBUS_SINT_MESSAGE;
     if (msg->msg_type != HYPERV_MSGTYPE_NONE) {
         vmbus_debug("SINT Message!");
-        enqueue(runqueue, VMBUS_PCPU_GET(sc, message_task, cpu));
+        async_apply_bh(VMBUS_PCPU_GET(sc, message_task, cpu));
     }
 }
 

--- a/src/hyperv/vmbus/vmbus_chan.c
+++ b/src/hyperv/vmbus/vmbus_chan.c
@@ -714,7 +714,7 @@ vmbus_event_flags_proc(vmbus_dev sc, volatile u64 *event_flags,
             if (chan->ch_flags & VMBUS_CHAN_FLAG_BATCHREAD)
                 vmbus_rxbr_intr_mask(&chan->ch_rxbr);
             if (!sc->poll_mode) {
-                enqueue_irqsafe(chan->sched_queue, chan->ch_tq);
+                assert(enqueue_irqsafe(chan->sched_queue, chan->ch_tq));
             } else {
                 apply(chan->ch_tq);
             }

--- a/src/kernel/flush.c
+++ b/src/kernel/flush.c
@@ -133,7 +133,7 @@ static void queue_flush_service(void)
 {
     if (!service_scheduled) {
         service_scheduled = true;
-        assert(enqueue_irqsafe(bhqueue, flush_service));
+        async_apply_bh(flush_service);
     }
 }
 

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -143,7 +143,7 @@ closure_function(2, 2, void, fsstarted,
     boolean klibs_in_bootfs = klibs && buffer_compare_with_cstring(klibs, "bootfs");
 
     merge m;
-    enqueue(runqueue, create_init(init_heaps, root, fs, &m));
+    async_apply(create_init(init_heaps, root, fs, &m));
     boolean opening_bootfs = false;
     if (mbr) {
         heap bh = (heap)heap_linear_backed(init_heaps);

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -93,7 +93,7 @@ static void kernel_context_resume(context c)
 static void kernel_context_schedule_return(context c)
 {
     kernel_context kc = (kernel_context)c;
-    assert(enqueue_irqsafe(runqueue, &kc->kernel_return));
+    async_apply_bh((thunk)&kc->kernel_return);
 }
 
 define_closure_function(1, 0, void, kernel_context_return,

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1373,8 +1373,8 @@ define_closure_function(1, 0, void, pagecache_node_queue_free,
 {
     thunk t = (void *)&bound(pn)->free;
 #ifdef KERNEL
-    /* freeing the node must be deferred to bhqueue to avoid state lock reentrance */
-    enqueue(bhqueue, t);
+    /* freeing the node must be deferred to avoid state lock reentrance */
+    async_apply(t);
 #else
     apply(t);
 #endif

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -91,7 +91,7 @@ static void migrate_from_self(cpuinfo ci, u64 first_cpu, u64 ncpus)
             wakeup_cpu(cpu);
         } else if ((t = dequeue(ci->thread_queue)) != INVALID_ADDRESS) {
             sched_debug("migrating thread from self to idle CPU %d\n", cpu);
-            enqueue(cpui->thread_queue, t);
+            assert(enqueue(cpui->thread_queue, t));
             wakeup_cpu(cpu);
         }
         ncpus -= cpu - first_cpu + 1;
@@ -277,10 +277,9 @@ void init_scheduler(heap h)
     assert(wakeup_vector != INVALID_PHYSICAL);
 
     /* scheduling queues init */
-    // XXX configs
-    bhqueue = allocate_queue(h, 2048);
-    runqueue = allocate_queue(h, 2048);
-    async_queue_1 = allocate_queue(h, 8192);
+    bhqueue = allocate_queue(h, BHQUEUE_SIZE);
+    runqueue = allocate_queue(h, RUNQUEUE_SIZE);
+    async_queue_1 = allocate_queue(h, ASYNC_QUEUE_1_SIZE);
     shutting_down = false;
 }
 

--- a/src/kernel/tracelog.c
+++ b/src/kernel/tracelog.c
@@ -75,7 +75,7 @@ build_assert((TRACELOG_ENTRY_SIZE & (TRACELOG_ENTRY_SIZE - 1)) == 0);
 static inline void schedule_collator(void)
 {
     if (!atomic_swap_boolean(&tracelog.collator_scheduled, true))
-        enqueue_irqsafe(runqueue, &tracelog.collator);
+        async_apply_bh((thunk)&tracelog.collator);
 }
 
 static inline tracelog_buffer get_tracelog_buffer(cpuinfo ci)
@@ -455,7 +455,7 @@ static boolean tracelog_do_http_get(buffer_handler out, buffer relative_uri)
 
 static inline void schedule_send_http_chunk(void)
 {
-    enqueue_irqsafe(runqueue, &tracelog.send_http_chunk);
+    async_apply((thunk)&tracelog.send_http_chunk);
 }
 
 define_closure_function(2, 0, void, tracelog_send_http_chunk,

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -157,7 +157,7 @@ static void netsock_check_loop(void)
      * enqueued more than once. */
     if (!net_loop_poll_queued) {
         net_loop_poll_queued = true;
-        enqueue_irqsafe(runqueue, net_loop_poll);
+        async_apply(net_loop_poll);
     }
 }
 
@@ -1119,7 +1119,7 @@ static void udp_input_lower(void *z, struct udp_pcb *pcb, struct pbuf *p,
 	e->pbuf = p;
 	runtime_memcpy(&e->raddr, addr, sizeof(ip_addr_t));
 	e->rport = port;
-	enqueue(s->incoming, e);
+	assert(enqueue(s->incoming, e));
 	s->sock.rx_len += p->tot_len;
     } else {
 	msg_err("null pbuf\n");

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -2,8 +2,6 @@
 
 #define apply(__c, ...) (*(__c))((void *)(__c), ## __VA_ARGS__)
 
-#define async_apply(__t, __c, ...) async_apply_##__t(__c, ## __VA_ARGS__)
-
 #define __closure(__c, __p, __s, __name, ...)    \
     _fill_##__name(__c, __p, __s, ##__VA_ARGS__)
 

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -58,7 +58,7 @@ static void blockq_apply(blockq bq, thread t, u64 bq_flags)
                  (bq_flags & BLOCKQ_ACTION_TIMEDOUT) ? "timedout" : "");
 
     assert(t->blocked_on == bq);
-    async_apply_1((async_1)t->bq_action, (void *)bq_flags); /* retval ignored */
+    async_apply_1((async_1)t->bq_action, (void *)bq_flags); /* bq_action retval ignored */
 }
 
 /* A blockq_thread timed out. */

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -238,7 +238,7 @@ static boolean demand_filebacked_page(thread t, context ctx, vmap vm, u64 vaddr,
     spin_unlock_irq(&t->p->faulting_lock, saved_flags);
 
     /* no need to reserve context; we're on exception/int stack */
-    enqueue(bhqueue, &t->demand_file_page);
+    async_apply_bh((thunk)&t->demand_file_page);
     count_major_fault();
     return false;
   sched_thread_return:

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -193,7 +193,7 @@ static void thread_resume(context ctx)
 static void thread_schedule_return(context ctx)
 {
     thread t = (thread)ctx;
-    enqueue_irqsafe(t->scheduling_queue, &t->thread_return);
+    assert(enqueue_irqsafe(t->scheduling_queue, &t->thread_return));
 }
 
 define_closure_function(1, 0, void, thread_return,

--- a/src/virtio/virtio_pci.c
+++ b/src/virtio/virtio_pci.c
@@ -216,7 +216,7 @@ closure_function(1, 0, void, vtpci_non_msix_irq,
     if ((isr_status & VIRTIO_PCI_ISR_CONFIG) && dev->config_handler) {
         virtio_pci_debug("       queueing config change handler %F\n",
                          dev->config_handler);
-        enqueue(runqueue, dev->config_handler);
+        async_apply_bh((thunk)dev->config_handler);
     }
 }
 
@@ -301,7 +301,7 @@ closure_function(2, 0, void, vtpci_config_change_msix_irq,
 {
     virtio_pci_debug("%s: dev %p, queueing config change handler %F\n",
                      __func__, bound(dev), bound(handler));
-    enqueue(runqueue, bound(handler));
+    async_apply_bh(bound(handler));
 }
 
 status vtpci_register_config_change_handler(vtpci dev, thunk handler)

--- a/src/virtio/virtio_scsi.c
+++ b/src/virtio/virtio_scsi.c
@@ -484,8 +484,8 @@ closure_function(4, 2, void, virtio_scsi_read_capacity_done,
     virtio_scsi_debug("%s: target %d, lun %d, block size 0x%lx, capacity 0x%lx\n",
         __func__, target, lun, d->block_size, d->capacity);
 
-    enqueue_irqsafe(runqueue, closure(s->v->virtio_dev.general, virtio_scsi_init_done,
-                                      d, bound(attach_id), bound(a)));
+    async_apply(closure(s->v->virtio_dev.general, virtio_scsi_init_done,
+                        d, bound(attach_id), bound(a)));
   out:
     closure_finish();
 }

--- a/src/vmware/pvscsi.c
+++ b/src/vmware/pvscsi.c
@@ -691,7 +691,7 @@ static void pvscsi_process_cmp_ring(pvscsi dev)
         /* only called from int handler, but use irqsafe in case this changes */
         list_delete(&q); /* trick: remove (local) head and queue first element */
         assert(enqueue_irqsafe(dev->rx_servicequeue, l));
-        enqueue_irqsafe(bhqueue, dev->rx_service);
+        async_apply_bh(dev->rx_service);
     }
 }
 

--- a/src/vmware/vmxnet3_net.c
+++ b/src/vmware/vmxnet3_net.c
@@ -606,6 +606,6 @@ static void process_interrupt(vmxnet3 vn)
         /* trick: remove (local) head and queue first element */
         list_delete(&q);
         assert(enqueue(vn->rx_servicequeue, l));
-        enqueue(runqueue, vn->rx_service);
+        async_apply_bh(vn->rx_service);
     }
 }

--- a/src/x86_64/breakpoint.c
+++ b/src/x86_64/breakpoint.c
@@ -69,7 +69,7 @@ boolean breakpoint_insert(heap h, u64 a, u8 type, u8 log_length, thunk completio
             thunk t = closure(h, set_breakpoint, true, a, type, i, total_processors, completion);
             cpuinfo ci;
             vector_foreach(cpuinfos, ci) {
-                enqueue_irqsafe(ci->cpu_queue, t);
+                assert(enqueue_irqsafe(ci->cpu_queue, t));
             }
             wakeup_or_interrupt_cpu_all();
             return(true);
@@ -86,7 +86,7 @@ boolean breakpoint_remove(heap h, u32 a, thunk completion)
             thunk t = closure(h, set_breakpoint, false, 0, 0, i, total_processors, completion);
             cpuinfo ci;
             vector_foreach(cpuinfos, ci) {
-                enqueue_irqsafe(ci->cpu_queue, t);
+                assert(enqueue_irqsafe(ci->cpu_queue, t));
             }
             wakeup_or_interrupt_cpu_all();
             return(true);

--- a/src/xen/xen.c
+++ b/src/xen/xen.c
@@ -1037,7 +1037,7 @@ define_closure_function(0, 1, void, xen_watch_handler,
     }
     if (depth == 0)
         return;
-    enqueue(runqueue, &xen_info.scan_service);
+    async_apply_bh((thunk)&xen_info.scan_service);
 }
 
 define_closure_function(0, 0, void, xen_scan_service)
@@ -1046,7 +1046,7 @@ define_closure_function(0, 0, void, xen_scan_service)
 
     /* Avoid concurrent scans. */
     if (atomic_test_and_set_bit(&xen_info.scanning, 0)) {
-        enqueue(runqueue, &xen_info.scan_service);
+        async_apply((thunk)&xen_info.scan_service);
         return;
     }
 

--- a/src/xen/xenblk.c
+++ b/src/xen/xenblk.c
@@ -257,7 +257,7 @@ define_closure_function(1, 0, void, xenblk_event_handler,
     xenblk_service_ring(xbd);
     xenblk_service_pending(xbd);
     if (done_empty && !list_empty(&xbd->done))
-        enqueue(bhqueue, &xbd->bh_service);
+        async_apply_bh((thunk)&xbd->bh_service);
     spin_unlock(&xbd->lock);
 }
 
@@ -401,7 +401,7 @@ define_closure_function(1, 1, void, xenblk_watch_handler,
 {
     xenblk_dev xbd = bound(xbd);
     xenblk_debug("%s: path %s", __func__, path);
-    enqueue(runqueue, &xbd->watch_service);
+    async_apply_bh((thunk)&xbd->watch_service);
 }
 
 #define XENBLK_INFORM_BACKEND_RETRIES   64

--- a/src/xen/xennet.c
+++ b/src/xen/xennet.c
@@ -290,7 +290,7 @@ static void xennet_service_tx_ring(xennet_dev xd)
             /* trick: remove (local) head and queue first element */
             list_delete(&q);
             assert(enqueue(xd->tx_servicequeue, l));
-            enqueue(runqueue, xd->tx_service);
+            async_apply_bh(xd->tx_service);
         }
         RING_FINAL_CHECK_FOR_RESPONSES(&xd->tx_ring, more);
     } while (more);
@@ -616,7 +616,7 @@ static void xennet_service_rx_ring(xennet_dev xd)
             list_delete(&q);
             assert(l->prev);
             assert(enqueue(xd->rx_servicequeue, l));
-            enqueue(runqueue, xd->rx_service);
+            async_apply_bh(xd->rx_service);
         }
         RING_FINAL_CHECK_FOR_RESPONSES(&xd->rx_ring, more);
     } while (more);


### PR DESCRIPTION
This change creates the async_apply() and async_apply_bh() functions for
scheduling thunks to the runqueue and bhqueues, respectively. Previously,
thunks were directly enqueued to the scheduling queue, which proved to be
error-prone as return values were often unchecked, leading to queueing
failures being undetected. The selection between enqueue() vs
enqueue_irqsafe() variants is also risky, as a (non-irqsafe) enqueue()
competing with an enqueue from an interrupt handler could potentially lead to
a hang. The semantics for the two queues have been clarified such that
scheduling to the runqueue is not allowed from interrupt handling; scheduling
from interrupt level must occur only to the bhqueue. This interface also hides
the implementation details of the scheduling queues, thus making it easier to
revise these details without affecting much of the calling code.

All async_apply*() functions are now void returns, indicating that such
scheduling should never fail. Internally, the functions simply assert that
enqueues succeed, but in the future they could possibly lead to alternate
paths to mitigate the limit (such as suspending the execution context, if
possible, while queues are drained and resources are made available). It may
also be desirable to adopt a lock-free queue that is extendable, avoiding the
need for fixed queue sizes altogether.

Within the scheduler, the queue sizes set on initialization are now defined in
config.h, and the async_queue_1 size has been expanded to make room for large
bursts of enqueues, such as those that occur while servicing virtqueues.