### PR TITLE
Unix timers: add support for process and thread CPU time

### DIFF
--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -262,7 +262,7 @@ closure_function(0, 0, void, global_shutdown)
 void init_scheduler(heap h)
 {
     /* timer init */
-    kernel_timers = allocate_timerqueue(h, "runloop");
+    kernel_timers = allocate_timerqueue(h, 0, "runloop");
     assert(kernel_timers != INVALID_ADDRESS);
     kernel_timers->min = microseconds(RUNLOOP_TIMER_MIN_PERIOD_US);
     kernel_timers->max = microseconds(RUNLOOP_TIMER_MAX_PERIOD_US);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -216,6 +216,7 @@ static void thread_cputime_update(thread t)
         t->utime += diff;
         t->task.runtime = diff;
         t->start_time = 0;
+        cputime_update(t, diff, true);
     }
 }
 


### PR DESCRIPTION
This changeset adds support for CLOCK_PROCESS_CPUTIME_ID and CLOCK_THREAD_CPUTIME_ID to the Unix timers created via the timer_create syscall; in addition, ITIMER_PROF is now supported by the getitimer and setitimer syscalls.
The timerqueue code has been enhanced so that it can be used with clock types (such as process and thread CPU time) that are not derived from the monotonic system clock. The Unix process struct now has its own timerqueue, which handles timers that track the total CPU time spent by a process. Analogously, the thread struct has a timerqueue that handles timers tracking CPU time spent by a single thread (the thread timerqueue is only instantiated if/when a timer that requires it is created).
The Unix timer code uses the appropriate timerqueue based on the type of clock used by a given timer.
Process and thread timerqueues are serviced when the CPU time spent by a thread is updated; this means that a timer based on a thread CPU time may fire with a delay up to RUNLOOP_TIMER_MAX_PERIOD_US microseconds (assuming execution of a syscall does not take longer than that), and a timer based on the process CPU time may fire with a delay up to RUNLOOP_TIMER_MAX_PERIOD_US * NCPU) microseconds, where NCPU is the number of vCPUs of the VM.
The timer runtime test has been amended to exercise the newly supported timers.

The second commit fixes an issue in the calculation of the total CPU time spent by a process.
The first commit fixes a bug that has been exposed by the second commit.

Closes #1787