### PR TITLE
Klibs: add sandbox klib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ test test-noaccel: image
 	$(Q) $(MAKE) -C test test
 	$(Q) $(MAKE) runtime-tests$(subst test,,$@)
 
-RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws inotify io_uring ktest mkdir mmap netlink netsock pipe readv rename sendfile signal sigoverflow socketpair syslog time unlink thread_test tlbshootdown tun unixsocket vsyscall write writev
+RUNTIME_TESTS=	aio creat dup epoll eventfd fadvise fallocate fcntl fst fs_full futex futexrobust getdents getrandom hw hwg hws inotify io_uring ktest mkdir mmap netlink netsock pipe readv rename sandbox sendfile signal sigoverflow socketpair syslog time unlink thread_test tlbshootdown tun unixsocket vsyscall write writev
 
 .PHONY: runtime-tests runtime-tests-noaccel
 

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -8,6 +8,7 @@ PROGRAMS= \
 	gcp \
 	ntp \
 	radar \
+	sandbox \
 	syslog \
 	tls \
 	tun \
@@ -31,6 +32,11 @@ SRCS-ntp= \
 
 SRCS-radar= \
 	$(CURDIR)/radar.c \
+
+SRCS-sandbox= \
+	$(CURDIR)/pledge.c \
+	$(CURDIR)/sandbox.c \
+	$(CURDIR)/unveil.c \
 
 SRCS-syslog= \
 	$(CURDIR)/syslog.c \

