### PR TITLE
virtio-net performance improvements

### DIFF
--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -52,13 +52,14 @@
 
 #define LWIP_WND_SCALE 1
 #define TCP_MSS 1460            /* Assuming ethernet; may want to derive this */
-#define TCP_WND 65535
-#define TCP_SND_BUF 65535
+#define TCP_WND 0x34000         /* For maximum throughput should be the same as TCP_SND_BUF */
+#define TCP_SND_BUF 0x34000     /* Same as /proc/sys/net/core/wmem_default on Linux */
+#define TCP_SNDLOWAT (0xFFFE - (4 * TCP_MSS))   /* Unused, but needed to pass lwIP sanity checks */
 #define TCP_SND_QUEUELEN TCP_SNDQUEUELEN_OVERFLOW
 #define TCP_OVERSIZE TCP_MSS
 #define TCP_QUEUE_OOSEQ 1
 
-#define TCP_RCV_SCALE 0         /* XXX check */
+#define TCP_RCV_SCALE 2         /* (0xFFFFU << TCP_RCV_SCALE) must be greater than TCP_WND */
 #define TCP_LISTEN_BACKLOG 1
 #define LWIP_DHCP 1
 // would prefer to set this dynamically...also,

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1008,7 +1008,8 @@ closure_function(1, 2, sysreturn, netsock_ioctl,
     }
 }
 
-#define SOCK_QUEUE_LEN 128
+/* Must fit in a u8_t, because it may be used as backlog value for tcp_listen_with_backlog(). */
+#define SOCK_QUEUE_LEN 255
 
 closure_function(1, 2, sysreturn, socket_close,
                  netsock, s,

--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -120,6 +120,7 @@ physical virtqueue_desc_paddr(struct virtqueue *vq);
 physical virtqueue_avail_paddr(struct virtqueue *vq);
 physical virtqueue_used_paddr(struct virtqueue *vq);
 u16 virtqueue_entries(virtqueue vq);
+void virtqueue_set_polling(virtqueue vq, boolean enable);
 
 typedef struct vqmsg *vqmsg;
 

--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -336,7 +336,7 @@ closure_function(2, 1, boolean, vtpci_net_probe,
     if (!vtpci_probe(d, VIRTIO_ID_NETWORK))
         return false;
     vtpci dev = attach_vtpci(bound(general), bound(page_allocator), d,
-        VIRTIO_NET_F_MAC | VIRTIO_F_ANY_LAYOUT);
+        VIRTIO_NET_F_MAC | VIRTIO_F_ANY_LAYOUT | VIRTIO_F_RING_EVENT_IDX);
     virtio_net_attach(&dev->virtio_dev);
     return true;
 }

--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -312,6 +312,7 @@ static void virtio_net_attach(vtdev dev)
        page 53 of http://docs.oasis-open.org/virtio/virtio/v1.0/cs01/virtio-v1.0-cs01.pdf */
     vn->dev = dev;
     virtio_alloc_virtqueue(dev, "virtio net tx", 1, &vn->txq);
+    virtqueue_set_polling(vn->txq, true);
     virtio_alloc_virtqueue(dev, "virtio net rx", 0, &vn->rxq);
     // just need vn->net_header_len contig bytes really
     vn->empty = alloc_map(contiguous, contiguous->h.pagesize, &vn->empty_phys);

--- a/test/runtime/netsock.manifest
+++ b/test/runtime/netsock.manifest
@@ -4,6 +4,5 @@
     )
     program:/netsock
     fault:t
-    so_rcvbuf:65536
     environment:()
 )


### PR DESCRIPTION
This change set improves performance of network transfers over the virtio-net network interface. As an example, the Warp (https://github.com/minio/warp) mixed benchamrk (run with `./warp mixed --autoterm --objects 40 --duration 1m`) against a minIO server showed a change in results from `Cluster Total: 59.45 MiB/s, 9.88 obj/s over 53s` to `Cluster Total: 83.11 MiB/s, 13.88 obj/s over 50s`.
The first commit increases the TCP send buffer size and TCP window size (since lwIP implements TCP window scaling, the window size is not limited to a maximum of 65535).
The second commit adds support for the VIRTIO_F_RING_EVENT_IDX feature, which allows a virtIO driver to indicate to the device when it wants to be notified of an update to used buffers, and similarly allows a virtIO device to indicate to the driver when it wants to be notified of an update to available buffers. By avoiding unneeded device interrupts and driver notifications, the number of VM exits and hypervisor syscalls (e.g. to execute KVM_SIGNAL_MSI ioctls) is minimized, which decreases CPU load on the host.
The third commit implements polling mode in the virtIO code and enables it in the TX queue of the virtio_net driver. When a virtIO queue is in polling mode, the driver does not want to be notified (via an interrupt) when a virtIO buffer in the queue has been used by the device. This has been shown to improve the speed of TCP transfers: for example, the average performance of a Go web server as measured by the Jenkins CI job increases by ~12%.