### PR TITLE
SMP support for RISC-V

### DIFF
--- a/.gdbinit-riscv64
+++ b/.gdbinit-riscv64
@@ -1,0 +1,5 @@
+set architecture riscv:rv64
+display/i $pc
+target remote :1234
+symbol-file ./output/platform/riscv-virt/bin/kernel.elf
+

--- a/platform/riscv-virt/Makefile
+++ b/platform/riscv-virt/Makefile
@@ -165,6 +165,11 @@ SRCS-kernel.elf+= \
 	$(SRCDIR)/kernel/management_telnet.c
 endif
 
+ifneq ($(NOSMP),)
+CFLAGS+=	-DSPIN_LOCK_DEBUG_NOSMP
+else
+CFLAGS+=	-DSMP_ENABLE
+endif
 #CFLAGS+=	-DLWIPDIR_DEBUG -DEPOLL_DEBUG -DNETSYSCALL_DEBUG -DKERNEL_DEBUG
 AFLAGS+=	-I$(OBJDIR)/
 LDFLAGS+=	$(KERNLDFLAGS) --undefined=_start -T linker_script
@@ -228,12 +233,12 @@ ifneq ($(ARCH),riscv64)
 $(error The riscv platform only supports the riscv64 architecture.)
 endif
 
-all: $(KERNEL) kernel.dis
+all: $(KERNEL)
 
 mkfs vdsogen:
 	$(Q) $(MAKE) -C $(ROOTDIR)/tools $@
 
-kernel: $(KERNEL) $(OBJDIR)/kernel.dis
+kernel: $(KERNEL) kernel.dis
 
 kernel.dis: $(KERNEL) $(OBJDIR)/kernel.dis
 
@@ -347,7 +352,8 @@ endif
 # various combinations of flags that are usefull when debugging
 #QEMU_FLAGS+=   -machine dumpdtb=riscv.dtb
 #QEMU_FLAGS+=	-d in_asm,cpu -D $(ROOTDIR)/asm.out
-#QEMU_FLAGS+=	-d int -D int
+#QEMU_FLAGS+=	-smp 4
+#QEMU_FLAGS+=	-d int -D $(ROOTDIR)/int.log
 #QEMU_FLAGS+=	-s -S
 #QEMU_FLAGS+=   -d int,trace:pci_cfg_write,trace:pci_cfg_read,trace:msix_write_config,trace:virtio_blk_req_complete,trace:virtio_blk_rw_complete,trace:virtio_blk_handle_read,trace:virtio_blk_handle_write,trace:virtio_blk_submit_multireq,trace:virtio_blk_handle_write,trace:virtio_blk_handle_read,trace:virtio_blk_submit_multireq,trace:virtio_queue_notify,trace:virtio_notify,trace:virtio_set_status,trace:virtio_notify_irqfd,guest_errors,trace:virtio_blk_data_plane_start,trace:virtio_input_queue_full,trace:kvm_irqchip_commit_routes,trace:kvm_irqchip_add_msi_route,trace:kvm_irqchip_update_msi_route,trace:kvm_irqchip_release_virq,trace:kvm_set_ioeventfd_mmio,trace:kvm_set_ioeventfd_pio,trace:kvm_set_user_memory,trace:kvm_clear_dirty_log,trace:kvm_resample_fd_notify,trace:kvm_run_exit,trace:kvm_ioctl,trace:kvm_vm_ioctl,trace:kvm_vcpu_ioctl,trace:kvm_device_ioctl -D $(ROOTDIR)/trace.out
 

--- a/platform/riscv-virt/kernel_platform.h
+++ b/platform/riscv-virt/kernel_platform.h
@@ -16,8 +16,6 @@
 #define DEV_BASE_PCIE_MMIO    0x40000000
 #define DEV_BASE_PCIE_PIO     0x03000000
 
-#define SBI_SETTIME           0
-
 #define SYSCON_POWEROFF       0x5555
 #define SYSCON_POWEROFF_FAIL  0x3333
 #define SYSCON_REBOOT         0x7777
@@ -30,4 +28,6 @@
 void early_debug(const char *s);
 void early_debug_u64(u64 n);
 void early_dump(void *p, unsigned long length);
+
+#include "sbi_ecall_interface.h"
 #endif