--- a/klib/pledge.c
+++ b/klib/pledge.c
@@ -1,0 +1,923 @@
+#include <net_system_structs.h>
+#include <unix_internal.h>
+#include <socket.h>
+
+#include "sandbox.h"
+
+#define PLEDGE_STDIO        U64_FROM_BIT(0)
+#define PLEDGE_RPATH        U64_FROM_BIT(1)
+#define PLEDGE_WPATH        U64_FROM_BIT(2)
+#define PLEDGE_CPATH        U64_FROM_BIT(3)
+#define PLEDGE_DPATH        U64_FROM_BIT(4)
+#define PLEDGE_TMPPATH      U64_FROM_BIT(5)
+#define PLEDGE_INET         U64_FROM_BIT(6)
+#define PLEDGE_MCAST        U64_FROM_BIT(7)
+#define PLEDGE_FATTR        U64_FROM_BIT(8)
+#define PLEDGE_CHOWN        U64_FROM_BIT(9)
+#define PLEDGE_FLOCK        U64_FROM_BIT(10)
+#define PLEDGE_UNIX         U64_FROM_BIT(11)
+#define PLEDGE_DNS          U64_FROM_BIT(12)
+#define PLEDGE_GETPW        U64_FROM_BIT(13)
+#define PLEDGE_SENDFD       U64_FROM_BIT(14)
+#define PLEDGE_RECVFD       U64_FROM_BIT(15)
+#define PLEDGE_TAPE         U64_FROM_BIT(16)
+#define PLEDGE_TTY          U64_FROM_BIT(17)
+#define PLEDGE_PROC         U64_FROM_BIT(18)
+#define PLEDGE_EXEC         U64_FROM_BIT(19)
+#define PLEDGE_PROT_EXEC    U64_FROM_BIT(20)
+#define PLEDGE_SETTIME      U64_FROM_BIT(21)
+#define PLEDGE_PS           U64_FROM_BIT(22)
+#define PLEDGE_VMINFO       U64_FROM_BIT(23)
+#define PLEDGE_ID           U64_FROM_BIT(24)
+#define PLEDGE_PF           U64_FROM_BIT(25)
+#define PLEDGE_ROUTE        U64_FROM_BIT(26)
+#define PLEDGE_WROUTE       U64_FROM_BIT(27)
+#define PLEDGE_AUDIO        U64_FROM_BIT(28)
+#define PLEDGE_VIDEO        U64_FROM_BIT(29)
+#define PLEDGE_BPF          U64_FROM_BIT(30)
+#define PLEDGE_UNVEIL       U64_FROM_BIT(31)
+#define PLEDGE_ERROR        U64_FROM_BIT(32)
+
+#define PLEDGE_NEVER    U64_FROM_BIT(63)    /* these syscalls cannot be enabled by any promise */
+#define PLEDGE_ALL      -1ull
+
+static struct {
+    u64 sc_abilities[SYS_MAX];
+    u64 abilities;
+    struct spinlock lock;
+} pldg;
+
+#define pledge_syscall_register(syscalls, call, abil, handler)  do {    \
+    pldg.sc_abilities[SYS_##call] = abil;                               \
+    vector_push(&(syscalls)[SYS_##call].sb_handlers, pledge_##handler); \
+} while(0)
+
+#define pledge_syscall_register_default(syscalls, call, abil)   \
+    pledge_syscall_register(syscalls, call, abil, default_handler)
+
+static sysreturn pledge_fail(thread t)
+{
+    if (pldg.abilities & PLEDGE_ERROR)
+        return -ENOSYS;
+    struct siginfo s = {
+        .si_signo = SIGABRT,
+        .si_errno = 0,
+        .si_code = 0,
+    };
+    deliver_signal_to_thread(t, &s);
+    return 0;
+}
+
+static boolean pledge_syscall_check(syscall_context sc, sysreturn *rv)
+{
+    if (pldg.abilities & pldg.sc_abilities[sc->call])
+        return false;
+    *rv = pledge_fail(sc->t);
+    return true;
+}
+
+static boolean pledge_default_handler(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                      sysreturn *rv)
+{
+    if (pldg.abilities == PLEDGE_ALL)
+        return false;
+    return pledge_syscall_check((syscall_context)get_current_context(current_cpu()), rv);
+}
+
+static u64 pledge_get_ability(buffer promise)
+{
+    static const char *promises[] = {
+        "stdio",
+        "rpath",
+        "wpath",
+        "cpath",
+        "dpath",
+        "tmppath",
+        "inet",
+        "mcast",
+        "fattr",
+        "chown",
+        "flock",
+        "unix",
+        "dns",
+        "getpw",
+        "sendfd",
+        "recvfd",
+        "tape",
+        "tty",
+        "proc",
+        "exec",
+        "prot_exec",
+        "settime",
+        "ps",
+        "vminfo",
+        "id",
+        "pf",
+        "route",
+        "wroute",
+        "audio",
+        "video",
+        "bpf",
+        "unveil",
+        "error",
+    };
+    for (int i = 0; i < _countof(promises); i++)
+        if (buffer_compare_with_cstring(promise, promises[i]))
+            return U64_FROM_BIT(i);
+    return 0;
+}
+
+static sysreturn pledge(const char *promises, const char *execpromises)
+{
+    if (!promises)
+        return 0;
+    if (!fault_in_user_string(promises))
+        return -EFAULT;
+    heap h = heap_locked(&get_unix_heaps()->kh);
+    u64 new_abilities = 0;
+    vector prom = split(h, alloca_wrap_cstring(promises), ' ');
+    string pr;
+    vector_foreach(prom, pr) {
+        u64 ability = pledge_get_ability(pr);
+        if (!ability)
+            return -EINVAL;
+        new_abilities |= ability;
+    }
+    spin_lock(&pldg.lock);
+    sysreturn rv;
+    if (new_abilities & ~pldg.abilities) {
+        rv = -EPERM;
+    } else {
+        pldg.abilities = new_abilities;
+        rv = 0;
+    }
+    spin_unlock(&pldg.lock);
+    split_dealloc(prom);
+    return rv;
+}
+
+static boolean pledge_prot_exec(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                sysreturn *rv)
+{
+    syscall_context sc = (syscall_context)get_current_context(current_cpu());
+    if (pledge_syscall_check(sc, rv))
+        return true;
+    if ((pldg.abilities & PLEDGE_PROT_EXEC) || !(arg2 & PROT_EXEC))
+        return false;
+    *rv = pledge_fail(sc->t);
+    return true;
+}
+
+static boolean pledge_ioctl(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                            sysreturn *rv)
+{
+    if (pldg.abilities == PLEDGE_ALL)
+        return false;
+    syscall_context sc = (syscall_context)get_current_context(current_cpu());
+    if (pledge_syscall_check(sc, rv))
+        return true;
+    int fd = arg0;
+    unsigned long request = arg1;
+    fdesc f = 0;
+    switch (request) {
+    case FIONREAD:
+    case FIONBIO:
+    case FIONCLEX:
+    case FIOCLEX:
+        goto pass;
+    }
+    thread t = sc->t;
+    f = fdesc_get(t->p, fd);
+    if (f) {
+        if (f->type == FDESC_TYPE_SOCKET) {
+            if (pldg.abilities & PLEDGE_ROUTE)
+                switch (request) {
+                case SIOCGIFADDR:
+                case SIOCGIFFLAGS:
+                case SIOCGIFMETRIC:
+                    goto pass;
+                }
+            if (pldg.abilities & PLEDGE_WROUTE)
+                switch (request) {
+                case SIOCSIFADDR:
+                case SIOCDIFADDR:
+                case SIOCSIFFLAGS:
+                case SIOCSIFMETRIC:
+                    goto pass;
+                }
+        }
+        fdesc_put(f);
+    }
+    *rv = pledge_fail(t);
+    return true;
+  pass:
+    if (f)
+        fdesc_put(f);
+    return false;
+}
+
+static boolean pledge_socket_check_domain(thread t, int domain, sysreturn *rv)
+{
+    switch (domain) {
+    case AF_INET:
+    case AF_INET6:
+        if (!(pldg.abilities & PLEDGE_INET))
+            goto fail;
+        break;
+    case AF_UNIX:
+        if (!(pldg.abilities & PLEDGE_UNIX))
+            goto fail;
+        break;
+    default:
+        if (pldg.abilities != PLEDGE_ALL)
+            goto fail;
+    }
+    return false;
+  fail:
+    *rv = pledge_fail(t);
+    return true;
+}
+
+static boolean pledge_socket(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    syscall_context sc = (syscall_context)get_current_context(current_cpu());
+    if (pledge_syscall_check(sc, rv))
+        return true;
+    return pledge_socket_check_domain(sc->t, arg0, rv);
+}
+
+static boolean pledge_sockfd(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    syscall_context sc = (syscall_context)get_current_context(current_cpu());
+    if (pledge_syscall_check(sc, rv))
+        return true;
+    thread t = sc->t;
+    fdesc f = fdesc_get(t->p, arg0);
+    if (!f)
+        return false;
+    boolean result;
+    if (f->type == FDESC_TYPE_SOCKET)
+        result = pledge_socket_check_domain(t, ((struct sock *)f)->domain, rv);
+    else
+        result = false;
+    fdesc_put(f);
+    return result;
+}
+
+static boolean pledge_sendto(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    syscall_context sc = (syscall_context)get_current_context(current_cpu());
+    if (pledge_syscall_check(sc, rv))
+        return true;
+    struct sockaddr *dest_addr = (struct sockaddr *)arg4;
+    if (!dest_addr || (pldg.abilities & (PLEDGE_INET | PLEDGE_UNIX | PLEDGE_DNS)))
+        return false;
+    *rv = pledge_fail(sc->t);
+    return true;
+}
+
+static boolean pledge_sendmsg(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                              sysreturn *rv)
+{
+    syscall_context sc = (syscall_context)get_current_context(current_cpu());
+    if (pledge_syscall_check(sc, rv))
+        return true;
+    const struct msghdr *msg = (const struct msghdr *)arg1;
+    if (!(pldg.abilities & (PLEDGE_INET | PLEDGE_UNIX | PLEDGE_DNS)) &&
+        validate_user_memory(msg, sizeof(*msg), false) && msg->msg_name) {
+        *rv = pledge_fail(sc->t);
+        return true;
+    }
+    return false;
+}
+
+static boolean pledge_sockopt_check(boolean set, int level, int optname, sysreturn *rv)
+{
+    if (pldg.abilities == PLEDGE_ALL)
+        return false;
+    syscall_context sc = (syscall_context)get_current_context(current_cpu());
+    if (pledge_syscall_check(sc, rv))
+        return true;
+    switch (level) {
+    case SOL_SOCKET:
+        switch (optname) {
+        case SO_RCVBUF:
+        case SO_ERROR:
+            return false;
+        }
+        break;
+    case SOL_TCP:
+        switch (optname) {
+        case TCP_NODELAY:
+            return false;
+        }
+        break;
+    }
+    if (!(pldg.abilities & (PLEDGE_INET | PLEDGE_UNIX | PLEDGE_DNS)))
+        goto fail;
+    if ((level == SOL_SOCKET) && (optname == SO_TIMESTAMP))
+        return false;
+    if ((pldg.abilities & PLEDGE_DNS) && (level == IPPROTO_IPV6))
+        switch (optname) {
+        case IPV6_RECVPKTINFO:
+        case IPV6_USE_MIN_MTU:
+            return false;
+        }
+    if (!(pldg.abilities & (PLEDGE_INET | PLEDGE_UNIX)))
+        goto fail;
+    if (level == SOL_SOCKET)
+        return false;
+    if (!(pldg.abilities & PLEDGE_INET))
+        goto fail;
+    switch (level) {
+    case SOL_TCP:
+        switch (optname) {
+        case TCP_MD5SIG:
+        case TCP_MAXSEG:
+        case TCP_INFO:
+            return false;
+        }
+        break;
+    case IPPROTO_IP:
+        switch (optname) {
+        case IP_OPTIONS:
+            if (!set)
+                return false;
+            break;
+        case IP_TOS:
+        case IP_TTL:
+        case IP_MINTTL:
+            return false;
+        case IP_MULTICAST_IF:
+        case IP_MULTICAST_TTL:
+        case IP_MULTICAST_LOOP:
+        case IP_ADD_MEMBERSHIP:
+        case IP_DROP_MEMBERSHIP:
+            if (pldg.abilities & PLEDGE_MCAST)
+                return false;
+            break;
+        }
+        break;
+    case IPPROTO_IPV6:
+        switch (optname) {
+        case IPV6_TCLASS:
+        case IPV6_UNICAST_HOPS:
+        case IPV6_MINHOPCOUNT:
+        case IPV6_RECVHOPLIMIT:
+        case IPV6_RECVPKTINFO:
+        case IPV6_V6ONLY:
+            return false;
+        case IPV6_MULTICAST_IF:
+        case IPV6_MULTICAST_HOPS:
+        case IPV6_MULTICAST_LOOP:
+            if (pldg.abilities & PLEDGE_MCAST)
+                return false;
+            break;
+        }
+        break;
+    }
+  fail:
+    *rv = pledge_fail(sc->t);
+    return true;
+}
+
+static boolean pledge_setsockopt(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                 sysreturn *rv)
+{
+    return pledge_sockopt_check(true, arg1, arg2, rv);
+}
+
+static boolean pledge_getsockopt(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                 sysreturn *rv)
+{
+    return pledge_sockopt_check(false, arg1, arg2, rv);
+}
+
+static boolean path_canonicalize(const char *path, char *canon_path, int buf_size)
+{
+    if (path[0] != '/')
+        return false;
+    const char *p = path;
+    char *q = canon_path;
+    while (*p && (q - canon_path < buf_size)) {
+        if ((p[0] == '/') && ((p[1] == '/') || (p[1] == '\0')))
+            p++;
+        else if ((p[0] == '/') && (p[1] == '.') && ((p[2] == '/') || (p[2] == '\0')))
+            p += 2;
+        else if ((p[0] == '/') && (p[1] == '.') && (p[2] == '.') &&
+                 ((p[3] == '/') || (p[3] == '\0'))) {
+            p += 3;
+            if (q != canon_path)
+                /* remove the last path component */
+                do {
+                    q--;
+                } while (*q != '/');
+
+        } else {
+            *q++ = *p++;
+        }
+    }
+    if ((*p == '\0') && (q - canon_path < buf_size)) {
+        if (q == canon_path)
+            *q++ = '/';
+        *q = 0;
+        return true;
+    }
+    return false;
+}
+
+static boolean path_is_in_dir(const char *path, const char *dir)
+{
+    int dir_path_len = runtime_strlen(dir);
+    if (runtime_strlen(path) < dir_path_len)
+        return false;
+    return (runtime_memcmp(path, dir, dir_path_len) == 0);
+}
+
+static boolean pledge_filepath_create(const char *path, sysreturn *rv)
+{
+    syscall_context sc = (syscall_context)get_current_context(current_cpu());
+    if (pledge_syscall_check(sc, rv))
+        return true;
+    if (pldg.abilities & PLEDGE_CPATH)
+        return false;
+    if (!fault_in_user_string(path))
+        return false;
+    char canon_path[PATH_MAX];
+    boolean canon = path_canonicalize(path, canon_path, sizeof(canon_path));
+    if ((pldg.abilities & PLEDGE_TMPPATH) && canon && path_is_in_dir(canon_path, "/tmp/"))
+        return false;
+    *rv = pledge_fail(sc->t);
+    return true;
+}
+
+static boolean pledge_filepath_io(int call, const char *path, int flags, sysreturn *rv)
+{
+    syscall_context sc = (syscall_context)get_current_context(current_cpu());
+    if (pledge_syscall_check(sc, rv))
+        return true;
+    if (!fault_in_user_string(path))
+        return false;
+    char canon_path[PATH_MAX];
+    boolean canon = path_canonicalize(path, canon_path, sizeof(canon_path));
+    if ((pldg.abilities & PLEDGE_TMPPATH) && canon && path_is_in_dir(canon_path, "/tmp/"))
+        return false;
+    if (!(pldg.abilities & PLEDGE_CPATH) && (flags & O_CREAT))
+        goto fail;
+    switch (flags & O_ACCMODE) {
+    case O_RDONLY:
+        if (!(pldg.abilities & PLEDGE_RPATH)) {
+            if (!canon)
+                goto fail;
+            switch (call) {
+            case SYS_openat:
+                if (path_is_in_dir(canon_path, "/usr/share/zoneinfo/") ||
+                    !runtime_strcmp(canon_path, "/etc/localtime"))
+                    return false;
+                if ((pldg.abilities & PLEDGE_DNS) &&
+                    (!runtime_strcmp(canon_path, "/etc/resolv.conf") ||
+                     !runtime_strcmp(canon_path, "/etc/hosts") ||
+                     !runtime_strcmp(canon_path, "/etc/services") ||
+                     !runtime_strcmp(canon_path, "/etc/protocols")))
+                    return false;
+                break;
+            case SYS_faccessat:
+                if (!runtime_strcmp(canon_path, "/etc/localtime"))
+                    return false;
+                break;
+            case SYS_newfstatat:
+                if ((pldg.abilities & PLEDGE_DNS) &&
+                    (!runtime_strcmp(canon_path, "/etc/resolv.conf") ||
+                     !runtime_strcmp(canon_path, "/etc/hosts")))
+                    return false;
+                break;
+            }
+            goto fail;
+        }
+        break;
+    case O_WRONLY:
+        if (!(pldg.abilities & PLEDGE_WPATH))
+            goto fail;
+        break;
+    case O_RDWR:
+        if (!(pldg.abilities & PLEDGE_RPATH) || !(pldg.abilities & PLEDGE_WPATH))
+            goto fail;
+        break;
+    }
+    return false;
+  fail:
+    *rv = pledge_fail(sc->t);
+    return true;
+}
+
+static boolean pledge_openat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    return pledge_filepath_io(SYS_openat, (const char *)arg1, arg2, rv);
+}
+
+static boolean pledge_create_arg1(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                  sysreturn *rv)
+{
+    return pledge_filepath_create((const char *)arg1, rv);
+}
+
+static boolean pledge_newfstatat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                 sysreturn *rv)
+{
+    return pledge_filepath_io(SYS_newfstatat, (const char *)arg1, O_RDONLY, rv);
+}
+
+static boolean pledge_symlinkat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                sysreturn *rv)
+{
+    return pledge_filepath_create((const char *)arg2, rv);
+}
+
+static boolean pledge_readlinkat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                 sysreturn *rv)
+{
+    return pledge_filepath_io(SYS_readlinkat, (const char *)arg1, O_RDONLY, rv);
+}
+
+static boolean pledge_renameat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                               sysreturn *rv)
+{
+    return pledge_filepath_create((const char *)arg1, rv) ||
+           pledge_filepath_create((const char *)arg3, rv);
+}
+
+static boolean pledge_faccessat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                sysreturn *rv)
+{
+    return pledge_filepath_io(SYS_faccessat, (const char *)arg1, O_RDONLY, rv);
+}
+
+#ifdef __x86_64__
+
+static boolean pledge_open(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                           sysreturn *rv)
+{
+    return pledge_filepath_io(SYS_openat, (const char *)arg0, arg1, rv);
+}
+
+static boolean pledge_stat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                           sysreturn *rv)
+{
+    return pledge_filepath_io(SYS_newfstatat, (const char *)arg0, O_RDONLY, rv);
+}
+
+static boolean pledge_lstat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                            sysreturn *rv)
+{
+    return pledge_filepath_io(SYS_lstat, (const char *)arg0, O_RDONLY, rv);
+}
+
+static boolean pledge_access(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    return pledge_filepath_io(SYS_faccessat, (const char *)arg0, O_RDONLY, rv);
+}
+
+static boolean pledge_rename(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    return pledge_filepath_create((const char *)arg0, rv) ||
+           pledge_filepath_create((const char *)arg2, rv);
+}
+
+static boolean pledge_create_arg0(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                  sysreturn *rv)
+{
+    return pledge_filepath_create((const char *)arg0, rv);
+}
+
+static boolean pledge_creat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                            sysreturn *rv)
+{
+    return pledge_filepath_io(SYS_creat, (const char *)arg0, O_CREAT | O_WRONLY | O_TRUNC, rv);
+}
+
+static boolean pledge_readlink(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                               sysreturn *rv)
+{
+    return pledge_filepath_io(SYS_readlinkat, (const char *)arg0, O_RDONLY, rv);
+}
+
+static boolean pledge_uselib(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    if (pledge_filepath_io(SYS_uselib, (const char *)arg0, O_RDONLY, rv))
+        return true;
+    if (pldg.abilities & PLEDGE_PROT_EXEC)
+        return false;
+    *rv = pledge_fail(current);
+    return true;
+}
+
+#endif
+
+static boolean pledge_sendmmsg(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                               sysreturn *rv)
+{
+    syscall_context sc = (syscall_context)get_current_context(current_cpu());
+    if (pledge_syscall_check(sc, rv))
+        return true;
+    struct mmsghdr *msgvec = (struct mmsghdr *)arg1;
+    unsigned int vlen = arg2;
+    if (!(pldg.abilities & (PLEDGE_INET | PLEDGE_UNIX)) &&
+        validate_user_memory(msgvec, vlen * sizeof(struct mmsghdr), false))
+        for (unsigned int i = 0; i < vlen; i++)
+            if (msgvec[i].msg_hdr.msg_name) {
+                *rv = pledge_fail(sc->t);
+                return true;
+            }
+    return false;
+}
+
+boolean pledge_init(sb_syscall syscalls, tuple cfg)
+{
+    pldg.abilities = PLEDGE_ALL;
+    register_syscall(linux_syscalls, pledge, pledge, 0);
+    pledge_syscall_register_default(syscalls, read, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, write, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, close, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, fstat, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, lseek, PLEDGE_STDIO);
+    pledge_syscall_register(syscalls, mmap, PLEDGE_STDIO, prot_exec);
+    pledge_syscall_register(syscalls, mprotect, PLEDGE_STDIO, prot_exec);
+    pledge_syscall_register_default(syscalls, munmap, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, brk, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, rt_sigaction, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, rt_sigprocmask, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, rt_sigreturn, PLEDGE_STDIO);
+    pledge_syscall_register(syscalls, ioctl, PLEDGE_STDIO, ioctl);
+    pledge_syscall_register_default(syscalls, pread64, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, pwrite64, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, readv, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, writev, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sched_yield, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, mremap, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, msync, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, mincore, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, madvise, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, dup, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, nanosleep, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, getitimer, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, setitimer, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, getpid, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sendfile, PLEDGE_STDIO);
+    pledge_syscall_register(syscalls, socket, PLEDGE_INET | PLEDGE_UNIX, socket);
+    pledge_syscall_register(syscalls, connect, PLEDGE_INET | PLEDGE_UNIX, sockfd);
+    pledge_syscall_register(syscalls, accept, PLEDGE_INET | PLEDGE_UNIX, sockfd);
+    pledge_syscall_register(syscalls, sendto, PLEDGE_STDIO, sendto);
+    pledge_syscall_register_default(syscalls, recvfrom, PLEDGE_STDIO);
+    pledge_syscall_register(syscalls, sendmsg, PLEDGE_STDIO, sendmsg);
+    pledge_syscall_register_default(syscalls, recvmsg, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, shutdown, PLEDGE_STDIO);
+    pledge_syscall_register(syscalls, bind, PLEDGE_INET | PLEDGE_UNIX, sockfd);
+    pledge_syscall_register(syscalls, listen, PLEDGE_INET | PLEDGE_UNIX, sockfd);
+    pledge_syscall_register(syscalls, getsockname, PLEDGE_INET | PLEDGE_UNIX, sockfd);
+    pledge_syscall_register(syscalls, getpeername, PLEDGE_INET | PLEDGE_UNIX, sockfd);
+    pledge_syscall_register_default(syscalls, socketpair, PLEDGE_STDIO);
+    pledge_syscall_register(syscalls, setsockopt, PLEDGE_STDIO, setsockopt);
+    pledge_syscall_register(syscalls, getsockopt, PLEDGE_STDIO, getsockopt);
+    pledge_syscall_register_default(syscalls, clone, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, wait4, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, kill, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, uname, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, fcntl, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, flock, PLEDGE_FLOCK);
+    pledge_syscall_register_default(syscalls, fsync, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, fdatasync, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, truncate, PLEDGE_WPATH);
+    pledge_syscall_register_default(syscalls, ftruncate, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, getcwd, PLEDGE_RPATH | PLEDGE_WPATH);
+    pledge_syscall_register_default(syscalls, chdir, PLEDGE_RPATH);
+    pledge_syscall_register_default(syscalls, fchdir, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, fchmod, PLEDGE_FATTR);
+    pledge_syscall_register_default(syscalls, fchown, PLEDGE_FATTR | PLEDGE_CHOWN);
+    pledge_syscall_register_default(syscalls, umask, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, gettimeofday, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, getrlimit, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, getrusage, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, times, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, getuid, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, getgid, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, setuid, PLEDGE_ID);
+    pledge_syscall_register_default(syscalls, setgid, PLEDGE_ID);
+    pledge_syscall_register_default(syscalls, geteuid, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, getegid, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, setreuid, PLEDGE_ID);
+    pledge_syscall_register_default(syscalls, setregid, PLEDGE_ID);
+    pledge_syscall_register_default(syscalls, getgroups, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, setgroups, PLEDGE_ID);
+    pledge_syscall_register_default(syscalls, setresuid, PLEDGE_ID);
+    pledge_syscall_register_default(syscalls, getresuid, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, getresgid, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, getpgid, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, getsid, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, rt_sigpending, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, rt_sigtimedwait, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, rt_sigqueueinfo, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, rt_sigsuspend, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sigaltstack, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, statfs, PLEDGE_RPATH);
+    pledge_syscall_register_default(syscalls, fstatfs, PLEDGE_RPATH);
+    pledge_syscall_register_default(syscalls, sched_setparam, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sched_getparam, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sched_setscheduler, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sched_getscheduler, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sched_get_priority_max, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sched_get_priority_min, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sched_rr_get_interval, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, mlock, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, munlock, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, mlockall, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, munlockall, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, pivot_root, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, prctl, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, adjtimex, PLEDGE_SETTIME);
+    pledge_syscall_register_default(syscalls, setrlimit, PLEDGE_PROC | PLEDGE_ID);
+    pledge_syscall_register_default(syscalls, chroot, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, sync, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, acct, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, settimeofday, PLEDGE_SETTIME);
+    pledge_syscall_register_default(syscalls, mount, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, umount2, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, swapon, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, swapoff, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, reboot, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, sethostname, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, setdomainname, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, init_module, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, delete_module, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, quotactl, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, gettid, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, readahead, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, setxattr, PLEDGE_FATTR);
+    pledge_syscall_register_default(syscalls, lsetxattr, PLEDGE_FATTR);
+    pledge_syscall_register_default(syscalls, fsetxattr, PLEDGE_FATTR);
+    pledge_syscall_register_default(syscalls, getxattr, PLEDGE_RPATH | PLEDGE_WPATH);
+    pledge_syscall_register_default(syscalls, lgetxattr, PLEDGE_RPATH | PLEDGE_WPATH);
+    pledge_syscall_register_default(syscalls, fgetxattr, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, listxattr, PLEDGE_RPATH | PLEDGE_WPATH);
+    pledge_syscall_register_default(syscalls, llistxattr, PLEDGE_RPATH | PLEDGE_WPATH);
+    pledge_syscall_register_default(syscalls, flistxattr, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, removexattr, PLEDGE_FATTR);
+    pledge_syscall_register_default(syscalls, lremovexattr, PLEDGE_FATTR);
+    pledge_syscall_register_default(syscalls, fremovexattr, PLEDGE_FATTR);
+    pledge_syscall_register_default(syscalls, tkill, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, futex, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sched_setaffinity, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sched_getaffinity, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, io_setup, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, io_destroy, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, io_getevents, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, io_submit, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, io_cancel, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, lookup_dcookie, PLEDGE_RPATH | PLEDGE_WPATH);
+    pledge_syscall_register_default(syscalls, getdents64, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, set_tid_address, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, fadvise64, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, timer_create, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, timer_settime, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, timer_gettime, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, timer_getoverrun, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, timer_delete, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, clock_settime, PLEDGE_SETTIME);
+    pledge_syscall_register_default(syscalls, clock_gettime, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, clock_getres, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, clock_nanosleep, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, epoll_ctl, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, tgkill, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, mbind, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, set_mempolicy, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, get_mempolicy, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, add_key, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, request_key, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, keyctl, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, ioprio_get, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, ioprio_set, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, inotify_add_watch, PLEDGE_RPATH | PLEDGE_WPATH);
+    pledge_syscall_register_default(syscalls, inotify_rm_watch, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, migrate_pages, PLEDGE_STDIO);
+    pledge_syscall_register(syscalls, openat, PLEDGE_RPATH | PLEDGE_WPATH | PLEDGE_TMPPATH, openat);
+    pledge_syscall_register(syscalls, mkdirat, PLEDGE_CPATH | PLEDGE_TMPPATH, create_arg1);
+    pledge_syscall_register_default(syscalls, mknodat, PLEDGE_DPATH);
+    pledge_syscall_register_default(syscalls, fchownat, PLEDGE_FATTR | PLEDGE_CHOWN);
+    pledge_syscall_register(syscalls, newfstatat, PLEDGE_RPATH | PLEDGE_WPATH | PLEDGE_TMPPATH,
+                            newfstatat);
+    pledge_syscall_register(syscalls, unlinkat, PLEDGE_CPATH | PLEDGE_TMPPATH, create_arg1);
+    pledge_syscall_register(syscalls, renameat, PLEDGE_CPATH | PLEDGE_TMPPATH, renameat);
+    pledge_syscall_register_default(syscalls, linkat, PLEDGE_CPATH);
+    pledge_syscall_register(syscalls, symlinkat, PLEDGE_CPATH | PLEDGE_TMPPATH, symlinkat);
+    pledge_syscall_register(syscalls, readlinkat, PLEDGE_RPATH | PLEDGE_TMPPATH, readlinkat);
+    pledge_syscall_register_default(syscalls, fchmodat, PLEDGE_FATTR);
+    pledge_syscall_register(syscalls, faccessat, PLEDGE_RPATH | PLEDGE_WPATH | PLEDGE_TMPPATH,
+                            faccessat);
+    pledge_syscall_register_default(syscalls, pselect6, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, ppoll, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, set_robust_list, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, get_robust_list, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, splice, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, tee, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sync_file_range, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, vmsplice, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, move_pages, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, utimensat, PLEDGE_FATTR);
+    pledge_syscall_register_default(syscalls, epoll_pwait, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, timerfd_create, PLEDGE_STDIO);
+#ifdef __x86_64__
+    pledge_syscall_register(syscalls, open, PLEDGE_RPATH | PLEDGE_WPATH | PLEDGE_TMPPATH, open);
+    pledge_syscall_register(syscalls, stat, PLEDGE_RPATH | PLEDGE_WPATH | PLEDGE_TMPPATH, stat);
+    pledge_syscall_register(syscalls, lstat, PLEDGE_RPATH | PLEDGE_WPATH | PLEDGE_TMPPATH, lstat);
+    pledge_syscall_register_default(syscalls, poll, PLEDGE_STDIO);
+    pledge_syscall_register(syscalls, access, PLEDGE_RPATH | PLEDGE_WPATH | PLEDGE_TMPPATH, access);
+    pledge_syscall_register_default(syscalls, pipe, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, select, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, dup2, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, pause, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, alarm, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, getdents, PLEDGE_STDIO);
+    pledge_syscall_register(syscalls, rename, PLEDGE_CPATH | PLEDGE_TMPPATH, rename);
+    pledge_syscall_register(syscalls, mkdir, PLEDGE_CPATH | PLEDGE_TMPPATH, create_arg0);
+    pledge_syscall_register(syscalls, rmdir, PLEDGE_CPATH | PLEDGE_TMPPATH, create_arg0);
+    pledge_syscall_register(syscalls, creat, PLEDGE_CPATH | PLEDGE_TMPPATH, creat);
+    pledge_syscall_register(syscalls, unlink, PLEDGE_CPATH | PLEDGE_TMPPATH, create_arg0);
+    pledge_syscall_register(syscalls, symlink, PLEDGE_CPATH | PLEDGE_TMPPATH, create_arg1);
+    pledge_syscall_register(syscalls, readlink, PLEDGE_RPATH | PLEDGE_TMPPATH, readlink);
+    pledge_syscall_register_default(syscalls, chmod, PLEDGE_FATTR);
+    pledge_syscall_register_default(syscalls, chown, PLEDGE_FATTR | PLEDGE_CHOWN);
+    pledge_syscall_register_default(syscalls, lchown, PLEDGE_FATTR | PLEDGE_CHOWN);
+    pledge_syscall_register_default(syscalls, getpgrp, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, utime, PLEDGE_FATTR);
+    pledge_syscall_register_default(syscalls, mknod, PLEDGE_DPATH);
+    pledge_syscall_register(syscalls, uselib, PLEDGE_STDIO, uselib);
+    pledge_syscall_register_default(syscalls, modify_ldt, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, _sysctl, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, arch_prctl, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, iopl, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, ioperm, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, time, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, set_thread_area, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, get_thread_area, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, epoll_create, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, epoll_wait, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, utimes, PLEDGE_FATTR);
+    pledge_syscall_register_default(syscalls, inotify_init, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, futimesat, PLEDGE_FATTR);
+    pledge_syscall_register_default(syscalls, signalfd, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, eventfd, PLEDGE_STDIO);
+#endif
+    pledge_syscall_register_default(syscalls, fallocate, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, timerfd_settime, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, timerfd_gettime, PLEDGE_STDIO);
+    pledge_syscall_register(syscalls, accept4, PLEDGE_INET | PLEDGE_UNIX, sockfd);
+    pledge_syscall_register_default(syscalls, signalfd4, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, eventfd2, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, epoll_create1, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, dup3, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, pipe2, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, inotify_init1, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, preadv, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, pwritev, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, rt_tgsigqueueinfo, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, perf_event_open, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, recvmmsg, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, fanotify_init, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, fanotify_mark, PLEDGE_RPATH | PLEDGE_WPATH);
+    pledge_syscall_register_default(syscalls, prlimit64, PLEDGE_PROC | PLEDGE_ID);
+    pledge_syscall_register_default(syscalls, name_to_handle_at, PLEDGE_RPATH | PLEDGE_WPATH);
+    pledge_syscall_register_default(syscalls, open_by_handle_at, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, clock_adjtime, PLEDGE_SETTIME);
+    pledge_syscall_register_default(syscalls, syncfs, PLEDGE_NEVER);
+    pledge_syscall_register(syscalls, sendmmsg, PLEDGE_STDIO, sendmmsg);
+    pledge_syscall_register_default(syscalls, getcpu, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, finit_module, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, sched_setattr, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, sched_getattr, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, renameat2, PLEDGE_CPATH);
+    pledge_syscall_register_default(syscalls, seccomp, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, getrandom, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, memfd_create, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, bpf, PLEDGE_BPF);
+    pledge_syscall_register_default(syscalls, userfaultfd, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, membarrier, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, mlock2, PLEDGE_NEVER);
+    pledge_syscall_register_default(syscalls, copy_file_range, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, preadv2, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, pwritev2, PLEDGE_STDIO);
+    pledge_syscall_register(syscalls, pkey_mprotect, PLEDGE_STDIO, prot_exec);
+    pledge_syscall_register_default(syscalls, pkey_alloc, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, pkey_free, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, io_uring_setup, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, io_uring_enter, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, io_uring_register, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, clone3, PLEDGE_STDIO);
+    pledge_syscall_register_default(syscalls, unveil, PLEDGE_UNVEIL);
+    return true;
+}

