### PR TITLE
Unix socket and getsockopt improvements

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1230,6 +1230,12 @@ sysreturn socket(int domain, int type, int protocol)
     switch (domain) {
     case AF_INET:
     case AF_INET6:
+        /* Validate protocol/type combination */
+        if (protocol) {
+            if ((type == SOCK_STREAM && protocol != IP_PROTO_TCP) ||
+                (type == SOCK_DGRAM && protocol != IP_PROTO_UDP))
+                return -EPROTONOSUPPORT;
+        }
         break;
     case AF_UNIX:
         return unixsock_open(type, protocol);
@@ -2241,6 +2247,10 @@ static sysreturn netsock_getsockopt(struct sock *sock, int level,
         }
         case SO_REUSEPORT:
             ret_optval.val = 0;
+            ret_optlen = sizeof(ret_optval.val);
+            break;
+        case SO_PROTOCOL:
+            ret_optval.val = s->sock.type == SOCK_STREAM ? IP_PROTO_TCP : IP_PROTO_UDP;
             ret_optlen = sizeof(ret_optval.val);
             break;
         default:

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -819,6 +819,7 @@ struct io_uring_params {
 #define SO_LINGER       13
 #define SO_REUSEPORT    15
 #define SO_ACCEPTCONN   30
+#define SO_PROTOCOL     38
 
 #define IPV6_V6ONLY     26
 

--- a/test/runtime/unixsocket.c
+++ b/test/runtime/unixsocket.c
@@ -29,6 +29,14 @@
     } \
 } while (0)
 
+static void test_getsockopt(int fd, int type)
+{
+    int opt;
+    socklen_t optlen = sizeof(int);
+    test_assert(getsockopt(fd, SOL_SOCKET, SO_TYPE, &opt, &optlen) == 0);
+    test_assert(opt == type);
+}
+
 static void *uds_stream_server(void *arg)
 {
     int fd = (long) arg;
@@ -124,6 +132,7 @@ static void uds_stream_test(void)
     test_assert(s1 >= 0);
     addr.sun_family = AF_UNIX;
 
+    test_getsockopt(s1, SOCK_STREAM);
     test_assert((bind(s1, NULL, addr_len) == -1) && (errno == EFAULT));
     test_assert(bind(s1, (struct sockaddr *) &addr, 0) == -1);
     test_assert(errno == EINVAL);
@@ -314,6 +323,7 @@ static void uds_dgram_test(void)
 
     s1 = socket(AF_UNIX, SOCK_DGRAM, 0);
     test_assert(s1 >= 0);
+    test_getsockopt(s1, SOCK_DGRAM);
     client_addr.sun_family = server_addr.sun_family = AF_UNIX;
     strcpy(client_addr.sun_path, CLIENT_SOCKET_PATH);
     strcpy(server_addr.sun_path, SERVER_SOCKET_PATH);


### PR DESCRIPTION
This PR fixes several small issues related to sockets. First, it implements the getsockopt syscall for unix sockets,
which was previously not supported, however it only implements SO_TYPE. Second, it adds support for the
SO_PROTOCOL option for inet and inet6 sockets as well as adds some input checking for type and protocol when
creating sockets in these domains. Finally, it fixes an issue with udp sockets where calling shutdown on a udp
socket would not wake any blocked waiters on receive.
