### PR TITLE
Go runtime tests: update RunConfig struct field names

### DIFF
--- a/test/go/go_test.go
+++ b/test/go/go_test.go
@@ -32,7 +32,7 @@ func prepareTestImage(finalImage string) {
 	c.Env["USER"] = "bobby"
 	c.Env["PWD"] = "password"
 
-	c.RunConfig.Imagename = finalImage
+	c.RunConfig.ImageName = finalImage
 	c.Program = "../../output/test/runtime/bin/webg"
 
 	err := lepton.BuildImage(c)


### PR DESCRIPTION
The `Imagename` field has been renamed to `ImageName`.