--- a/klib/sandbox.c
+++ b/klib/sandbox.c
@@ -1,0 +1,50 @@
+#include <unix_internal.h>
+
+#include "sandbox.h"
+
+static struct sb_syscall sb_syscalls[SYS_MAX];
+
+static sysreturn sb_handler(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5)
+{
+    syscall_context sc = (syscall_context)get_current_context(current_cpu());
+    sb_syscall sbsc = &sb_syscalls[sc->call];
+    sb_syscall_handler h;
+    sysreturn rv;
+    vector_foreach(&sbsc->sb_handlers, h) {
+        if (h(arg0, arg1, arg2, arg3, arg4, arg5, &rv))
+            return rv;
+    }
+    if (sbsc->default_handler)
+        return sbsc->default_handler(arg0, arg1, arg2, arg3, arg4, arg5);
+    else
+        return -ENOSYS;
+}
+
+int init(status_handler complete)
+{
+    tuple root = get_root_tuple();
+    if (!root)
+        return KLIB_INIT_FAILED;
+    tuple sb_config = get_tuple(root, sym(sandbox));
+    if (!sb_config)
+        return KLIB_INIT_OK;
+    heap h = heap_locked(get_kernel_heaps());
+    for (int i = 0; i < SYS_MAX; i++) {
+        bytes handler_memsize = 2 * sizeof(sb_syscall_handler);
+        void *handlers_mem = allocate(h, handler_memsize);
+        assert(handlers_mem != INVALID_ADDRESS);
+        init_buffer(&sb_syscalls[i].sb_handlers, handler_memsize, false, h, handlers_mem);
+    }
+    tuple pledge_cfg = get_tuple(sb_config, sym(pledge));
+    if (pledge_cfg && !pledge_init(sb_syscalls, pledge_cfg))
+        return KLIB_INIT_FAILED;
+    tuple unveil_cfg = get_tuple(sb_config, sym(unveil));
+    if (unveil_cfg && !unveil_init(sb_syscalls, unveil_cfg))
+        return KLIB_INIT_FAILED;
+    for (int i = 0; i < SYS_MAX; i++) {
+        sb_syscall sbsc = &sb_syscalls[i];
+        if (buffer_length(&sbsc->sb_handlers) != 0)
+            sbsc->default_handler = swap_syscall_handler(linux_syscalls, i, sb_handler);
+    }
+    return KLIB_INIT_OK;
+}

