### PR TITLE
Disallow overwriting of program and interpreter files by default

### DIFF
--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -174,8 +174,7 @@ closure_function(6, 0, void, startup,
     value p = get(root, sym(program));
     assert(p);
     tuple pro = resolve_path(root, split(general, p, '/'));
-    if (get(root, sym(exec_protection)))
-        set(pro, sym(exec), null_value);  /* set executable flag */
+    program_set_perms(root, pro);
     init_network_iface(root);
     filesystem_read_entire(fs, pro, (heap)heap_page_backed(kh), pg, closure(general, read_program_fail));
     closure_finish();

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -316,6 +316,7 @@ process exec_elf(buffer ex, process kp)
     register_root_notify(sym(trace), closure(heap_locked(kh), trace_notify, proc));
 
     if (interp) {
+        program_set_perms(root, interp);
         exec_debug("reading interp...\n");
         filesystem_read_entire(fs, interp, (heap)heap_page_backed(kh),
                                closure(heap_locked(kh), load_interp_complete, t, kh),

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -571,6 +571,12 @@ out:
     return INVALID_ADDRESS;
 }
 
+void program_set_perms(tuple root, tuple prog)
+{
+    if (get(root, sym(exec_protection)))
+        set(prog, sym(exec), null_value);
+}
+
 static void dump_heap_stats(buffer b, const char *name, heap h)
 {
     bytes allocated = heap_allocated(h);

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -575,6 +575,8 @@ void program_set_perms(tuple root, tuple prog)
 {
     if (get(root, sym(exec_protection)))
         set(prog, sym(exec), null_value);
+    else if (!get(root, sym(program_overwrite)))
+        set(prog, sym(readonly), null_value);
 }
 
 static void dump_heap_stats(buffer b, const char *name, heap h)

--- a/src/unix/unix.h
+++ b/src/unix/unix.h
@@ -9,6 +9,8 @@ void process_get_cwd(process p, filesystem *cwd_fs, inode *cwd);
 thread create_thread(process p, u64 tid);
 process exec_elf(buffer ex, process kernel_process);
 
+void program_set_perms(tuple root, tuple prog);
+
 void dump_mem_stats(buffer b);
 
 void coredump_set_limit(u64 s);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -586,13 +586,18 @@ static inline u32 anon_perms(process p)
 
 static inline u32 file_meta_perms(process p, tuple m)
 {
+    u32 perms;
     if (proc_is_exec_protected(p)) {
         if (m && get(m, sym(exec)))
-            return (ACCESS_PERM_READ | ACCESS_PERM_EXEC);
+            perms = ACCESS_PERM_READ | ACCESS_PERM_EXEC;
         else
-            return (ACCESS_PERM_READ | ACCESS_PERM_WRITE);
+            perms = ACCESS_PERM_READ | ACCESS_PERM_WRITE;
+    } else {
+        perms = ACCESS_PERM_ALL;
     }
-    return ACCESS_PERM_ALL;
+    if ((perms & ACCESS_PERM_WRITE) && m && get(m, sym(readonly)))
+        perms &= ~ACCESS_PERM_WRITE;
+    return perms;
 }
 
 static inline u32 file_perms(process p, file f)

--- a/test/runtime/write.manifest
+++ b/test/runtime/write.manifest
@@ -10,6 +10,5 @@
     fault:t
 #    arguments:[write -p]
     environment:(USER:bobby PWD:/)
-    exec_protection:t
     imagesize:64M
 )


### PR DESCRIPTION
With this change, the user application by default is not allowed to overwrite the program (and interpreter, if present) binary file.
This default behavior can be overridden by inserting a "program_overwrite" attribute in the root tuple of the manifest.
In the write runtime test, the "exec_protection" flag has been removed in order to test that the executable file by default cannot be overwritten even without exec protection.
File access permissions are implemented in a generic way so that it is possible to mark an arbitrary file as read-only by inserting a "readonly" attribute in the file tuple in the manifest.
In addition, when exec protection is enabled (which protects the program file from overwriting, independently of this new feature), the kernel disallows overwriting of the interpreter file as well, if present.