### PR TITLE
Fix last_raw update race condition

### DIFF
--- a/src/runtime/clock.h
+++ b/src/runtime/clock.h
@@ -68,14 +68,15 @@ static inline timestamp now(clock_id id)
     u64 gen;
     do {
         gen = __vdso_dat->vdso_gen & ~1ull;
+        s64 last_raw = __vdso_dat->last_raw;
+        read_barrier();
 #endif
         t = apply(platform_monotonic_now);
 #if defined(KERNEL) || defined(BUILD_VDSO)
         if (id == CLOCK_ID_MONOTONIC_RAW)
             return t;
-        s64 last_raw = __vdso_dat->last_raw;
-        s64 interval = t - last_raw;
         assert(t >= last_raw);
+        s64 interval = t - last_raw;
         t += clock_freq_adjust(interval);
         if (t < last_raw) {
             msg_err("t(%T) < last_raw(%T) after freq adjust (%f)\n", t, last_raw, __vdso_dat->base_freq);


### PR DESCRIPTION
The vdso last_raw gets updated periodically, and if it were updated on one processor while another is running now(), there can be a race condition where the now() cpu fetches monotonic time, then the other cpu updates last_raw with a slightly later monotonic time, then the now() cpu fetches the saved last_raw but then fails the assertion check comparing the two timestamps.

This change fixes the problem by reading the last_raw value before fetching the current monotonic time.