--- a/klib/sandbox.h
+++ b/klib/sandbox.h
@@ -1,0 +1,14 @@
+typedef boolean (*sb_syscall_handler)(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                      sysreturn *rv);
+
+typedef struct sb_syscall {
+    struct buffer sb_handlers;
+    sysreturn (*default_handler)();
+} *sb_syscall;
+
+/* OpenBSD syscalls, mapped to unused syscall numbers in Linux */
+#define SYS_pledge  335
+#define SYS_unveil  336
+
+boolean pledge_init(sb_syscall syscalls, tuple cfg);
+boolean unveil_init(sb_syscall syscalls, tuple cfg);

--- a/klib/unveil.c
+++ b/klib/unveil.c
@@ -1,0 +1,701 @@
+#include <unix_internal.h>
+#include <net_system_structs.h>
+#include <socket.h>
+
+#include "sandbox.h"
+
+#define UNVEIL_READ     U64_FROM_BIT(0)
+#define UNVEIL_WRITE    U64_FROM_BIT(1)
+#define UNVEIL_EXEC     U64_FROM_BIT(2)
+#define UNVEIL_CREATE   U64_FROM_BIT(3)
+
+#define UNVEIL_PERMS_VALID  U64_FROM_BIT(63)
+
+static struct {
+    heap h;
+    table dirs;
+    struct rw_spinlock lock;
+    boolean locked;
+} unv;
+
+typedef struct unveil_dir {
+    filesystem fs;
+    inode ino;
+    u64 perms;
+    table dir_entries;
+} *unveil_dir;
+
+#define unveil_syscall_register_handler(syscalls, call, handler)    \
+    vector_push(&(syscalls)[SYS_##call].sb_handlers, unveil_##handler)
+
+#define unveil_syscall_register(syscalls, call) \
+    unveil_syscall_register_handler(syscalls, call, call)
+
+/* increments refcount of returned filesystem */
+static filesystem get_cwd_fs(int dirfd, const char *path, inode *cwd)
+{
+    filesystem fs;
+    process p = current->p;
+    if (*path == '/') {
+        fs = p->root_fs;
+        filesystem_reserve(fs);
+        *cwd = inode_from_tuple(filesystem_getroot(fs));
+    } else if (dirfd == AT_FDCWD) {
+        process_get_cwd(p, &fs, cwd);
+    } else {
+        fdesc f = fdesc_get(p, dirfd);
+        if (!f)
+            return 0;
+        if (fdesc_type(f) == FDESC_TYPE_DIRECTORY) {
+            fs = ((file)f)->fs;
+            filesystem_reserve(fs);
+            *cwd = ((file)f)->n;
+        } else {
+            fs = 0;
+        }
+        fdesc_put(f);
+        if (!fs)
+            return 0;
+    }
+    return fs;
+}
+
+static key unveil_dir_key(void *a)
+{
+    return ((unveil_dir)a)->ino;
+}
+
+static boolean unveil_dir_equal(void *a, void *b)
+{
+    return ((unveil_dir)a)->fs == ((unveil_dir)b)->fs;
+}
+
+static unveil_dir unveil_new_dir(filesystem fs, tuple md, u64 perms)
+{
+    unveil_dir dir = allocate(unv.h, sizeof(*dir));
+    if (dir == INVALID_ADDRESS)
+        return 0;
+    dir->fs = fs;
+    dir->ino = inode_from_tuple(md);
+    dir->perms = perms;
+    dir->dir_entries = 0;
+    table_set(unv.dirs, dir, dir);
+    return dir;
+}
+
+static unveil_dir unveil_find_dir(filesystem fs, tuple md)
+{
+    struct unveil_dir d = {
+        .fs = fs,
+        .ino = inode_from_tuple(md),
+    };
+    return table_find(unv.dirs, &d);
+}
+
+static sysreturn unveil_set_dir_perms(filesystem fs, tuple md, u64 perms)
+{
+    unveil_dir dir = unveil_find_dir(fs, md);
+    if (!dir) {
+        dir = unveil_new_dir(fs, md, 0);
+        if (!dir)
+            return -ENOMEM;
+    }
+    u64 old_perms = dir->perms;
+    if ((old_perms & UNVEIL_PERMS_VALID) && (perms & ~old_perms))
+        return -EPERM;
+    dir->perms = perms;
+    return 0;
+}
+
+static sysreturn unveil_set_dir_entry_perms(filesystem fs, tuple md, symbol name, u64 perms)
+{
+    unveil_dir dir = unveil_find_dir(fs, md);
+    if (!dir) {
+        dir = unveil_new_dir(fs, md, 0);
+        if (!dir)
+            return -ENOMEM;
+    }
+    if (!dir->dir_entries) {
+        table entries = allocate_table(unv.h, key_from_symbol, pointer_equal);
+        if (entries == INVALID_ADDRESS)
+            return -ENOMEM;
+        dir->dir_entries = entries;
+    }
+    u64 old_perms = u64_from_pointer(table_find(dir->dir_entries, name));
+    if ((old_perms & UNVEIL_PERMS_VALID) && (perms & ~old_perms))
+        return -EPERM;
+    table_set(dir->dir_entries, name, pointer_from_u64(perms));
+    return 0;
+}
+
+static sysreturn unveil(const char *path, const char *permissions)
+{
+    if (!path && !permissions) {
+        unv.locked = true;
+        return 0;
+    }
+    if (unv.locked)
+        return -EPERM;
+    if (!fault_in_user_string(path) || !fault_in_user_string(permissions))
+        return -EFAULT;
+    u64 perms = UNVEIL_PERMS_VALID;
+    char p;
+    while ((p = *permissions)) {
+        switch (p) {
+        case 'r':
+            perms |= UNVEIL_READ;
+            break;
+        case 'w':
+            perms |= UNVEIL_WRITE;
+            break;
+        case 'x':
+            perms |= UNVEIL_EXEC;
+            break;
+        case 'c':
+            perms |= UNVEIL_CREATE;
+            break;
+        default:
+            return -EINVAL;
+        }
+        permissions++;
+    }
+    sysreturn rv = 0;
+    spin_wlock(&unv.lock);
+    if (!unv.dirs) {
+        table dirs = allocate_table(unv.h, unveil_dir_key, unveil_dir_equal);
+        if (dirs != INVALID_ADDRESS) {
+            unv.dirs = dirs;
+        } else {
+            rv = -ENOMEM;
+            goto unlock;
+        }
+    }
+    filesystem fs, cwd_fs;
+    inode cwd;
+    tuple n;
+    process_get_cwd(current->p, &cwd_fs, &cwd);
+    fs = cwd_fs;
+    if (filesystem_get_node(&fs, cwd, path, false, false, false, false, &n, 0) == FS_STATUS_OK) {
+        if (is_dir(n)) {
+            rv = unveil_set_dir_perms(fs, n, perms);
+        } else {
+            tuple parent = get_tuple(n, sym_this(".."));
+            rv = unveil_set_dir_entry_perms(fs, parent, tuple_get_symbol(children(parent), n),
+                                            perms);
+        }
+        filesystem_put_node(fs, n);
+    } else {
+        /* Unveiling a nonexistent path: if the parent directory exists, set unveil permissions for
+         * the given file name in the parent directory. */
+        u64 path_len = runtime_strlen(path);
+        const char *dir_separator = path_find_last_delim(path, path_len);
+        char *parent_path;
+        if (dir_separator) {
+            if (dir_separator - path == path_len - 1) {
+                rv = -ENOENT;
+                goto release;
+            }
+            parent_path = stack_allocate(dir_separator - path + 2);   /* include final '/' */
+            runtime_memcpy(parent_path, path, dir_separator - path + 1);
+            parent_path[dir_separator - path + 1] = '\0';
+        } else {
+            parent_path = ".";
+        }
+        if (filesystem_get_node(&fs, cwd, parent_path, false, false, false, false, &n, 0) ==
+            FS_STATUS_OK) {
+            symbol dir_entry = dir_separator ? sym_this(dir_separator + 1) : sym_this(path);
+            rv = unveil_set_dir_entry_perms(fs, n, dir_entry, perms);
+            filesystem_put_node(fs, n);
+        } else {
+            rv = -ENOENT;
+        }
+    }
+  release:
+    filesystem_release(cwd_fs);
+  unlock:
+    spin_wunlock(&unv.lock);
+    return rv;
+}
+
+/* Given a filesystem node, retrieves its permissions by traversing the node path up to the root
+ * node, until an unveil entry is found. */
+static u64 unveil_get_perms(filesystem fs, tuple md)
+{
+    spin_rlock(&unv.lock);
+    unveil_dir dir = unveil_find_dir(fs, md);
+    u64 perms = 0;
+    if (dir)
+        perms = dir->perms;
+    while (!(perms & UNVEIL_PERMS_VALID)) {
+        tuple parent = get_tuple(md, sym_this(".."));
+        if (parent == md)
+            break;
+        dir = unveil_find_dir(fs, parent);
+        if (dir) {
+            if (dir->dir_entries) {
+                symbol name = tuple_get_symbol(children(parent), md);
+                perms = u64_from_pointer(table_find(dir->dir_entries, name));
+            }
+            if (!(perms & UNVEIL_PERMS_VALID))
+                perms = dir->perms;
+        }
+        md = parent;
+    }
+    spin_runlock(&unv.lock);
+    return perms;
+}
+
+static sysreturn unveil_check_path_internal(filesystem fs, inode cwd, buffer path, boolean nofollow,
+                                            u64 perms)
+{
+    tuple n;
+    fs_status fss = filesystem_get_node(&fs, cwd, buffer_ref(path, 0), nofollow,
+                                        false, false, false, &n, 0);
+    u64 unveil_perms = 0;
+    if (fss == FS_STATUS_OK) {
+        do {
+            unveil_perms = unveil_get_perms(fs, n);
+            if ((unveil_perms & UNVEIL_PERMS_VALID) || (n == filesystem_getroot(fs))) {
+                filesystem_put_node(fs, n);
+                break;
+            }
+            inode ino = inode_from_tuple(n);
+            filesystem_put_node(fs, n);
+            fss = filesystem_get_node(&fs, ino, "..", true, false, false, false, &n, 0);
+        } while (fss == FS_STATUS_OK);
+    } else {
+        /* Nonexistent path: look for the parent directory. */
+        char *dir_separator = path_find_last_delim(buffer_ref(path, 0), buffer_length(path));
+        const char *parent_path;
+        if (dir_separator) {
+            if (dir_separator != buffer_ref(path, 0)) {
+                *dir_separator = '\0';
+                parent_path = buffer_ref(path, 0);
+            } else {
+                parent_path = "/";
+            }
+        } else {
+            parent_path = ".";
+        }
+        fss = filesystem_get_node(&fs, cwd, parent_path, false, false, false, false, &n, 0);
+        if (fss == FS_STATUS_OK) {
+            unveil_dir dir = unveil_find_dir(fs, n);
+            if (dir && dir->dir_entries) {
+                symbol dir_entry = dir_separator ? sym_this(dir_separator + 1) :
+                                                   sym_this(buffer_ref(path, 0));
+                unveil_perms = u64_from_pointer(table_find(dir->dir_entries, dir_entry));
+            }
+            filesystem_put_node(fs, n);
+        }
+        if (!(unveil_perms & UNVEIL_PERMS_VALID)) {
+            if (dir_separator) {
+                path->end = path->start + (void *)dir_separator - buffer_ref(path, 0);
+                return unveil_check_path_internal(fs, cwd, path, false, perms);
+            } else {
+                tuple md = filesystem_get_meta(fs, cwd);
+                if (md) {
+                    unveil_perms = unveil_get_perms(fs, md);
+                    filesystem_put_meta(fs, md);
+                }
+            }
+        }
+    }
+    if (!(unveil_perms & UNVEIL_PERMS_VALID))
+        return -ENOENT;
+    return (perms & ~unveil_perms) ? -EACCES : 0;
+}
+
+static boolean unveil_check_path_at(int dirfd, const char *path, boolean nofollow, u64 perms,
+                                    sysreturn *rv)
+{
+    if (!unv.dirs || !fault_in_user_string(path))
+        return false;
+    inode cwd;
+    filesystem fs = get_cwd_fs(dirfd, path, &cwd);
+    if (!fs)
+        return false;
+    buffer b = stack_allocate(sizeof(struct buffer));
+    bytes path_len = runtime_strlen(path) + 1;  /* include string terminator character */
+    char *path_copy = stack_allocate(path_len);
+    init_buffer(b, path_len, true, 0, path_copy);
+    buffer_write(b, path, path_len);
+    sysreturn ret = unveil_check_path_internal(fs, cwd, b, nofollow, perms);
+    filesystem_release(fs);
+    if (!ret)
+        return false;
+    *rv = ret;
+    return true;
+}
+
+static boolean unveil_check_path(const char *path, boolean nofollow, u64 perms, sysreturn *rv)
+{
+    return unveil_check_path_at(AT_FDCWD, path, nofollow, perms, rv);
+}
+
+static boolean unveil_bind(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                           sysreturn *rv)
+{
+    fdesc f = fdesc_get(current->p, arg0);
+    boolean result = false;
+    if (!f)
+        return result;
+    struct sockaddr_un *addr = (struct sockaddr_un *)arg1;
+    socklen_t addrlen = arg2;
+    if ((f->type == FDESC_TYPE_SOCKET) && (((struct sock *)f)->domain == AF_UNIX) &&
+        (addrlen > offsetof(struct sockaddr_un *, sun_path)) &&
+        validate_user_memory(addr, addrlen, false))
+        result = unveil_check_path(addr->sun_path, false, UNVEIL_CREATE, rv);
+    fdesc_put(f);
+    return result;
+}
+
+static boolean unveil_truncate(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                               sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, false, UNVEIL_WRITE, rv);
+}
+
+static boolean unveil_chdir(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                            sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, false, UNVEIL_READ, rv);
+}
+
+static boolean unveil_statfs(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, false, UNVEIL_READ, rv);
+}
+
+static boolean unveil_acct(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                           sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, false, UNVEIL_WRITE, rv);
+}
+
+static boolean unveil_mount(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                            sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg1, false, UNVEIL_READ, rv);
+}
+
+static boolean unveil_umount2(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                              sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, false, UNVEIL_READ, rv);
+}
+
+static boolean unveil_swapon(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, false, UNVEIL_READ | UNVEIL_WRITE, rv);
+}
+
+static boolean unveil_swapoff(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                              sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, false, UNVEIL_READ, rv);
+}
+
+static boolean unveil_setxattr(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                               sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, false, UNVEIL_WRITE, rv);
+}
+
+static boolean unveil_lsetxattr(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, true, UNVEIL_WRITE, rv);
+}
+
+static boolean unveil_getxattr(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                               sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, false, UNVEIL_READ, rv);
+}
+
+static boolean unveil_lgetxattr(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, true, UNVEIL_READ, rv);
+}
+
+static boolean unveil_listxattr(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, false, UNVEIL_READ, rv);
+}
+
+static boolean unveil_llistxattr(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                 sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, true, UNVEIL_READ, rv);
+}
+
+static boolean unveil_removexattr(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                  sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, false, UNVEIL_WRITE, rv);
+}
+
+static boolean unveil_lremovexattr(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                   sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg0, true, UNVEIL_WRITE, rv);
+}
+
+static boolean unveil_inotify_add_watch(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                        sysreturn *rv)
+{
+    return unveil_check_path((const char *)arg1, !!(arg2 & IN_DONT_FOLLOW), UNVEIL_READ, rv);
+}
+
+static boolean unveil_openat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    int flags = arg2;
+    u64 perms;
+    switch (flags & O_ACCMODE) {
+    case O_RDONLY:
+        perms = UNVEIL_READ;
+        break;
+    case O_WRONLY:
+        perms = UNVEIL_WRITE;
+        break;
+    case O_RDWR:
+        perms = UNVEIL_READ | UNVEIL_WRITE;
+        break;
+    default:
+        perms = 0;
+    }
+    if (flags & O_TRUNC)
+        perms |= UNVEIL_WRITE;
+    if (flags & O_CREAT)
+        perms |= UNVEIL_CREATE;
+    return unveil_check_path_at(arg0, (const char *)arg1, !!(flags & O_NOFOLLOW), perms, rv);
+}
+
+static boolean unveil_createat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                               sysreturn *rv)
+{
+    return unveil_check_path_at(arg0, (const char *)arg1, true, UNVEIL_CREATE, rv);
+}
+
+static boolean unveil_newfstatat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                 sysreturn *rv)
+{
+    return unveil_check_path_at(arg0, (const char *)arg1, !!(arg3 & AT_SYMLINK_NOFOLLOW),
+                                UNVEIL_READ, rv);
+}
+
+static boolean unveil_unlinkat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                               sysreturn *rv)
+{
+    const char *path = (const char *)arg1;
+    if (unveil_check_path_at(arg0, path, true, UNVEIL_CREATE, rv))
+        return true;
+    if ((arg2 & AT_REMOVEDIR) && unv.dirs && fault_in_user_string(path)) {
+        /* If the directory being removed has an unveil entry, remove the unveil entry. */
+        inode cwd;
+        filesystem cwd_fs = get_cwd_fs(arg0, path, &cwd);
+        if (!cwd_fs)
+            return false;
+        filesystem fs = cwd_fs;
+        tuple n;
+        fs_status fss = filesystem_get_node(&fs, cwd, path, true, false, false, false, &n, 0);
+        if (fss == FS_STATUS_OK) {
+            struct unveil_dir d = {
+                .fs = fs,
+                .ino = inode_from_tuple(n),
+            };
+            spin_wlock(&unv.lock);
+            unveil_dir dir = table_remove(unv.dirs, &d);
+            spin_wunlock(&unv.lock);
+            if (dir) {
+                if (dir->dir_entries)
+                    deallocate_table(dir->dir_entries);
+                deallocate(unv.h, dir, sizeof(*dir));
+            }
+            filesystem_put_node(fs, n);
+        }
+        filesystem_release(cwd_fs);
+    }
+    return false;
+}
+
+static boolean unveil_renameat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                sysreturn *rv)
+{
+    return unveil_check_path_at(arg0, (const char *)arg1, true, UNVEIL_CREATE, rv) ||
+           unveil_check_path_at(arg2, (const char *)arg3, true, UNVEIL_CREATE, rv);
+}
+
+static boolean unveil_linkat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    return unveil_check_path_at(arg2, (const char *)arg3, true, UNVEIL_CREATE, rv);
+}
+
+static boolean unveil_symlinkat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                sysreturn *rv)
+{
+    return unveil_check_path_at(arg1, (const char *)arg2, true, UNVEIL_CREATE, rv);
+}
+
+static boolean unveil_readlinkat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                 sysreturn *rv)
+{
+    return unveil_check_path_at(arg0, (const char *)arg1, true, UNVEIL_READ, rv);
+}
+
+static boolean unveil_faccessat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                sysreturn *rv)
+{
+    int mode = arg2;
+    u64 perms = 0;
+    if (mode != F_OK) {
+        if (mode & R_OK)
+            perms |= UNVEIL_READ;
+        if (mode & W_OK)
+            perms |= UNVEIL_WRITE;
+    }
+    return unveil_check_path_at(arg0, (const char *)arg1, !!(arg3 & AT_SYMLINK_NOFOLLOW),
+                                perms, rv);
+}
+
+#ifdef __x86_64__
+
+static boolean unveil_open(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                           sysreturn *rv)
+{
+    return unveil_openat(AT_FDCWD, arg0, arg1, arg2, 0, 0, rv);
+}
+
+static boolean unveil_stat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                           sysreturn *rv)
+{
+    return unveil_newfstatat(AT_FDCWD, arg0, arg1, 0, 0, 0, rv);
+}
+
+static boolean unveil_lstat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                            sysreturn *rv)
+{
+    return unveil_newfstatat(AT_FDCWD, arg0, arg1, AT_SYMLINK_NOFOLLOW, 0, 0, rv);
+}
+
+static boolean unveil_access(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    return unveil_faccessat(AT_FDCWD, arg0, arg1, 0, 0, 0, rv);
+}
+
+static boolean unveil_rename(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    return unveil_renameat(AT_FDCWD, arg0, AT_FDCWD, arg1, 0, 0, rv);
+}
+
+static boolean unveil_rmdir(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                            sysreturn *rv)
+{
+    return unveil_unlinkat(AT_FDCWD, arg0, AT_REMOVEDIR, 0, 0, 0, rv);
+}
+
+static boolean unveil_create(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    return unveil_createat(AT_FDCWD, arg0, 0, 0, 0, 0, rv);
+}
+
+static boolean unveil_creat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                            sysreturn *rv)
+{
+    return unveil_open(arg0, O_CREAT | O_WRONLY | O_TRUNC, arg1, 0, 0, 0, rv);
+}
+
+static boolean unveil_symlink(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                              sysreturn *rv)
+{
+    return unveil_symlinkat(arg0, AT_FDCWD, arg1, 0, 0, 0, rv);
+}
+
+static boolean unveil_readlink(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                               sysreturn *rv)
+{
+    return unveil_readlinkat(AT_FDCWD, arg0, 0, 0, 0, 0, rv);
+}
+
+static boolean unveil_uselib(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    return unveil_open(arg0, O_RDONLY, 0, 0, 0, 0, rv);
+}
+
+static boolean unveil_utimes(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                             sysreturn *rv)
+{
+    return unveil_open(arg0, O_WRONLY, 0, 0, 0, 0, rv);
+}
+
+static boolean unveil_futimesat(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5,
+                                sysreturn *rv)
+{
+    return unveil_openat(arg0, arg1, O_WRONLY, 0, 0, 0, rv);
+}
+
+#endif
+
+boolean unveil_init(sb_syscall syscalls, tuple cfg)
+{
+    unv.h = heap_locked(get_kernel_heaps());
+    spin_rw_lock_init(&unv.lock);
+    register_syscall(linux_syscalls, unveil, unveil, 0);
+    unveil_syscall_register(syscalls, bind);
+    unveil_syscall_register(syscalls, truncate);
+    unveil_syscall_register(syscalls, chdir);
+    unveil_syscall_register(syscalls, statfs);
+    unveil_syscall_register(syscalls, acct);
+    unveil_syscall_register(syscalls, mount);
+    unveil_syscall_register(syscalls, umount2);
+    unveil_syscall_register(syscalls, swapon);
+    unveil_syscall_register(syscalls, swapoff);
+    unveil_syscall_register(syscalls, setxattr);
+    unveil_syscall_register(syscalls, lsetxattr);
+    unveil_syscall_register(syscalls, getxattr);
+    unveil_syscall_register(syscalls, lgetxattr);
+    unveil_syscall_register(syscalls, listxattr);
+    unveil_syscall_register(syscalls, llistxattr);
+    unveil_syscall_register(syscalls, removexattr);
+    unveil_syscall_register(syscalls, lremovexattr);
+    unveil_syscall_register(syscalls, inotify_add_watch);
+    unveil_syscall_register(syscalls, openat);
+    unveil_syscall_register_handler(syscalls, mkdirat, createat);
+    unveil_syscall_register_handler(syscalls, mknodat, createat);
+    unveil_syscall_register(syscalls, newfstatat);
+    unveil_syscall_register(syscalls, unlinkat);
+    unveil_syscall_register(syscalls, renameat);
+    unveil_syscall_register(syscalls, linkat);
+    unveil_syscall_register(syscalls, symlinkat);
+    unveil_syscall_register(syscalls, readlinkat);
+    unveil_syscall_register(syscalls, faccessat);
+#ifdef __x86_64__
+    unveil_syscall_register(syscalls, open);
+    unveil_syscall_register(syscalls, stat);
+    unveil_syscall_register(syscalls, lstat);
+    unveil_syscall_register(syscalls, access);
+    unveil_syscall_register(syscalls, rename);
+    unveil_syscall_register_handler(syscalls, mkdir, create);
+    unveil_syscall_register(syscalls, rmdir);
+    unveil_syscall_register(syscalls, creat);
+    unveil_syscall_register_handler(syscalls, unlink, create);
+    unveil_syscall_register(syscalls, symlink);
+    unveil_syscall_register(syscalls, readlink);
+    unveil_syscall_register_handler(syscalls, mknod, create);
+    unveil_syscall_register(syscalls, uselib);
+    unveil_syscall_register(syscalls, utimes);
+    unveil_syscall_register(syscalls, futimesat);
+#endif
+    unveil_syscall_register_handler(syscalls, renameat2, renameat);
+    return true;
+}

