### PR TITLE
lwIP: implement multithreaded operation

### DIFF
--- a/klib/aws.c
+++ b/klib/aws.c
@@ -111,10 +111,12 @@ closure_function(3, 1, input_buffer_handler, aws_metadata_ch,
 boolean aws_metadata_available(void)
 {
     ip_addr_t md_server = AWS_MD_SERVER;
-    lwip_lock();
-    boolean result = (ip_route(&ip_addr_any, &md_server) != 0);
-    lwip_unlock();
-    return result;
+    struct netif *n = ip_route(&ip_addr_any, &md_server);
+    if (n) {
+        netif_unref(n);
+        return true;
+    }
+    return false;
 }
 
 void aws_metadata_get(heap h, const char *uri, buffer_handler handler)

--- a/klib/cloud_init.c
+++ b/klib/cloud_init.c
@@ -339,9 +339,7 @@ static void cloud_download(connection_handler ch)
     runtime_memcpy(host, buffer_ref(&cfg->server_host, 0), host_len);
     host[host_len] = '\0';                                \
     ip_addr_t addr;
-    lwip_lock();
     err_t err = dns_gethostbyname(host, &addr, cloud_download_dns_cb, ch);
-    lwip_unlock();
     switch (err) {
     case ERR_OK:
         s = cloud_download_connect(&addr, ch);

--- a/klib/cloudwatch.c
+++ b/klib/cloudwatch.c
@@ -174,9 +174,7 @@ static void cw_dns_cb(const char *name, const ip_addr_t *ipaddr, void *callback_
 static void cw_connect(const char *server, void (*handler)(const ip_addr_t *server))
 {
     ip_addr_t cw_host;
-    lwip_lock();
     err_t err = dns_gethostbyname(server, &cw_host, cw_dns_cb, handler);
-    lwip_unlock();
     switch (err) {
     case ERR_OK:
         cw_dns_cb(server, &cw_host, handler);

--- a/klib/ntp.c
+++ b/klib/ntp.c
@@ -540,7 +540,7 @@ static boolean sanity_checks(ntp_server server, struct ntp_packet *p)
 
 /* called with lwIP lock held */
 static void ntp_input(void *z, struct udp_pcb *pcb, struct pbuf *p,
-                      const ip_addr_t *addr, u16 port)
+                      struct ip_globals *ip_data, u16 port)
 {
     ntp.query_ongoing = false;
     struct ntp_packet *pkt = p->payload;
@@ -550,6 +550,7 @@ static void ntp_input(void *z, struct udp_pcb *pcb, struct pbuf *p,
         success = false;
         goto done;
     }
+    const ip_addr_t *addr = &ip_data->current_iphdr_src;
     ntp_lock();
     if (ntp.current_server >= 0) {
         ntp_server server = vector_get(ntp.servers, ntp.current_server);

--- a/src/aws/ena/ena_datapath.c
+++ b/src/aws/ena/ena_datapath.c
@@ -101,13 +101,11 @@ void ena_deferred_mq_start(void *arg, int pending)
     struct ena_ring *tx_ring = (struct ena_ring*) arg;
     struct netif *netif = &tx_ring->adapter->ifp;
 
-    lwip_lock();
     while (!queue_empty(tx_ring->br) && tx_ring->running && netif_is_flag_set(netif, NETIF_FLAG_UP)) {
         ENA_RING_MTX_LOCK(tx_ring);
         ena_start_xmit(tx_ring);
         ENA_RING_MTX_UNLOCK(tx_ring);
     }
-    lwip_unlock();
 }
 
 err_t ena_linkoutput(struct netif *netif, struct pbuf *p)
@@ -196,7 +194,6 @@ static int ena_tx_cleanup(struct ena_ring *tx_ring)
     io_cq = &adapter->ena_dev->io_cq_queues[ena_qid];
     next_to_clean = tx_ring->next_to_clean;
 
-    lwip_lock();
     do {
         struct ena_tx_buffer *tx_info;
         struct pbuf *mbuf;
@@ -234,7 +231,6 @@ static int ena_tx_cleanup(struct ena_ring *tx_ring)
             total_done = 0;
         }
     } while (likely(--budget));
-    lwip_unlock();
 
     work_done = TX_BUDGET - budget;
 
@@ -384,7 +380,6 @@ static int ena_rx_cleanup(struct ena_ring *rx_ring)
 
     ena_trace(NULL, ENA_DBG, "rx: qid %d\n", qid);
 
-    lwip_lock();
     do {
         ena_rx_ctx.ena_bufs = rx_ring->ena_bufs;
         ena_rx_ctx.max_bufs = adapter->max_rx_sgl_size;
@@ -401,7 +396,6 @@ static int ena_rx_cleanup(struct ena_ring *rx_ring)
                 reset_reason = ENA_REGS_RESET_INV_RX_REQ_ID;
             }
             ena_trigger_reset(adapter, reset_reason);
-            lwip_unlock();
             return (0);
         }
 
@@ -433,7 +427,6 @@ static int ena_rx_cleanup(struct ena_ring *rx_ring)
         rx_ring->rx_stats.cnt++;
         adapter->hw_stats.rx_packets++;
     } while (--budget);
-    lwip_unlock();
 
     rx_ring->next_to_clean = next_to_clean;
 

--- a/src/drivers/netconsole.c
+++ b/src/drivers/netconsole.c
@@ -26,9 +26,6 @@ static void netconsole_write(void *_d, const char *s, bytes count)
        If so, the pbuf_alloc should be happening elsewhere (e.g. background
        task and queued to free list) */
     assert(!in_interrupt());
-    boolean lock = !mutex_is_acquired(lwip_mutex);
-    if (lock)
-        lwip_lock();
     while (count > 0) {
         bytes len = MIN(count, MAX_PAYLOAD);
         struct pbuf *pb = pbuf_alloc(PBUF_TRANSPORT, len, PBUF_RAM);
@@ -40,16 +37,12 @@ static void netconsole_write(void *_d, const char *s, bytes count)
         count -= len;
         off += len;
     }
-    if (lock)
-        lwip_unlock();
 }
 
 static void netconsole_config(void *_d, tuple r)
 {
     netconsole_driver nd = _d;
-    lwip_lock();
     nd->pcb = udp_new();
-    lwip_unlock();
     if (!nd->pcb) {
         msg_err("failed to allocate pcb\n");
         return;

--- a/src/gdb/gdbtcp.c
+++ b/src/gdb/gdbtcp.c
@@ -42,7 +42,6 @@ void init_tcp_gdb(heap h, process p, u16 port)
 {
     tcpgdb g = (tcpgdb) allocate(h, sizeof(struct tcpgdb));
     assert(g != INVALID_ADDRESS);
-    lwip_lock();
     g->p = tcp_new_ip_type(IPADDR_TYPE_ANY);
     // XXX threads lock taken here...shouldn't be issue but validate
     g->input = init_gdb(h, p, closure(h, gdb_send, g));
@@ -50,5 +49,4 @@ void init_tcp_gdb(heap h, process p, u16 port)
     g->p = tcp_listen(g->p);
     tcp_arg(g->p, g);
     tcp_accept(g->p, gdb_accept);
-    lwip_unlock();
 }

--- a/src/hyperv/netvsc/netvsc.c
+++ b/src/hyperv/netvsc/netvsc.c
@@ -275,13 +275,11 @@ netvsc_attach(kernel_heaps kh, hv_device* device)
     if (ret != 0)
         return timm("err", "err");
 
-    lwip_lock();
     netif_add(hn->netif,
               0, 0, 0,
               hn,
               vmxif_init,
               ethernet_input);
-    lwip_unlock();
 
     mm_register_mem_cleaner(init_closure(&hn->mem_cleaner, hn_mem_cleaner));
     netvsc_debug("%s: hwaddr %02x:%02x:%02x:%02x:%02x:%02x", __func__,
@@ -411,9 +409,7 @@ netvsc_recv(struct hv_device *device_ctx, netvsc_packet *packet)
             vaddr + packet->page_buffers[i].gpa_ofs);
     }
 
-    lwip_lock();
     err_enum_t err = hn->netif->input((struct pbuf *)x, hn->netif);
-    lwip_unlock();
     if (err != ERR_OK) {
         msg_err("netvsc: rx drop by stack, err %d\n", err);
         receive_buffer_release((struct pbuf *)x);

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -20,22 +20,8 @@
 
 status direct_connect(heap h, ip_addr_t *addr, u16 port, connection_handler ch);
 
-struct netif *netif_get_default(void);
-
 u16 ifflags_from_netif(struct netif *netif);
 boolean ifflags_to_netif(struct netif *netif, u16 flags); /* do not call with lwIP lock held */
 void netif_name_cpy(char *dest, struct netif *netif);
 
 #define netif_is_loopback(netif)    (((netif)->name[0] == 'l') && ((netif)->name[1] == 'o'))
-
-extern mutex lwip_mutex;
-
-static inline void lwip_lock(void)
-{
-    mutex_lock(lwip_mutex);
-}
-
-static inline void lwip_unlock(void)
-{
-    mutex_unlock(lwip_mutex);
-}

--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -1,3 +1,8 @@
+/* guard against double include of header file */
+#ifndef KMEM_BASE
+#include <kernel.h>
+#endif
+
 #define NO_SYS 1
 #define LWIP_SOCKET 0
 #define LWIP_NETCONN 0
@@ -48,6 +53,9 @@
 #define LWIP_NO_LIMITS_H 1
 #define LWIP_NO_CTYPE_H 1
 
+/* Must be a type on which atomic operations are supported by the CPU. */
+#define LWIP_PBUF_REF_T u32_t
+
 #define LWIP_CHKSUM_ALGORITHM   3
 
 #define LWIP_WND_SCALE 1
@@ -94,6 +102,7 @@ typedef short s16_t;
 typedef signed char s8_t;
 typedef u16_t uint16_t;
 typedef void *sys_prot_t;
+typedef struct spinlock sys_lock_t;
 typedef u64_t ptrdiff_t;
 typedef unsigned long mem_ptr_t;
 
@@ -107,6 +116,16 @@ typedef unsigned long mem_ptr_t;
 #define X32_F "8x"
 #define SZT_F "d"
 
+#define SYS_ARCH_LOCK_INIT  spin_lock_init
+#define SYS_ARCH_LOCK       spin_lock
+#define SYS_ARCH_UNLOCK     spin_unlock
+#define SYS_ARCH_TRYLOCK    spin_try
+
+#define SYS_ARCH_INC(var, val) __sync_fetch_and_add(&(var), val)
+#define SYS_ARCH_DEC(var, val) __sync_fetch_and_add(&(var), -(val))
+
+#define SYS_PAUSE   kern_pause
+
 // some ifdef rot
 #define API_MSG_M_DEF(m)                m
 #define API_MSG_M_DEF_C(t, m)           t m
@@ -116,14 +135,7 @@ struct tcpip_api_call_data
 {
 };
 
-static inline sys_prot_t sys_arch_protect(void)
-{
-    return 0;
-}
-
-static inline void sys_arch_unprotect(sys_prot_t x)
-{
-}
+#define SYS_LIGHTWEIGHT_PROT    0
 
 typedef unsigned long long time; 
 extern void lwip_debug(char * format, ...);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -91,7 +91,7 @@ void *lwip_allocate(u64 size)
     /* To maintain the malloc/free interface with mcache, allocations must stay
        within the range of objcaches and not fall back to parent allocs. */
     assert(size <= U64_FROM_BIT(MAX_LWIP_ALLOC_ORDER));
-    void *p = allocate_zero(lwip_heap, size);
+    void *p = allocate(lwip_heap, size);
     return ((p != INVALID_ADDRESS) ? p : 0);
 }
 

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1132,11 +1132,11 @@ sysreturn shutdown(int sockfd, int how)
 }
 
 static void udp_input_lower(void *z, struct udp_pcb *pcb, struct pbuf *p,
-			    const ip_addr_t * addr, u16 port)
+                            struct ip_globals *ip_data, u16 port)
 {
     netsock s = z;
 #ifdef NETSYSCALL_DEBUG
-    u8 *n = (u8 *)addr;
+    u8 *n = (u8 *)(&ip_data->current_iphdr_src);
 #endif
     net_debug("sock %d, pcb %p, buf %p, src addr %d.%d.%d.%d, port %d\n",
 	      s->sock.fd, pcb, p, n[0], n[1], n[2], n[3], port);
@@ -1150,7 +1150,7 @@ static void udp_input_lower(void *z, struct udp_pcb *pcb, struct pbuf *p,
 	struct udp_entry * e = allocate(s->sock.h, sizeof(*e));
 	assert(e != INVALID_ADDRESS);
 	e->pbuf = p;
-	runtime_memcpy(&e->raddr, addr, sizeof(ip_addr_t));
+	runtime_memcpy(&e->raddr, &ip_data->current_iphdr_src, sizeof(ip_addr_t));
 	e->rport = port;
 	assert(enqueue(s->incoming, e));
 	s->sock.rx_len += p->tot_len;

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1701,15 +1701,15 @@ sysreturn uname(struct utsname *v)
         v->nodename[length] = '\0';
     } else {
         v->nodename[0] = 0;
-        lwip_lock();
+        struct netif *netif_default = netif_get_default();
         if (netif_default) {
             /* Derive nodename from the IP address of the default network interface. */
             const ip4_addr_t *addr = netif_ip4_addr(netif_default);
             if (!ip4_addr_isany_val(*addr))
                 rsnprintf(v->nodename, sizeof(v->nodename), "%d-%d-%d-%d",
                           ip4_addr1(addr), ip4_addr2(addr), ip4_addr3(addr), ip4_addr4(addr));
+            netif_unref(netif_default);
         }
-        lwip_unlock();
         if (!v->nodename[0])
             runtime_memcpy(v->nodename, sysname, sizeof(sysname));
     }

--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -86,9 +86,7 @@ closure_function(1, 1, void, tx_complete,
                  struct pbuf *, p,
                  u64, len)
 {
-    lwip_lock();
     pbuf_free(bound(p));
-    lwip_unlock();
     closure_finish();
 }
 
@@ -201,11 +199,8 @@ define_closure_function(0, 1, void, vnet_input,
             err = true;
         }
     }
