### PR TITLE
Unix stdout: describe file descriptor as a pseudo-tty

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1438,6 +1438,11 @@ static void fill_stat(int type, filesystem fs, fsfile f, tuple n, struct stat *s
     case FDESC_TYPE_DIRECTORY:
         s->st_mode = S_IFDIR | 0777;
         break;
+    case FDESC_TYPE_STDIO:
+        /* Describing stdout as a pseudo-tty makes glibc apply line buffering (instead of full
+         * buffering) when the process writes to stdout. */
+        s->st_rdev = makedev(UNIX98_PTY_SLAVE_MAJOR, 0);
+        /* fall through */
     case FDESC_TYPE_SPECIAL:
         s->st_mode = S_IFCHR;   /* assuming only character devs now */
         break;
@@ -1445,7 +1450,6 @@ static void fill_stat(int type, filesystem fs, fsfile f, tuple n, struct stat *s
         s->st_mode = S_IFSOCK;
         break;
     case FDESC_TYPE_PIPE:
-    case FDESC_TYPE_STDIO:
         s->st_mode = S_IFIFO;
         break;
     case FDESC_TYPE_EPOLL:

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -14,6 +14,11 @@
 #define S_ISGID  0002000
 #define S_ISVTX  0001000
 
+#define UNIX98_PTY_SLAVE_MAJOR  136
+
+#define makedev(major, minor)   (((minor) & 0xff) | (((major) & 0xfff) << 8) |  \
+    ((u64)((minor) & ~0xff) << 12) | ((u64)((major) & ~0xfff) << 32))
+
 // take this from filesystem
 struct utsname {
     char sysname[65];    

--- a/test/runtime/aio.c
+++ b/test/runtime/aio.c
@@ -224,8 +224,6 @@ int main(int argc, char **argv)
 {
     aio_context_t ioc = 0;
 
-    setbuf(stdout, NULL);
-
     test_assert((syscall(SYS_io_setup, 1, NULL) == -1) && (errno == EFAULT));
     test_assert((syscall(SYS_io_setup, 0, &ioc) == -1) && (errno == EINVAL));
 

--- a/test/runtime/fallocate.c
+++ b/test/runtime/fallocate.c
@@ -40,8 +40,6 @@ int main(int argc, char **argv)
     unsigned long alloc_size, file_size;
     int ret;
 
-    setbuf(stdout, NULL);
-
     test_assert((fallocate(0, 0, 0, 1) == -1) && (errno == ESPIPE));
 
     fd = open("my_file", O_RDONLY | O_CREAT, S_IRWXU);

--- a/test/runtime/fs_full.c
+++ b/test/runtime/fs_full.c
@@ -89,7 +89,6 @@ int main(int argc, char **argv)
     struct statfs statbuf;
     int fd;
 
-    setbuf(stdout, NULL);
     assert(statfs(argv[0], &statbuf) == 0);
     uint64_t bfree = statbuf.f_bfree;
     uint64_t btotal = statbuf.f_blocks;

--- a/test/runtime/ftrace.c
+++ b/test/runtime/ftrace.c
@@ -122,9 +122,6 @@ register_timeout(unsigned long sec)
 
 int main(int argc, char * argv[])
 {
-    /* flush printfs immediately */
-    setbuf(stdout, NULL);
-
     prctl(PR_SET_NAME, "ftrace_test");
 
     printf("available tracers: ");

--- a/test/runtime/futexrobust.c
+++ b/test/runtime/futexrobust.c
@@ -80,7 +80,6 @@ main(int argc, char **argv)
 {
     pthread_t threads[MAX_THREADS];
 
-    setbuf(stdout, NULL);
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr); /* initialize the attributes object */
     pthread_mutexattr_setrobust(&attr, PTHREAD_MUTEX_ROBUST); /* set robustness */

--- a/test/runtime/io_uring.c
+++ b/test/runtime/io_uring.c
@@ -1204,8 +1204,6 @@ static void iour_test_register_files(void)
 
 int main(int argc, char **argv)
 {
-    setbuf(stdout, NULL);
-
     iour_test_basic();
     iour_test_readwrite();
     iour_test_eventfd();

--- a/test/runtime/mkdir.c
+++ b/test/runtime/mkdir.c
@@ -278,8 +278,6 @@ fail:
 
 int main(int argc, char **argv)
 {
-    setbuf(stdout, NULL);
-
     char c;
     char *cwd = getcwd(&c, 1);
     if (cwd || (errno != ERANGE)) {

--- a/test/runtime/mmap.c
+++ b/test/runtime/mmap.c
@@ -1449,9 +1449,6 @@ int main(int argc, char * argv[])
             exec_enabled = 1;
     }
 
-    /* flush printfs immediately */
-    setbuf(stdout, NULL);
-
     heap h = init_process_runtime();
     mmap_test();
     mincore_test();

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -490,8 +490,6 @@ static void netsock_test_netconf(void)
 
 int main(int argc, char **argv)
 {
-    setbuf(stdout, NULL);
-
     netsock_test_basic(SOCK_STREAM);
     netsock_test_basic(SOCK_DGRAM);
     netsock_test_fionread();

--- a/test/runtime/nullpage.c
+++ b/test/runtime/nullpage.c
@@ -4,7 +4,6 @@
 int
 main()
 {
-	setbuf(stdout, NULL);
 	printf("started\n");
 
 	char *p = 0;

--- a/test/runtime/paging.c
+++ b/test/runtime/paging.c
@@ -94,7 +94,6 @@ static void usage(char * progname)
 
 int main(int argc, char * argv[])
 {
-    setbuf(stdout, NULL);
     pagesize = sysconf(_SC_PAGESIZE);
     if (argc == 2) {
         if (!strcmp(argv[1], "write-exec"))

--- a/test/runtime/signal.c
+++ b/test/runtime/signal.c
@@ -1481,8 +1481,6 @@ void test_nested_handling(void)
 
 int main(int argc, char * argv[])
 {
-    setbuf(stdout, NULL);
-
 #ifdef __x86_64__
     test_sigfpe();
 #endif

--- a/test/runtime/sigoverflow.c
+++ b/test/runtime/sigoverflow.c
@@ -29,7 +29,6 @@ int main(int argc, char **argv)
 {
     pthread_t pt;
 
-    setbuf(stdout, NULL);
     printf("expecting signal stack overflow to segfault...\n");
     pid_t pid = getpid();
     pthread_create(&pt, NULL, thread, 0);

--- a/test/runtime/symlink.c
+++ b/test/runtime/symlink.c
@@ -22,8 +22,6 @@ int main(int argc, char **argv)
     struct stat s;
     char *cwd;
 
-    setbuf(stdout, NULL);
-
     test_assert(readlink("/proc/self/exe", buf, sizeof(buf)) > 0);
 
     test_assert(readlink("link", buf, sizeof(buf)) == -1);

--- a/test/runtime/time.c
+++ b/test/runtime/time.c
@@ -861,7 +861,6 @@ int main(int argc, char *argv[])
             break;
         }
     }
-    setbuf(stdout, NULL);
     test_time_and_times();
     for (int i = 0; i < N_INTERVALS; i++) {
         test_nanosleep(test_intervals[i]);

--- a/test/runtime/tlbshootdown.c
+++ b/test/runtime/tlbshootdown.c
@@ -104,7 +104,6 @@ int main(int argc, char **argv)
     int loops;
     struct sigaction sa;
 
-    setbuf(stdout, NULL);
     pthread_cond_init(&kid_cv, NULL);
     pthread_cond_init(&sync_cv, NULL);
     pthread_mutex_init(&sync_mut, NULL);

--- a/test/runtime/unixsocket.c
+++ b/test/runtime/unixsocket.c
@@ -457,7 +457,6 @@ static void uds_nonblocking_test(void)
 
 int main(int argc, char **argv)
 {
-    setbuf(stdout, NULL);
     uds_stream_test();
     uds_dgram_test();
     uds_nonblocking_test();

--- a/test/runtime/vsyscall.c
+++ b/test/runtime/vsyscall.c
@@ -24,8 +24,6 @@ static getcpu_fn vgetcpu = (getcpu_fn)(VSYSCALL_BASE + VSYSCALL_OFFSET_VGETCPU);
 
 int main(int argc, char * argv[])
 {
-    setvbuf(stdout, NULL, _IOLBF, 0);
-
     unsigned cpu = 0, node = 0;
     if (vgetcpu(&cpu, &node, NULL) != 0) {
         printf("vgetcpu failed: %s (%d)\n", strerror(errno), errno);

--- a/test/runtime/write.c
+++ b/test/runtime/write.c
@@ -800,7 +800,6 @@ int main(int argc, char **argv)
     int c, op = WRITE_OP_ALL;
     long long size = DEFAULT_BULK_SIZE;
     char *endptr;
-    setvbuf(stdout, NULL, _IOLBF, 0);
 
     while ((c = getopt(argc, argv, "hbws:p")) != EOF) {
         switch (c) {


### PR DESCRIPTION
Describing stdout as a pseudo-tty makes glibc apply line buffering (instead of full buffering) when the process writes to stdout. This removes the need for calling `setbuf(stdout, NULL)` in the runtime test programs.
On x86, tested with glibc version 2.23, 2.24, 2.27, 2.28, 2.31, and 2.34; musl libc does not apply full buffering (tested with version 1.2.2), with or without this change.
On ARM, tested with glibc version 2.28.
On risc-v, tested with glibc version 2.32.