### PR TITLE
virtio_scsi: honor maximum transfer length limit

### DIFF
--- a/src/virtio/scsi.h
+++ b/src/virtio/scsi.h
@@ -243,6 +243,7 @@ struct scsi_res_inquiry
 
 /* Vital Product Data page codes */
 #define SCSI_VPD_DEVID  0x83
+#define SCSI_VPD_BLIM   0xB0    /* Block Limits */
 
 struct scsi_devid_desc
 {
@@ -253,12 +254,39 @@ struct scsi_devid_desc
     char id[];
 } __attribute__((packed));
 
-struct scsi_res_inquiry_vpd_devid
+struct scsi_res_inquiry_vpd
 {
     u8 device;
     u8 page_code;
+} __attribute__((packed));
+
+struct scsi_res_inquiry_vpd_devid
+{
+    struct scsi_res_inquiry_vpd common;
     u16 length;
     struct scsi_devid_desc desc[];
+} __attribute__((packed));
+
+struct scsi_res_inquiry_vpd_blim
+{
+    struct scsi_res_inquiry_vpd common;
+    u16 length;
+    u8 features;
+    u8 max_caw_len;
+    u16 opt_xfer_len_gran;
+    u32 max_xfer_len;
+    u32 opt_xfer_len;
+    u32 max_prefetch_len;
+    u32 max_unmap_lba_count;
+    u32 max_unmap_bd_count;
+    u32 opt_unmap_gran;
+    u32 unmap_gran_align;
+    u64 max_write_same_len;
+    u32 max_atomic_xfer_len;
+    u32 atomic_align;
+    u32 atomic_xfer_len_gran;
+    u32 max_atomic_xfer_len_ab;
+    u32 max_atomic_boundary_size;
 } __attribute__((packed));
 
 struct scsi_cdb_readwrite_16


### PR DESCRIPTION
A virtio SCSI disk may have a limit on the number of blocks that can be requested in a single I/O transfer; the value of this limit can be found in the block limits Vital Product Data (VPD) page.
This change adds retrieval of the maximum transfer length for a SCSI disk when the disk is probed, and ensures that this limit is not exceeded when executing STORAGE_OP_READSG and STORAGE_OP_WRITESG requests.
This fixes booting in GCP, where the boot disk has a maximum transfer length of 512 blocks (256 KB), which is less than the size of a TFS log extension.