### PR TITLE
ATA: honor maximum number of sectors in each I/O request

### DIFF
--- a/src/drivers/ata.c
+++ b/src/drivers/ata.c
@@ -201,8 +201,6 @@ static boolean ata_set_lba(struct ata *dev, u64 lba, u64 nsectors)
 
     if (dev->command_sets & ATA_CS_LBA48) {
         assert(nsectors <= 65536);
-        if (nsectors == 65536)
-            nsectors = 0;
         ata_out8(dev, ATA_COUNT, nsectors >> 8);
         ata_out8(dev, ATA_COUNT, nsectors);
         ata_out8(dev, ATA_CYL_MSB, lba >> 40);
@@ -213,7 +211,7 @@ static boolean ata_set_lba(struct ata *dev, u64 lba, u64 nsectors)
         ata_out8(dev, ATA_SECTOR, lba);
         ata_out8(dev, ATA_DRIVE, ATA_D_LBA | ATA_DEV(dev->unit));
     } else {
-        assert(nsectors <= 255);
+        assert(nsectors <= 256);
         ata_out8(dev, ATA_COUNT, nsectors);
         ata_out8(dev, ATA_CYL_MSB, lba >> 16);
         ata_out8(dev, ATA_CYL_LSB, lba >> 8);

--- a/src/drivers/ata.c
+++ b/src/drivers/ata.c
@@ -392,3 +392,8 @@ u64 ata_get_capacity(struct ata *dev)
 {
     return dev->capacity;
 }
+
+u64 ata_get_io_max_blocks(struct ata *dev)
+{
+    return (dev->command_sets & ATA_CS_LBA48) ? U64_FROM_BIT(16) : U64_FROM_BIT(8);
+}

--- a/src/drivers/ata.h
+++ b/src/drivers/ata.h
@@ -4,6 +4,7 @@ struct ata *ata_alloc(heap general);
 void ata_dealloc(struct ata *);
 boolean ata_probe(struct ata *);
 u64 ata_get_capacity(struct ata *);
+u64 ata_get_io_max_blocks(struct ata *dev);
 
 /* ATA commands (from sys/sys/ata.h) */
 #define ATA_NOP                         0x00    /* NOP */


### PR DESCRIPTION
In an ATA disk, the maximum number of sectors that can be submitted in a single I/O request depends on whether LBA48 addressing is supported. This change amends both the x86_64 bootloader and the kernel ATA PCI driver to split I/O requests sent to the ATA driver so that each request doesn't exceed the limit.
This fixes booting on vsphere VMs with IDE disk emulation.