### PR TITLE
Pagecache: fix page refcounting and races with page eviction

### DIFF
--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1370,7 +1370,11 @@ closure_function(1, 1, boolean, pagecache_page_release,
     pagecache_lock_state(pc);
     if (!pp->evicted)
         pagecache_page_release_locked(pc, pp);
+    /* a pagecache node being released means no outstanding page references are possible */
+    assert(page_state(pp) == PAGECACHE_PAGESTATE_FREE);
+    pagelist_remove(&pc->free, pp);
     pagecache_unlock_state(pc);
+    deallocate(pc->h, pp, sizeof(*pp));
     return true;
 }
 

--- a/src/kernel/pagecache_internal.h
+++ b/src/kernel/pagecache_internal.h
@@ -114,16 +114,16 @@ typedef struct pagecache_shared_map {
 
 typedef struct pagecache_page *pagecache_page;
 
-declare_closure_struct(2, 0, void, pagecache_page_free,
+declare_closure_struct(2, 0, void, pagecache_page_read_release,
                        pagecache, pc, pagecache_page, pp);
 
 struct pagecache_page {
     struct rbnode rbnode;
-    struct refcount refcount;   /* 24 */
+    struct refcount read_refcount;  /* 24 */
     u64 state_offset;           /* 40 - state and offset in pages */
     void *kvirt;                /* 48 */
     int write_count;            /* 56 */
-    int pad0;                   /* 60 */
+    int refcount;               /* 60 */
     /* end of first cacheline */
 
     pagecache_node node;
@@ -131,11 +131,6 @@ struct pagecache_page {
     u64 phys;                   /* physical address */
     struct list bh_completions; /* default for non-kernel use */
 
-    closure_struct(pagecache_page_free, free);
+    closure_struct(pagecache_page_read_release, read_release);
     boolean evicted;
 };
-
-static inline void pagecache_release_page(pagecache_page pp)
-{
-    refcount_release(&pp->refcount);
-}

--- a/src/runtime/sg.c
+++ b/src/runtime/sg.c
@@ -143,6 +143,24 @@ u64 sg_copy_to_buf_and_release(void *target, sg_list sg, u64 n)
     return n - remain;
 }
 
+/* touch n bytes from sg, without consuming the SG list or its buffers */
+void sg_fault_in(sg_list sg, u64 n)
+{
+    sg_buf sgb;
+    u64 sgb_index = 0;
+    while (n > 0 && (sgb = sg_list_peek_at(sg, sgb_index)) != INVALID_ADDRESS) {
+        s64 len = MIN(n, sg_buf_len(sgb));
+        n -= len;
+        volatile u8 *bp = sgb->buf + sgb->offset;
+        while (len > 0) {
+            (void)*bp;
+            bp += PAGESIZE;
+            len -= PAGESIZE;
+        }
+        sgb_index++;
+    }
+}
+
 sg_list allocate_sg_list(void)
 {
     sg_lock();

--- a/src/runtime/sg.h
+++ b/src/runtime/sg.h
@@ -43,12 +43,14 @@ static inline sg_buf sg_list_tail_add(sg_list sg, word length)
    with sg_buf_release. Unremoved items from the list can be released
    at once with sg_list_finish. */
 
-static inline sg_buf sg_list_head_peek(sg_list sg)
+static inline sg_buf sg_list_peek_at(sg_list sg, u64 index)
 {
-    if (buffer_length(sg->b) < sizeof(struct sg_buf))
+    if (buffer_length(sg->b) < (index + 1) * sizeof(struct sg_buf))
         return INVALID_ADDRESS;
-    return (sg_buf)buffer_ref(sg->b, 0);
+    return (sg_buf)buffer_ref(sg->b, index * sizeof(struct sg_buf));
 }
+
+#define sg_list_head_peek(sg)   sg_list_peek_at((sg), 0)
 
 static inline sg_buf sg_list_head_remove(sg_list sg)
 {
@@ -90,4 +92,5 @@ u64 sg_copy_to_buf(void *target, sg_list sg, u64 length);
 u64 sg_copy_to_buf_and_release(void *dest, sg_list src, u64 limit);
 u64 sg_move(sg_list dest, sg_list src, u64 n);
 u64 sg_zero_fill(sg_list sg, u64 n);
+void sg_fault_in(sg_list sg, u64 n);
 sg_io sg_wrapped_block_reader(block_io bio, int block_order, heap backed);


### PR DESCRIPTION
The first commit fixes handling of concurrent page writes and reads.
The second commit makes page refcounting race-free with regard to the pagecache drain functionality, fixes a missing refcount release after a write completion, and fixes a 'refcount_release: invalid count 0' error occurring when a node with evicted pages is deallocated.
The third commit fixes a memory leak occurring when pages belonging to a deallocated node are released, and properly removes these pages from the global free page list.