### PR TITLE
vm_exit(): add idle_on_exit option

### DIFF
--- a/platform/riscv-virt/service.c
+++ b/platform/riscv-virt/service.c
@@ -70,44 +70,17 @@ static inline void virt_shutdown(u64 code)
     mmio_write_32(mmio_base_addr(SYSCON), code);
 }
 
-void vm_exit(u8 code)
+void vm_shutdown(u8 code)
 {
-#ifdef SMP_DUMP_FRAME_RETURN_COUNT
-    rprintf("cpu\tframe returns\n");
-    cpuinfo ci;
-    vector_foreach(cpuinfos, ci) {
-        if (ci->frcount)
-            rprintf("%d\t%ld\n", i, ci->frcount);
-    }
-#endif
-
-#ifdef DUMP_MEM_STATS
-    buffer b = allocate_buffer(heap_locked(get_kernel_heaps()), 512);
-    if (b != INVALID_ADDRESS) {
-        dump_mem_stats(b);
-        buffer_print(b);
-    }
-#endif
-
-#if 0
-    /* TODO MP: coordinate via IPIs */
-    tuple root = get_root_tuple();
-    if (root && get(root, sym(reboot_on_exit))) {
-        triple_fault();
-    } else {
-        QEMU_HALT(code);
-    }
-#endif
-    tuple root = get_root_tuple();
-    if (root) {
-       u64 expected_code;
-       if (get_u64(root, sym(expected_exit_code), &expected_code) &&
-                expected_code == code)
-            code = 0;
-    }
     virt_shutdown(code);
 
     while (1) asm("wfi");
+}
+
+void vm_reset(void)
+{
+    mmio_write_32(mmio_base_addr(SYSCON), SYSCON_REBOOT);
+    while (1);  /* to honor noreturn attribute */
 }
 
 u64 total_processors = 1;

--- a/src/aarch64/gic.c
+++ b/src/aarch64/gic.c
@@ -520,6 +520,11 @@ void gic_percpu_init(void)
     init_gicc();
 }
 
+void gic_percpu_disable(void)
+{
+    gicc_write(PMR, 0); /* mask interrupts at any priority */
+}
+
 void send_ipi(u64 cpu, u8 vector)
 {
     if (gic.v3_iface) {

--- a/src/aarch64/kernel_machine.c
+++ b/src/aarch64/kernel_machine.c
@@ -9,6 +9,7 @@
 #define PSCI_FN64(n)    (PSCI_FN64_BASE + (n))
 
 #define PSCI_FN_SYSTEM_OFF  PSCI_FN(8)
+#define PSCI_FN_RESET       PSCI_FN(9)
 #define PSCI_FN64_CPU_ON    PSCI_FN64(3)
 
 //#define TAG_HEAP_DEBUG
@@ -95,6 +96,11 @@ void psci_shutdown(void)
 {
     u32 psci_fn = PSCI_FN_SYSTEM_OFF;
     arm_hvc(psci_fn, 0, 0, 0);
+}
+
+void psci_reset(void)
+{
+    arm_hvc(PSCI_FN_RESET, 0, 0, 0);
 }
 
 BSS_RO_AFTER_INIT static buffer mpid_map;

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -495,5 +495,6 @@ void aarch64_cpu_init(void);
 void arm_hvc(u64 x0, u64 x1, u64 x2, u64 x3);
 void angel_shutdown(u64 x0);
 void psci_shutdown(void);
+void psci_reset(void);
 
 #endif /* __ASSEMBLY__ */

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -481,7 +481,9 @@ static inline u64 *get_current_fp(void)
 /* IPI */
 static inline void machine_halt(void)
 {
-    __asm__("hlt #0"); /* XXX */
+    extern void gic_percpu_disable(void);
+    gic_percpu_disable();
+    __asm__("wfi");
 }
 
 u64 allocate_msi_interrupt(void);

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -440,6 +440,38 @@ void __attribute__((noreturn)) kernel_shutdown(int status)
     while(1);
 }
 
+void vm_exit(u8 code)
+{
+#ifdef SMP_DUMP_FRAME_RETURN_COUNT
+    rprintf("cpu\tframe returns\n");
+    cpuinfo ci;
+    vector_foreach(cpuinfos, ci) {
+        if (ci->frcount)
+            rprintf("%d\t%ld\n", ci->id, ci->frcount);
+    }
+#endif
+
+#ifdef DUMP_MEM_STATS
+    buffer b = allocate_buffer(heap_locked(get_kernel_heaps()), 512);
+    if (b != INVALID_ADDRESS) {
+        extern void dump_mem_stats(buffer b);
+        dump_mem_stats(b);
+        buffer_print(b);
+    }
+#endif
+
+    tuple root = get_root_tuple();
+    if (root) {
+        u64 expected_code;
+        if (get_u64(root, sym(expected_exit_code), &expected_code) &&
+                expected_code == code)
+            code = 0;
+        if ((code != 0) && get(root, sym(reboot_on_exit)))
+            vm_reset();
+    }
+    vm_shutdown(code);
+}
+
 static char *hex_digits="0123456789abcdef";
 
 void early_debug(const char *s)

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -468,6 +468,10 @@ void vm_exit(u8 code)
             code = 0;
         if ((code != 0) && get(root, sym(reboot_on_exit)))
             vm_reset();
+        if ((code == 0) && get(root, sym(idle_on_exit))) {
+            send_ipi(TARGET_EXCLUSIVE_BROADCAST, shutdown_vector);
+            machine_halt();
+        }
     }
     vm_shutdown(code);
 }

