### PR TITLE
Miscellaneous features and fixes for Nvidia GPU support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: copy build artifacts
           command: |
             shopt -s extglob
-            mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/platform/pc/boot/bootx64.efi temp/ && mkdir temp/klibs && cp output/klib/bin/!(test) temp/klibs
+            mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/platform/pc/boot/bootx64.efi temp/ && mkdir temp/klibs && cp output/klib/bin/!(test|*.dbg) temp/klibs
       - run: echo "export COMMIT_ID="`git rev-parse --short=7 HEAD` >> $BASH_ENV
       - run: cd temp && tar cvzf ../nanos-release-linux-${COMMIT_ID}.tar.gz *
       - run: gsutil cp nanos-release-linux-${COMMIT_ID}.tar.gz gs://nanos/release/${COMMIT_ID}/
@@ -84,7 +84,7 @@ jobs:
           name: copy build artifacts
           command: |
             shopt -s extglob
-            mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/platform/pc/boot/bootx64.efi temp/ && cp output/tools/bin/mkfs temp/ && cp output/tools/bin/dump temp/ && mkdir temp/klibs && cp output/klib/bin/!(test) temp/klibs
+            mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/platform/pc/boot/bootx64.efi temp/ && cp output/tools/bin/mkfs temp/ && cp output/tools/bin/dump temp/ && mkdir temp/klibs && cp output/klib/bin/!(test|*.dbg) temp/klibs
       - run: cd temp && tar cvzf nanos-nightly-linux.tar.gz * && gsutil cp nanos-nightly-linux.tar.gz gs://nanos/release/nightly
       - run: gsutil acl ch -u AllUsers:R gs://nanos/release/nightly/nanos-nightly-linux.tar.gz
       - run: rm -r temp
@@ -140,7 +140,7 @@ jobs:
           name: copy build artifacts
           command: |
             shopt -s extglob
-            mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/platform/pc/boot/bootx64.efi temp/ && cp output/tools/bin/mkfs temp/ && cp output/tools/bin/dump temp/ && mkdir temp/klibs && cp output/klib/bin/!(test) temp/klibs
+            mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/platform/pc/boot/bootx64.efi temp/ && cp output/tools/bin/mkfs temp/ && cp output/tools/bin/dump temp/ && mkdir temp/klibs && cp output/klib/bin/!(test|*.dbg) temp/klibs
       - run: cd temp && tar cvzf nanos-nightly-darwin.tar.gz * && gsutil cp nanos-nightly-darwin.tar.gz gs://nanos/release/nightly
       - run: gsutil acl ch -u AllUsers:R gs://nanos/release/nightly/nanos-nightly-darwin.tar.gz
       - run: rm -r temp
@@ -192,7 +192,7 @@ jobs:
           name: copy build artifacts
           command: |
             shopt -s extglob
-            mkdir temp && cp output/platform/virt/bin/kernel.img temp/ && cp output/platform/virt/boot/bootaa64.efi temp/ && cp output/tools/bin/mkfs temp/ && cp output/tools/bin/dump temp/ && mkdir temp/klibs && cp output/klib/bin/!(test) temp/klibs
+            mkdir temp && cp output/platform/virt/bin/kernel.img temp/ && cp output/platform/virt/boot/bootaa64.efi temp/ && cp output/tools/bin/mkfs temp/ && cp output/tools/bin/dump temp/ && mkdir temp/klibs && cp output/klib/bin/!(test|*.dbg) temp/klibs
       - run: cd temp && tar cvzf nanos-nightly-linux-virt.tar.gz * && gsutil cp nanos-nightly-linux-virt.tar.gz gs://nanos/release/nightly
       - run: gsutil acl ch -u AllUsers:R gs://nanos/release/nightly/nanos-nightly-linux-virt.tar.gz
       - run: rm -r temp

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -138,6 +138,9 @@ all: klib-syms $(ADDITIONAL_PROGRAMS)
 
 KLIB_SYMS= $(OBJDIR)/klib-syms.lds
 
+DEBUG_STRIP= y
+STRIPFLAGS= -g
+
 include ../rules.mk
 
 msg_add_syms=	KLIB_SYMS	$@

--- a/klib/tun.c
+++ b/klib/tun.c
@@ -3,6 +3,8 @@
 #include <lwip.h>
 #include <socket.h>
 