-    if (!err) {
-        lwip_lock();
+    if (!err)
         err = (vn->n->input(&x->p.pbuf, vn->n) != ERR_OK);
-        lwip_unlock();
-    }
     if (err)
         receive_buffer_release(&x->p.pbuf);
     // we need to get a signal from the device side that there was
@@ -220,7 +215,6 @@ static void post_receive(vnet vn)
     assert(x != INVALID_ADDRESS);
     x->vn = vn;
     x->p.custom_free_function = receive_buffer_release;
-    /* no lwip lock necessary */
     pbuf_alloced_custom(PBUF_RAW,
                         vn->rxbuflen,
                         PBUF_REF,
@@ -319,13 +313,11 @@ static void virtio_net_attach(vtdev dev)
     vn->n->state = vn;
     // initialization complete
     vtdev_set_status(dev, VIRTIO_CONFIG_STATUS_DRIVER_OK);
-    lwip_lock();
     netif_add(vn->n,
               0, 0, 0, 
               vn,
               virtioif_init,
               ethernet_input);
-    lwip_unlock();
 }
 
 closure_function(2, 1, boolean, vtpci_net_probe,

--- a/src/vmware/vmxnet3_net.c
+++ b/src/vmware/vmxnet3_net.c
@@ -254,9 +254,7 @@ closure_function(1, 0, void, vmxnet3_rx_service_bh,
             assert(i);
             xpbuf rxb = struct_from_list(i, xpbuf, l);
             list_delete(i);
-            lwip_lock();
             err_enum_t err = vn->n->input((struct pbuf *)rxb, vn->n);
-            lwip_unlock();
             if (err != ERR_OK) {
                 msg_err("vmxnet3: rx drop by stack, err %d\n", err);
                 receive_buffer_release((struct pbuf *)rxb);
@@ -417,13 +415,11 @@ static void vmxnet3_net_attach(heap general, heap page_allocator, pci_dev d)
     vmxnet3_read_cmd(dev, VMXNET3_CMD_ENABLE);
     pci_bar_write_4(&dev->bar0, VMXNET3_BAR0_RXH1(0), 0);
     pci_bar_write_4(&dev->bar0, VMXNET3_BAR0_RXH2(0), 0);
-    lwip_lock();
     netif_add(vn->n,
               0, 0, 0,
               vn,
               vmxif_init,
               ethernet_input);
-    lwip_unlock();
     vmxnet3_interrupts_enable(dev);
 }
 

--- a/src/xen/xennet.c
+++ b/src/xen/xennet.c
@@ -302,7 +302,6 @@ closure_function(1, 0, void, xennet_tx_service_bh,
     xennet_dev xd = bound(xd);
     xennet_debug("%s: dev id %d", __func__, xd->dev.if_id);
     list l;
-    lwip_lock();
     while ((l = (list)dequeue(xd->tx_servicequeue)) != INVALID_ADDRESS) {
         struct list q;
         list_insert_before(l, &q); /* restore list head */
@@ -317,7 +316,6 @@ closure_function(1, 0, void, xennet_tx_service_bh,
             xennet_return_txbuf(xd, txb);
         }
     }
-    lwip_unlock();
     xennet_debug("%s: exit", __func__);
 }
 
@@ -628,7 +626,6 @@ closure_function(1, 0, void, xennet_rx_service_bh,
     xennet_dev xd = bound(xd);
     xennet_debug("%s: dev id %d", __func__, xd->dev.if_id);
     list l;
-    lwip_lock();
     while ((l = (list)dequeue(xd->rx_servicequeue)) != INVALID_ADDRESS) {
         struct list q;
         assert(l);
@@ -645,7 +642,6 @@ closure_function(1, 0, void, xennet_rx_service_bh,
             }
         }
     }
-    lwip_unlock();
     xennet_debug("%s: exit", __func__);
 }
 
@@ -719,13 +715,11 @@ static status xennet_enable(xennet_dev xd)
     s = xenbus_set_state(0, xdev->frontend, XenbusStateConnected);
     if (!is_ok(s))
         goto out_dealloc_rx_buffers;
-    lwip_lock();
     netif_add(xd->netif,
               0, 0, 0,
               xd,
               xennet_netif_init,
               ethernet_input);
-    lwip_unlock();
     /* we're kind of always up ... start rx now */
     xd->rx_ring.sring->rsp_event = xd->rx_ring.rsp_cons + 1;
     write_barrier();


### PR DESCRIPTION
This change set removes the global lwIP lock and adapts the networking code to the lwIP changes that allow concurrent invocation of lwIP raw API functions. The lwIP lightweight protection implementation (which does not provide protection from concurrent access in multi-core systems) is being disabled, and locking primitives (as well as atomic operations needed for reference counting) are being defined.
A spinlock is now used to protect the lwIP heap.
lwIP functions that inolve a tcp_pcb structure are now called with the PCB lock held (by calling `tcp_lock` and `tcp_unlock`).
tcp_ref() and tcp_unref() are used to properly reference-count tcp_pcb structures used in net/netsyscall.c and net/direct.c.
In net/netsyscall.c, the file descriptor lock is used (instead of the global lwIP lock) to protect the netsock structure from concurrent access. In order to avoid deadlock, the lock of a TCP PCB associated to a socket must not be acquired while holding the file descriptor lock (unless the PCB is in a state where lwIP callbacks are never invoked, e.g. before establishing a TCP connection). In addition, in order to avoid a potential deadlock with the epoll code, notify_dispatch is called without holding the file descriptor lock.

Depends on https://github.com/nanovms/lwip/pull/4