### PR TITLE
Add option to run user program after getting ip4 address

### DIFF
--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -53,6 +53,14 @@ closure_function(5, 1, status, read_program_complete,
     }
     closure_member(program_start, bound(start), elf) = b;
     storage_when_ready(apply_merge(bound(m)));
+    value v;
+    if ((v = get(root, sym(exec_wait_for_ip4_secs)))) {
+        u64 ts;
+        if (u64_from_value(v, &ts))
+            ip4_when_ready(apply_merge(bound(m)), seconds(ts));
+        else
+            rprintf("exec_wait_for_ip4_secs has invalid time, ignoring\n");
+    }
     apply(bound(completion), STATUS_OK);
     closure_finish();
     return STATUS_OK;

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -3,4 +3,5 @@
 
 void init_net(kernel_heaps kh);
 void init_network_iface(tuple root);
+void ip4_when_ready(status_handler complete, timestamp timeout);
 status listen_port(heap h, u16 port, connection_handler c);

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -355,21 +355,21 @@ static inline s64 lwip_to_errno(s8 err)
     switch (err) {
     case ERR_OK: return 0;
     case ERR_MEM: return -ENOMEM;
-    case ERR_BUF: return -ENOMEM;
-    case ERR_TIMEOUT: return -ENOMEM;
-    case ERR_RTE: return -ENOMEM;
-    case ERR_INPROGRESS: return -EAGAIN;
+    case ERR_BUF: return -ENOBUFS;
+    case ERR_TIMEOUT: return -EAGAIN;
+    case ERR_RTE: return -EHOSTUNREACH;
+    case ERR_INPROGRESS: return -EINPROGRESS;
     case ERR_VAL: return -EINVAL;
     case ERR_WOULDBLOCK: return -EAGAIN;
-    case ERR_USE: return -EBUSY;
+    case ERR_USE: return -EADDRINUSE;
     case ERR_ALREADY: return -EALREADY;
     case ERR_ISCONN: return -EISCONN;
     case ERR_CONN: return -ENOTCONN;
     case ERR_IF: return -EINVAL;
-    case ERR_ABRT: return -EINVAL;
+    case ERR_ABRT: return -ECONNABORTED;
     case ERR_RST: return -ECONNRESET;
-    case ERR_CLSD: return -EPIPE;
-    case ERR_ARG: return -EINVAL;
+    case ERR_CLSD: return -ENOTCONN;
+    case ERR_ARG: return -EIO;
     }
     return -EINVAL;		/* XXX unknown - check return value */
 }

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -83,6 +83,7 @@ typedef struct iovec {
 #define EMSGSIZE        90		/* Message too long */
 #define EPROTOTYPE      91		/* Wrong protocol type for socket */
 #define EOPNOTSUPP      95		/* Operation not supported */
+#define ECONNABORTED    103             /* Software caused connection abort */
 #define EISCONN         106
 #define ENOTCONN        107
 #define ETIMEDOUT       110             /* Connection timed out */


### PR DESCRIPTION
Some user programs assume the network is ready to go when executing, but
if dhcp takes a long time then the user program may hit network errors
if an address and gateway isn't acquired yet. This change adds a new manifest
option 'exec_wait_for_ip4_secs', which will delay running the user program
until either an ip4 address is acquired or the timeout specified in the option
has elapsed. If a static address is set then the program is executed immediately.

Additionally, the translation of lwip to errno codes has been updated to more
accurately reflect the nature of the lwip errors.