### PR TITLE
Update frequency adjust check in now()

### DIFF
--- a/src/runtime/clock.h
+++ b/src/runtime/clock.h
@@ -75,8 +75,12 @@ static inline timestamp now(clock_id id)
             return t;
         s64 last_raw = __vdso_dat->last_raw;
         s64 interval = t - last_raw;
-        t += clock_freq_adjust(interval);
         assert(t >= last_raw);
+        t += clock_freq_adjust(interval);
+        if (t < last_raw) {
+            msg_err("t(%T) < last_raw(%T) after freq adjust (%f)\n", t, last_raw, __vdso_dat->base_freq);
+            t = last_raw;
+        }
         switch (id) {
         case CLOCK_ID_REALTIME:
         case CLOCK_ID_REALTIME_COARSE:


### PR DESCRIPTION
The now() function asserted that the frequency-adjusted timestamp is newer than the last_raw value as a guarantee that time does not go backwards. This change modifies the check to only assert the unmodified timestamp is greater or equal to the last_raw value and instead modifies the frequency-adjusted timestamp to last_raw if the calculation results in a older timestamp.