--- a/platform/riscv-virt/sbi_ecall_interface.h
+++ b/platform/riscv-virt/sbi_ecall_interface.h
@@ -1,0 +1,251 @@
+/*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2019 Western Digital Corporation or its affiliates.
+ *
+ * Authors:
+ *   Anup Patel <anup.patel@wdc.com>
+ */
+
+#ifndef __SBI_ECALL_INTERFACE_H__
+#define __SBI_ECALL_INTERFACE_H__
+
+/* clang-format off */
+
+/* SBI Extension IDs */
+#define SBI_EXT_0_1_SET_TIMER			0x0
+#define SBI_EXT_0_1_CONSOLE_PUTCHAR		0x1
+#define SBI_EXT_0_1_CONSOLE_GETCHAR		0x2
+#define SBI_EXT_0_1_CLEAR_IPI			0x3
+#define SBI_EXT_0_1_SEND_IPI			0x4
+#define SBI_EXT_0_1_REMOTE_FENCE_I		0x5
+#define SBI_EXT_0_1_REMOTE_SFENCE_VMA		0x6
+#define SBI_EXT_0_1_REMOTE_SFENCE_VMA_ASID	0x7
+#define SBI_EXT_0_1_SHUTDOWN			0x8
+#define SBI_EXT_BASE				0x10
+#define SBI_EXT_TIME				0x54494D45
+#define SBI_EXT_IPI				0x735049
+#define SBI_EXT_RFENCE				0x52464E43
+#define SBI_EXT_HSM				0x48534D
+#define SBI_EXT_SRST				0x53525354
+#define SBI_EXT_PMU				0x504D55
+
+/* SBI function IDs for BASE extension*/
+#define SBI_EXT_BASE_GET_SPEC_VERSION		0x0
+#define SBI_EXT_BASE_GET_IMP_ID			0x1
+#define SBI_EXT_BASE_GET_IMP_VERSION		0x2
+#define SBI_EXT_BASE_PROBE_EXT			0x3
+#define SBI_EXT_BASE_GET_MVENDORID		0x4
+#define SBI_EXT_BASE_GET_MARCHID		0x5
+#define SBI_EXT_BASE_GET_MIMPID			0x6
+
+/* SBI function IDs for TIME extension*/
+#define SBI_EXT_TIME_SET_TIMER			0x0
+
+/* SBI function IDs for IPI extension*/
+#define SBI_EXT_IPI_SEND_IPI			0x0
+
+/* SBI function IDs for RFENCE extension*/
+#define SBI_EXT_RFENCE_REMOTE_FENCE_I		0x0
+#define SBI_EXT_RFENCE_REMOTE_SFENCE_VMA	0x1
+#define SBI_EXT_RFENCE_REMOTE_SFENCE_VMA_ASID	0x2
+#define SBI_EXT_RFENCE_REMOTE_HFENCE_GVMA_VMID	0x3
+#define SBI_EXT_RFENCE_REMOTE_HFENCE_GVMA	0x4
+#define SBI_EXT_RFENCE_REMOTE_HFENCE_VVMA_ASID	0x5
+#define SBI_EXT_RFENCE_REMOTE_HFENCE_VVMA	0x6
+
+/* SBI function IDs for HSM extension */
+#define SBI_EXT_HSM_HART_START			0x0
+#define SBI_EXT_HSM_HART_STOP			0x1
+#define SBI_EXT_HSM_HART_GET_STATUS		0x2
+#define SBI_EXT_HSM_HART_SUSPEND		0x3
+
+#define SBI_HSM_STATE_STARTED			0x0
+#define SBI_HSM_STATE_STOPPED			0x1
+#define SBI_HSM_STATE_START_PENDING		0x2
+#define SBI_HSM_STATE_STOP_PENDING		0x3
+#define SBI_HSM_STATE_SUSPENDED			0x4
+#define SBI_HSM_STATE_SUSPEND_PENDING		0x5
+#define SBI_HSM_STATE_RESUME_PENDING		0x6
+
+#define SBI_HSM_SUSP_BASE_MASK			0x7fffffff
+#define SBI_HSM_SUSP_NON_RET_BIT		0x80000000
+#define SBI_HSM_SUSP_PLAT_BASE			0x10000000
+
+#define SBI_HSM_SUSPEND_RET_DEFAULT		0x00000000
+#define SBI_HSM_SUSPEND_RET_PLATFORM		SBI_HSM_SUSP_PLAT_BASE
+#define SBI_HSM_SUSPEND_RET_LAST		SBI_HSM_SUSP_BASE_MASK
+#define SBI_HSM_SUSPEND_NON_RET_DEFAULT		SBI_HSM_SUSP_NON_RET_BIT
+#define SBI_HSM_SUSPEND_NON_RET_PLATFORM	(SBI_HSM_SUSP_NON_RET_BIT | \
+						 SBI_HSM_SUSP_PLAT_BASE)
+#define SBI_HSM_SUSPEND_NON_RET_LAST		(SBI_HSM_SUSP_NON_RET_BIT | \
+						 SBI_HSM_SUSP_BASE_MASK)
+
+/* SBI function IDs for SRST extension */
+#define SBI_EXT_SRST_RESET			0x0
+
+#define SBI_SRST_RESET_TYPE_SHUTDOWN		0x0
+#define SBI_SRST_RESET_TYPE_COLD_REBOOT	0x1
+#define SBI_SRST_RESET_TYPE_WARM_REBOOT	0x2
+#define SBI_SRST_RESET_TYPE_LAST	SBI_SRST_RESET_TYPE_WARM_REBOOT
+
+#define SBI_SRST_RESET_REASON_NONE	0x0
+#define SBI_SRST_RESET_REASON_SYSFAIL	0x1
+
+/* SBI function IDs for PMU extension */
+#define SBI_EXT_PMU_NUM_COUNTERS	0x0
+#define SBI_EXT_PMU_COUNTER_GET_INFO	0x1
+#define SBI_EXT_PMU_COUNTER_CFG_MATCH	0x2
+#define SBI_EXT_PMU_COUNTER_START	0x3
+#define SBI_EXT_PMU_COUNTER_STOP	0x4
+#define SBI_EXT_PMU_COUNTER_FW_READ	0x5
+
+/** General pmu event codes specified in SBI PMU extension */
+enum sbi_pmu_hw_generic_events_t {
+	SBI_PMU_HW_NO_EVENT			= 0,
+	SBI_PMU_HW_CPU_CYCLES			= 1,
+	SBI_PMU_HW_INSTRUCTIONS			= 2,
+	SBI_PMU_HW_CACHE_REFERENCES		= 3,
+	SBI_PMU_HW_CACHE_MISSES			= 4,
+	SBI_PMU_HW_BRANCH_INSTRUCTIONS		= 5,
+	SBI_PMU_HW_BRANCH_MISSES		= 6,
+	SBI_PMU_HW_BUS_CYCLES			= 7,
+	SBI_PMU_HW_STALLED_CYCLES_FRONTEND	= 8,
+	SBI_PMU_HW_STALLED_CYCLES_BACKEND	= 9,
+	SBI_PMU_HW_REF_CPU_CYCLES		= 10,
+
+	SBI_PMU_HW_GENERAL_MAX,
+};
+
+/**
+ * Generalized hardware cache events:
+ *
+ *       { L1-D, L1-I, LLC, ITLB, DTLB, BPU, NODE } x
+ *       { read, write, prefetch } x
+ *       { accesses, misses }
+ */
+enum sbi_pmu_hw_cache_id {
+	SBI_PMU_HW_CACHE_L1D		= 0,
+	SBI_PMU_HW_CACHE_L1I		= 1,
+	SBI_PMU_HW_CACHE_LL		= 2,
+	SBI_PMU_HW_CACHE_DTLB		= 3,
+	SBI_PMU_HW_CACHE_ITLB		= 4,
+	SBI_PMU_HW_CACHE_BPU		= 5,
+	SBI_PMU_HW_CACHE_NODE		= 6,
+
+	SBI_PMU_HW_CACHE_MAX,
+};
+
+enum sbi_pmu_hw_cache_op_id {
+	SBI_PMU_HW_CACHE_OP_READ	= 0,
+	SBI_PMU_HW_CACHE_OP_WRITE	= 1,
+	SBI_PMU_HW_CACHE_OP_PREFETCH	= 2,
+
+	SBI_PMU_HW_CACHE_OP_MAX,
+};
+
+enum sbi_pmu_hw_cache_op_result_id {
+	SBI_PMU_HW_CACHE_RESULT_ACCESS	= 0,
+	SBI_PMU_HW_CACHE_RESULT_MISS	= 1,
+
+	SBI_PMU_HW_CACHE_RESULT_MAX,
+};
+
+/**
+ * Special "firmware" events provided by the OpenSBI, even if the hardware
+ * does not support performance events. These events are encoded as a raw
+ * event type in Linux kernel perf framework.
+ */
+enum sbi_pmu_fw_event_code_id {
+	SBI_PMU_FW_MISALIGNED_LOAD	= 0,
+	SBI_PMU_FW_MISALIGNED_STORE	= 1,
+	SBI_PMU_FW_ACCESS_LOAD		= 2,
+	SBI_PMU_FW_ACCESS_STORE		= 3,
+	SBI_PMU_FW_ILLEGAL_INSN		= 4,
+	SBI_PMU_FW_SET_TIMER		= 5,
+	SBI_PMU_FW_IPI_SENT		= 6,
+	SBI_PMU_FW_IPI_RECVD		= 7,
+	SBI_PMU_FW_FENCE_I_SENT		= 8,
+	SBI_PMU_FW_FENCE_I_RECVD	= 9,
+	SBI_PMU_FW_SFENCE_VMA_SENT	= 10,
+	SBI_PMU_FW_SFENCE_VMA_RCVD	= 11,
+	SBI_PMU_FW_SFENCE_VMA_ASID_SENT	= 12,
+	SBI_PMU_FW_SFENCE_VMA_ASID_RCVD	= 13,
+
+	SBI_PMU_FW_HFENCE_GVMA_SENT	= 14,
+	SBI_PMU_FW_HFENCE_GVMA_RCVD	= 15,
+	SBI_PMU_FW_HFENCE_GVMA_VMID_SENT = 16,
+	SBI_PMU_FW_HFENCE_GVMA_VMID_RCVD = 17,
+
+	SBI_PMU_FW_HFENCE_VVMA_SENT	= 18,
+	SBI_PMU_FW_HFENCE_VVMA_RCVD	= 19,
+	SBI_PMU_FW_HFENCE_VVMA_ASID_SENT = 20,
+	SBI_PMU_FW_HFENCE_VVMA_ASID_RCVD = 21,
+	SBI_PMU_FW_MAX,
+};
+
+/** SBI PMU event idx type */
+enum sbi_pmu_event_type_id {
+	SBI_PMU_EVENT_TYPE_HW				= 0x0,
+	SBI_PMU_EVENT_TYPE_HW_CACHE			= 0x1,
+	SBI_PMU_EVENT_TYPE_HW_RAW			= 0x2,
+	SBI_PMU_EVENT_TYPE_FW				= 0xf,
+	SBI_PMU_EVENT_TYPE_MAX,
+};
+
+/** SBI PMU counter type */
+enum sbi_pmu_ctr_type {
+	SBI_PMU_CTR_TYPE_HW = 0,
+	SBI_PMU_CTR_TYPE_FW,
+};
+
+/* Helper macros to decode event idx */
+#define SBI_PMU_EVENT_IDX_OFFSET 20
+#define SBI_PMU_EVENT_IDX_MASK 0xFFFFF
+#define SBI_PMU_EVENT_IDX_CODE_MASK 0xFFFF
+#define SBI_PMU_EVENT_IDX_TYPE_MASK 0xF0000
+#define SBI_PMU_EVENT_RAW_IDX 0x20000
+
+#define SBI_PMU_EVENT_IDX_INVALID 0xFFFFFFFF
+
+/* Flags defined for config matching function */
+#define SBI_PMU_CFG_FLAG_SKIP_MATCH	(1 << 0)
+#define SBI_PMU_CFG_FLAG_CLEAR_VALUE	(1 << 1)
+#define SBI_PMU_CFG_FLAG_AUTO_START	(1 << 2)
+#define SBI_PMU_CFG_FLAG_SET_VUINH	(1 << 3)
+#define SBI_PMU_CFG_FLAG_SET_VSINH	(1 << 4)
+#define SBI_PMU_CFG_FLAG_SET_UINH	(1 << 5)
+#define SBI_PMU_CFG_FLAG_SET_SINH	(1 << 6)
+#define SBI_PMU_CFG_FLAG_SET_MINH	(1 << 7)
+
+/* Flags defined for counter start function */
+#define SBI_PMU_START_FLAG_SET_INIT_VALUE (1 << 0)
+
+/* Flags defined for counter stop function */
+#define SBI_PMU_STOP_FLAG_RESET (1 << 0)
+
+/* SBI base specification related macros */
+#define SBI_SPEC_VERSION_MAJOR_OFFSET		24
+#define SBI_SPEC_VERSION_MAJOR_MASK		0x7f
+#define SBI_SPEC_VERSION_MINOR_MASK		0xffffff
+#define SBI_EXT_VENDOR_START			0x09000000
+#define SBI_EXT_VENDOR_END			0x09FFFFFF
+#define SBI_EXT_FIRMWARE_START			0x0A000000
+#define SBI_EXT_FIRMWARE_END			0x0AFFFFFF
+
+/* SBI return error codes */
+#define SBI_SUCCESS				0
+#define SBI_ERR_FAILED				-1
+#define SBI_ERR_NOT_SUPPORTED			-2
+#define SBI_ERR_INVALID_PARAM			-3
+#define SBI_ERR_DENIED				-4
+#define SBI_ERR_INVALID_ADDRESS			-5
+#define SBI_ERR_ALREADY_AVAILABLE		-6
+#define SBI_ERR_ALREADY_STARTED			-7
+#define SBI_ERR_ALREADY_STOPPED			-8
+
+#define SBI_LAST_ERR				SBI_ERR_ALREADY_STOPPED
+
+/* clang-format on */
+
+#endif