--- a/platform/riscv-virt/Makefile
+++ b/platform/riscv-virt/Makefile
@@ -141,7 +141,7 @@ INCLUDES=\
 
 AFLAGS+=-I$(ARCHDIR) -march=rv64gc -mabi=lp64d
 
-CFLAGS+=$(KERNCFLAGS) -DKERNEL -O3 -march=rv64gc -mabi=lp64d -fno-pic
+CFLAGS+=$(KERNCFLAGS) -DKERNEL -O3 -fno-pic
 CFLAGS+=-Wno-address # lwIP build sadness
 CFLAGS+=$(INCLUDES)
 

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -155,7 +155,7 @@ INCLUDES=\
 
 AFLAGS+=-I$(ARCHDIR)
 
-CFLAGS+=$(KERNCFLAGS) -DKERNEL -DSMP_ENABLE -O3 -march=armv8-a+nofp+nosimd -mcpu=cortex-a72 -ffixed-x18 -fno-pic
+CFLAGS+=$(KERNCFLAGS) -DKERNEL -DSMP_ENABLE -O3 -fno-pic
 CFLAGS+=-Wno-address # lwIP build sadness
 CFLAGS+=-DCONFIG_LTRACE
 CFLAGS+=$(INCLUDES)

--- a/rules.mk
+++ b/rules.mk
@@ -122,10 +122,15 @@ KERNCFLAGS+=    -mno-sse \
 endif
 
 ifeq ($(ARCH),aarch64)
