### PR TITLE
open(2): add support for O_TRUNC flag

### DIFF
--- a/klib/cloud_init.c
+++ b/klib/cloud_init.c
@@ -105,7 +105,7 @@ static int cloud_download_parse(tuple config, cloud_download_cfg parsed_cfg)
         return KLIB_INIT_FAILED;
     }
     parsed_cfg->optional = parsed_cfg->done = false;
-    fsfile f = fsfile_open_or_create(parsed_cfg->file_path);
+    fsfile f = fsfile_open_or_create(parsed_cfg->file_path, false);
     if (!f) {
         rprintf("cloud_init: download destination file '%b' cannot be created\n",
             parsed_cfg->file_path);
@@ -196,15 +196,9 @@ closure_function(6, 1, boolean, cloud_download_recv,
     if (data) {
         if (bound(parser) == INVALID_ADDRESS) {
             /* This is the first chunk of data received after connection establishment. */
-            fsfile f = fsfile_open_or_create(cfg->file_path);
+            fsfile f = fsfile_open_or_create(cfg->file_path, true);
             if (!f) {
                 s = timm("result", "%s: failed to open file '%b'", __func__, cfg->file_path);
-                goto error;
-            }
-            fs_status fss = fsfile_truncate(f, 0);
-            if (fss != FS_STATUS_OK) {
-                s = timm("result", "%s: failed to truncate file '%b' (%d)",
-                    __func__, cfg->file_path, fss);
                 goto error;
             }
 

--- a/klib/syslog.c
+++ b/klib/syslog.c
@@ -93,7 +93,7 @@ static void syslog_file_rotate(void)
 
     if (ret == 0) {
         /* Continue logging on a new file. */
-        fsfile file = fsfile_open_or_create(syslog.file_path);
+        fsfile file = fsfile_open_or_create(syslog.file_path, true);
         syslog.file_offset = 0;
         syslog.fs_write = fsfile_get_writer(file);
     } else {
@@ -427,7 +427,7 @@ int init(status_handler complete)
         return KLIB_INIT_FAILED;
     }
     if (syslog.file_path) {
-        syslog.fsf = fsfile_open_or_create(syslog.file_path);
+        syslog.fsf = fsfile_open_or_create(syslog.file_path, false);
         if (!syslog.fsf) {
             rprintf("cannot create syslog output file\n");
             return KLIB_INIT_FAILED;

--- a/src/kernel/storage.c
+++ b/src/kernel/storage.c
@@ -143,7 +143,7 @@ static void volume_mount(volume v, buffer mount_point)
     tuple root = filesystem_getroot(storage.root_fs);
     tuple mount_dir_t;
     fs_status fss = filesystem_get_node(&fs, inode_from_tuple(root), cmount_point,
-        false, false, false, &mount_dir_t, 0);
+        false, false, false, false, &mount_dir_t, 0);
     if (fss != FS_STATUS_OK) {
         msg_err("mount point %s not found\n", cmount_point);
         return;

--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -1531,7 +1531,8 @@ closure_function(1, 1, boolean, free_extent,
 }
 
 fs_status filesystem_get_node(filesystem *fs, inode cwd, const char *path, boolean nofollow,
-                              boolean create, boolean exclusive, tuple *n, fsfile *f)
+                              boolean create, boolean exclusive, boolean truncate, tuple *n,
+                              fsfile *f)
 {
     tuple cwd_t = filesystem_get_meta(*fs, cwd);
     if (!cwd_t)
@@ -1577,10 +1578,13 @@ fs_status filesystem_get_node(filesystem *fs, inode cwd, const char *path, boole
 
         }
     } else {
-        if (exclusive)
+        if (exclusive) {
             fss = FS_STATUS_EXIST;
-        else
+        } else {
             fsf = fsfile_from_node(*fs, t);
+            if (fsf && truncate)
+                fss = filesystem_truncate_locked(*fs, fsf, 0);
+        }
     }
   out:
     if (fss == FS_STATUS_OK) {

--- a/src/tfs/tfs.h
+++ b/src/tfs/tfs.h
@@ -111,7 +111,8 @@ fs_status filesystem_mkdirpath(filesystem fs, tuple cwd, const char *fp,
         boolean persistent);
 fs_status filesystem_mkdir(filesystem fs, inode cwd, const char *path);
 fs_status filesystem_get_node(filesystem *fs, inode cwd, const char *path, boolean nofollow,
-                              boolean create, boolean exclusive, tuple *n, fsfile *f);
+                              boolean create, boolean exclusive, boolean truncate, tuple *n,
+                              fsfile *f);
 void filesystem_put_node(filesystem fs, tuple n);
 tuple filesystem_get_meta(filesystem fs, inode n);
 void filesystem_put_meta(filesystem fs, tuple n);

--- a/src/unix/coredump.c
+++ b/src/unix/coredump.c
@@ -228,15 +228,10 @@ void coredump(thread t, struct siginfo *si, status_handler complete)
     shutting_down = true;
     wakeup_or_interrupt_cpu_all();
 
-    fsfile f = fsfile_open_or_create(alloca_wrap_cstring(CORE_PATH));
+    fsfile f = fsfile_open_or_create(alloca_wrap_cstring(CORE_PATH), true);
     if (f == INVALID_ADDRESS) {
         core_debug("failed to open core file\n");
         s = timm("result", "no core generated: failed to open core file");
-        goto error;
-    }
-    if (fsfile_truncate(f, 0) != FS_STATUS_OK) {
-        core_debug("failed to truncate core file\n");
-        s = timm("result", "no core generated: failed to truncate core file");
         goto error;
     }
 

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -77,7 +77,7 @@ fs_status filesystem_chdir(process p, const char *path)
     filesystem fs = p->cwd_fs;
     fs_status fss;
     tuple n;
-    fss = filesystem_get_node(&fs, p->cwd, path, false, false, false, &n, 0);
+    fss = filesystem_get_node(&fs, p->cwd, path, false, false, false, false, &n, 0);
     if (fss != FS_STATUS_OK)
         goto out;
     if (!is_dir(n)) {
@@ -151,7 +151,7 @@ static sysreturn utime_internal(const char *filename, timestamp actime,
         return -EFAULT;
     process_get_cwd(current->p, &fs, &cwd);
     filesystem cwd_fs = fs;
-    fs_status fss = filesystem_get_node(&fs, cwd, filename, false, false, false, &t, 0);
+    fs_status fss = filesystem_get_node(&fs, cwd, filename, false, false, false, false, &t, 0);
     sysreturn rv;
     if (fss != FS_STATUS_OK) {
         rv = sysreturn_from_fs_status(fss);
@@ -217,7 +217,7 @@ sysreturn statfs(const char *path, struct statfs *buf)
         rv = -EFAULT;
         goto out;
     }
-    fs_status fss = filesystem_get_node(&fs, cwd, path, true, false, false, &t, 0);
+    fs_status fss = filesystem_get_node(&fs, cwd, path, true, false, false, false, &t, 0);
     if (fss != FS_STATUS_OK) {
         rv = sysreturn_from_fs_status(fss);
     } else {
@@ -355,7 +355,7 @@ void file_release(file f)
 }
 
 /* file_path is treated as an absolute path. */
-fsfile fsfile_open_or_create(buffer file_path)
+fsfile fsfile_open_or_create(buffer file_path, boolean truncate)
 {
     tuple file;
     fsfile fsf;
@@ -371,7 +371,8 @@ fsfile fsfile_open_or_create(buffer file_path)
             return 0;
         file_str[separator] = '/';
     }
-    s = filesystem_get_node(&fs, inode_from_tuple(root), file_str, true, true, false, &file, &fsf);
+    s = filesystem_get_node(&fs, inode_from_tuple(root), file_str, true, true, false, truncate,
+                            &file, &fsf);
     if (s == FS_STATUS_OK) {
         filesystem_put_node(fs, file);
         return fsf;

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -44,7 +44,7 @@ sysreturn fs_rename(buffer oldpath, buffer newpath);
 
 void file_release(file f);
 
-fsfile fsfile_open_or_create(buffer file_path);
+fsfile fsfile_open_or_create(buffer file_path, boolean truncate);
 fs_status fsfile_truncate(fsfile f, u64 len);
 
 notify_entry fs_watch(heap h, tuple n, u64 eventmask, event_handler eh, notify_set *s);

--- a/src/unix/inotify.c
+++ b/src/unix/inotify.c
@@ -333,7 +333,7 @@ sysreturn inotify_add_watch(int fd, const char *pathname, u32 mask)
     filesystem cwd_fs = fs;
     tuple n;
     fs_status fss = filesystem_get_node(&fs, cwd, pathname, (mask & IN_DONT_FOLLOW) != 0, false,
-                                        false, &n, 0);
+                                        false, false, &n, 0);
     if (fss != FS_STATUS_OK) {
         rv = sysreturn_from_fs_status(fss);
         goto out;

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -347,7 +347,7 @@ void register_special_files(process p)
     tuple self_exe;
     heap h = heap_locked((kernel_heaps)p->uh);
 
-    fs_status fss = filesystem_get_node(&fs, p->cwd, "/proc/self/exe", false, false, false,
+    fs_status fss = filesystem_get_node(&fs, p->cwd, "/proc/self/exe", false, false, false, false,
         &self_exe, 0);
     if (fss == FS_STATUS_OK) {
         filesystem_put_node(fs, self_exe);

--- a/test/runtime/write.c
+++ b/test/runtime/write.c
@@ -386,6 +386,21 @@ void truncate_test(const char *prog)
     }
     close(fd);
 
+    fd = open("new_file", O_RDWR | O_TRUNC);
+    if (fd < 0) {
+        perror("open(O_TRUNC)");
+        exit(EXIT_FAILURE);
+    }
+    if (fstat(fd, &s) < 0) {
+        perror("fstat");
+        goto out_fail;
+    }
+    if (s.st_size != 0) {
+        printf("O_TRUNC test failed (file size %ld)\n", s.st_size);
+        goto out_fail;
+    }
+    close(fd);
+
     fd = open("new_file", O_RDONLY);
     if (fd < 0) {
         perror("open");

--- a/tools/tfs-fuse.c
+++ b/tools/tfs-fuse.c
@@ -442,7 +442,7 @@ static int open_internal(const char *name, int flags, int mode)
 
     fsfile fsf;
     fs_status fss = filesystem_get_node(&rootfs, cwd_inode, name, !!(flags & O_NOFOLLOW),
-        !!(flags & O_CREAT), !!(flags & O_EXCL), &n, &fsf);
+        !!(flags & O_CREAT), !!(flags & O_EXCL), !!(flags & O_TRUNC), &n, &fsf);
     ret = rv_from_fs_status(fss);
     if ((ret == 0) && (flags & O_NOFOLLOW) && is_symlink(n) && !(flags & O_PATH)) {
         filesystem_put_node(rootfs, n);


### PR DESCRIPTION
When this flag is specified in an open() or openat() syscall, if the file being opened already exists and is a regular file it is truncated to length 0.
To implement this feature, the filesystem_get_node() function has been amended to take an additional 'truncate' boolean argument; the fsfile_open_or_create() function (which calls filesystem_get_node) has also been amended to take an additional 'truncate' argument, and this allowed to remove calls to fsfile_truncate() in a few places.

Closes #1803.