--- a/platform/riscv-virt/service.c
+++ b/platform/riscv-virt/service.c
@@ -96,14 +96,6 @@ void vm_reset(void)
 u64 total_processors = 1;
 u64 present_processors = 1;
 
-void start_secondary_cores(kernel_heaps kh)
-{
-}
-
-void count_cpus_present(void)
-{
-}
-
 static void __attribute__((noinline)) init_service_new_stack(void)
 {
     init_debug("in init_service_new_stack\n");

--- a/src/kernel/mutex.c
+++ b/src/kernel/mutex.c
@@ -203,7 +203,7 @@ static inline boolean mutex_lock_internal(mutex m, boolean wait)
     while (spins_remain-- > 0) {
         if (m->turn == 0 && compare_and_swap_64((u64*)&m->turn, 0, u64_from_pointer(ctx))) {
             if (on_mcs)
-                mcs_unlock(m, ci);
+                mcs_unlock(m, current_cpu());
 #ifdef LOCK_STATS
             LOCKSTATS_RECORD_LOCK(m->s, true, spins, sleeps);
 #endif
@@ -218,7 +218,7 @@ static inline boolean mutex_lock_internal(mutex m, boolean wait)
 
     /* we cannot reschedule while holding the mcs lock, so join waiters */
     if (on_mcs) {
-        mcs_unlock(m, ci);
+        mcs_unlock(m, current_cpu());
         on_mcs = false;
         goto wait;
     }

--- a/src/kernel/mutex.c
+++ b/src/kernel/mutex.c
@@ -43,7 +43,7 @@ static inline cpuinfo mutex_get_next(mutex m, cpuinfo ci, cpuinfo prev)
 
            If we're unlocking ci and at the end of the list, then this is just
            a simple removal. */
-        if (m->mcs_tail == ci &&
+        if (((volatile mutex)m)->mcs_tail == ci &&
             compare_and_swap_64((u64*)&m->mcs_tail, u64_from_pointer(ci),
                                 u64_from_pointer(prev)))
             return 0;
@@ -51,7 +51,7 @@ static inline cpuinfo mutex_get_next(mutex m, cpuinfo ci, cpuinfo prev)
         /* If a spin waiter has latched onto us, exchange its next with
            null. This is necessary to keep step A spinning until the node
            being removed gets a new prev link. */
-        if (ci->mcs_next) {
+        if (*(volatile cpuinfo *)&ci->mcs_next) {
             cpuinfo next = pointer_from_u64(atomic_swap_64((u64*)&ci->mcs_next, 0));
             if (next)
                 return next;
@@ -89,7 +89,7 @@ static inline boolean mutex_lock_internal(mutex m, boolean wait)
     u64 sleeps = 0;
 #endif
     /* not preemptable (could become option on allocate) */
-    if (m->turn == ctx)
+    if (((volatile mutex)m)->turn == ctx)
         halt("%s: lock already held - cpu %d, mutex %p, ctx %p, ra %p\n", __func__,
              ci->id, m, ctx, __builtin_return_address(0));
 
@@ -141,8 +141,8 @@ static inline boolean mutex_lock_internal(mutex m, boolean wait)
        step A: first undo the setting of prev->mcs_next (unless we are handed
        the lock in the meantime), thus making prev spin wait in
        mutex_get_next() for a valid next pointer */
-    while (prev->mcs_next != ci || !compare_and_swap_64((u64*)&prev->mcs_next,
-                                                        u64_from_pointer(ci), 0)) {
+    while (((volatile cpuinfo)prev)->mcs_next != ci ||
+           !compare_and_swap_64((u64*)&prev->mcs_next, u64_from_pointer(ci), 0)) {
         /* unlock might hand us the lock */
         if (!ci->mcs_waiting) {
             compiler_barrier(); /* load aquire */
@@ -271,6 +271,7 @@ void mutex_unlock(mutex m)
     next->waiting_on = 0;
 
     /* cover race between enqueue and context_suspend() */
+    compiler_barrier();
     while (!frame_is_full(next->frame))
         kern_pause();
 

--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -2,14 +2,7 @@
 
 #include <kernel.h>
 
-#ifdef KERNEL
-static struct spinlock pt_lock;
-#define pagetable_lock() u64 _savedflags = spin_lock_irq(&pt_lock)
-#define pagetable_unlock() spin_unlock_irq(&pt_lock, _savedflags)
-#else
-#define pagetable_lock()
-#define pagetable_unlock()
-#endif
+struct spinlock pt_lock;
 
 //#define PAGE_INIT_DEBUG
 //#define PAGE_DEBUG

--- a/src/kernel/page.h
+++ b/src/kernel/page.h
@@ -1,3 +1,12 @@
+#ifdef KERNEL
+extern struct spinlock pt_lock;
+#define pagetable_lock() u64 _savedflags = spin_lock_irq(&pt_lock)
+#define pagetable_unlock() spin_unlock_irq(&pt_lock, _savedflags)
+#else
+#define pagetable_lock()
+#define pagetable_unlock()
+#endif
+
 /* Though page flags are just a u64, we hide it behind this type to
    emphasize that page flags should be composed using helpers with
    clear semantics, not architecture bits. This is to avoid mistakes

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -102,7 +102,7 @@ static void migrate_from_self(cpuinfo ci, u64 first_cpu, u64 ncpus)
 static inline boolean update_timer(void)
 {
     timestamp next = kernel_timers->next_expiry;
-    if (!compare_and_swap_boolean(&kernel_timers->update, true, false))
+    if (!compare_and_swap_32(&kernel_timers->update, true, false))
         return false;
     s64 delta = next - now(CLOCK_ID_MONOTONIC_RAW);
     timestamp timeout = delta > (s64)kernel_timers->min ? MIN(delta, kernel_timers->max) : kernel_timers->min;

--- a/src/riscv64/clock.c
+++ b/src/riscv64/clock.c
@@ -43,7 +43,7 @@ closure_function(0, 1, void, riscv_deadline_timer,
     u64 tv = mmio_read_64(mmio_base_addr(CLINT) + CLINT_MTIME);
     tv += (interval*CLINT_TIMEBASE_FREQ) >> 32; 
     /* Must set via ecall and not mmio or else opensbi won't trap the timer */
-    supervisor_ecall(SBI_SETTIME, tv);
+    supervisor_ecall_1(SBI_EXT_0_1_SET_TIMER, tv);
 }
 
 closure_function(0, 0, void, riscv_timer_percpu_init)

--- a/src/riscv64/crt0.S
+++ b/src/riscv64/crt0.S
@@ -8,8 +8,18 @@ KERNEL_INDEX_OFF = (((KERNEL_BASE>>30)&0x1ff) * 8)
 ROOT_PT_ADDR = KERNEL_PHYS - 0x1000
 KERN_PT_ADDR = KERNEL_PHYS - 0x2000
 
+.macro  start_setup
+        // disable interrupts and FPU
+        csrw CSR_IE, zero
+        csrw CSR_IP, zero
+        li t0, SR_FS
+        csrc CSR_STATUS, t0
+.endm
+
 .globl _start
 _start:
+        start_setup
+
         // XXX does bios clear bss for us?
         // clear bss
         la t0, bss_start
@@ -47,16 +57,46 @@ mlp:    ori t1, t0, 0xef
         add t0, t0, t3
         addi s0, s0, 8
         blt t0, t2, mlp
+
         // load the root page into satp
         srli s0, s0, 12
         li t0, 0x8 << 60    // Sv39
         or s0, s0, t0
         csrw satp, s0
         sfence.vma
-        li sp, KERN_PT_ADDR // stack just below the temp pagetable
-        lui t0, %hi(start)
-        addi t0, t0, %lo(start)
+
+        // save boot hartid
+        la t0, boot_hartid
+        sd a0, 0(t0)
+
+        // stack just below the temp pagetable
+        li sp, KERN_PT_ADDR
+        la t0, start
         jr t0
+
+install_tablebase:
+        la t0, tablebase
+        ld t0, 0(t0)
+        srli t0, t0, 12
+        li s0, 0x9 << 60    // Sv48
+        or t0, t0, s0
+        csrw satp, t0
+        sfence.vma
+
+        // relocate pc on return
+        li t0, (KERNEL_BASE - KERNEL_PHYS)
+        add ra, ra, t0
+        ret
+
+.globl secondary_core_start_from_sbi
+secondary_core_start_from_sbi:
+        start_setup
+        li t0, 0x1 << 18    // SUM
+        csrs sstatus, t0
+        call install_tablebase
+        la t0, ap_start
+        mv sp, a1
+        jr t0   // hartid in a0
 
 // needs sp/tp to be appropriately set, so it does not save either reg
 .macro  frame_save
@@ -169,7 +209,7 @@ frame_return:
         ld t0, FRAME_PC*8(a0)
         csrw sepc, t0
         csrr t0, sstatus
-        li t1, ~(STATUS_SPP|STATUS_SIE|(FS_MASK<<STATUS_BIT_FS))
+        li t1, ~(STATUS_SPP|STATUS_SPIE|STATUS_SIE|(FS_MASK<<STATUS_BIT_FS))
         and t0, t0, t1
         ld t1, FRAME_STATUS*8(a0)
         or t0, t0, t1
@@ -213,10 +253,13 @@ frame_return:
         ld t2, FRAME_FCSR*8(t1)
         fscsr t2
 2:      csrw sstatus, t0
-        ld x1, FRAME_X1*8(a0)
+        // only restore tls for user mode
+        andi x1, t0, STATUS_SPP
+        bnez x1, 3f
+        ld x4, FRAME_X4*8(a0)
+3:      ld x1, FRAME_X1*8(a0)
         ld x2, FRAME_X2*8(a0)
         ld x3, FRAME_X3*8(a0)
-        ld x4, FRAME_X4*8(a0)
         ld x5, FRAME_X5*8(a0)
         ld x6, FRAME_X6*8(a0)
         ld x7, FRAME_X7*8(a0)
@@ -252,7 +295,12 @@ context_suspend:
         frame_save
         // t0 now contains pointer to frame
         sd sp, FRAME_SP*8(t0)
-        sd tp, FRAME_TP*8(t0)
-        sd ra, FRAME_PC*8(t0)
+        ld x1, FRAME_STATUS*8(t0)
+        andi x1, x1, ~STATUS_SPIE
+        ori x1, x1, STATUS_SPP
+        sd x1, FRAME_STATUS*8(t0)
+        ld t1, FRAME_RA*8(t0)
+        sd t1, FRAME_PC*8(t0)
+        mv a0, t0
         j context_suspend_finish
 

--- a/src/riscv64/kernel_machine.c
+++ b/src/riscv64/kernel_machine.c
@@ -1,5 +1,6 @@
 #include <kernel.h>
 #include <plic.h>
+#include <devicetree.h>
 
 //#define TAG_HEAP_DEBUG
 #ifdef TAG_HEAP_DEBUG
@@ -27,6 +28,9 @@ heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize)
     return allocate_mcache(h, backed, 5, find_order(pagesize) - 1, pagesize);
 }
 
+extern void *trap_handler;
+BSS_RO_AFTER_INIT u64 boot_hartid;
+
 void cpu_init(int cpu)
 {
     cpuinfo ci = cpuinfo_from_id(cpu);
@@ -35,8 +39,8 @@ void cpu_init(int cpu)
     asm volatile("csrr %0, sstatus" : "=r"(a));
     a |= STATUS_SIE|(FS_INITIAL<<STATUS_BIT_FS); // XXX
     asm volatile("csrw sstatus, %0" :: "r"(a));
-    a = 0x666;
-    asm volatile("csrw sie, %0" :: "r"(a));
+    asm volatile("csrw stvec, %0" :: "r"(&trap_handler));
+    asm volatile("csrw sie, %0" :: "r"(SI_SEIP | SI_STIP | SI_SSIP));
 }
 
 void init_cpuinfo_machine(cpuinfo ci, heap backed)
@@ -50,6 +54,7 @@ void init_cpuinfo_machine(cpuinfo ci, heap backed)
     assert(p != INVALID_ADDRESS);
     ci->m.tstack_top = p + TRAP_STACK_SIZE;
     ci->m.current_context = ci->m.kernel_context = &kc->context;
+    ci->m.hartid = ci->id == 0 ? boot_hartid : -1ull;
 }
 
 void clone_frame_pstate(context_frame dest, context_frame src)
@@ -60,6 +65,109 @@ void clone_frame_pstate(context_frame dest, context_frame src)
 void interrupt_exit(void)
 {
     plic_eoi(plic_dispatch_int());
+}
+
+static struct spinlock ap_lock;
+
+static void ap_start_newstack(int cpuid)
+{
+    total_processors++;
+    spin_unlock(&ap_lock);
+    cpu_init(cpuid);
+    run_percpu_init();
+    disable_interrupts();
+    kernel_sleep();
+}
+
+BSS_RO_AFTER_INIT static vector hartids_by_cpuid;
+
+static inline u64 cpuid_from_hartid(u64 hartid)
+{
+    for (u64 cpuid = 0; cpuid < vector_length(hartids_by_cpuid); cpuid++) {
+        if ((u64)vector_get(hartids_by_cpuid, cpuid) == hartid)
+            return cpuid;
+    }
+    return INVALID_PHYSICAL;
+}
+
+void ap_start(u64 hartid)
+{
+    spin_lock(&ap_lock);
+    memory_barrier();
+    u64 cpuid = cpuid_from_hartid(hartid);
+    assert(cpuid != INVALID_PHYSICAL);
+    assert(cpuid > 0);
+    cpuinfo ci = init_cpuinfo((heap)heap_linear_backed(get_kernel_heaps()), cpuid);
+    assert(ci != INVALID_ADDRESS);
+    ci->m.hartid = hartid;
+    context_frame f = ci->m.kernel_context->frame;
+    switch_stack_1(frame_get_stack_top(f), ap_start_newstack, cpuid);
+}
+
+extern void secondary_core_start_from_sbi(void);
+void *ap_stack;
+
+void start_secondary_cores(kernel_heaps kh)
+{
+    spin_lock_init(&ap_lock);
+    ap_stack = allocate_stack((heap)heap_page_backed(kh), 4 * PAGESIZE);
+    assert(ap_stack != INVALID_ADDRESS);
+    init_flush(heap_locked(kh));
+    u64 target = physical_from_virtual(secondary_core_start_from_sbi);
+    for (int cpuid = 1; cpuid < present_processors; cpuid++) {
+        struct sbiret r;
+        u64 hartid = (u64)vector_get(hartids_by_cpuid, cpuid);
+        r = supervisor_ecall(SBI_EXT_HSM, SBI_EXT_HSM_HART_START, hartid, target,
+                             u64_from_pointer(ap_stack), 0, 0, 0);
+        if (r.error) {
+            halt("failed to start cpu %d (hartid %d): error 0x%lx, value 0x%lx\n",
+                 cpuid, hartid, r.error, r.value);
+        }
+        plic_set_threshold(hartid, 0);
+    }
+}
+
+closure_function(1, 2, boolean, cpu_dtb_handler,
+                 u64 *, proc_count,
+                 dt_node, n, char *, name)
+{
+    dt_prop device_type = dtb_get_prop(DEVICETREE, n, "device_type");
+    if (device_type == INVALID_ADDRESS)
+        return true;
+    dt_value dtval = dtb_read_value(DEVICETREE, n, device_type);
+    if (dtval.type != DT_VALUE_STRING ||
+        runtime_strcmp(dtval.u.string, "cpu"))
+        return true;
+
+    dt_prop reg = dtb_get_prop(DEVICETREE, n, "reg");
+    if (reg == INVALID_ADDRESS)
+        halt("unable to find \"reg\" property for cpu\n");
+    dt_value reg_val = dtb_read_value(DEVICETREE, n, reg);
+    if (reg_val.type != DT_VALUE_REG)
+        halt("invalid dt_value type %d for cpu reg property\n", reg_val.type);
+    range r;
+    assert(dtb_reg_iterate(&reg_val.u.ri, &r));
+    if (r.start != boot_hartid) {
+        u64 cpuid = (*bound(proc_count))++;
+        vector_set(hartids_by_cpuid, cpuid, (void*)r.start);
+    }
+    return true;
+}
+
+void count_cpus_present(void)
+{
+    hartids_by_cpuid = allocate_vector(heap_general(get_kernel_heaps()), 8);
+    assert(hartids_by_cpuid != INVALID_ADDRESS);
+    vector_set(hartids_by_cpuid, 0, (void*)boot_hartid);
+    dt_node n = dtb_find_node_by_path(DEVICETREE, "/cpus");
+    if (n == INVALID_ADDRESS) {
+        msg_err("unable to find \"/cpus/cpu-map/cluster0\" in device tree; resorting to single cpu\n");
+        return;
+    }
+
+    u64 proc_count = 1;
+    dtb_walk_node_children(DEVICETREE, n, 0, stack_closure(cpu_dtb_handler, &proc_count));
+    present_processors = proc_count;
 }
 
 #ifdef KERNEL

--- a/src/riscv64/kernel_machine.c
+++ b/src/riscv64/kernel_machine.c
@@ -55,6 +55,7 @@ void init_cpuinfo_machine(cpuinfo ci, heap backed)
     ci->m.tstack_top = p + TRAP_STACK_SIZE;
     ci->m.current_context = ci->m.kernel_context = &kc->context;
     ci->m.hartid = ci->id == 0 ? boot_hartid : -1ull;
+    ci->m.ipi_mask = 0;
 }
 
 void clone_frame_pstate(context_frame dest, context_frame src)

--- a/src/riscv64/kernel_machine.h
+++ b/src/riscv64/kernel_machine.h
@@ -23,8 +23,6 @@
 
 #define VIRTUAL_ADDRESS_BITS 48
 
-#define FLUSH_HANDLER_FAKE_IRQ 0x8000
-
 #define SCAUSE_INTERRUPT_BIT 63
 #define SCAUSE_INTERRUPT(x) ((x)>>SCAUSE_INTERRUPT_BIT)
 #define SCAUSE_CODE(x)       ((x)&~U64_FROM_BIT(SCAUSE_INTERRUPT_BIT))
@@ -182,6 +180,8 @@ struct cpuinfo_machine {
 
     /* Next syscall context to install */
     context syscall_context;
+
+    u64 ipi_mask;
 };
 
 typedef struct cpuinfo *cpuinfo;

--- a/src/riscv64/page.c
+++ b/src/riscv64/page.c
@@ -22,8 +22,10 @@ boolean is_protection_fault(context_frame f)
     /* XXX is there no hw distinction between writing to a valid
        readonly page versus writing to a non-existant page? */
     pte e;
-    // XXX this lookup is not locked but will need to be for smp
-    if (physical_and_pte_from_virtual(frame_fault_address(f), &e) == INVALID_PHYSICAL)
+    pagetable_lock();
+    physical p = __physical_and_pte_from_virtual_locked(frame_fault_address(f), &e);
+    pagetable_unlock();
+    if (p == INVALID_PHYSICAL)
         return false;
     u64 cause = SCAUSE_CODE(f[FRAME_CAUSE]);
     return (e & PAGE_VALID) && (cause == TRAP_E_SPAGE_FAULT);

--- a/src/riscv64/page_machine.h
+++ b/src/riscv64/page_machine.h
@@ -243,7 +243,7 @@ static inline u64 *pte_lookup_ptr(u64 table, u64 vaddr, int offset)
         return page_from_pte(*l ## level) | (vaddr & MASK(PT_SHIFT_L ## level)); \
     }
 
-static inline physical physical_and_pte_from_virtual(u64 xt, pte *e)
+static inline physical __physical_and_pte_from_virtual_locked(u64 xt, pte *e)
 {
     _pfv_level(tablebase, xt, 0);
     _pfv_check_leaf(0, xt, e);
@@ -258,7 +258,7 @@ static inline physical physical_and_pte_from_virtual(u64 xt, pte *e)
 
 static inline physical __physical_from_virtual_locked(void *x)
 {
-    return physical_and_pte_from_virtual(u64_from_pointer(x), 0);
+    return __physical_and_pte_from_virtual_locked(u64_from_pointer(x), 0);
 }
 
 physical physical_from_virtual(void *x);

--- a/src/riscv64/plic.c
+++ b/src/riscv64/plic.c
@@ -82,28 +82,3 @@ void init_plic()
 void msi_format(u32 *address, u32 *data, int vector)
 {
 }
-
-static void send_ipi_internal(u64 cpu)
-{
-    /* get hartid for cpu */
-    cpuinfo target_ci = cpuinfo_from_id(cpu);
-    u64 hartid = target_ci->m.hartid;
-    // rewrite to actually use mask, adjust hbase; otherwise limited to 64 cpus
-    struct sbiret r = supervisor_ecall(SBI_EXT_IPI, SBI_EXT_IPI_SEND_IPI,
-                                       (1ull << hartid), 0, 0, 0, 0, 0);
-    assert(r.error == 0);
-}
-
-void send_ipi(u64 cpu, u8 vector)
-{
-    if (cpu == TARGET_EXCLUSIVE_BROADCAST) {
-        cpuinfo ci = current_cpu();
-        for (int i = 0; i < present_processors; i++) {
-            if (i == ci->id)
-                continue;
-            send_ipi_internal(i);
-        }
-    } else {
-        send_ipi_internal(cpu);
-    }
-}

--- a/src/riscv64/plic.c
+++ b/src/riscv64/plic.c
@@ -10,29 +10,44 @@
 #define set_plic_bit(r, i) do { u32 off = ((i)/32)*sizeof(u32); write_plic(r+off, read_plic(r+off)|(1<<((i)%32))); } while(0)
 #define clear_plic_bit(r, i) do { u32 off = ((i)/32)*sizeof(u32); write_plic(r+off, read_plic(r+off)&~(1<<((i)%32))); } while(0)
 
+static inline u64 context_from_hartid(u64 hartid)
+{
+    return (hartid << 1) + 1;
+}
+
 void plic_disable_int(int irq)
 {
-    clear_plic_bit(PLIC_ENABLE_C1, irq);
+    for (int cpuid = 0; cpuid < present_processors; cpuid++) {
+        cpuinfo ci = cpuinfo_from_id(cpuid);
+        clear_plic_bit(PLIC_ENABLE(context_from_hartid(ci->m.hartid)), irq);
+    }
 }
 
 void plic_enable_int(int irq)
 {
-    set_plic_bit(PLIC_ENABLE_C1, irq);
+    for (int cpuid = 0; cpuid < present_processors; cpuid++) {
+        cpuinfo ci = cpuinfo_from_id(cpuid);
+        set_plic_bit(PLIC_ENABLE(context_from_hartid(ci->m.hartid)), irq);
+    }
 }
 
 void plic_clear_pending_int(int irq)
 {
-    boolean en = read_plic_bit(PLIC_ENABLE_C1, irq);
-    if (!en)
-        set_plic_bit(PLIC_ENABLE_C1, irq);
-    u32 v;
-    while ((v = read_plic(PLIC_CLAIM_C1))) {
-        write_plic(PLIC_CLAIM_C1, v);
-        if (v == irq)
-            break;
+    for (int cpuid = 0; cpuid < present_processors; cpuid++) {
+        cpuinfo ci = cpuinfo_from_id(cpuid);
+        u64 context = context_from_hartid(ci->m.hartid);
+        boolean en = read_plic_bit(PLIC_ENABLE(context), irq);
+        if (!en)
+            set_plic_bit(PLIC_ENABLE(context), irq);
+        u32 v;
+        while ((v = read_plic(PLIC_CLAIM(context)))) {
+            write_plic(PLIC_CLAIM(context), v);
+            if (v == irq)
+                break;
+        }
+        if (!en)
+            clear_plic_bit(PLIC_ENABLE(context), irq);
     }
-    if (!en)
-        clear_plic_bit(PLIC_ENABLE_C1, irq);
 }
 
 void plic_set_int_priority(int irq, u32 pri)
@@ -40,9 +55,9 @@ void plic_set_int_priority(int irq, u32 pri)
     write_plic_irq(PLIC_PRIORITY, irq, pri);
 }
 
-void plic_set_c1_threshold(u32 thresh)
+void plic_set_threshold(u64 hartid, u32 thresh)
 {
-    write_plic(PLIC_THRESH_C1, thresh);
+    write_plic(PLIC_THRESH(context_from_hartid(hartid)), thresh);
 }
 
 boolean plic_int_is_pending(int irq)
@@ -52,12 +67,12 @@ boolean plic_int_is_pending(int irq)
 
 u64 plic_dispatch_int(void)
 {
-    return read_plic(PLIC_CLAIM_C1);
+    return read_plic(PLIC_CLAIM(context_from_hartid(current_cpu()->m.hartid)));
 }
 
 void plic_eoi(int irq)
 {
-    write_plic(PLIC_CLAIM_C1, irq);
+    write_plic(PLIC_CLAIM(context_from_hartid(current_cpu()->m.hartid)), irq);
 }
 
 void init_plic()
@@ -68,6 +83,27 @@ void msi_format(u32 *address, u32 *data, int vector)
 {
 }
 
+static void send_ipi_internal(u64 cpu)
+{
+    /* get hartid for cpu */
+    cpuinfo target_ci = cpuinfo_from_id(cpu);
+    u64 hartid = target_ci->m.hartid;
+    // rewrite to actually use mask, adjust hbase; otherwise limited to 64 cpus
+    struct sbiret r = supervisor_ecall(SBI_EXT_IPI, SBI_EXT_IPI_SEND_IPI,
+                                       (1ull << hartid), 0, 0, 0, 0, 0);
+    assert(r.error == 0);
+}
+
 void send_ipi(u64 cpu, u8 vector)
 {
+    if (cpu == TARGET_EXCLUSIVE_BROADCAST) {
+        cpuinfo ci = current_cpu();
+        for (int i = 0; i < present_processors; i++) {
+            if (i == ci->id)
+                continue;
+            send_ipi_internal(i);
+        }
+    } else {
+        send_ipi_internal(cpu);
+    }
 }

--- a/src/riscv64/plic.h
+++ b/src/riscv64/plic.h
@@ -4,17 +4,23 @@
 #define PLIC_PCIE_INTS_START 0x20
 #define PLIC_PCIE_INTS_END 0x23
 
-#define PLIC_PRIORITY   0
-#define PLIC_PENDING    0x1000
-#define PLIC_ENABLE_C1  0x2080
-#define PLIC_THRESH_C1  0x201000
-#define PLIC_CLAIM_C1   0x201004
+#define PLIC_PRIORITY       0
+#define PLIC_PENDING        0x1000
+#define PLIC_ENABLE_BASE    0x2000
+#define PLIC_ENABLE_CTX_LEN 0x80
+#define PLIC_ENABLE(CTX)    (PLIC_ENABLE_BASE + PLIC_ENABLE_CTX_LEN * (CTX))
+#define PLIC_THRESH_BASE    0x200000
+#define PLIC_CLAIM_BASE     0x200004
+#define PLIC_THRESH_CTX_LEN 0x1000
+#define PLIC_CLAIM_CTX_LEN  0x1000
+#define PLIC_THRESH(CTX)    (PLIC_THRESH_BASE + PLIC_THRESH_CTX_LEN * (CTX))
+#define PLIC_CLAIM(CTX)     (PLIC_CLAIM_BASE + PLIC_CLAIM_CTX_LEN * (CTX))
 
 void plic_disable_int(int irq);
 void plic_enable_int(int irq);
 void plic_clear_pending_int(int irq);
 void plic_set_int_priority(int irq, u32 pri);
-void plic_set_c1_threshold(u32 thresh);
+void plic_set_threshold(u64 hartid, u32 thresh);
 void plic_set_int_config(int irq, u32 cfg);
 boolean plic_int_is_pending(int irq);
 u64 plic_dispatch_int(void);

--- a/src/runtime/symbol.c
+++ b/src/runtime/symbol.c
@@ -36,6 +36,24 @@ symbol intern_u64(u64 u)
     return intern(b);
 }
 
+static u64 s[2] = { 0xa5a5beefa5a5cafe, 0xbeef55aaface55aa };
+
+#ifndef ROL
+#define ROL(x, y) (((x) << y) | (x) >> (64 - (y)))
+#endif
+
+static u64 intern_hash_u64()
+{
+    u64 s0 = s[0];
+    u64 s1 = s[1];
+    u64 result = s0 + s1;
+
+    s1 ^= s0;
+    s[0] = ROL(s0, 55) ^ s1 ^ (s1 << 14); // a, b
+    s[1] = ROL(s1, 36); // c
+    return result;
+}
+
 symbol intern(string name)
 {
     symbol s;
@@ -49,7 +67,7 @@ symbol intern(string name)
         s = allocate(sheap, sizeof(struct symbol));
         if (s == INVALID_ADDRESS)
             goto alloc_fail;
-        s->k = random_u64();
+        s->k = intern_hash_u64();
         s->s = b;
         table_set(symbols, b, s);
     }

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -36,8 +36,8 @@ typedef struct timerqueue {
     thunk service;
     timestamp min;
     timestamp max;
-    boolean service_scheduled;  /* CAS */
-    boolean update;             /* CAS; timer re-programming needed */
+    u32 service_scheduled;  /* CAS */
+    u32 update;             /* CAS; timer re-programming needed */
     const char *name;
 } *timerqueue;
 

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -550,6 +550,8 @@ static void process_remove_range_locked(process p, range q, boolean unmap);
 
 void *process_map_physical(process p, u64 phys_addr, u64 size, u64 vmflags)
 {
+    vmap_debug("%s: phys_addr 0x%lx, size 0x%lx, vmflags 0x%lx\n",
+               __func__, phys_addr, size, vmflags);
     vmap_lock(p);
     u64 virt_addr = process_allocate_range_locked(p, size, ivmap(vmflags, 0, 0, 0),
                                                   PROCESS_VIRTUAL_MMAP_RANGE);

--- a/src/virtio/virtio_rng.c
+++ b/src/virtio/virtio_rng.c
@@ -35,7 +35,7 @@ struct virtio_rng {
     virtqueue requestq;
     struct entropy_buf ebufs[2];
     u8 ebuf_idx;
-    boolean initialized;
+    u32 initialized;
 } virtio_rng;
 
 /* no lock, single consumer thanks to rng mutex */
@@ -65,7 +65,7 @@ define_closure_function(1, 1, void, ebuf_fill_complete,
     bound(ebuf)->offset = 0;
     bound(ebuf)->len = len;
     bound(ebuf)->filling = false;
-    if (compare_and_swap_boolean(&virtio_rng.initialized, false, true)) {
+    if (compare_and_swap_32(&virtio_rng.initialized, false, true)) {
         random_reseed();
     }
 }


### PR DESCRIPTION
This introduces SMP support for the riscv-virt platform. The first two commits correct a bug in mutex_lock() and remove the symbol code's dependence on random_u64() (and thus the chacha mutex), respectively.