### PR TITLE
Scheduler: implement fair scheduling between user threads

### DIFF
--- a/src/aarch64/interrupt.c
+++ b/src/aarch64/interrupt.c
@@ -240,14 +240,6 @@ void synchronous_handler(void)
             context_release_refcount(retctx);
             frame_return(retctx->frame);
         }
-        if (is_syscall_context(ctx)) {
-            /* This indicates an unhandled fault on a user page from within a
-               syscall. We need to abandon the syscall at this point and let
-               the thread run so it may receive the appropriate signal. The
-               frame is left full so that future context dumps will report the
-               actual processor state when the exception occurred. */
-            context_release_refcount(ctx);
-        }
         assert(!is_kernel_context(ctx));
         runloop();
     } else {

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -166,8 +166,7 @@ cpuinfo init_cpuinfo(heap backed, int cpu)
     /* state */
     ci->id = cpu;
     ci->state = cpu_not_present;
-    ci->thread_queue = allocate_queue(backed, MAX_THREADS);
-    assert(ci->thread_queue != INVALID_ADDRESS);
+    assert(sched_queue_init(&ci->thread_queue, backed));
     ci->free_kernel_contexts = allocate_queue(backed, FREE_KERNEL_CONTEXT_QUEUE_SIZE);
     assert(ci->free_kernel_contexts != INVALID_ADDRESS);
     ci->free_syscall_contexts = allocate_queue(backed, FREE_SYSCALL_CONTEXT_QUEUE_SIZE);

--- a/src/riscv64/interrupt.c
+++ b/src/riscv64/interrupt.c
@@ -295,14 +295,6 @@ void trap_exception(void)
             context_release_refcount(retctx);
             frame_return(retctx->frame);
         }
-        if (is_syscall_context(ctx)) {
-            /* This indicates an unhandled fault on a user page from within a
-               syscall. We need to abandon the syscall at this point and let
-               the thread run so it may receive the appropriate signal. The
-               frame is left full so that future context dumps will report the
-               actual processor state when the exception occurred. */
-            context_release_refcount(ctx);
-        }
         assert(!is_kernel_context(ctx));
         runloop();
     } else {

--- a/src/runtime/pqueue.c
+++ b/src/runtime/pqueue.c
@@ -125,6 +125,11 @@ void *pqueue_peek(pqueue q)
     return INVALID_ADDRESS;
 }
 
+u64 pqueue_length(pqueue q)
+{
+    return vector_length(q->body);
+}
+
 void pqueue_reorder(pqueue q)
 {
     /* Floyd's heap construction algorithm */

--- a/src/runtime/pqueue.h
+++ b/src/runtime/pqueue.h
@@ -5,6 +5,7 @@ void pqueue_insert(pqueue q, void *v);
 boolean pqueue_remove(pqueue q, void *v);
 void *pqueue_peek(pqueue q);
 void *pqueue_pop(pqueue q);
+u64 pqueue_length(pqueue q);
 void pqueue_reorder(pqueue q);
 typedef closure_type(pqueue_element_handler, boolean, void *);
 boolean pqueue_walk(pqueue q, pqueue_element_handler h);

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -241,6 +241,7 @@ define_closure_function(1, 1, context, unix_fault_handler,
             if (is_syscall_context(ctx)) {
                 thread_log(t, "fault on user page 0x%lx from within syscall; "
                            "abandoning syscall context\n", vaddr);
+                orphan_syscall_context(current_cpu(), (syscall_context)ctx);
                 t->syscall_abandoned = true;
             } else if (is_kernel_context(ctx)) {
                 errmsg = "Page fault for user memory within kernel context";

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -279,7 +279,8 @@ typedef struct thread {
 
     char name[16]; /* thread name */
     syscall_context syscall;
-    queue scheduling_queue;
+    struct sched_task task;
+    sched_queue scheduling_queue;
     process p;
 
     /* Heaps in the unix world are typically found through

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -245,16 +245,14 @@ void common_handler()
                 context_release_refcount(retctx);
                 frame_return(retctx->frame);
             }
-            if (is_syscall_context(ctx)) {
+            if (is_syscall_context(ctx))
                 /* This indicates an unhandled fault on a user page from
                    within a syscall. We need to abandon the syscall at this
                    point and let the thread run so it may receive the
                    appropriate signal. The frame is left full so that future
                    context dumps will report the actual processor state when
                    the exception occurred. */
-                context_release_refcount(ctx);
                 runloop();
-            }
             assert(!is_kernel_context(ctx));
         } else {
             console("\nno fault handler\n");

--- a/test/runtime/thread_test.c
+++ b/test/runtime/thread_test.c
@@ -113,6 +113,13 @@ void *terminus(void *k)
     }
     if (x == expected_sum(NNUMS, nthreads) && check_expected_float_sum(NNUMS, nthreads, y)) {
         printf("passed\n");
+
+        /* A glibc bug (https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1982326) may cause
+         * pthread_exit() to abort the program when this thread is interrupted in the middle of
+         * exit() and another thread calls pthread_exit(). As a workaround, sleep before calling
+         * exit(), so that the other threads have a chance to run (and terminate cleanly). */
+        usleep(1);
+
         exit(0);
     }
     printf("%lld %f\n", x, y);


### PR DESCRIPTION
This change introduces a new scheduling algorithm that assigns CPU resources to a task based on how much CPU time the task used in the past. It uses a priority queue where tasks are ordered based on their CPU time: when a task is enqueued, it is positioned according to the time it has been running since it was last scheduled; when a task is dequeued, its CPU time is subtracted from the CPU time of any other tasks in the queue, so that their priority in the queue is increased; this is implemented by storing a reference CPU time in the queue (min_runtime struct member), which prevents long-running tasks from being starved by newly created tasks.
This algorithm is applied for scheduling user threads, so that CPU time is distributed fairly between all runnable threads.

The first commit is a fix to a pre-existing bug that has been exposed by modifying the execution order of runnable user threads.