### PR TITLE
Print out list of loaded klibs on panic or assert fail

### DIFF
--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -52,6 +52,8 @@ void print_frame_trace(u64 *fp)
         print_u64_with_sym(*rap);
         rputs("\n");
     }
+
+    print_loaded_klibs();
 }
 
 void print_frame_trace_from_here(void)

--- a/src/kernel/klib.h
+++ b/src/kernel/klib.h
@@ -1,6 +1,5 @@
 /* in-kernel loadable library interface */
 #include "../klib/klib.h"
-#define KLIB_MAX_NAME 16
 
 typedef struct klib_mapping {
     struct rmnode n; /* virtual */
@@ -11,7 +10,7 @@ typedef struct klib_mapping {
 typedef int (*klib_init)(status_handler complete);
 
 typedef struct klib {
-    char name[KLIB_MAX_NAME];
+    buffer name;
     range load_range;
     rangemap mappings;
     buffer elf;
@@ -20,9 +19,11 @@ typedef struct klib {
 
 typedef closure_type(klib_handler, void, klib, int);
 
-void load_klib(const char *name, klib_handler complete, status_handler sh);
+void load_klib(buffer name, klib_handler complete, status_handler sh);
 
 /* The caller must assure no references to klib remain before unloading. */
 void unload_klib(klib kl);
 
 void init_klib(kernel_heaps kh, void *fs, tuple root, status_handler complete);
+
+void print_loaded_klibs(void);


### PR DESCRIPTION
When analyzing backtraces it can be useful to know if and where any klibs are loaded. This change adds a new call to print out a list of the loaded klib information including name, load address, and load size. This print will occur when frame_trace is called since it can be useful to know when looking at frame trace addresses and ensures it is printed out for common failures like panics or assertion failures.