### PR TITLE
TFS fill_gap(): fix extent initialization when reserving storage

### DIFF
--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -850,7 +850,7 @@ static fs_status fill_gap(fsfile f, sg_list sg, range blocks, merge m, u64 *edge
 {
     tfs_debug("   %s: writing new extent blocks %R\n", __func__, blocks);
     extent ex;
-    fs_status fss = create_extent(f->fs, blocks, false, &ex);
+    fs_status fss = create_extent(f->fs, blocks, m ? false : true, &ex);
     if (fss != FS_STATUS_OK)
         return fss;
     blocks = ex->node.r;


### PR DESCRIPTION
When filesystem_check_or_reserve_extent() is called to reserve storage space before writing to a file, it can create new extents so that the needed storage space is marked as allocated. The initial file data associated to the new extents is zero and is not stored in the storage medium; for this reason, the extents should be marked as "uninited", so that any subsequent reads from these extents (for example during a RMW when writing a portion of a page cache node) return a zeroed block of data instead of retrieving the data from the storage medium.
This change fixes the above issue by modifying the fill_gap() function so that it creates "uninited" extents when there is no file data to be written to the storage medium; the issue has been discovered when running a modified "write" runtime test, which was
failing with a ""scatter test fail: read content mismatch" error.