### PR TITLE
Syscalls: improve support for file data and metadata synchronization to the storage device

### DIFF
--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -66,7 +66,7 @@ void filesystem_read_entire(filesystem fs, tuple t, heap bufheap, buffer_handler
 fsfile allocate_fsfile(filesystem fs, tuple md);
 void fsfile_reserve(fsfile f);
 void fsfile_release(fsfile f);
-// XXX per-file flush
+void fsfile_flush(fsfile f, boolean datasync, status_handler completion);
 
 typedef enum {
     FS_STATUS_OK = 0,

--- a/src/tfs/tfs_internal.h
+++ b/src/tfs/tfs_internal.h
@@ -61,6 +61,11 @@ typedef struct filesystem {
     closure_struct(fs_free, free);
 } *filesystem;
 
+/* fsfile status flags */
+#define FSF_DIRTY_DATASYNC  (1 << 0)    /* metadata needed for retrieving file data */
+#define FSF_DIRTY_OTHER     (1 << 1)    /* any other metadata */
+#define FSF_DIRTY           (FSF_DIRTY_DATASYNC | FSF_DIRTY_OTHER)
+
 declare_closure_struct(1, 1, void, fsf_sync_complete,
                        struct fsfile *, f,
                        status, s);
@@ -75,6 +80,7 @@ typedef struct fsfile {
     sg_io write;
     struct refcount refcount;
     closure_struct(fsf_sync_complete, sync_complete);
+    u8 status;
 } *fsfile;
 
 typedef struct uninited_queued_op {

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -96,8 +96,11 @@ typedef struct iovec {
 #define O_TRUNC		00001000
 #define O_APPEND	00002000
 #define O_NONBLOCK	00004000
+#define O_DSYNC         00010000
 #define O_NOATIME       01000000
 #define O_CLOEXEC       02000000
+#define _O_SYNC         04000000
+#define O_SYNC          (O_SYNC | O_DSYNC)
 #define O_PATH         010000000
 #define O_TMPFILE     020000000
 

--- a/src/unix/unix.h
+++ b/src/unix/unix.h
@@ -11,9 +11,6 @@ process exec_elf(buffer ex, process kernel_process);
 
 void dump_mem_stats(buffer b);
 
-void filesystem_sync(filesystem fs, status_handler sh);
-void filesystem_sync_node(filesystem fs, pagecache_node pn, status_handler sh);
-
 void coredump_set_limit(u64 s);
 u64 coredump_get_limit(void);
 

--- a/src/virtio/virtio_scsi.c
+++ b/src/virtio/virtio_scsi.c
@@ -298,7 +298,7 @@ closure_function(1, 2, void, virtio_scsi_io_done,
         scsi_dump_sense(resp->sense, sizeof(resp->sense));
         st = timm("result", "status %d", resp->status);
     }
-    apply(bound(sh), st);
+    async_apply_status_handler(bound(sh), st);
     closure_finish();
 }
 

--- a/src/virtio/virtio_storage.c
+++ b/src/virtio/virtio_storage.c
@@ -131,7 +131,7 @@ closure_function(4, 1, void, complete,
     status st = 0;
     // 1 is io error, 2 is unsupported operation
     if (bound(req)->status) st = timm("result", "%d", bound(req)->status);
-    apply(bound(f), st);
+    async_apply_status_handler(bound(f), st);
     deallocate_virtio_blk_req(bound(s), bound(req), bound(phys));
     closure_finish();
 }
@@ -249,7 +249,7 @@ define_closure_function(0, 1, void, virtio_storage_req_handler,
         if (st->v->features & VIRTIO_BLK_F_FLUSH)
             storage_flush(st, req->completion);
         else
-            apply(req->completion, STATUS_OK);
+            async_apply_status_handler(req->completion, STATUS_OK);
         break;
     case STORAGE_OP_READ:
         storage_rw_internal(st, false, req->data, req->blocks, req->completion);

--- a/test/runtime/symlink.c
+++ b/test/runtime/symlink.c
@@ -43,6 +43,8 @@ int main(int argc, char **argv)
 
     fd = open("link", O_RDONLY | O_NOFOLLOW | O_PATH);
     test_assert(fd >= 0);
+    test_assert((fsync(fd) == -1) && (errno == EBADF));
+    test_assert((fdatasync(fd) == -1) && (errno == EBADF));
     close(fd);
 
     test_assert((faccessat(AT_FDCWD, "link", F_OK, AT_SYMLINK_NOFOLLOW) == 0));

--- a/test/runtime/write.c
+++ b/test/runtime/write.c
@@ -285,6 +285,19 @@ void append_write_test()
     exit(EXIT_FAILURE);
 }
 
+void sync_write_test(void)
+{
+    int fd = open("sync_write", O_CREAT | O_RDWR | O_SYNC, S_IRUSR | S_IWUSR);
+    if (fd < 0) {
+        perror("sync_write open");
+        exit(EXIT_FAILURE);
+    }
+    scatter_write_test_fd(fd, 1 << 12, 1, 512);
+    close(fd);
+    unlink("sync_write");
+    writetest_debug("sync write test passed\n");
+}
+
 void truncate_test(const char *prog)
 {
     unsigned char tmp[BUFLEN];
@@ -853,6 +866,7 @@ int main(int argc, char **argv)
         basic_write_test();
         scatter_write_test(1 << 18, 64, 1 << 12);
         append_write_test();
+        sync_write_test();
         truncate_test(argv[0]);
         write_exec_test(argv[0]);
         fs_stress_test();


### PR DESCRIPTION
The first commit changes the implementation of fsync and fdatasync to avoid flushing the TFS log when not needed. The filesystem_sync() function has been removed in favor of using filesystem_flush(), because there was duplicated code between these functions, and each filesystem_sync() call was triggering two calls to pagecache_sync_volume(). Similarly, filesystem_sync_node() (which was triggering an unnecessary call to pagecache_sync_volume) is being replaced by fsfile_flush(). In order to ensure that the completion of an fync/fdatasync syscall runs in the appropriate syscall context, calls to apply() have been replaced by calls to async_apply_status_handler() in the TFS code and the storage drivers that implement the flush operation.
The second commit adds support for the O_SYNC and O_DSYNC open(2) flags. When a regular file is opened with O_SYNC, by the time write(2) (or similar) returns, the output data and associated file metadata have been transferred to the underlying hardware. The O_DSYNC flag is similar, but it only flushes file metadata if they are needed to correctly handle a subsequent data retrieval.