+#define TUN_MINOR   200
+
 /* ioctl requests */
 #define TUNSETIFF   0x400454ca
 #define TUNGETIFF   0x800454d2
@@ -441,7 +443,7 @@ int init(status_handler complete)
     spec_file_open open = closure(tun_heap, tun_open);
     if (open == INVALID_ADDRESS)
         return KLIB_INIT_FAILED;
-    if (create_special_file("/dev/net/tun", open, 0)) {
+    if (create_special_file("/dev/net/tun", open, 0, makedev(MISC_MAJOR, TUN_MINOR))) {
         return KLIB_INIT_OK;
     } else {
         deallocate_closure(open);

--- a/rules.mk
+++ b/rules.mk
@@ -235,17 +235,28 @@ DEPS-$1=	$$(patsubst %.o,%.d,$$(OBJS-$1))
 $1: $$(PROG-$1)
 
 ifneq ($$(OBJS-$1),)
+ifeq ($(DEBUG_STRIP),)
 $$(PROG-$1): $$(OBJS-$1)
 	@$(MKDIR) $$(dir $$@)
 	$$(call cmd,ld)
 ifeq ($1,kernel.elf)
 	$(call cmd,mvdis)
 endif
+else
+$$(PROG-$1).dbg: $$(OBJS-$1)
+	@$(MKDIR) $$(dir $$@)
+	$$(call cmd,ld)
+$$(PROG-$1): $$(PROG-$1).dbg
+	$$(call cmd,strip)
+endif
 endif
 
 DEPFILES+=	$$(DEPS-$1)
 GENHEADERS+=	$$(GENHEADERS-$1)
 CLEANFILES+=	$$(PROG-$1) $$(OBJS-$1) $$(DEPS-$1) $$(GENHEADERS-$1)
+ifneq ($(DEBUG_STRIP),)
+CLEANFILES+=	$$(PROG-$1).dbg
+endif
 CLEANDIRS+=	$(OBJDIR)/bin $(OBJDIR)/src $$(OBJDIRS-$1)
 endef
 

--- a/src/drivers/vga.c
+++ b/src/drivers/vga.c
@@ -175,7 +175,7 @@ closure_function(2, 1, boolean, vga_pci_probe,
                  heap, general, heap, virtual,
                  pci_dev, _d)
 {
-    if (pci_get_class(_d) != PCIC_DISPLAY)
+    if ((pci_get_class(_d) != PCIC_DISPLAY) || (pci_get_subclass(_d) != PCIS_VGA))
         return false;
 
     vga_debug("%s: VGA PCI\n", __func__);

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -210,7 +210,7 @@ void __attribute__((noreturn)) context_switch_finish(context prev, context next,
         cpuinfo ci = current_cpu();
         set_current_context(ci, next);
         context_release(prev);
-        if (!shutting_down && next->resume)
+        if (next->resume)
             next->resume(next);
     }
     ((void (*)(u64, u64))a)(arg0, arg1);

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -485,8 +485,6 @@ static inline void __attribute__((always_inline)) context_release(context ctx)
 static inline void __attribute__((always_inline)) context_pause(context ctx)
 {
     context_debug("%s: ctx %p\n", __func__, ctx);
-    if (shutting_down)
-        return;
     if (ctx->pause)
         ctx->pause(ctx);
 }
@@ -495,10 +493,9 @@ static inline void __attribute__((always_inline)) context_resume(context ctx)
 {
     context_debug("%s: ctx %p\n", __func__, ctx);
     cpuinfo ci = current_cpu();
-    if (!shutting_down)
-        context_acquire(ctx, ci);
+    context_acquire(ctx, ci);
     set_current_context(ci, ctx);
-    if (!shutting_down && ctx->resume)
+    if (ctx->resume)
         ctx->resume(ctx);
 }
 

--- a/src/kernel/mutex.h
+++ b/src/kernel/mutex.h
@@ -17,6 +17,7 @@ void mutex_lock(mutex ql);
 
 void mutex_unlock(mutex ql);
 
+#define mutex_is_locked(m)      ((m)->turn != 0)
 #define mutex_is_acquired(m)    ((m)->turn == get_current_context(current_cpu()))
 
 mutex allocate_mutex(heap h, u64 spin_iterations);

--- a/src/kernel/page.h
+++ b/src/kernel/page.h
@@ -45,6 +45,9 @@ static inline void update_map_flags(u64 vaddr, u64 length, pageflags flags)
     update_map_flags_with_complete(vaddr, length, flags, 0);
 }
 
+/* overwrite any existing mappings in the virtual address range */
+void remap(u64 v, physical p, u64 length, pageflags flags);
+
 void zero_mapped_pages(u64 vaddr, u64 length);
 void remap_pages(u64 vaddr_new, u64 vaddr_old, u64 length);
 void unmap(u64 virtual, u64 length);

--- a/src/kernel/pci.h
+++ b/src/kernel/pci.h
@@ -50,6 +50,9 @@
 #define PCIPI_STORAGE_NVME  0x02
 
 #define PCIC_DISPLAY 0x03
+#define PCIS_VGA        0x00
+#define PCIS_XGA        0x01
+#define PCIS_3D         0x02
 
 #define PCIC_BRIDGE 0x06
 #define PCIS_BRIDGE_PCI 0x04

--- a/src/kernel/pci.h
+++ b/src/kernel/pci.h
@@ -18,6 +18,7 @@
 /* PCI config register */
 #define PCIR_VENDOR     0x00
 #define PCIR_DEVICE     0x02
+#define PCIR_STATUS     0x06
 #define PCIR_REVID      0x08
 #define PCIR_PROG_IF    0x09
 #define PCIR_SUBCLASS   0x0a
@@ -37,6 +38,7 @@
 #define PCIR_MEMLIMIT1_2 0x28
 #define PCIR_IOBASEL_1  0x1c
 #define PCIR_IOLIMITL_1 0x1d
+#define PCIR_SUBS_VND   0x2c
 #define PCIR_SUBDEV_0   0x2e
 #define PCIR_IOBASEH_1  0x30
 #define PCIR_IOLIMITH_1 0x32
@@ -105,6 +107,11 @@ static inline u16 pci_get_subdevice(pci_dev dev)
     return pci_cfgread(dev, PCIR_SUBDEV_0, 2);
 }
 
+static inline u16 pci_get_subsystem_vendor(pci_dev dev)
+{
+    return pci_cfgread(dev, PCIR_SUBS_VND, 2);
+}
+
 static inline u8 pci_get_revid(pci_dev dev)
 {
     return pci_cfgread(dev, PCIR_REVID, 1);
@@ -170,6 +177,7 @@ u64 pci_bar_read_8(struct pci_bar *b, u64 offset);
 void pci_bar_write_8(struct pci_bar *b, u64 offset, u64 val);
 
 /* Capability Identification Numbers */
+#define PCIY_MSI    0x05
 #define PCIY_VENDOR 0x09
 #define PCIY_MSIX 0x11
 

--- a/src/net/net_system_structs.h
+++ b/src/net/net_system_structs.h
@@ -20,7 +20,8 @@
 enum protocol_type {
     SOCK_STREAM  = 1,    /* stream (connection) socket	*/
     SOCK_DGRAM   = 2,    /* datagram (conn.less) socket	*/
-    SOCK_RAW     = 3     /* raw socket			*/
+    SOCK_RAW     = 3,    /* raw socket			*/
+    SOCK_SEQPACKET = 5,
 };
 
 #define SOCK_TYPE_MASK	0xf

--- a/src/runtime/list.h
+++ b/src/runtime/list.h
@@ -27,6 +27,12 @@ static inline boolean list_empty(struct list * head)
     return (head->next == head);
 }
 
+/* a singular list is a list containing a single element */
+static inline boolean list_singular(struct list *head)
+{
+    return (head->next != head) && (head->next == head->prev);
+}
+
 /* XXX fix, this isn't used right */
 static inline struct list * list_get_next(struct list * head)
 {
@@ -64,6 +70,14 @@ static inline void list_insert_before(struct list * pos,
     new->next = pos;
     pos->prev->next = new;
     pos->prev = new;
+}
+
+static inline void list_replace(struct list *old, struct list *new)
+{
+    new->next = old->next;
+    new->next->prev = new;
+    new->prev = old->prev;
+    new->prev->next = new;
 }
 
 static inline struct list *list_begin(struct list *head)
@@ -104,9 +118,6 @@ static inline void list_move(struct list *dest, struct list *src)
         list_init(dest);
         return;
     }
-    dest->next = src->next;
-    dest->next->prev = dest;
-    dest->prev = src->prev;
-    dest->prev->next = dest;
+    list_replace(src, dest);
     list_init(src); /* make it an empty list */
 }

