### PR TITLE
Tracing: add support for selectively enabling trace message types

### DIFF
--- a/klib/radar.c
+++ b/klib/radar.c
@@ -1,6 +1,5 @@
 #include <kernel.h>
 #include <http.h>
-#include <log.h>
 #include <lwip.h>
 #include <pagecache.h>
 #include <storage.h>

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -3,7 +3,6 @@
 #include <pagecache.h>
 #include <storage.h>
 #include <tfs.h>
-#include <log.h>
 #include <net.h>
 #include <symtab.h>
 #include <drivers/console.h>

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -11,6 +11,7 @@ void runloop_target(void) __attribute__((noreturn));
 
 #include <kernel_machine.h>
 
+#include <log.h>
 #ifdef CONFIG_TRACELOG
 #include <tracelog.h>
 #else

--- a/src/kernel/log.h
+++ b/src/kernel/log.h
@@ -1,3 +1,9 @@
+#define TRACE_OTHER         U64_FROM_BIT(0)
+#define TRACE_THREAD_RUN    U64_FROM_BIT(1)
+#define TRACE_PAGE_FAULT    U64_FROM_BIT(2)
+
+u64 trace_get_flags(value v);
+
 typedef struct klog_dump {
     u8 header[4];
     u64 boot_id;

--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -36,9 +36,9 @@ closure_function(5, 1, status, read_program_complete,
                  buffer, b)
 {
     tuple root = bound(root);
-    if (get(root, sym(trace))) {
+    if (trace_get_flags(get(root, sym(trace))) & TRACE_OTHER) {
         rprintf("read program complete: %p ", root);
-        rprintf("gitversion: %s ", gitversion);
+        rprintf("gitversion: %s\n", gitversion);
 
         /* XXX - disable this until we can be assured that print_root
            won't go haywire on a large manifest... */

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -278,7 +278,7 @@ static boolean get_static_ip6_config(tuple t, struct netif *n, const char *ifnam
 void init_network_iface(tuple root) {
     struct netif *n;
     struct netif *default_iface = 0;
-    boolean trace = get(root, sym(trace)) != 0;
+    boolean trace = !!(trace_get_flags(get(root, sym(trace))) & TRACE_OTHER);
 
     lwip_lock();
     /* NETIF_FOREACH traverses interfaces in reverse order...so go by index */

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -222,7 +222,7 @@ closure_function(1, 1, boolean, trace_notify,
                  process, p,
                  value, v)
 {
-    bound(p)->trace = !!v;      /* allow any value for true */
+    bound(p)->trace = trace_get_flags(v);
     return true;
 }
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -500,7 +500,7 @@ closure_function(7, 1, void, file_read_complete,
     if (is_ok(s)) {
         file f = bound(f);
         u64 count = sg_copy_to_buf_and_release(bound(dest), sg, bound(limit));
-        thread_log(bound(t), "   read count %ld\n", count);
+        thread_log(bound(t), "   read count %ld", count);
         if (bound(is_file_offset)) /* vs specified offset (pread) */
             f->offset += count;
         rv = count;

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -286,8 +286,8 @@ define_closure_function(1, 0, void, thread_return,
 
     context_frame f = t->context.frame;
     assert(f[FRAME_FULL]);
-    thread_log(t, "run thread, cpu %d, frame %p, pc 0x%lx, sp 0x%lx, rv 0x%lx",
-               current_cpu()->id, f, f[SYSCALL_FRAME_PC], f[SYSCALL_FRAME_SP], f[SYSCALL_FRAME_RETVAL1]);
+    thread_trace(t, TRACE_THREAD_RUN, "run thread, cpu %d, frame %p, pc 0x%lx, sp 0x%lx, rv 0x%lx",
+                 current_cpu()->id, f, f[SYSCALL_FRAME_PC], f[SYSCALL_FRAME_SP], f[SYSCALL_FRAME_RETVAL1]);
     ci->frcount++;
     clear_fault_handler();
     context_switch(&t->context);

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -1,7 +1,6 @@
 #include <unix_internal.h>
 #include <ftrace.h>
 #include <gdb.h>
-#include <log.h>
 #include <filesystem.h>
 #include <drivers/console.h>
 
@@ -10,7 +9,7 @@
 #define pf_debug(x, ...) do {tprintf(sym(fault), 0, "tid %02d " x "\n", \
                                      current ? current->tid : -1, ##__VA_ARGS__);} while(0)
 #else
-#define pf_debug(x, ...) thread_log(current, x, ##__VA_ARGS__);
+#define pf_debug(x, ...) thread_trace(current, TRACE_PAGE_FAULT, x, ##__VA_ARGS__);
 #endif
 
 #define MAX_PROCESSES 2

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -501,7 +501,7 @@ typedef struct process {
     vector            itimers;      /* unix_timer by ITIMER_ type */
     id_heap           aio_ids;
     vector            aio;
-    boolean           trace;
+    u8                trace;
     boolean           trap;         /* do not run threads when set */
     struct spinlock   lock; /* generic lock for struct members without a specific lock */
 } *process;
@@ -843,7 +843,12 @@ void truncate_file_maps(process p, fsfile f, u64 new_length);
 const char *string_from_mmap_type(int type);
 
 void thread_log_internal(thread t, const char *desc, ...);
-#define thread_log(__t, __desc, ...) do {if (!__t || !__t->p->trace) break; thread_log_internal(__t, __desc, ##__VA_ARGS__);} while (0)
+#define thread_trace(__t, __f, __desc, ...)                 \
+    do {                                                    \
+        if ((__t) && ((__t)->p->trace & (__f)))             \
+        thread_log_internal(__t, __desc, ##__VA_ARGS__);    \
+    } while (0)
+#define thread_log(__t, __desc, ...)    thread_trace(__t, TRACE_OTHER, __desc, ##__VA_ARGS__)
 
 void thread_sleep_interruptible(void) __attribute__((noreturn));
 void thread_sleep_uninterruptible(thread t) __attribute__((noreturn));


### PR DESCRIPTION
This change set adds support for specifying trace flags (i.e. a comma-delimited set of trace message types) in the "trace" symbol of the root tuple. A given trace message is output only if its message type is enabled in the trace flags. For backward
compatibility, any unknown trace flag results in the TRACE_OTHER bit being set, i.e. it enables all messages output via calls to thread_log(). Page-fault-related messages and messages output when returning to user threads are now classified in their own categories ("pf" and "threadrun", respectively), i.e. they need to be explicitly enabled in the trace flags.
If "all" is specified in the trace flags, all tracing messages are enabled.

Example: a "trace:pf,other" value in the manifest enables page-fault-related messages and messages classified as "other".