### PR TITLE
Improve handling of empty timerqueues

### DIFF
--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -38,6 +38,7 @@ typedef struct timerqueue {
     timestamp max;
     u32 service_scheduled;  /* CAS */
     u32 update;             /* CAS; timer re-programming needed */
+    boolean empty;          /* indicating the queue is empty */
     const char *name;
 } *timerqueue;
 
@@ -121,9 +122,14 @@ static inline void timer_get_remaining(timer t, timestamp *remain, timestamp *in
 
 static inline void refresh_timer_update_locked(timerqueue tq, timer next)
 {
+    if (next == INVALID_ADDRESS) {
+        tq->empty = true;
+        return;
+    }
     timestamp n = timer_expiry(next);
     if (n != tq->next_expiry)
         tq->next_expiry = n;
+    tq->empty = false;
     tq->update = true;
 }
 


### PR DESCRIPTION
The timerqueue is used mainly for tracking timers in the kernel, which checks the next_expiry field to determine when to set the machine timer. There is, however, ambiguity in checking that field when the expiry timestamp is in the past and the timerqueue is not updated. This could mean either the timerqueue was serviced and there are no more timers in the queue and thus the next_expiry field is stale since it is not updated when there are no timers, or it can mean that the timer has fired and queued the timer service routine but it has not been executed or is executing on a different cpu. This ambiguity creates a bug when the timer interrupt hasn't run yet but the next_expiry is in the past and the scheduler assumes it is empty and resets the timer interrupt to fire much later, preventing the expired timer from being serviced at the appropriate time.
This change fixes that by adding a new 'empty' boolean to the timer queue that reflects the current state of the timerqueue. It gets modified only under the timerqueue lock, and can be checked safely outside of the lock in smp, unlike checking the underlying priorityqueue directly. The scheduler can check this variable to determine an empty timerqueue instead of using an expiry_timer value in the past.
This change also revealed a bug in the timerqueue code where it was incorrectly checking the end/empty of the underlying priorityqueue with a null value instead of with INVALID_ADDRESS.
Another small change is to read the current tsc in the runloop when checking if the timer is updated and then reusing that value later when calculatin the next timeout just before running the user thread.