--- a/src/runtime/runtime_init.c
+++ b/src/runtime/runtime_init.c
@@ -123,6 +123,7 @@ void init_runtime(heap general, heap safe)
     register_format('p', format_pointer, 0);
     register_format('x', format_number, 1);
     register_format('d', format_number, 1);
+    register_format('u', format_number, 1);
     register_format('s', format_cstring, 0);
     register_format('b', format_buffer, 0);
     register_format('n', format_spaces, 0);

--- a/src/runtime/sg.h
+++ b/src/runtime/sg.h
@@ -63,6 +63,8 @@ static inline sg_buf sg_list_head_remove(sg_list sg)
     return sgb;
 }
 
+#define sg_list_length(sg)  (buffer_length((sg)->b) / sizeof(struct sg_buf))
+
 #define sg_list_foreach(sg, sgb) \
     for (sg_buf sgb = buffer_ref((sg)->b, 0); sgb != buffer_end((sg)->b); sgb++)
 

--- a/src/runtime/table.h
+++ b/src/runtime/table.h
@@ -29,6 +29,9 @@ void *table_find(table t, void *c);
 void table_set(table t, void *c, void *v);
 void table_clear(table t);
 
+/* Returns the value being removed if found, 0 otherwise. */
+void *table_remove(table t, void *c);
+
 #define eZ(x,y) ((entry) x)->y
 
 #define table_foreach(__t, __k, __v)\

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -172,6 +172,19 @@ void filesystem_set_mtime(filesystem fs, tuple t, timestamp tim)
     filesystem_set_time(fs, t, sym(mtime), tim);
 }
 
