### PR TITLE
init_network_iface(): set default DNS server

### DIFF
--- a/src/net/net.c
+++ b/src/net/net.c
@@ -336,6 +336,11 @@ void init_network_iface(tuple root) {
 
     if (default_iface) {
         netif_set_default(default_iface);
+
+        /* Set a default DNS server for any kernel (or klib) code that may need to resolve host
+         * names. The DNS server can be overwritten via DHCP. */
+        ip_addr_t dns_server = IPADDR4_INIT_BYTES(1, 1, 1, 1);
+        dns_setserver(0, &dns_server);
     } else {
         rprintf("NET: no network interface found\n");
     }


### PR DESCRIPTION
Several klibs (cloud_init, cloudwatch, ntp, radar, syslog) may need to resolve host names. If DHCP is not being used (such as when network interfaces are statically configured), no DNS server is configured in lwIP, which prevents dns_gethostbyname() from working.
This change sets a default DNS server when initializing network interfaces, so that host names can be resolved even if DNS servers are not configured via DHCP.