### PR TITLE
CircleCI: nightly-build-mac: remove `brew upgrade python` command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,6 @@ jobs:
           environment:
             NANOS_TARGET_ROOT: ~/project/target-root
           command: make
-      - run: brew upgrade python
       - run: curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-396.0.0-darwin-x86_64.tar.gz
       - run: tar xzf google-cloud-cli*.tar.gz
       - run: ./google-cloud-sdk/install.sh -q


### PR DESCRIPTION
In the CircleCI Mac container, Python is not installed by default, thus the `brew upgrade python` command fails with "Error: python not installed".
This change removes the above command, which is not needed because the Google Cloud client installer (which is run in the following steps) automatically installs Python 3.7 (and would use this Python installation even if another Python version was already installed).