### PR TITLE
Pagecache: use an objcache as page heap

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -60,7 +60,7 @@
 #define XENNET_TX_SERVICEQUEUE_DEPTH 512
 
 /* mm stuff */
-#define PAGECACHE_DRAIN_CUTOFF (64 * MB)
+#define MEM_CLEAN_THRESHOLD (64 * MB)
 #define PAGECACHE_SCAN_PERIOD_SECONDS 5
 #define PAGECACHE_MEMORY_RESERVE (4 * MB)
 #define USER_MEMORY_RESERVE (4 * MB)
@@ -69,9 +69,6 @@
 
 /* don't go below this minimum amount of physical memory when inflating balloon */
 #define BALLOON_MEMORY_MINIMUM (16 * MB)
-
-/* attempt to deflate balloon when physical memory is below this threshold */
-#define BALLOON_DEFLATE_THRESHOLD (16 * MB)
 
 /* must be large enough for vendor code that use malloc/free interface */
 #define MAX_MCACHE_ORDER 16

--- a/src/config.h
+++ b/src/config.h
@@ -73,6 +73,8 @@
 /* Number of objects that should be retained in the cache when a cache drain is requested */
 #define NET_RX_BUFFERS_RETAIN           64
 #define STORAGE_REQUESTS_RETAIN         64
+#define PAGECACHE_PAGES_RETAIN          64
+#define PAGECACHE_COMPLETIONS_RETAIN    64
 
 /* must be large enough for vendor code that use malloc/free interface */
 #define MAX_MCACHE_ORDER 16

--- a/src/config.h
+++ b/src/config.h
@@ -70,6 +70,10 @@
 /* don't go below this minimum amount of physical memory when inflating balloon */
 #define BALLOON_MEMORY_MINIMUM (16 * MB)
 
+/* Number of objects that should be retained in the cache when a cache drain is requested */
+#define NET_RX_BUFFERS_RETAIN           64
+#define STORAGE_REQUESTS_RETAIN         64
+
 /* must be large enough for vendor code that use malloc/free interface */
 #define MAX_MCACHE_ORDER 16
 

