### PR TITLE
sendfile(2): change file offset on output file

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -420,8 +420,8 @@ closure_function(9, 2, void, sendfile_bh,
     assert(bound(cur_buf));
     void *buf = bound(cur_buf)->buf + bound(cur_buf)->offset;
     u32 n = sg_buf_len(bound(cur_buf));
-    thread_log(t, "   writing %d bytes from %p", rv, n, buf);
-    apply(bound(out)->write, buf, n, 0, t, true, (io_completion)closure_self());
+    thread_log(t, "   writing %d bytes from %p", n, buf);
+    apply(bound(out)->write, buf, n, infinity, t, true, (io_completion)closure_self());
     return;
 out_complete:
     sg_list_release(bound(sg));


### PR DESCRIPTION
When sendfile() is called on an output file descriptor corresponding to a regular file, it should write at the current file offset and update the offset according to the number of bytes written. The existing code is writing at offset zero and is not updating the offset.
This change fixes the above issue and amends the sendfile runtime test so that it would have failed without this fix.