### PR TITLE
pagecache_node_fetch_internal: reset sgb to 0 when submitting early

### DIFF
--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1099,6 +1099,7 @@ static void pagecache_node_fetch_internal(pagecache_node pn, range q, pp_handler
                 if (!success)
                     break;
                 read_sg = 0;
+                sgb = 0;
             }
         } else {
             /* This page needs to be fetched: add it to read_sg. */


### PR DESCRIPTION
When the pagecache fetches a range and builds up an sg list, if it encounters an already-filled page then it will submit the existing sg_list and use a new sg_list for the rest of the range that is not filled. If sgb is not also reset to 0 then a pointer to the earlier submitted sg_list could be used instead.