### PR TITLE
File syscalls: initialize fsfile pointer and check for null value

### DIFF
--- a/test/runtime/symlink.c
+++ b/test/runtime/symlink.c
@@ -45,6 +45,12 @@ int main(int argc, char **argv)
     test_assert(fd >= 0);
     test_assert((fsync(fd) == -1) && (errno == EBADF));
     test_assert((fdatasync(fd) == -1) && (errno == EBADF));
+    test_assert((read(fd, buf, sizeof(buf)) == -1) && (errno == EBADF));
+    close(fd);
+
+    fd = open("link", O_RDWR | O_NOFOLLOW | O_PATH);
+    test_assert(fd >= 0);
+    test_assert((write(fd, buf, sizeof(buf)) == -1) && (errno == EBADF));
     close(fd);
 
     test_assert((faccessat(AT_FDCWD, "link", F_OK, AT_SYMLINK_NOFOLLOW) == 0));


### PR DESCRIPTION
When a file is opened, the fsf member of the file structure should be properly set to NULL for non-regular files; with this fix, fsync(2) works properly when invoked on a file descriptor corresponding to a directory, and read/write (and similar) syscalls properly return an error code when invoked on file descriptors corresponding to non-regular files.