### PR TITLE
get_robust_list: fix misuse of thread_release

### DIFF
--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -393,14 +393,16 @@ sysreturn get_robust_list(int pid, void *head, u64 *len)
     thread_log(current, "get_robust_list syscall for pid %d", pid);
 
     thread t = 0;
-    if (pid == 0)
+    if (pid == 0) {
         t = current;
-    else
+    } else {
         t = thread_from_tid(current->p, pid);
-    if (t == INVALID_ADDRESS)
-        return -ESRCH;
+        if (t == INVALID_ADDRESS)
+            return -ESRCH;
+    }
     *hp = t->robust_list;
-    thread_release(t);
+    if (pid != 0)
+        thread_release(t);
     *len = sizeof(**hp);
     return 0;
 }


### PR DESCRIPTION
In get_robust_list, thread_from_tid is called if pid != 0, yet thread_release is called unconditionally, resulting in an incorrect thread reference count. This conditionalizes the release, as well as a check only necessary after the call to thread_from_tid, on pid != 0.