### PR TITLE
Add ltrace functionality

### DIFF
--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -34,6 +34,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/kernel/linear_backed_heap.c \
 	$(SRCDIR)/kernel/locking_heap.c \
 	$(SRCDIR)/kernel/log.c \
+	$(SRCDIR)/kernel/ltrace.c \
 	$(SRCDIR)/kernel/mutex.c \
 	$(SRCDIR)/kernel/page.c \
 	$(SRCDIR)/kernel/page_backed_heap.c \
@@ -178,6 +179,7 @@ AFLAGS+=-I$(ARCHDIR)/
 
 CFLAGS+=$(KERNCFLAGS) -DKERNEL -O3 -fno-pic -mcmodel=kernel
 CFLAGS+=-Wno-address # lwIP build sadness
+CFLAGS+=-DCONFIG_LTRACE
 CFLAGS+=$(INCLUDES)
 
 # Enable tracing by specifying TRACE=ftrace on command line

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -45,6 +45,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/kernel/linear_backed_heap.c \
 	$(SRCDIR)/kernel/locking_heap.c \
 	$(SRCDIR)/kernel/log.c \
+	$(SRCDIR)/kernel/ltrace.c \
 	$(SRCDIR)/kernel/mutex.c \
 	$(SRCDIR)/kernel/page.c \
 	$(SRCDIR)/kernel/page_backed_heap.c \
@@ -156,6 +157,7 @@ AFLAGS+=-I$(ARCHDIR)
 
 CFLAGS+=$(KERNCFLAGS) -DKERNEL -DSMP_ENABLE -O3 -march=armv8-a+nofp+nosimd -mcpu=cortex-a72 -ffixed-x18 -fno-pic
 CFLAGS+=-Wno-address # lwIP build sadness
+CFLAGS+=-DCONFIG_LTRACE
 CFLAGS+=$(INCLUDES)
 
 # Enable tracing by specifying TRACE=ftrace on command line

--- a/src/aarch64/elf64.c
+++ b/src/aarch64/elf64.c
@@ -18,10 +18,10 @@ void elf_apply_relocate_add(buffer elf, Elf64_Shdr *s, u64 offset)
     }
 }
 
