### PR TITLE
Syscalls: add recvmmsg implementation

### DIFF
--- a/src/aarch64/unix_machine.c
+++ b/src/aarch64/unix_machine.c
@@ -276,7 +276,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, preadv, 0, 0);
     register_syscall(map, pwritev, 0, 0);
     register_syscall(map, perf_event_open, 0, 0);
-    register_syscall(map, recvmmsg, 0, 0);
     register_syscall(map, fanotify_init, 0, 0);
     register_syscall(map, fanotify_mark, 0, 0);
     register_syscall(map, name_to_handle_at, 0, 0);

--- a/src/net/net_system_structs.h
+++ b/src/net/net_system_structs.h
@@ -46,6 +46,7 @@ enum protocol_type {
 #define MSG_CONFIRM     0x00000800
 #define MSG_NOSIGNAL    0x00004000
 #define MSG_MORE        0x00008000
+#define MSG_WAITFORONE  0x00010000
 
 // tuplify
 #define SOCK_NONBLOCK 00004000

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -482,6 +482,11 @@ static sysreturn sock_read_bh_internal(netsock s, struct msghdr *msg, int flags,
             assert(dequeue(s->incoming) == p);
             if (s->sock.type == SOCK_DGRAM) {
                 s->sock.rx_len -= pbuf->tot_len;
+                if (cur_buf) {
+                    msg->msg_flags |= MSG_TRUNC;
+                    if (flags & MSG_TRUNC)
+                        xfer_total = pbuf->tot_len;
+                }
                 deallocate(s->sock.h, p, sizeof(struct udp_entry));
             }
             pbuf_free(pbuf);

--- a/src/riscv64/unix_machine.c
+++ b/src/riscv64/unix_machine.c
@@ -221,7 +221,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, preadv, 0, 0);
     register_syscall(map, pwritev, 0, 0);
     register_syscall(map, perf_event_open, 0, 0);
-    register_syscall(map, recvmmsg, 0, 0);
     register_syscall(map, fanotify_init, 0, 0);
     register_syscall(map, fanotify_mark, 0, 0);
     register_syscall(map, name_to_handle_at, 0, 0);

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -44,6 +44,7 @@ struct _closure_common {
 #define init_closure(__p, __name, ...)                                  \
     __closure(0, (__p), sizeof(struct _closure_##__name), __name, ##__VA_ARGS__)
 
+#define closure_struct_type(__name)     struct _closure_##__name
 #define closure_struct(__name, __field) struct _closure_##__name __field;
 
 #define closure_ref(__name, __var) struct _closure_##__name *__var

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -58,7 +58,6 @@ struct sock {
     blockq rxbq;
     blockq txbq;
     u64 rx_len;
-    unsigned int msg_count;
     sysreturn (*bind)(struct sock *sock, struct sockaddr *addr,
             socklen_t addrlen);
     sysreturn (*listen)(struct sock *sock, int backlog);
@@ -76,8 +75,9 @@ struct sock {
     sysreturn (*recvfrom)(struct sock *sock, void *buf, u64 len, int flags,
              struct sockaddr *dest_addr, socklen_t *addrlen);
     sysreturn (*sendmsg)(struct sock *sock, const struct msghdr *msg,
-            int flags);
-    sysreturn (*recvmsg)(struct sock *sock, struct msghdr *msg, int flags);
+                         int flags, boolean in_bh, io_completion completion);
+    sysreturn (*recvmsg)(struct sock *sock, struct msghdr *msg, int flags, boolean in_bh,
+                         io_completion completion);
     sysreturn (*shutdown)(struct sock *sock, int how);
 };
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -232,8 +232,7 @@ void iov_op(fdesc f, boolean write, struct iovec *iov, int iovcnt, u64 offset,
     p->curr_offset = 0;
     p->total_len = 0;
     p->completion = completion;
-    init_closure(&p->bh, iov_bh, p, current);
-    apply_context_to_closure(&p->bh, get_current_context(current_cpu()));
+    contextual_closure_init(iov_bh, &p->bh, p, current);
     init_closure(&p->each_complete, iov_op_each_complete, iovcnt,
         p);
     io_completion each = (io_completion)&p->each_complete;

--- a/src/x86_64/unix_machine.c
+++ b/src/x86_64/unix_machine.c
@@ -389,7 +389,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, preadv, 0, 0);
     register_syscall(map, pwritev, 0, 0);
     register_syscall(map, perf_event_open, 0, 0);
-    register_syscall(map, recvmmsg, 0, 0);
     register_syscall(map, fanotify_init, 0, 0);
     register_syscall(map, fanotify_mark, 0, 0);
     register_syscall(map, name_to_handle_at, 0, 0);

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -576,6 +576,17 @@ static void netsock_test_msg(int sock_type)
     test_assert(sendmmsg(tx_fd, mmsg1, 0, 0) == 0); /* dummy sendmmsg() */
     test_assert(recvmmsg(rx_fd, mmsg2, 0, 0, NULL) == 0);   /* dummy recvmmsg() */
 
+    if (sock_type == SOCK_DGRAM) {
+        /* test reception of truncated messages */
+        test_assert(sendmsg(tx_fd, &msg1, 0) == total_len);
+        test_assert(sendmsg(tx_fd, &msg1, 0) == total_len);
+        msg2.msg_iovlen = 1;
+        test_assert(recvmsg(rx_fd, &msg2, 0) == msg2.msg_iov[0].iov_len);
+        test_assert(msg2.msg_flags == MSG_TRUNC);
+        test_assert(recvmsg(rx_fd, &msg2, MSG_TRUNC) == total_len);
+        test_assert(msg2.msg_flags == MSG_TRUNC);
+    }
+
     memset(&mmsg1, 0, sizeof(mmsg1));
     iov1[0].iov_base = tx_buf;
     iov1[0].iov_len = 4;


### PR DESCRIPTION
This Linux-specific syscall allows receiving multiple messages from a socket. The timeout feature (which even in Linux does not work as intended) is not implemented.
In addition, the functionality of the existing sendmmsg syscall has been expanded to cover not only network sockets, but any type of socket that implements the sendmsg callback.
For network sockets, the code that handles data transmission and reception has been refactored to use iovec structures instead of a single contiguous buffer; this allows avoiding the additional buffer allocation and copying that was done for sendmsg, sendmmsg, and recvmsg.
For datagram sockets, the MSG_TRUNC option is now implemented (both as an input flag specified by the user process in a syscall, and as an output flags set by the kernel).