### PR TITLE
netsock_getsockopt(): add support for TCP_MAXSEG and TCP_FASTOPEN

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -2201,30 +2201,25 @@ static sysreturn netsock_getsockopt(struct sock *sock, int level,
         int val;
         struct linger linger;
     } ret_optval;
-    int ret_optlen;
+    int ret_optlen = sizeof(ret_optval.val);
 
     switch (level) {
     case SOL_SOCKET:
         switch (optname) {
         case SO_TYPE:
             ret_optval.val = s->sock.type;
-            ret_optlen = sizeof(ret_optval.val);
             break;
         case SO_ERROR:
             ret_optval.val = -lwip_to_errno(get_and_clear_lwip_error(s));
-            ret_optlen = sizeof(ret_optval.val);
             break;
         case SO_SNDBUF:
             ret_optval.val = (s->sock.type == SOCK_STREAM) ? TCP_SND_BUF : 0;
-            ret_optlen = sizeof(ret_optval.val);
             break;
         case SO_RCVBUF:
             ret_optval.val = so_rcvbuf;
-            ret_optlen = sizeof(ret_optval.val);
             break;
         case SO_PRIORITY:
             ret_optval.val = 0; /* default value in Linux */
-            ret_optlen = sizeof(ret_optval.val);
             break;
         case SO_LINGER:
             ret_optval.linger.l_onoff = 0;
@@ -2233,7 +2228,6 @@ static sysreturn netsock_getsockopt(struct sock *sock, int level,
             break;
         case SO_ACCEPTCONN:
             ret_optval.val = (s->sock.type == SOCK_STREAM) && (s->info.tcp.state == TCP_SOCK_LISTENING);
-            ret_optlen = sizeof(ret_optval.val);
             break;
         case SO_REUSEADDR:
         case SO_KEEPALIVE:
@@ -2250,17 +2244,14 @@ static sysreturn netsock_getsockopt(struct sock *sock, int level,
                 rv = -EINVAL;
                 goto out;
             }
-            ret_optlen = sizeof(ret_optval.val);
             lwip_unlock();
             break;
         }
         case SO_REUSEPORT:
             ret_optval.val = 0;
-            ret_optlen = sizeof(ret_optval.val);
             break;
         case SO_PROTOCOL:
             ret_optval.val = s->sock.type == SOCK_STREAM ? IP_PROTO_TCP : IP_PROTO_UDP;
-            ret_optlen = sizeof(ret_optval.val);
             break;
         default:
             goto unimplemented;
@@ -2274,7 +2265,6 @@ static sysreturn netsock_getsockopt(struct sock *sock, int level,
                 ret_optval.val = tcp_nagle_disabled(s->info.tcp.lw);
             else
                 ret_optval.val = ((s->info.tcp.flags & TF_NODELAY) != 0);
-            ret_optlen = sizeof(ret_optval.val);
             lwip_unlock();
             break;
         default:
@@ -2285,7 +2275,6 @@ static sysreturn netsock_getsockopt(struct sock *sock, int level,
         switch (optname) {
         case IPV6_V6ONLY:
             ret_optval.val = s->ipv6only;
-            ret_optlen = sizeof(ret_optval.val);
             break;
         default:
             goto unimplemented;

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -122,6 +122,7 @@ static void netsock_test_basic(int sock_type)
         test_assert(setsockopt(tx_fd, IPPROTO_TCP, TCP_NODELAY, &val, len) == 0);
 
         test_assert(getsockopt(tx_fd, SOL_SOCKET, SO_ACCEPTCONN, &val, &len) == 0 && val == 0);
+        test_assert(getsockopt(tx_fd, IPPROTO_TCP, TCP_MAXSEG, &val, &len) == 0 && val > 0);
         test_assert(close(fd) == 0);
     } else {
         netsock_toggle_and_check_sockopt(fd, SOL_SOCKET, SO_BROADCAST, 1);


### PR DESCRIPTION
These options are accepted when the `level` argument is SOL_TCP.
TCP_MAXSEG indicates the maximum segment size of a TCP connection.
TCP_FASTOPEN indicates the maximum number of pending TCP Fast Open (TFO) requests a listening socket allows before disabling TFO (the kernel currently does not support TFO, thus the returned value is always zero).

Closes https://github.com/nanovms/nanos/issues/1797.