-boolean elf_apply_relocate_syms(buffer elf, Elf64_Shdr *s, elf_sym_relocator relocator)
+boolean elf_apply_relocate_syms(buffer elf, Elf64_Rela *rel, int relcount,
+                                elf_sym_relocator relocator)
 {
-    Elf64_Rela *rel = buffer_ref(elf, s->sh_addr);
-    for (int i = 0; i < s->sh_size / sizeof(*rel); i++) {
+    for (int i = 0; i < relcount; i++) {
         switch (ELF64_R_TYPE(rel[i].r_info)) {
         case R_AARCH64_GLOB_DAT:
         case R_AARCH64_JUMP_SLOT:

--- a/src/aarch64/gdb_machine.h
+++ b/src/aarch64/gdb_machine.h
@@ -4,14 +4,6 @@ static inline int computeSignal (context_frame c)
     return 0;
 }
 
-static inline void clear_thread_stepping(thread t)
-{
-}
-
-static inline void set_thread_stepping(thread t)
-{
-}
-
 static inline int get_register(u64 num, void *buf, context_frame c)
 {
     return -1;

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -45,6 +45,7 @@
 #define ESR_EC_DATA_ABRT      0x25
 #define ESR_EC_SP_ALIGN_FAULT 0x26
 #define ESR_EC_SERROR_INT     0x2f
+#define ESR_EC_SS             0x32
 #define ESR_EC_BRK            0x3c
 
 #define ESR_IL        U64_FROM_BIT(25)
@@ -351,6 +352,13 @@ static inline boolean is_breakpoint(context_frame f)
     return false;
 }
 
+static inline boolean is_trap(context_frame f)
+{
+    u64 esr = esr_from_frame(f);
+    u32 ec = field_from_u64(esr, ESR_EC);
+    return (ec == ESR_EC_SS) || (ec == ESR_EC_BRK);
+}
+
 static inline boolean is_illegal_instruction(context_frame f)
 {
     u64 esr = esr_from_frame(f);
@@ -403,6 +411,11 @@ static inline void frame_set_stack_top(context_frame f, void *st)
 static inline void frame_reset_stack(context_frame f)
 {
     f[FRAME_SP] = f[FRAME_STACK_TOP];
+}
+
+static inline void frame_set_insn_ptr(context_frame f, u64 ip)
+{
+    f[FRAME_ELR] = ip;
 }
 
 static inline void frame_enable_stepping(context_frame f)

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -158,7 +158,10 @@
 #define SCTLR_EL1_M       U64_FROM_BIT(0) /* MMU enable */
 
 #define SPSR_I U64_FROM_BIT(7)
+#define SPSR_SS  U64_FROM_BIT(21)
 #define SPSR_TCO U64_FROM_BIT(25)
+
+#define MDSCR_EL1_SS    U64_FROM_BIT(0)     /* software step enable */
 
 #ifndef __ASSEMBLY__
 /* interrupt control */
@@ -400,6 +403,17 @@ static inline void frame_set_stack_top(context_frame f, void *st)
 static inline void frame_reset_stack(context_frame f)
 {
     f[FRAME_SP] = f[FRAME_STACK_TOP];
+}
+
+static inline void frame_enable_stepping(context_frame f)
+{
+    f[FRAME_ESR_SPSR] |= SPSR_SS;
+    write_psr(MDSCR_EL1, read_psr(MDSCR_EL1) | MDSCR_EL1_SS);
+}
+
+static inline void frame_disable_stepping(context_frame f)
+{
+    write_psr(MDSCR_EL1, read_psr(MDSCR_EL1) & ~MDSCR_EL1_SS);
 }
 
 static inline boolean validate_frame_ptr(u64 *fp)

--- a/src/gdb/gdbstub.c
+++ b/src/gdb/gdbstub.c
@@ -10,6 +10,16 @@
 
 static int sigval;
 
+static inline void clear_thread_stepping(thread t)
+{
+    frame_disable_stepping(thread_frame(t));
+}
+
+static inline void set_thread_stepping(thread t)
+{
+    frame_enable_stepping(thread_frame(t));
+}
+
 static void reset_parser(gdb g)
 {
     g->checksum =0;

--- a/src/kernel/elf64.h
+++ b/src/kernel/elf64.h
@@ -249,6 +249,8 @@ typedef closure_type(elf_loader, void, u64 /* offset */, u64 /* length */, void 
 typedef closure_type(elf_sym_handler, void, char *, u64, u64, u8);
 typedef closure_type(elf_sym_resolver, void *, const char *);
 void elf_symbols(buffer elf, elf_sym_handler each);
+boolean elf_dyn_parse(buffer elf, Elf64_Shdr **symtab, Elf64_Shdr **strtab, Elf64_Rela **reltab,
+                      int *relcount);
 boolean elf_dyn_link(buffer elf, void *load_addr, elf_sym_resolver resolver);
 void walk_elf(buffer elf, range_handler rh);
 void *load_elf(buffer elf, u64 load_offset, elf_map_handler mapper);
@@ -257,7 +259,8 @@ void load_elf_to_physical(heap h, elf_loader loader, u64 *entry, status_handler 
 /* Architecture-specific */
 typedef closure_type(elf_sym_relocator, boolean, Elf64_Rela *);
 void elf_apply_relocate_add(buffer elf, Elf64_Shdr *s, u64 offset);
-boolean elf_apply_relocate_syms(buffer elf, Elf64_Shdr *s, elf_sym_relocator relocator);
+boolean elf_apply_relocate_syms(buffer elf, Elf64_Rela *reltab, int relcount,
+                                elf_sym_relocator relocator);
 
 static inline void elf_apply_relocs(buffer elf, u64 offset)
 {

--- a/src/kernel/elf64.h
+++ b/src/kernel/elf64.h
@@ -228,10 +228,12 @@ typedef struct {
 #define DT_RELAENT  9
 #define DT_JMPREL   23
 
+#define SHT_PROGBITS 1
 #define SHT_SYMTAB 2/* symbol table section */
 #define SHT_STRTAB 3/* string table section */
 #define SHT_RELA   4
 #define SHT_DYNAMIC 6
+#define SHT_NOBITS  8
 #define SHT_DYNSYM  11
 
 #define foreach_phdr(__e, __p)\
@@ -248,10 +250,12 @@ typedef closure_type(elf_loader, void, u64 /* offset */, u64 /* length */, void 
                      status_handler);
 typedef closure_type(elf_sym_handler, void, char *, u64, u64, u8);
 typedef closure_type(elf_sym_resolver, void *, const char *);
+char *elf_string(buffer elf, Elf64_Shdr *string_section, u64 offset);
 void elf_symbols(buffer elf, elf_sym_handler each);
 boolean elf_dyn_parse(buffer elf, Elf64_Shdr **symtab, Elf64_Shdr **strtab, Elf64_Rela **reltab,
                       int *relcount);
 boolean elf_dyn_link(buffer elf, void *load_addr, elf_sym_resolver resolver);
+boolean elf_plt_get(buffer elf, u64 *addr, u64 *offset, u64 *size);
 void walk_elf(buffer elf, range_handler rh);
 void *load_elf(buffer elf, u64 load_offset, elf_map_handler mapper);
 void load_elf_to_physical(heap h, elf_loader loader, u64 *entry, status_handler sh);

--- a/src/kernel/ltrace.c
+++ b/src/kernel/ltrace.c
@@ -1,0 +1,220 @@
+#include <kernel.h>
+#include <elf64.h>
+#include <ltrace.h>
+
+#define PLT_ENTRY_SIZE_DEFAULT  16
+
+#ifdef LTRACE_DEBUG
+#define ltrace_debug(x, ...) do {rprintf("ltrace: " x "\n", ##__VA_ARGS__);} while(0)
+#else
+#define ltrace_debug(x, ...)
+#endif
+
+#if defined(__x86_64__)
+
+static const u8 swbkp_insn[] = {0xcc};
+
+#define LTRACE_SWBKP_ADDR(f)    (frame_fault_pc(f) - sizeof(swbkp_insn))
+
+static boolean ltrace_plt_parse(void *plt_entry, u64 addr, u64 *entry_size, u64 *sym_offset)
+{
+    const u8 jmpq[] = {0xff, 0x25};
+    const u8 endbr64[] = {0xf3, 0x0f, 0x1e, 0xfa};
+    const u8 bndjmp[] = {0xf2, 0xff, 0x25};
+    const u8 pushq = 0x68;
+    if (!runtime_memcmp(plt_entry, jmpq, sizeof(jmpq))) {
+        /* first instruction: jmpq *0x11223344(%rip) */
+        *sym_offset = *(s32 *)(plt_entry + 2) + addr + 6;
+        /* if the second instruction is pushq, than this entry is used for lazy binding */
+        *entry_size = (*(u8 *)(plt_entry + 6) == pushq) ? 16 : 8;
+    } else if (!runtime_memcmp(plt_entry, endbr64, sizeof(endbr64)) &&
+               !runtime_memcmp(plt_entry + 4, bndjmp, sizeof(bndjmp))) {
+        /* first instruction: endbr64 */
+        /* second instruction: bnd jmp *0x11223344(%rip) */
+        *sym_offset = *(s32 *)(plt_entry + 7) + addr + 11;
+        *entry_size = 16;
+    } else {
+        return false;
+    }
+    return true;
+}
+
+#elif defined(__aarch64__)
+
+static const u8 swbkp_insn[] = {0x00, 0x00, 0x20, 0xd4};
+
+#define LTRACE_SWBKP_ADDR(f)    frame_fault_pc(f)
+
+static boolean ltrace_plt_parse(void *plt_entry, u64 addr, u64 *entry_size, u64 *sym_offset)
+{
+    u32 insn1 = *(u32*)plt_entry;
+    u32 insn2 = *(u32*)(plt_entry + 4);
+    if (((insn1 & 0x9f000000) == 0x90000000) && ((insn2 & 0xffc00000) == 0xf9400000)) {
+        /* first instruction: adrp xyy, 0x11223344 */
+        /* second instruction: ldr xzz, [xyy, #1234] */
+        s64 addr_offset = ((insn1 & 0x007fffe0) >> 3) | ((insn1 & 0x60000000) >> 29);
+        addr_offset <<= 12;
+        if (insn1 & 0x00100000)
+            addr_offset = -addr_offset;
+        addr_offset += (insn2 & 0x003ffc00) >> 7;
+        *sym_offset = (addr & 0xfffffffffffff000) + addr_offset;
+        *entry_size = 16;
+    } else {
+        return false;
+    }
+    return true;
+}
+
+#else
+
+#error "ltrace not implemented for this architecture"
+
+#endif
+
+static u64 ltrace_get_sym(Elf64_Rela *reltab, int relcount, u64 sym_offset, u64 *rel_index)
+{
+    for (u64 i = *rel_index + 1; i != *rel_index; i++) {
+        if (i >= relcount)
+            i = 0;
+        if (reltab[i].r_offset == sym_offset) {
+            *rel_index = i;
+            return ELF64_R_SYM(reltab[i].r_info);
+        }
+    }
+    return -1ull;
+}
+
+typedef struct ltrace_brkpt {
+    struct rbnode n;    /* must be first */
+    void *plt_entry;
+    u64 addr;   /* userspace instruction pointer */
+    u8 insn[sizeof(swbkp_insn)];
+    const char *sym_name;
+} *ltrace_brkpt;
+
+declare_closure_struct(0, 2, int, ltrace_brkpt_compare,
+                       rbnode, a, rbnode, b);
+struct ltrace {
+    rbtree plt_map; /* maps PLT entries to breakpoints */
+    closure_struct(ltrace_brkpt_compare, brkpt_compare);
+    table ctx_map;  /* maps single-stepping context frames to breakpoints */
+    struct spinlock lock;
+};
+
+static struct ltrace *ltrace;
+
+define_closure_function(0, 2, int, ltrace_brkpt_compare,
+                        rbnode, a, rbnode, b)
+{
+    ltrace_brkpt ba = (ltrace_brkpt)a;
+    ltrace_brkpt bb = (ltrace_brkpt)b;
+    return ba->addr == bb->addr ? 0 : (ba->addr < bb->addr ? -1 : 1);
+}
+
+void ltrace_init(value cfg, buffer exe, u64 load_offset)
+{
+    Elf64_Shdr *symtab, *strtab;
+    Elf64_Rela *reltab;
+    int relcount;
+    if (!elf_dyn_parse(exe, &symtab, &strtab, &reltab, &relcount))
+        halt("ltrace: failed to parse dynamic section\n");
+    if (!symtab || !strtab || !reltab) {
+        rprintf("ltrace: not a dynamically linked executable\n");
+        return;
+    }
+    u64 plt_addr, plt_offset, plt_size;
+    if (!elf_plt_get(exe, &plt_addr, &plt_offset, &plt_size)) {
+        halt("ltrace: failed to get PLT\n");
+        return;
+    }
+    Elf64_Sym *syms = buffer_ref(exe, symtab->sh_offset);
+    u64 sym_count = symtab->sh_size / symtab->sh_entsize;
+    heap h = heap_locked(get_kernel_heaps());
+    ltrace = allocate(h, sizeof(*ltrace));
+    assert(ltrace != INVALID_ADDRESS);
+    ltrace->plt_map = allocate_rbtree(h, init_closure(&ltrace->brkpt_compare, ltrace_brkpt_compare), 0);
+    assert(ltrace->plt_map != INVALID_ADDRESS);
+    ltrace->ctx_map = allocate_table(h, identity_key, pointer_equal);
+    assert(ltrace->ctx_map != INVALID_ADDRESS);
+    spin_lock_init(&ltrace->lock);
+
+    /* For each PLT entry, retrieve the offset of the corresponding symbol, then retrieve the symbol
+     * index from the relocation table; then, replace the first instruction in the PLT entry with a
+     * breakpoint instruction. */
+    void *plt_base = buffer_ref(exe, plt_offset);
+    u64 plt_entry_size;
+    u64 rel_index = relcount;
+    for (void *plt_entry = plt_base; plt_entry < plt_base + plt_size;
+         plt_entry += plt_entry_size, plt_addr += plt_entry_size) {
+        u64 sym_offset;
+        if (!ltrace_plt_parse(plt_entry, plt_addr, &plt_entry_size, &sym_offset)) {
+            ltrace_debug("skipping PLT entry at 0x%lx", plt_addr);
+            plt_entry_size = PLT_ENTRY_SIZE_DEFAULT;
+            continue;
+        }
+        u64 sym_index = ltrace_get_sym(reltab, relcount, sym_offset, &rel_index);
+        if (sym_index >= sym_count) {
+            ltrace_debug("PLT entry at 0x%lx: cannot find symbol at 0x%lx", plt_addr, sym_offset);
+            continue;
+        }
+        ltrace_brkpt brkpt = allocate(h, sizeof(*brkpt));
+        assert(brkpt != INVALID_ADDRESS);
+        brkpt->plt_entry = plt_entry;
+        brkpt->addr = plt_addr + load_offset;
+        runtime_memcpy(brkpt->insn, plt_entry, sizeof(swbkp_insn));
+        runtime_memcpy(plt_entry, swbkp_insn, sizeof(swbkp_insn));
+        brkpt->sym_name = elf_string(exe, strtab, syms[sym_index].st_name);
+        if (!brkpt->sym_name)
+            halt("ltrace: no name for symbol 0x%lx\n", sym_index);
+        ltrace_debug("PLT entry at 0x%lx: relocation 0x%lx, symbol 0x%lx at 0x%lx (%s)", plt_addr,
+                     rel_index, sym_index, sym_offset, brkpt->sym_name);
+        init_rbnode(&brkpt->n);
+        rbtree_insert_node(ltrace->plt_map, &brkpt->n);
+    }
+}
+
+/* This function is called after either hitting a breakpoint, or executing a single-stepped
+ * instruction.
+ * Note: replacing instructions with breakpoints and vice versa is not multi-thread-safe: if
+ * different threads call the same dynamic library function at the same time, it can happen that a
+ * function call is not logged, or is logged more than once, or even that invalid instructions are
+ * executed; but this can (and does) happen also with the Linux ltrace tool.  */
+boolean ltrace_handle_trap(context_frame f)
+{
+    if (!ltrace)
+        return false;
+    spin_lock(&ltrace->lock);
+    ltrace_brkpt brkpt = table_remove(ltrace->ctx_map, f);
+    spin_unlock(&ltrace->lock);
+    if (brkpt) {
+        /* A single-stepped instruction has been executed: reinsert the breakpoint and disable
+         * single stepping. */
+        runtime_memcpy(brkpt->plt_entry, swbkp_insn, sizeof(swbkp_insn));
+        frame_disable_stepping(f);
+        return true;
+    }
+    u64 insn_addr = LTRACE_SWBKP_ADDR(f);
+    struct ltrace_brkpt k = {
+        .addr = insn_addr,
+    };
+    brkpt = (ltrace_brkpt)rbtree_lookup(ltrace->plt_map, &k.n);
+    if (brkpt == INVALID_ADDRESS)
+        return false;
+
+    /* A breakpoint has been hit: replace the breakpoint with the original instruction, then enable
+     * single stepping and execute the original instruction. */
+    rprintf("[LTRACE] %s\n", brkpt->sym_name);
+    spin_lock(&ltrace->lock);
+    table_set(ltrace->ctx_map, f, brkpt);
+    spin_unlock(&ltrace->lock);
+    runtime_memcpy(brkpt->plt_entry, brkpt->insn, sizeof(swbkp_insn));
+    frame_enable_stepping(f);
+    frame_set_insn_ptr(f, insn_addr);
+    return true;
+}
+
+void ltrace_signal(u32 signo)
+{
+    if (ltrace)
+        rprintf("[LTRACE] --- SIGNAL %d ---\n", signo);
+}

--- a/src/kernel/ltrace.h
+++ b/src/kernel/ltrace.h
@@ -1,0 +1,13 @@
+#ifdef CONFIG_LTRACE
+
+void ltrace_init(value cfg, buffer exe, u64 load_offset);
+boolean ltrace_handle_trap(context_frame f);
+void ltrace_signal(u32 signo);
+
+#else
+
+static inline void ltrace_init(value cfg, buffer exe, u64 load_offset) {}
+static inline boolean ltrace_handle_trap(context_frame f) {return false;}
+static inline void ltrace_signal(u32 signo) {}
+
+#endif

--- a/src/riscv64/elf64.c
+++ b/src/riscv64/elf64.c
@@ -18,11 +18,10 @@ void elf_apply_relocate_add(buffer elf, Elf64_Shdr *s, u64 offset)
     }
 }
 
-boolean elf_apply_relocate_syms(buffer elf, Elf64_Shdr *s, elf_sym_relocator relocator)
+boolean elf_apply_relocate_syms(buffer elf, Elf64_Rela *rel, int relcount,
+                                elf_sym_relocator relocator)
 {
-    Elf64_Rela *rel = buffer_ref(elf, s->sh_addr);
-    assert(sizeof(*rel) == s->sh_entsize);
-    for (int i = 0; i < s->sh_size / sizeof(*rel); i++) {
+    for (int i = 0; i < relcount; i++) {
         switch (ELF64_R_TYPE(rel[i].r_info)) {
         case R_RISCV_64:
         case R_RISCV_JUMP_SLOT:

--- a/src/riscv64/gdb_machine.h
+++ b/src/riscv64/gdb_machine.h
@@ -4,14 +4,6 @@ static inline int computeSignal (context_frame frame)
     return 0;
 }
 
-static inline void clear_thread_stepping(thread t)
-{
-}
-
-static inline void set_thread_stepping(thread t)
-{
-}
-
 static inline int get_register(u64 num, void *buf, context_frame c)
 {
     return -1;

--- a/src/riscv64/kernel_machine.h
+++ b/src/riscv64/kernel_machine.h
@@ -250,6 +250,11 @@ static inline boolean is_breakpoint(context_frame f)
     return SCAUSE_CODE(f[FRAME_CAUSE]) == TRAP_E_BREAKPOINT;
 }
 
+static inline boolean is_trap(context_frame f)
+{
+    return is_breakpoint(f);
+}
+
 static inline boolean is_illegal_instruction(context_frame f)
 {
     return SCAUSE_CODE(f[FRAME_CAUSE]) == TRAP_E_ILLEGAL_INST;
@@ -298,6 +303,11 @@ static inline void frame_set_stack_top(context_frame f, void *st)
 static inline void frame_reset_stack(context_frame f)
 {
     f[FRAME_SP] = f[FRAME_STACK_TOP];
+}
+
+static inline void frame_set_insn_ptr(context_frame f, u64 ip)
+{
+    f[FRAME_PC] = ip;
 }
 
 static inline void frame_enable_stepping(context_frame f)

--- a/src/riscv64/kernel_machine.h
+++ b/src/riscv64/kernel_machine.h
@@ -300,6 +300,14 @@ static inline void frame_reset_stack(context_frame f)
     f[FRAME_SP] = f[FRAME_STACK_TOP];
 }
 
+static inline void frame_enable_stepping(context_frame f)
+{
+}
+
+static inline void frame_disable_stepping(context_frame f)
+{
+}
+
 static inline boolean validate_frame_ptr(u64 *fp)
 {
     if (!validate_virtual(fp - 1, sizeof(u64)) ||

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -3,6 +3,7 @@
 #include <gdb.h>
 #include <symtab.h>
 #include <filesystem.h>
+#include <ltrace.h>
 
 //#define EXEC_DEBUG
 #ifdef EXEC_DEBUG
@@ -304,6 +305,12 @@ process exec_elf(buffer ex, process kp)
         exec_debug("ingesting symbols...\n");
         add_elf_syms(ex, load_offset);
         exec_debug("...done\n");
+    }
+
+    value ltrace = get(proc->process_root, sym(ltrace));
+    if (ltrace) {
+        exec_debug("initializing ltrace...\n");
+        ltrace_init(ltrace, ex, load_offset);
     }
 
     register_root_notify(sym(trace), closure(heap_locked(kh), trace_notify, proc));

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -1,5 +1,6 @@
 #include <unix_internal.h>
 #include <ftrace.h>
+#include <ltrace.h>
 
 //#define SIGNAL_DEBUG
 #ifdef SIGNAL_DEBUG
@@ -1153,6 +1154,8 @@ boolean dispatch_signals(thread t)
         default_signal_action(t, &qs);
         assert(0); // should not get here
     }
+
+    ltrace_signal(si->si_signo);
 
     /* apply signal mask for handler */
     t->signal_mask |= mask_from_sig(signum) | sa->sa_mask.sig[0];

--- a/src/x86_64/elf64.c
+++ b/src/x86_64/elf64.c
@@ -24,10 +24,10 @@ void elf_apply_relocate_add(buffer elf, Elf64_Shdr *s, u64 offset)
     }
 }
 
-boolean elf_apply_relocate_syms(buffer elf, Elf64_Shdr *s, elf_sym_relocator relocator)
+boolean elf_apply_relocate_syms(buffer elf, Elf64_Rela *rel, int relcount,
+                                elf_sym_relocator relocator)
 {
-    Elf64_Rela *rel = buffer_ref(elf, s->sh_addr);
-    for (int i = 0; i < s->sh_size / sizeof(*rel); i++) {
+    for (int i = 0; i < relcount; i++) {
         switch (ELF64_R_TYPE(rel[i].r_info)) {
         case R_X86_64_GLOB_DAT:
         case R_X86_64_JUMP_SLOT:

--- a/src/x86_64/gdb_machine.h
+++ b/src/x86_64/gdb_machine.h
@@ -7,18 +7,6 @@ static inline int computeSignal (context_frame frame)
     return(signalmap[exceptionVector]);
 }
 
-static inline void clear_thread_stepping(thread t)
-{
-    thread_frame(t)[FRAME_EFLAGS] &= ~U64_FROM_BIT(EFLAG_TRAP);
-    thread_frame(t)[FRAME_EFLAGS] |= U64_FROM_BIT(EFLAG_RESUME);
-}
-
-static inline void set_thread_stepping(thread t)
-{
-    thread_frame(t)[FRAME_EFLAGS] &= ~U64_FROM_BIT(EFLAG_RESUME);
-    thread_frame(t)[FRAME_EFLAGS] |= U64_FROM_BIT(EFLAG_TRAP);
-}
-
 /* XXX This is a hack. The numbering of the registers is based on
  * xml files describing the registers. For reference, see
  * https://github.com/bminor/binutils-gdb/tree/master/gdb/features/i386

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -402,6 +402,11 @@ static inline boolean is_breakpoint(context_frame f)
     return f[FRAME_VECTOR] == 3;
 }
 
+static inline boolean is_trap(context_frame f)
+{
+    return (f[FRAME_VECTOR] == 1) /* single step */ || is_breakpoint(f);
+}
+
 static inline boolean is_illegal_instruction(context_frame f)
 {
     return f[FRAME_VECTOR] == 6;
@@ -430,6 +435,11 @@ static inline void frame_set_stack_top(context_frame f, void *st)
 static inline void frame_reset_stack(context_frame f)
 {
     f[FRAME_RSP] = f[FRAME_STACK_TOP];
+}
+
+static inline void frame_set_insn_ptr(context_frame f, u64 ip)
+{
+    f[FRAME_RIP] = ip;
 }
 
 static inline void frame_enable_stepping(context_frame f)

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -432,6 +432,18 @@ static inline void frame_reset_stack(context_frame f)
     f[FRAME_RSP] = f[FRAME_STACK_TOP];
 }
 
+static inline void frame_enable_stepping(context_frame f)
+{
+    f[FRAME_EFLAGS] &= ~U64_FROM_BIT(EFLAG_RESUME);
+    f[FRAME_EFLAGS] |= U64_FROM_BIT(EFLAG_TRAP);
+}
+
+static inline void frame_disable_stepping(context_frame f)
+{
+    f[FRAME_EFLAGS] &= ~U64_FROM_BIT(EFLAG_TRAP);
+    f[FRAME_EFLAGS] |= U64_FROM_BIT(EFLAG_RESUME);
+}
+
 static inline boolean validate_frame_ptr(u64 *fp)
 {
     if (!validate_virtual(fp, sizeof(u64)) ||


### PR DESCRIPTION
This feature allows tracing calls made by the application binary to dynamic library functions. It is enabled by adding an 'ltrace' attribute to the root tuple, and prints on the serial console (similarly to the Linux ltrace tool) a line for each dynamic library function call (with the function name) and for each signal delivered to the process (with the signal number).
This feature is implemented for the x86 and aarch64 architectures (in riscv, CPU debug registers cannot be accessed from supervisor mode, and the SBI does not currently have the functionality to access debug registers via SBI calls).
The new functions elf_dyn_parse() and elf_plt_get() have been added to the generic ELF code and are used by ltrace to retrieve the information needed to be able to place software breakpoints where dynamic function calls are made and map each breakpoint to the corresponding function.
The Unix fault handler has been changed so that trap exceptions generated after a single-stepped instruction are correctly handled (either by ltrace, or by generating a SIGTRAP signal).

Example Ops configuration to enable ltrace:
```
  "ManifestPassthrough": {
    "ltrace": {}
  }
```