### PR TITLE
Http and user socket improvements

### DIFF
--- a/src/http/http.h
+++ b/src/http/http.h
@@ -13,21 +13,23 @@ typedef enum {
 
 typedef closure_type(http_response, void, tuple);
 
+typedef struct http_responder *http_responder;
+
 buffer_handler allocate_http_parser(heap h, value_handler each);
 // just format the buffer?
 status http_request(heap h, buffer_handler bh, http_method method,
                     tuple headers, buffer body);
-status send_http_response(buffer_handler out,
+status send_http_response(http_responder out,
                           tuple t,
                           buffer c);
-status send_http_chunk(buffer_handler out, buffer c);
-status send_http_chunked_response(buffer_handler out, tuple t);
-status send_http_response(buffer_handler out, tuple t, buffer c);
+status send_http_chunk(http_responder out, buffer c);
+status send_http_chunked_response(http_responder out, tuple t);
+status send_http_response(http_responder out, tuple t, buffer c);
 
 extern const char * const http_request_methods[];
 
 typedef struct http_listener *http_listener;
-typedef closure_type(http_request_handler, void, http_method, buffer_handler, value);
+typedef closure_type(http_request_handler, void, http_method, http_responder, value);
 
 void http_register_uri_handler(http_listener hl, const char *uri, http_request_handler each);
 void http_register_default_handler(http_listener hl, http_request_handler each);

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -12,6 +12,10 @@ struct buffer {
 
 #define buffer_assert(x) assert(x)
 
+/* ascii string helpers */
+#define isupper(a) (((u8)(a)-(u8)'A') < 26)
+#define tolower(a) (isupper(a) ? ((a) | 0x20) : (a))
+
 static inline void init_buffer(buffer b, bytes s, boolean wrapped, heap h, void *contents)
 {
     b->start = 0;
@@ -364,6 +368,18 @@ static inline boolean buffer_compare_with_cstring(buffer b, const char *x)
     int len = buffer_length(b);
     for (int i = 0; i < len; i++) {
         if (byte(b, i) != (u8)x[i])
+            return false;
+        if (x[i] == '\0')       /* must terminate */
+            return i == len - 1;
+    }
+    return x[len] == '\0';
+}
+
+static inline boolean buffer_compare_with_cstring_ci(buffer b, const char *x)
+{
+    int len = buffer_length(b);
+    for (int i = 0; i < len; i++) {
+        if (tolower(byte(b, i)) != tolower((u8)x[i]))
             return false;
         if (x[i] == '\0')       /* must terminate */
             return i == len - 1;

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -1599,7 +1599,7 @@ format_usage_buffer(void)
 }
 
 static void
-ftrace_send_http_chunked_response(buffer_handler handler)
+ftrace_send_http_chunked_response(http_responder handler)
 {
     status s;
 
@@ -1609,7 +1609,7 @@ ftrace_send_http_chunked_response(buffer_handler handler)
 }
 
 static void
-ftrace_send_http_response(buffer_handler handler, buffer b)
+ftrace_send_http_response(http_responder handler, buffer b)
 {
     status s;
 
@@ -1619,7 +1619,7 @@ ftrace_send_http_response(buffer_handler handler, buffer b)
 }
 
 static void
-ftrace_send_http_uri_not_found(buffer_handler handler)
+ftrace_send_http_uri_not_found(http_responder handler)
 {
     status s;
 
@@ -1632,7 +1632,7 @@ ftrace_send_http_uri_not_found(buffer_handler handler)
 }
 
 static void
-ftrace_send_http_no_method(buffer_handler handler, http_method method)
+ftrace_send_http_no_method(http_responder handler, http_method method)
 {
     status s;
 
@@ -1645,7 +1645,7 @@ ftrace_send_http_no_method(buffer_handler handler, http_method method)
 }
 
 static void
-ftrace_send_http_server_error(buffer_handler handler)
+ftrace_send_http_server_error(http_responder handler)
 {
     status s;
 
@@ -1660,7 +1660,7 @@ ftrace_send_http_server_error(buffer_handler handler)
 
 static boolean
 __ftrace_send_http_chunk_internal(struct ftrace_routine * routine, struct ftrace_printer * p,
-                                  boolean local_printer, buffer_handler out)
+                                  boolean local_printer, http_responder out)
 {
     sysreturn ret;
     ret = routine->get_fn(p);
@@ -1717,7 +1717,7 @@ send_http_chunk_failed:
 /* simultaneous requests might present issues, so ... don't do them?? */
 closure_function(4, 2, void, __ftrace_send_http_chunk,
                  struct ftrace_routine *, routine, struct ftrace_printer *, p,
-                 boolean, local_printer, buffer_handler, out,
+                 boolean, local_printer, http_responder, out,
                  u64, expiry, u64, overruns)
 {
     if (overruns != timer_disabled &&
@@ -1731,7 +1731,7 @@ closure_function(4, 2, void, __ftrace_send_http_chunk,
 }
 
 static void
-__ftrace_do_http_method(buffer_handler out, struct ftrace_routine * routine,
+__ftrace_do_http_method(http_responder out, struct ftrace_routine * routine,
                         boolean is_put, buffer put_data)
 {
     sysreturn ret;
@@ -1802,21 +1802,21 @@ internal_err:
 }
 
 static void
-ftrace_do_http_get(buffer_handler handler, struct ftrace_routine * routine)
+ftrace_do_http_get(http_responder handler, struct ftrace_routine * routine)
 {
     __ftrace_do_http_method(handler, routine, false, 0);
 }
 
 
 static void
-ftrace_do_http_put(buffer_handler handler, struct ftrace_routine * routine,
+ftrace_do_http_put(http_responder handler, struct ftrace_routine * routine,
                    buffer put_data)
 {
     __ftrace_do_http_method(handler, routine, true, put_data);
 }
 
 closure_function(0, 3, void, ftrace_http_request,
-                 http_method, method, buffer_handler, handler, value, val)
+                 http_method, method, http_responder, handler, value, val)
 {
     buffer relative_uri;
     struct ftrace_routine * routine;

--- a/src/unix_process/socket_user.c
+++ b/src/unix_process/socket_user.c
@@ -1,9 +1,11 @@
 //#define SOCKET_USER_EPOLL_DEBUG
 
 #include <runtime.h>
+#include <sys/types.h>
 #include <sys/socket.h>
 //#include <stdlib.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -491,6 +493,8 @@ closure_function(4, 0, void, accepting,
     socklen_t len = sizeof(struct sockaddr_in);
     int s = accept(bound(c), (struct sockaddr *)&where, &len);
     if (s < 0 ) halt("accept %s\n", strerror(errno));
+    int en = 1;
+    setsockopt(s, SOL_TCP, TCP_NODELAY, &en, sizeof(en));
     register_conn_descriptor(h, n, s, bound(nc));
 }
 

--- a/src/unix_process/socket_user.c
+++ b/src/unix_process/socket_user.c
@@ -55,7 +55,7 @@ typedef struct conn_handler {
     descriptor f;
     closure_struct(connection_input, in);
     closure_struct(connection_output, out);
-    buffer_handler bh;
+    input_buffer_handler bh;
 } *conn_handler;
 
 static inline void select_bitmaps_init(heap h, select_bitmaps * b)
@@ -471,7 +471,7 @@ define_closure_function(0, 1, status, connection_output,
     return STATUS_OK;           /* pff */
 }
 
-static void register_conn_descriptor(heap h, notifier n, descriptor f, new_connection nc)
+static void register_conn_descriptor(heap h, notifier n, descriptor f, connection_handler nc)
 {
     conn_handler ch = allocate(h, sizeof(*ch));
     assert(ch != INVALID_ADDRESS);
@@ -483,7 +483,7 @@ static void register_conn_descriptor(heap h, notifier n, descriptor f, new_conne
 }
 
 closure_function(4, 0, void, accepting,
-                 heap, h, notifier, n, descriptor, c, new_connection, nc)
+                 heap, h, notifier, n, descriptor, c, connection_handler, nc)
 {
     heap h = bound(h);
     notifier n = bound(n);
@@ -496,7 +496,7 @@ closure_function(4, 0, void, accepting,
 
 
 closure_function(4, 0, void, connection_start,
-                 heap, h, descriptor, s, notifier, n, new_connection, c)
+                 heap, h, descriptor, s, notifier, n, connection_handler, c)
 {
     heap h = bound(h);
     descriptor s = bound(s);
@@ -511,7 +511,7 @@ closure_function(4, 0, void, connection_start,
 void connection(heap h,
                 notifier n,
                 buffer target,
-                new_connection c,
+                connection_handler c,
                 status_handler failure)
 {
     struct sockaddr_in where;
@@ -533,7 +533,7 @@ void connection(heap h,
 
 
 // should rety with asynch completion
-void listen_port(heap h, notifier n, u16 port, new_connection nc)
+void listen_port(heap h, notifier n, u16 port, connection_handler nc)
 {
     struct sockaddr_in where;
 

--- a/src/unix_process/socket_user.h
+++ b/src/unix_process/socket_user.h
@@ -9,13 +9,12 @@ typedef struct notifier {
 #define notifier_reset_fd(n, f) ((n)->reset_fd(n, f))
 #define notifier_spin(n) ((n)->spin(n));
 
-typedef closure_type(new_connection, buffer_handler, buffer_handler);
 void connection(heap h,
 		notifier n,
                 buffer target,
-                new_connection c,
+                connection_handler c,
                 status_handler failure);
-void listen_port(heap h, notifier n, u16 port, new_connection);
+void listen_port(heap h, notifier n, u16 port, connection_handler);
 notifier create_select_notifier(heap h);
 notifier create_poll_notifier(heap h);
 notifier create_epoll_notifier(heap h);

--- a/test/runtime/web.c
+++ b/test/runtime/web.c
@@ -5,7 +5,7 @@
 
 closure_function(1, 3, void, each_request,
                  heap, h,
-                 http_method, m, buffer_handler, out, value, v)
+                 http_method, m, http_responder, out, value, v)
 {
     send_http_response(out,
                        timm("ContentType", "text/html"),

--- a/test/runtime/web.c
+++ b/test/runtime/web.c
@@ -3,21 +3,13 @@
 #include <socket_user.h>
 #include <sys/epoll.h>
 
-closure_function(2, 1, void, each_request,
-                 heap, h, buffer_handler, out,
-                 value, v)
+closure_function(1, 3, void, each_request,
+                 heap, h,
+                 http_method, m, buffer_handler, out, value, v)
 {
-    send_http_response(bound(out),
+    send_http_response(out,
                        timm("ContentType", "text/html"),
                        aprintf(bound(h), "unibooty!"));
-}
-
-closure_function(1, 1, buffer_handler, conn,
-                 heap, h,
-                 buffer_handler, out)
-{
-    heap h = bound(h);
-    return allocate_http_parser(h, closure(h, each_request, h, out));
 }
 
 // no good place to put this
@@ -29,9 +21,11 @@ int main(int argc, char **argv)
     tuple t = parse_arguments(h, argc, argv);
     notifier n = get(t, sym(select)) ? create_select_notifier(h) :
         get(t, sym(poll)) ? create_poll_notifier(h) :
-	create_epoll_notifier(h);
+        create_epoll_notifier(h);
     u16 port = 8080;
-    listen_port(h, n, port, closure(h, conn, h));
+    http_listener hl = allocate_http_listener(h, port);
+    http_register_default_handler(hl, closure(h, each_request, h));
+    listen_port(h, n, port, connection_handler_from_http_listener(hl));
     rprintf("Server started on port %d\n", port);
     notifier_spin(n);
     return 0;

--- a/test/unit/buffer_test.c
+++ b/test/unit/buffer_test.c
@@ -59,6 +59,8 @@ boolean basic_tests(heap h)
     test_assert(buffer_set_capacity(b, b->length) == b->length);
     buffer_set_capacity(b, 3 * b->length);
     test_assert(buffer_compare_with_cstring(b, test_str));
+    test_assert(buffer_compare_with_cstring_ci(b, test_str));
+    test_assert(buffer_compare_with_cstring_ci(b, "THIS IS A TEST STRING"));
 
     test_assert(buffer_strcmp(b, test_str) == 0);
     test_assert(buffer_memcmp(b, test_str, sizeof(test_str)) < 0);

--- a/test/unit/network_test.c
+++ b/test/unit/network_test.c
@@ -62,7 +62,18 @@ closure_function(7, 1, void, value_in,
 
 heap make_tiny_heap(heap parent);
 
-closure_function(5, 1, buffer_handler, newconn,
+closure_function(1, 1, boolean, ibh_parser_wrap,
+                 buffer_handler, bh,
+                 buffer, b)
+{
+    status s = apply(bound(bh), b);
+    if (s != STATUS_OK) {
+        timm_dealloc(s);
+    }
+    return false;
+}
+
+closure_function(5, 1, input_buffer_handler, newconn,
                  heap, h, thunk, newconn, stats, s, tuple, t, status_handler, sth,
                  buffer_handler, out)
 {
@@ -76,8 +87,8 @@ closure_function(5, 1, buffer_handler, newconn,
     send_request(c, s, out, t);
     send_request(c, s, out, t);
     send_request(c, s, out, t);
-    return allocate_http_parser(c, closure(c, value_in, c, out, count, bound(sth), bound(newconn), s, t));
-
+    buffer_handler bh = allocate_http_parser(c, closure(c, value_in, c, out, count, bound(sth), bound(newconn), s, t));
+    return closure(c, ibh_parser_wrap, bh);
 }
 
 closure_function(8, 0, void, startconn,


### PR DESCRIPTION
This PR makes several improvements for web.c performance and compatibility by
updating web.c to use the http listener for better http support and then updating
the http.c code to support proper connection persistence based on the http
version of the request. The http response fuctions now take an http_responder pointer
that keeps track of whether or not to close the connection after the response and
automatically adds an appropriate connection header if necessary. These changes
allow apache-bench to work web.c, where previously it was timing out.

Also, the user socket code has been updated to set TCP_NODELAY after accepting
a connection. This drastically improves performance in web.c, particularly in a bridged
network situation, where the client's acks would take 20-40ms causing unnecessary
delays during tcp conversations.