+KERNCFLAGS+=	-march=armv8-a+nofp+nosimd -mcpu=cortex-a72 -ffixed-x18
 OUTLINE_ATOMICS=	$(shell $(CC) --help=target | grep -c outline-atomics)
 ifneq ($(OUTLINE_ATOMICS),0)
 KERNCFLAGS+=	-mno-outline-atomics
 endif
+endif
+
+ifeq ($(ARCH),riscv64)
+KERNCFLAGS+=	-march=rv64gc -mabi=lp64d
 endif
 
 KERNCFLAGS+=	-fno-omit-frame-pointer

--- a/src/net/net_system_structs.h
+++ b/src/net/net_system_structs.h
@@ -33,6 +33,21 @@ enum protocol_type {
 #define AF_INET6    10
 #define AF_NETLINK  16
 
+#define SIOCGIFNAME    0x8910
+#define SIOCGIFCONF    0x8912
+#define SIOCGIFFLAGS   0x8913
+#define SIOCSIFFLAGS   0x8914
+#define SIOCGIFADDR    0x8915
+#define SIOCSIFADDR    0x8916
+#define SIOCGIFNETMASK 0x891b
+#define SIOCSIFNETMASK 0x891c
+#define SIOCGIFMETRIC  0x891d
+#define SIOCSIFMETRIC  0x891e
+#define SIOCGIFMTU     0x8921
+#define SIOCSIFMTU     0x8922
+#define SIOCGIFINDEX   0x8933
+#define SIOCDIFADDR    0x8936
+
 /* ARP protocol HARDWARE identifiers */
 #define ARPHRD_ETHER    1
 #define ARPHRD_LOOPBACK 772

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -18,18 +18,6 @@
 #define net_debug(x, ...)
 #endif
 
-#define SIOCGIFNAME    0x8910
-#define SIOCGIFCONF    0x8912
-#define SIOCGIFFLAGS   0x8913
-#define SIOCSIFFLAGS   0x8914
-#define SIOCGIFADDR    0x8915
-#define SIOCSIFADDR    0x8916
-#define SIOCGIFNETMASK 0x891B
-#define SIOCSIFNETMASK 0x891C
-#define SIOCGIFMTU     0x8921
-#define SIOCSIFMTU     0x8922
-#define SIOCGIFINDEX   0x8933
-
 #define MTU_MAX (32 * KB)
 
 #define resolve_socket(__p, __fd) ({fdesc f = resolve_fd(__p, __fd); \
@@ -56,11 +44,6 @@ struct sockaddr_in6 {
     u32 sin6_flowinfo;
     struct in6_addr sin6_addr;
     u32 sin6_scope_id;
-};
-
-struct mmsghdr {
-    struct msghdr msg_hdr;
-    unsigned int msg_len;
 };
 
 struct ifconf {

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -12,11 +12,6 @@ declare_closure_struct(1, 2, boolean, unixsock_event_handler,
 declare_closure_struct(1, 0, void, unixsock_free,
     struct unixsock *, s);
 
-struct sockaddr_un {
-    u16 sun_family;
-    char sun_path[108];
-};
-
 typedef struct sharedbuf {
     buffer b;
     struct refcount refcount;

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -8,6 +8,11 @@ struct sockaddr_storage {
     u8 ss_data[126];
 };
 
+struct sockaddr_un {
+    u16 sun_family;
+    char sun_path[108];
+};
+
 typedef u32 socklen_t;
 
 struct msghdr {
@@ -18,6 +23,11 @@ struct msghdr {
     void *msg_control;
     u64 msg_controllen;
     int msg_flags;
+};
+
+struct mmsghdr {
+    struct msghdr msg_hdr;
+    unsigned int msg_len;
 };
 
 #define IFNAMSIZ    16

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2792,6 +2792,13 @@ void _register_syscall(struct syscall *m, int n, sysreturn (*f)(), const char *n
     m[n].flags = flags;
 }
 
+void *swap_syscall_handler(struct syscall *m, int n, sysreturn (*f)())
+{
+    sysreturn (*ret)() = m[n].handler;
+    m[n].handler = f;
+    return ret;
+}
+
 static struct trace_set {
     char *name;
     u64 flag;

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -803,6 +803,7 @@ struct io_uring_params {
 };
 
 /* Socket option levels */
+#define IPPROTO_IP      0
 #define SOL_SOCKET      1
 #define SOL_TCP         6
 #define IPPROTO_IPV6    41
@@ -819,10 +820,30 @@ struct io_uring_params {
 #define SO_PRIORITY     12
 #define SO_LINGER       13
 #define SO_REUSEPORT    15
+#define SO_TIMESTAMP    29
 #define SO_ACCEPTCONN   30
 #define SO_PROTOCOL     38
 
+#define IP_TOS              1
+#define IP_TTL              2
+#define IP_OPTIONS          4
+#define IP_MINTTL           21
+#define IP_MULTICAST_IF     32
+#define IP_MULTICAST_TTL    33
+#define IP_MULTICAST_LOOP   34
+#define IP_ADD_MEMBERSHIP   35
+#define IP_DROP_MEMBERSHIP  36
+
+#define IPV6_UNICAST_HOPS   16
+#define IPV6_MULTICAST_IF   17
+#define IPV6_MULTICAST_HOPS 18
+#define IPV6_MULTICAST_LOOP 19
 #define IPV6_V6ONLY     26
+#define IPV6_RECVPKTINFO    49
+#define IPV6_RECVHOPLIMIT   51
+#define IPV6_USE_MIN_MTU    63
+#define IPV6_TCLASS         67
+#define IPV6_MINHOPCOUNT    73
 
 /* eventfd flags */
 #define EFD_CLOEXEC     O_CLOEXEC

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -378,8 +378,6 @@ closure_function(0, 1, u32, std_input_events,
     return 0;
 }
 
-extern struct syscall *linux_syscalls;
-
 static boolean create_stdfiles(unix_heaps uh, process p)
 {
     heap h = heap_locked((kernel_heaps)uh);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -189,6 +189,7 @@ typedef struct syscall_context {
 
 syscall_context allocate_syscall_context(cpuinfo ci);
 
+extern struct syscall * const linux_syscalls;
 extern io_completion syscall_io_complete;
 extern io_completion io_completion_ignore;
 
@@ -802,6 +803,7 @@ boolean setup_sigframe(thread t, int signum, struct siginfo *si);
 void restore_ucontext(struct ucontext * uctx, thread t);
 
 void _register_syscall(struct syscall *m, int n, sysreturn (*f)(), const char *name, u64 flags);
+void *swap_syscall_handler(struct syscall *m, int n, sysreturn (*f)());
 
 #define register_syscall(m, n, f, fl) _register_syscall(m, SYS_##n, f, #n, fl)
 

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -30,6 +30,7 @@ PROGRAMS= \
 	pipe \
 	readv \
 	rename \
+	sandbox \
 	sendfile \
 	sigoverflow \
 	signal \
@@ -189,6 +190,11 @@ LDFLAGS-rename=		-static
 
 SRCS-sendfile=		$(CURDIR)/sendfile.c
 LDFLAGS-sendfile=	-static
+
+SRCS-sandbox= \
+	$(CURDIR)/sandbox.c \
+	$(SRCDIR)/unix_process/ssp.c
+LDFLAGS-sandbox=	-static
 
 SRCS-sigoverflow= \
 	$(CURDIR)/sigoverflow.c \

--- a/test/runtime/sandbox.c
+++ b/test/runtime/sandbox.c
@@ -1,0 +1,230 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#define test_assert(expr) do { \
+    if (!(expr)) { \
+        printf("Error: %s -- failed at %s:%d\n", #expr, __FILE__, __LINE__); \
+        exit(EXIT_FAILURE); \
+    } \
+} while (0)
+
+static int pledge(const char *promises, const char *execpromises)
+{
+    return syscall(335, promises, execpromises);
+}
+
+static int unveil(const char *path, const char *permissions)
+{
+    return syscall(336, path, permissions);
+}
+
+static void test_unveil_symlink(void)
+{
+    const char *link_name = "link";
+    const char *target_name = "sandbox";
+    char buf[8];
+    int fd;
+
+    /* link_name is veiled */
+    test_assert((symlink(target_name, link_name) == -1) && (errno == ENOENT));
+
+    test_assert(unveil(link_name, "c") == 0);
+    test_assert(symlink(target_name, link_name) == 0);
+
+    /* link_name does not have read permissions */
+    test_assert((readlink(link_name, buf, sizeof(buf)) == -1) && (errno == EACCES));
+
+    /* target_name is veiled */
+    fd = open(link_name, O_RDONLY);
+    test_assert((fd == -1) && (errno == ENOENT));
+
+    test_assert(unveil(target_name, "r") == 0);
+    fd = open(link_name, O_RDONLY);
+    test_assert(fd > 0);
+    close(fd);
+
+    test_assert(unlink(link_name) == 0);
+}
+
+static void test_unveil_unixsock(void)
+{
+    const char *sock_name = "sock";
+    int fd;
+    struct sockaddr_un addr;
+
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    test_assert(fd > 0);
+
+    /* sock_name is veiled */
+    addr.sun_family = AF_UNIX;
+    strcpy(addr.sun_path, sock_name);
+    test_assert((bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) && (errno == ENOENT));
+
+    test_assert(unveil(sock_name, "c") == 0);
+    test_assert(bind(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    test_assert(access(sock_name, F_OK) == 0);
+    test_assert((access(sock_name, R_OK) == -1) && (errno == EACCES));
+    test_assert((access(sock_name, W_OK) == -1) && (errno == EACCES));
+    test_assert(unlink(sock_name) == 0);
+
+    /* remove create permissions */
+    test_assert(unveil(sock_name, "") == 0);
+    test_assert((bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) && (errno == EACCES));
+
+    close(fd);
+}
+
+static void test_unveil_truncate(void)
+{
+    const char *file_name = "trunc";
+    int fd;
+
+    test_assert(unveil(file_name, "wc") == 0);
+    fd = creat(file_name, 0644);
+    test_assert(fd > 0);
+    close(fd);
+    test_assert(truncate(file_name, 0) == 0);
+
+    /* remove write permissions */
+    test_assert(unveil(file_name, "c") == 0);
+    test_assert((truncate(file_name, 0) == -1) && (errno == EACCES));
+
+    test_assert(unlink(file_name) == 0);
+}
+
+static void test_unveil_rename(void)
+{
+    const char *file1_name = "file1";
+    const char *file2_name = "file2";
+    int fd;
+
+    test_assert((creat(file1_name, 0644) == -1) && (errno == ENOENT));  /* file1_name is veiled */
+
+    test_assert(unveil(file1_name, "wc") == 0);
+    fd = creat(file1_name, 0644);
+    test_assert(fd > 0);
+    close(fd);
+
+    /* file2_name is veiled */
+    test_assert((rename(file1_name, file2_name) == -1) && (errno == ENOENT));
+
+    test_assert(unveil(file2_name, "c") == 0);
+    test_assert(rename(file1_name, file2_name) == 0);
+    test_assert(unlink(file2_name) == 0);
+}
+
+static void test_unveil(void)
+{
+    int fd;
+
+    test_assert(unveil("nonexistent", "wc") == 0);
+    fd = creat("nonexistent", 0644);
+    test_assert(fd > 0);
+    close(fd);
+    test_assert((open("nonexistent", O_RDONLY) == -1) && (errno == EACCES));
+    test_assert(unlink("nonexistent") == 0);
+
+    /* remove create permissions */
+    test_assert(unveil("nonexistent", "w") == 0);
+    test_assert((creat("nonexistent", 0644) == -1) && (errno == EACCES));
+
+    test_assert((unlink((const char *)1) == -1) && (errno == EFAULT));
+    test_assert((unlink("sandbox") == -1) && (errno == ENOENT));    /* path is veiled */
+
+    test_assert((unveil("nonexistent-dir/", "c") == -1) && (errno == ENOENT));
+
+    /* create a directory by using an unveil entry in the parent directory */
+    test_assert(unveil("/dir", "c") == 0);
+    test_assert((mkdir("/dir", 0755) == 0) && (rmdir("dir") == 0));
+
+    /* try to unveil a file in a nonexistent directory */
+    test_assert((unveil("dir/f", "wc") == -1) && (errno == ENOENT));
+
+    /* create a file by using an unveil entry in the parent directory */
+    test_assert(mkdir("dir", 0755) == 0);
+    test_assert(unveil("dir/f", "wc") == 0);
+    fd = creat("dir/f", 0644);
+    test_assert((fd > 0) && (unlink("dir/f") == 0));
+    close(fd);
+    test_assert(rmdir("dir") == 0);
+
+    test_assert(unveil("d1", "c") == 0);
+    test_assert(mkdir("d1", 0755) == 0);
+    test_assert(mkdir("d1/d2", 0755) == 0);
+    test_assert(mkdir("d1/d2/d3", 0755) == 0);
+    test_assert(mkdir("d1/d2/d3/d4", 0755) == 0);
+    test_assert(mkdir("d1/d2/d3/d4/d5", 0755) == 0);
+    test_assert(rmdir("d1/d2/d3/d4/d5") == 0);
+    test_assert(rmdir("d1/d2/d3/d4") == 0);
+    test_assert(rmdir("d1/d2/d3") == 0);
+    test_assert(rmdir("d1/d2") == 0);
+    test_assert(rmdir("d1") == 0);
+
+    test_unveil_symlink();
+    test_unveil_unixsock();
+    test_unveil_truncate();
+    test_unveil_rename();
+    test_assert(unveil("/", "rwxc") == 0);
+
+    /* try to change unveil permissions after disabling unveil calls */
+    test_assert(unveil(NULL, NULL) == 0);
+    test_assert((unveil("/", "r") == -1) && (errno == EPERM));
+}
+
+static void test_pledge(void)
+{
+    void *mem;
+    int fd;
+
+    test_assert(pledge(NULL, NULL) == 0);   /* no-op */
+    test_assert((pledge("invalid", NULL) == -1) && (errno == EINVAL));
+
+    test_assert(pledge("stdio rpath cpath tmppath unix error", NULL) == 0);
+    fd = open("sandbox", O_RDONLY);
+    test_assert(fd > 0);
+    close(fd);
+    test_assert((mkdir("dir", 0755) == 0) && (rmdir("dir") == 0));
+
+    /* remove rpath and cpath, keeping tmppath */
+    test_assert(pledge("stdio tmppath unix error", NULL) == 0);
+    test_assert((open("sandbox", O_RDONLY) == -1) && (errno == ENOSYS));
+    test_assert((mkdir("dir", 0755) == -1) && (errno == ENOSYS));
+    test_assert((open("/tmp/foo", O_RDONLY) == -1) && (errno == ENOENT));
+
+    /* remove tmppath */
+    test_assert(pledge("stdio unix error", NULL) == 0);
+    test_assert((open("/tmp/foo", O_RDONLY) == -1) && (errno == ENOSYS));
+
+    /* missing prot_exec promise */
+    test_assert(mmap(0, 4096, PROT_EXEC, MAP_ANONYMOUS | MAP_SHARED, -1, 0) == MAP_FAILED);
+    test_assert(errno == ENOSYS);
+    mem = mmap(0, 4096, PROT_READ, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+    test_assert(mem != MAP_FAILED);
+    test_assert(munmap(mem, 4096) == 0);
+
+    /* try to add a new promise */
+    test_assert((pledge("inet", NULL) == -1) && (errno == EPERM));
+
+    /* unix promise */
+    fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    test_assert(fd > 0);
+    close(fd);
+
+    /* missing inet promise */
+    test_assert((socket(AF_INET, SOCK_STREAM, 0) == -1) && (errno == ENOSYS));
+}
+
+int main(int argc, char *argv[])
+{
+    test_unveil();
+    test_pledge();
+    printf("Sandbox tests OK\n");
+    return 0;
+}

--- a/test/runtime/sandbox.manifest
+++ b/test/runtime/sandbox.manifest
@@ -1,0 +1,16 @@
+(
+    boot:(
+          children:(
+                    klib:(children:(
+                            sandbox:(contents:(host:output/klib/bin/sandbox))
+                        ))
+                    )
+          )
+    children:(
+        sandbox:(contents:(host:output/test/runtime/bin/sandbox))
+    )
+    program:/sandbox
+    klibs:bootfs
+    environment:()
+    sandbox:(pledge:() unveil:())
+)


### PR DESCRIPTION
This klib implements a sandboxing mechanism by which the capabilities of the running process can be restricted by overriding certain syscall handlers. The current implementation supports the OpenBSD pledge (https://man.openbsd.org/pledge.2) and unveil (https://man.openbsd.org/unveil.2) syscalls.

A pledge invocation forces the process into a restricted-service operating mode by limiting the set of syscalls (and in some cases the allowed values of syscall arguments) that can be invoked.
Syscalls that are present in both Nanos and OpenBSD are handled by following the pledge implementation in OpenBSD, except for syscalls that are not applicable to unikernels (e.g. those related to inter-process communication). Syscalls that are present (or could be implemented in the future) in Nanos but not in OpenBSD are handled based in the same way as "similar" or related OpenBSD syscalls when such syscalls could be found, and are always forbidden when no related syscalls could be found in OpenBSD.
The pledge syscall can be invoked in a C program by calling the `pledge()` function from the following code:
```
int pledge(const char *promises, const char *execpromises)
{
    return syscall(335, promises, execpromises);
}
```

The unveil syscall allows adding and removing (or restricting) visibility of filesystem paths for the running process. It can be invoked in a C program by calling the `unveil()` function from the following code:
```
int unveil((const char *path, const char *permissions)
{
    return syscall(336, path, permissions);
}
```

The pledge and unveil features are enabled in the sandbox klib if the manifest contains a "sandbox" tuple with a "pledge" and "unveil" tuple, respectively.
A new runtime test program is being added to exercise these features.