--- a/src/drivers/acpi.c
+++ b/src/drivers/acpi.c
@@ -491,8 +491,8 @@ ACPI_STATUS AcpiOsPredefinedOverride(const ACPI_PREDEFINED_NAMES *init_val, ACPI
 ACPI_STATUS AcpiOsCreateCache(char *cache_name, UINT16 object_size, UINT16 max_depth,
                               ACPI_CACHE_T **return_cache)
 {
-    heap h = allocate_objcache(acpi_heap, (heap)heap_linear_backed(get_kernel_heaps()), object_size,
-                               PAGESIZE);
+    caching_heap h = allocate_objcache(acpi_heap, (heap)heap_linear_backed(get_kernel_heaps()),
+                                       object_size, PAGESIZE, false);
     if (h == INVALID_ADDRESS)
         return AE_NO_MEMORY;
     *return_cache = (ACPI_CACHE_T *)h;
@@ -515,7 +515,8 @@ ACPI_STATUS AcpiOsReleaseObject(ACPI_CACHE_T *cache, void *object)
 
 ACPI_STATUS AcpiOsPurgeCache(ACPI_CACHE_T *cache)
 {
-    /* not implemented */
+    caching_heap ch = (caching_heap)cache;
+    cache_drain(ch, CACHE_DRAIN_ALL, 0);
     return AE_OK;
 }
 

--- a/src/hyperv/netvsc/hv_net_vsc.h
+++ b/src/hyperv/netvsc/hv_net_vsc.h
@@ -958,6 +958,8 @@ typedef struct netvsc_packet_ {
 /*
  * Device-specific softc structure
  */
+declare_closure_struct(0, 1, u64, hn_mem_cleaner,
+                       u64, clean_bytes);
 typedef struct hn_softc {
 	heap general;
 	heap contiguous;                /* physically */
@@ -968,8 +970,8 @@ typedef struct hn_softc {
 	/* lwIP */
 	struct netif *netif;
 	u16 rxbuflen;
-	heap rxbuffers;
-	struct spinlock rx_buflock;
+	caching_heap rxbuffers;
+	closure_struct(hn_mem_cleaner, mem_cleaner);
 } hn_softc_t;
 
 

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -756,8 +756,8 @@ void init_scheduler(heap);
 void init_scheduler_cpus(heap h);
 void mm_service(void);
 
-typedef closure_type(balloon_deflater, u64, u64);
-void mm_register_balloon_deflater(balloon_deflater deflater);
+typedef closure_type(mem_cleaner, u64, u64);
+boolean mm_register_mem_cleaner(mem_cleaner cleaner);
 
 kernel_heaps get_kernel_heaps(void);
 

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1652,10 +1652,8 @@ void init_pagecache(heap general, heap contiguous, heap physical, u64 pagesize)
     assert(pc->zero_page != INVALID_ADDRESS);
 
 #ifdef KERNEL
-    pc->completions =
-        locking_heap_wrapper(general, allocate_objcache(general, contiguous,
-                                                        sizeof(struct page_completion),
-                                                        PAGESIZE));
+    pc->completions = (heap)allocate_objcache(general, contiguous, sizeof(struct page_completion),
+                                              PAGESIZE, true);
     assert(pc->completions != INVALID_ADDRESS);
     spin_lock_init(&pc->state_lock);
     spin_lock_init(&pc->global_lock);

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -2346,8 +2346,8 @@ boolean netsyscall_init(unix_heaps uh, tuple cfg)
     else
         so_rcvbuf = DEFAULT_SO_RCVBUF;
     kernel_heaps kh = (kernel_heaps)uh;
-    heap socket_cache = locking_heap_wrapper(heap_general(kh), allocate_objcache(heap_general(kh),
-        (heap)heap_linear_backed(kh), sizeof(struct netsock), PAGESIZE));
+    caching_heap socket_cache = allocate_objcache(heap_general(kh), (heap)heap_linear_backed(kh),
+                                                  sizeof(struct netsock), PAGESIZE, true);
     if (socket_cache == INVALID_ADDRESS)
 	return false;
     uh->socket_cache = socket_cache;

--- a/src/runtime/heap/heap.h
+++ b/src/runtime/heap/heap.h
@@ -19,6 +19,15 @@ typedef struct backed_heap {
 #define alloc_map(__bh, __l, __p) ((__bh)->alloc_map(__bh, __l, __p))
 #define dealloc_unmap(__bh, __v, __p, __l) ((__bh)->dealloc_unmap(__bh, __v, __p, __l))
 
+typedef struct caching_heap {
+    struct heap h;
+    bytes (*drain)(struct caching_heap *ch, bytes len, bytes retain);
+} *caching_heap;
+
+#define CACHE_DRAIN_ALL ((bytes)-1)
+
+#define cache_drain(__ch, __l, __r) ((__ch)->drain(__ch, __l, __r))
+
 heap debug_heap(heap m, heap p);
 heap mem_debug(heap m, heap p, u64 padsize);
 heap mem_debug_objcache(heap meta, heap parent, u64 objsize, u64 pagesize);
@@ -44,9 +53,9 @@ static inline value heap_management(heap h)
 }
 
 heap wrap_freelist(heap meta, heap parent, bytes size);
-heap allocate_objcache(heap meta, heap parent, bytes objsize, bytes pagesize);
-heap allocate_wrapped_objcache(heap meta, heap parent, bytes objsize, bytes pagesize, heap wrapper);
-heap allocate_objcache_preallocated(heap meta, heap parent, bytes objsize, bytes pagesize, u64 prealloc_count, boolean prealloc_only);
+caching_heap allocate_objcache(heap meta, heap parent, bytes objsize, bytes pagesize, boolean locking);
+caching_heap allocate_wrapped_objcache(heap meta, heap parent, bytes objsize, bytes pagesize, heap wrapper);
+caching_heap allocate_objcache_preallocated(heap meta, heap parent, bytes objsize, bytes pagesize, u64 prealloc_count, boolean prealloc_only);
 boolean objcache_validate(heap h);
 heap objcache_from_object(u64 obj, bytes parent_pagesize);
 heap allocate_mcache(heap meta, heap parent, int min_order, int max_order, bytes pagesize);

--- a/src/runtime/heap/mcache.c
+++ b/src/runtime/heap/mcache.c
@@ -297,7 +297,7 @@ heap allocate_mcache(heap meta, heap parent, int min_order, int max_order, bytes
 #if defined(MEMDEBUG_MCACHE) || defined(MEMDEBUG_ALL)
 	heap h = mem_debug_objcache(meta, parent, obj_size, pagesize);
 #else
-	heap h = allocate_objcache(meta, parent, obj_size, pagesize);
+	caching_heap h = allocate_objcache(meta, parent, obj_size, pagesize, false);
 #endif
 #ifdef MCACHE_DEBUG
 	rputs(" - cache size ");

--- a/src/runtime/heap/mem_debug.c
+++ b/src/runtime/heap/mem_debug.c
@@ -173,7 +173,7 @@ heap mem_debug_objcache(heap meta, heap parent, u64 objsize, u64 pagesize)
     u64 padding = objsize >= PAGESIZE ? PAGESIZE : PAD_MIN;
 
     newsize = objsize + padding * 2;
-    mdh->parent = allocate_wrapped_objcache(meta, parent, newsize, pagesize, &mdh->h);
+    mdh->parent = (heap)allocate_wrapped_objcache(meta, parent, newsize, pagesize, &mdh->h);
     mdh->h.pagesize = objsize;
     mdh->h.alloc = mem_debug_alloc;
     mdh->h.dealloc = mem_debug_dealloc;

--- a/src/runtime/heap/objcache.c
+++ b/src/runtime/heap/objcache.c
@@ -89,8 +89,8 @@ static inline u16 index_from_obj(objcache o, page p, u64 obj)
 #define footer_from_list(l) struct_from_list(l, footer, list)
 
 #define foreach_page_footer(l, f)				\
-    for (f = footer_from_list((l)->next); &f->list != (l);	\
-	 f = footer_from_list(f->list.next))
+    for (footer __next, f = footer_from_list((l)->next);                        \
+        __next = footer_from_list(f->list.next), &f->list != (l); f = __next)
 
 static footer objcache_addpage(objcache o)
 {
@@ -238,7 +238,6 @@ static void objcache_destroy(heap h)
 	    o->alloced_objs, o);
     }
 
-    footer f;
     foreach_page_footer(&o->free, f)
         deallocate_u64(o->parent, page_from_footer(o, f), page_size(o));
     foreach_page_footer(&o->full, f)
@@ -280,8 +279,6 @@ boolean objcache_validate(heap h)
        - total_objs = page tally * objs_per_page
        - alloced_objs matches total objs_per_page minus f->avails
     */
-
-    footer f;
 
     u64 total_pages = 0;
     u64 total_avail = 0;

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -52,8 +52,7 @@ boolean pipe_init(unix_heaps uh)
     heap h = heap_locked((kernel_heaps)uh);
     heap backed = (heap)heap_linear_backed((kernel_heaps)uh);
 
-    uh->pipe_cache = locking_heap_wrapper(h, allocate_objcache(h, backed,
-        sizeof(struct pipe), PAGESIZE));
+    uh->pipe_cache = allocate_objcache(h, backed, sizeof(struct pipe), PAGESIZE, true);
     return (uh->pipe_cache == INVALID_ADDRESS ? false : true);
 }
 

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -138,15 +138,18 @@ typedef struct user_cap_data {
 } *cap_user_data_t;
 
 /* unix-specific memory objects and ids */
+declare_closure_struct(0, 1, u64, unix_mem_cleaner,
+                       u64, clean_bytes)
 typedef struct unix_heaps {
     struct kernel_heaps kh;	/* must be first */
 
     /* object caches */
-    heap file_cache;
-    heap pipe_cache;
+    caching_heap file_cache;
+    caching_heap pipe_cache;
 #ifdef NET
-    heap socket_cache;
+    caching_heap socket_cache;
 #endif
+    closure_struct(unix_mem_cleaner, mem_cleaner);
 
     /* id heaps */
     heap processes;
@@ -615,8 +618,8 @@ static inline thread thread_from_tid(process p, int tid)
 
 unix_heaps get_unix_heaps();
 
-#define unix_cache_alloc(uh, c) ({ heap __c = uh->c ## _cache; allocate(__c, __c->pagesize); })
-#define unix_cache_free(uh, c, p) ({ heap __c = uh->c ## _cache; deallocate(__c, p, __c->pagesize); })
+#define unix_cache_alloc(uh, c) ({ heap __c = (heap)uh->c ## _cache; allocate(__c, __c->pagesize); })
+#define unix_cache_free(uh, c, p) ({ heap __c = (heap)uh->c ## _cache; deallocate(__c, p, __c->pagesize); })
 
 #define fdesc_lock(f)   spin_lock(&(f)->lock)
 #define fdesc_unlock(f) spin_unlock(&(f)->lock)

--- a/src/virtio/virtio_balloon.c
+++ b/src/virtio/virtio_balloon.c
@@ -386,9 +386,10 @@ static boolean virtio_balloon_attach(heap general, backed_heap backed, id_heap p
     vtdev_set_status(v, VIRTIO_CONFIG_STATUS_DRIVER_OK);
     update_actual_pages(0);
     virtio_balloon_update();
-    balloon_deflater bd = closure(general, virtio_balloon_deflater);
+    mem_cleaner bd = closure(general, virtio_balloon_deflater);
     assert(bd != INVALID_ADDRESS);
-    mm_register_balloon_deflater(bd);
+    if (!mm_register_mem_cleaner(bd))
+        deallocate_closure(bd);
     if (balloon_has_stats_vq())
         virtio_balloon_init_statsq();
     return true;

--- a/test/unit/objcache_test.c
+++ b/test/unit/objcache_test.c
@@ -81,7 +81,7 @@ boolean objcache_test(heap meta, heap parent, int objsize)
 {
     /* just a cursory test */
     int opp = (TEST_PAGESIZE - FOOTER_SIZE) / objsize;
-    heap h = allocate_objcache(meta, parent, objsize, TEST_PAGESIZE);
+    heap h = (heap)allocate_objcache(meta, parent, objsize, TEST_PAGESIZE, false);
     vector objs = allocate_vector(meta, opp);
 
     msg_debug("objs %p, heap %p\n", objs, h);
@@ -128,7 +128,7 @@ boolean preallocated_objcache_test(heap meta, heap parent, int objsize, boolean 
 
     vector objs = allocate_vector(meta, opp);
 
-    heap h = allocate_objcache_preallocated(meta, parent, objsize, TEST_PAGESIZE, opp, prealloc_only);
+    heap h = (heap)allocate_objcache_preallocated(meta, parent, objsize, TEST_PAGESIZE, opp, prealloc_only);
     u64 meta_occupancy = heap_allocated(meta);
     u64 parent_occupancy = heap_allocated(parent);
 


### PR DESCRIPTION
In the pagecache code, allocating 4KB pages directly from the linear backed heap creates excessive fragmentation, which in
low-memory conditions may cause other allocations in the kernel (which typically use objcaches with a 2MB page size) to fail even when pagecache drain requests are fully executed.
This changeset addresses the fragmentation issue by changing the pagecache code to use an objcache (with a 2MB page size, and with the linear backed heap as parent heap) as page heap; this allows a pagecache drain to release memory in large chunks that are then available for other allocation requests throughout the kernel.
As part of this changeset, a generic memory cleaner interface is being implemented, which allows various parts of the kernel to register a closure to be invoked to release cached memory when the system is low on memory (#1130). In addition, a new heap sub-type, called caching_heap, is being defined; a caching_heap exports an additional callback to drain memory that has been
cached (#1494); the objcache heap is now a caching_heap.