### PR TITLE
pagecache_commit_dirty_node(): fix setting of `committing` flag

### DIFF
--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -965,7 +965,7 @@ static void pagecache_commit_dirty_node(pagecache_node pn, status_handler comple
     boolean busy = pn->committing;
     if (busy)
         assert(enqueue(pn->dirty_commits, sh));
-    else
+    else if (b)
         pn->committing = true;
     pagecache_unlock_node(pn);
     if (!busy && sh)


### PR DESCRIPTION
If pagecache_commit_dirty_node() is called on a node whose `dirty` rangemap is empty and when no committing is ongoing, it is incorrectly setting the `committing` flag to true. This prevents any future calls to this function on a given node from invoking their completion closure, which may cause syscalls such as fsync and fdatasync to fail to return to userspace.
This cange fixes the above issue (introduced by commit 68a8a3ca75ae0d7c5eead414dca2de994c6c4d30).