--- a/src/riscv64/kernel_machine.h
+++ b/src/riscv64/kernel_machine.h
@@ -369,8 +369,11 @@ static inline u64 *get_current_fp(void)
 /* IPI */
 static inline void machine_halt(void)
 {
-    disable_interrupts();
-    __asm__("wfi");
+    extern void plic_set_c1_threshold(u32 thresh);
+    plic_set_c1_threshold(1);   /* mask all interrupts */
+    enable_interrupts();    /* so that any interrupts already pending can be cleared */
+    while (1)
+        __asm__("wfi");
 }
 
 u64 allocate_msi_interrupt(void);

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -43,6 +43,8 @@ void print_u64(u64 s);
 void halt_with_code(u8 code, char *format, ...) __attribute__((noreturn));
 void kernel_shutdown(int status) __attribute__((noreturn));
 void vm_exit(u8 code) __attribute__((noreturn));
+void vm_shutdown(u8 code) __attribute__((noreturn));
+void vm_reset(void) __attribute__((noreturn));
 void print_frame_trace_from_here();
 
 // make into no-op for production

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -290,7 +290,6 @@ void common_handler()
     print_u64(i);
     console("\n");
     dump_context(ctx);
-    apic_ipi(TARGET_EXCLUSIVE_BROADCAST, ICR_ASSERT, shutdown_vector);
     vm_exit(VM_EXIT_FAULT);
 }
 
@@ -435,6 +434,5 @@ void __attribute__((noreturn)) __stack_chk_fail(void)
     context ctx = get_current_context(ci);
     rprintf("stack check failed on cpu %d\n", ci->id);
     dump_context(ctx);
-    apic_ipi(TARGET_EXCLUSIVE_BROADCAST, ICR_ASSERT, shutdown_vector);
     vm_exit(VM_EXIT_FAULT);
 }


### PR DESCRIPTION
This change introduces a new option, called "idle_on_exit", which when specified in the manifest keeps a VM running (with all VCPUs halted) after the user program exits successfully.
The implementation of the machine_halt() function for aarch64 and risc-v is being fixed so that it actually halts the CPU and does not return.
Generation of the broadcast shutdown IPI (which is only needed when the idle_on_exit option takes effect) is being removed from where it is not needed.
Handing of the reboot_on_exit option is being modified so that this option only takes effect if the exit code is not the expected one (i.e. if either the application terminates with error, or the kernel crashes), because this was the original intent behind this feature, and rebooting unconditionally makes it impossible to cleanly stop a running instance (e.g. with `ops instance stop`).