### PR TITLE
rangemap_reinsert: roll back to old range and reinsert on failure

### DIFF
--- a/src/runtime/range.c
+++ b/src/runtime/range.c
@@ -39,9 +39,15 @@ boolean rangemap_insert(rangemap rm, rmnode n)
 
 boolean rangemap_reinsert(rangemap rm, rmnode n, range k)
 {
+    range old = n->r;
     rangemap_remove_node(rm, n);
     n->r = k;
-    return rangemap_insert(rm, n);
+    if (!rangemap_insert(rm, n)) {
+        n->r = old;
+        assert(rangemap_insert(rm, n));
+        return false;
+    }
+    return true;
 }
 
 /* Can be called with a range already (partially or totally) present in the range map; merges the


### PR DESCRIPTION
If (for e.g.) the new heap range requested by brk was previously
mapped by mmap then rangemap_insert will fail. When this happens we
want to leave the rangemap how we found it. Otherwise it effectively
unmaps the heap.

So this reinserts the original range if the new one fails. Other
callsites of rangemap_reinsert all assert that it passes. So this
change should not effect them.

This should fix #1751 and with #1735 allow nodejs 18.x to run.