+u64 filesystem_get_rdev(filesystem fs, tuple t)
+{
+    u64 rdev = 0;
+    get_u64(t, sym(rdev), &rdev);
+    return rdev;
+}
+
+void filesystem_set_rdev(filesystem fs, tuple t, u64 rdev)
+{
+    value rdev_val = value_from_u64(fs->h, rdev);
+    set(t, sym(rdev), rdev_val);
+}
+
 void fixup_directory(tuple parent, tuple dir);
 
 closure_function(1, 2, boolean, fixup_directory_each,

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -2226,6 +2226,8 @@ int filesystem_resolve_cstring(filesystem *fs, tuple cwd, const char *f, tuple *
     int nbytes;
     int err;
 
+    if (*f == '\0') /* an empty path should result in FS_STATUS_NOENT */
+        t = 0;
     while ((y = *f)) {
         if (y == '/') {
             if (buffer_length(a)) {

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -1363,8 +1363,9 @@ closure_function(1, 2, boolean, file_unlink_each,
 /* Called with fs locked, returns with fs unlocked. */
 static void file_unlink(filesystem fs, tuple t)
 {
-    fsfile f = fsfile_from_node(fs, t);
-    table_set(fs->files, t, 0);
+    fsfile f = table_remove(fs->files, t);
+    if (f == INVALID_ADDRESS)   /* directory entry other than regular file */
+        f = 0;
     if (f) {
         f->md = 0;
     }

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -57,6 +57,9 @@ void filesystem_set_mtime(filesystem fs, tuple t, timestamp tim);
 #define filesystem_update_mtime(fs, t) \
     filesystem_set_mtime(fs, t, now(CLOCK_ID_REALTIME))
 
+u64 filesystem_get_rdev(filesystem fs, tuple t);
+void filesystem_set_rdev(filesystem fs, tuple t, u64 rdev);
+
 u64 fsfile_get_length(fsfile f);
 void fsfile_set_length(fsfile f, u64);
 u64 fsfile_get_blocks(fsfile f);    /* returns the number of allocated blocks */

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -43,7 +43,7 @@ static void build_exec_stack(process p, thread t, Elf64_Ehdr * e, void *start,
             get_aslr_offset(PROCESS_STACK_ASLR_RANGE);
 
     p->stack_map = allocate_vmap(p, irangel(stack_start, PROCESS_STACK_SIZE),
-                                 ivmap(VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE, 0, 0, 0));
+                                 ivmap(VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE, 0, 0, 0, 0));
     assert(p->stack_map != INVALID_ADDRESS);
 
     u64 * s = pointer_from_u64(stack_start);
@@ -188,7 +188,7 @@ closure_function(3, 4, u64, exec_elf_map,
     boolean is_bss = paddr == INVALID_PHYSICAL;
     exec_debug("%s: add to vmap: %R vmflags 0x%lx%s\n",
                __func__, r, vmflags, is_bss ? " bss" : "");
-    assert(allocate_vmap(bound(p), r, ivmap(vmflags, bound(allowed_flags), 0, 0)) !=
+    assert(allocate_vmap(bound(p), r, ivmap(vmflags, bound(allowed_flags), 0, 0, 0)) !=
            INVALID_ADDRESS);
     if (is_bss) {
         /* bss */
@@ -291,7 +291,7 @@ process exec_elf(buffer ex, process kp)
     proc->brk = pointer_from_u64(brk);
     proc->heap_base = brk;
     proc->heap_map = allocate_vmap(proc, irange(brk, brk),
-                                   ivmap(VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE, 0, 0, 0));
+                                   ivmap(VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE, 0, 0, 0, 0));
     assert(proc->heap_map != INVALID_ADDRESS);
     exec_debug("entry %p, brk %p (offset 0x%lx)\n", entry, proc->brk, brk_offset);
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1478,12 +1478,14 @@ static void fill_stat(int type, filesystem fs, fsfile f, tuple n, struct stat *s
         s->st_mode = S_IFDIR | 0777;
         break;
     case FDESC_TYPE_STDIO:
+        s->st_mode = S_IFCHR;
         /* Describing stdout as a pseudo-tty makes glibc apply line buffering (instead of full
          * buffering) when the process writes to stdout. */
         s->st_rdev = makedev(UNIX98_PTY_SLAVE_MAJOR, 0);
-        /* fall through */
+        break;
     case FDESC_TYPE_SPECIAL:
         s->st_mode = S_IFCHR;   /* assuming only character devs now */
+        s->st_rdev = filesystem_get_rdev(fs, n);
         break;
     case FDESC_TYPE_SOCKET:
         s->st_mode = S_IFSOCK;

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -17,6 +17,9 @@
 #define MISC_MAJOR              10
 #define UNIX98_PTY_SLAVE_MAJOR  136
 
+#define MAJOR(rdev)   ((((rdev) & 0xfff00) >> 8) | ((rdev) >> 32))
+#define MINOR(rdev)   (((rdev) & 0xff) | (((rdev) & 0xfff00000) >> 12))
+
 #define makedev(major, minor)   (((minor) & 0xff) | (((major) & 0xfff) << 8) |  \
     ((u64)((minor) & ~0xff) << 12) | ((u64)((major) & ~0xfff) << 32))
 
@@ -72,7 +75,9 @@ typedef struct iovec {
 #define ELOOP           40              /* Too many symbolic links */
 #define ENOPROTOOPT     42              /* Protocol not available */
 
+#define ENODATA         61		/* No data available */
 #define ETIME           62		/* Timer expired */
+#define EOVERFLOW       75		/* Value too large for defined data type */
 #define EBADFD          77		/* File descriptor in bad state */
 #define EDESTADDRREQ    89		/* Destination address required */
 #define EMSGSIZE        90		/* Message too long */
@@ -137,6 +142,13 @@ struct flock {
 #define F_RDLCK         0
 #define F_WRLCK         1
 #define F_UNLCK         2
+
+#define IOC_NR(req)     ((req) & 0x000000ff)
+#define IOC_TYPE(req)   (((req) & 0x0000ff00) >> 8)
+#define IOC_SIZE(req)   (((req) & 0x3fff0000) >> 16)
+
+#define IOC_READ    0x80000000
+#define IOC_WRITE   0x40000000
 
 #define FIONREAD        0x541b
 #define FIONBIO         0x5421

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -14,6 +14,7 @@
 #define S_ISGID  0002000
 #define S_ISVTX  0001000
 
+#define MISC_MAJOR              10
 #define UNIX98_PTY_SLAVE_MAJOR  136
 
 #define makedev(major, minor)   (((minor) & 0xff) | (((major) & 0xfff) << 8) |  \

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -74,18 +74,10 @@ define_closure_function(1, 2, void, fdesc_io_complete,
 
 void init_fdesc(heap h, fdesc f, int type)
 {
-    f->read = 0;
-    f->write = 0;
-    f->sg_read = 0;
-    f->sg_write = 0;
-    f->close = 0;
-    f->events = 0;
-    f->edge_trigger_handler = 0;
+    zero(f, sizeof(*f));
     init_closure(&f->io_complete, fdesc_io_complete, f);
-    f->ioctl = 0;
     f->refcnt = 1;
     f->type = type;
-    f->flags = 0;
     f->ns = allocate_notify_set(h);
     spin_lock_init(&f->lock);
 }
@@ -136,7 +128,7 @@ const char *string_from_mmap_type(int type)
 {
     return type == VMAP_MMAP_TYPE_ANONYMOUS ? "anonymous" :
         (type == VMAP_MMAP_TYPE_FILEBACKED ? "filebacked" :
-         (type == VMAP_MMAP_TYPE_IORING ? "io_uring" : "unknown"));
+         "unknown");
 }
 
 #define format_protection_violation(vaddr, ctx, vm, str)        \

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -990,7 +990,7 @@ int do_eventfd2(unsigned int count, int flags);
 typedef closure_type(spec_file_open, sysreturn, file f);
 
 void register_special_files(process p);
-boolean create_special_file(const char *path, spec_file_open open, u64 size);
+boolean create_special_file(const char *path, spec_file_open open, u64 size, u64 rdev);
 sysreturn spec_open(file f, tuple t);
 file spec_allocate(tuple t);
 void spec_deallocate(file f);

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -207,6 +207,9 @@ extern void write_xmsr(u64, u64);
 #define mov_to_cr(__x, __y) asm volatile("mov %0,%%"__x : : "a"(__y) : "memory");
 #define mov_from_cr(__x, __y) asm volatile("mov %%"__x", %0" : "=a"(__y) : : "memory");
 
+/* CPUID level 1 (EDX) */
+#define CPUID_PAT   (1 << 16)
+
 /* CPUID level 7 (EBX) */
 #define CPUID_FSGSBASE  (1 << 0)
 

--- a/test/runtime/thread_test.c
+++ b/test/runtime/thread_test.c
@@ -118,7 +118,7 @@ void *terminus(void *k)
          * pthread_exit() to abort the program when this thread is interrupted in the middle of
          * exit() and another thread calls pthread_exit(). As a workaround, sleep before calling
          * exit(), so that the other threads have a chance to run (and terminate cleanly). */
-        usleep(1);
+        usleep(8);
 
         exit(0);
     }

--- a/test/runtime/unlink.c
+++ b/test/runtime/unlink.c
@@ -101,6 +101,11 @@ int main(int argc, char **argv)
     int fd;
     struct stat s;
 
+    if ((unlink("") != -1) || (errno != ENOENT)) {
+        printf("empty path unlink test failed\n");
+        exit(EXIT_FAILURE);
+    }
+
     test_unlink("/file");
 
     if (mkdir("/dir", 0) < 0) {

--- a/test/unit/table_test.c
+++ b/test/unit/table_test.c
@@ -22,6 +22,7 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
     u64 heap_occupancy = heap_allocated(h);
     table t = allocate_table(h, key_function, pointer_equal);
     u64 count;
+    u64 val;
 
     table_validate(t, "basic_table_tests: alloc");
 
@@ -98,8 +99,21 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
         return false;
     }
 
+    val = u64_from_pointer(table_remove(t, (pointer_from_u64(1))));
+    if (val != 2) {
+        msg_err("invalid element %ld removed, should be 2\n", val);
+        return false;
+    }
+    table_validate(t, "basic_table_tests: after table_remove()");
+    count = table_elements(t);
+    if (count != n_elem - 2) {
+        msg_err("invalid table_elements() %ld after table_remove(), should be %ld\n",
+                count, n_elem - 2);
+        return false;
+    }
+
     /* Remove the rest: first forward (skimming off top of each bucket) */
-    for (count = 1; count < (n_elem / 2); count++)
+    for (count = 2; count < (n_elem / 2); count++)
         table_set(t, (void *)count, 0);
 
     table_validate(t, "basic_table_tests: after remove forward");


### PR DESCRIPTION
This PR contains a set of new features and fixes that are needed in order to run the out-of-tree Nvidia GPU klib (https://github.com/nanovms/gpu-nvidia):
- stripping of debug information from klib binaries
- support for associating a major and minor number to Unix special files
- fix to prevent VGA console driver from attaching to non-VGA PCI display devices
- fix to context pause/resume functions to prevent assertion failures when kernel threads are run during kernel shutdown
- support for file-descriptor-specific mmap() implementations
- support for SOCK_SEQPACKET Unix domain sockets
- addition of table_remove() function
- fix to handling of empty file paths in syscalls such as unlink(2)