### PR TITLE
Unix: implement RELATIME (relaxed update of file access time)

### DIFF
--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -1588,7 +1588,6 @@ fs_status filesystem_get_node(filesystem *fs, inode cwd, const char *path, boole
     }
   out:
     if (fss == FS_STATUS_OK) {
-        filesystem_update_atime(*fs, t);
         *n = t;
         if (f)
             *f = fsf;

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -97,6 +97,19 @@ fs_status filesystem_chdir(process p, const char *path)
     return fss;
 }
 
+void filesystem_update_relatime(filesystem fs, tuple md)
+{
+    timestamp here = now(CLOCK_ID_REALTIME);
+    timestamp atime = filesystem_get_atime(fs, md);
+    boolean update;
+    if (here > atime + seconds(24 * 60 * 60))
+        update = true;
+    else
+        update = (atime <= filesystem_get_mtime(fs, md));
+    if (update)
+        filesystem_set_atime(fs, md, here);
+}
+
 closure_function(2, 2, void, fs_op_complete,
                  thread, t, file, f,
                  fsfile, fsf, fs_status, s)

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -27,6 +27,8 @@ void file_readahead(file f, u64 offset, u64 len);
 
 fs_status filesystem_chdir(process p, const char *path);
 
+void filesystem_update_relatime(filesystem fs, tuple md);
+
 sysreturn symlink(const char *target, const char *linkpath);
 sysreturn symlinkat(const char *target, int dirfd, const char *linkpath);
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -497,7 +497,7 @@ static void begin_file_read(thread t, file f)
     tuple md = filesystem_get_meta(f->fs, f->n);
     if (md) {
         if ((f->length > 0) && !(f->f.flags & O_NOATIME))
-            filesystem_update_atime(f->fs, md);
+            filesystem_update_relatime(f->fs, md);
         fs_notify_event(md, IN_ACCESS);
         filesystem_put_meta(f->fs, md);
     }
@@ -1226,7 +1226,7 @@ static sysreturn getdents_internal(int fd, void *dirp, unsigned int count, boole
     if (apply(h, sym_this("."), md) && apply(h, parent_sym, get_tuple(md, parent_sym)))
         iterate(c, h);
     fs_notify_event(md, IN_ACCESS);
-    filesystem_update_atime(f->fs, md);
+    filesystem_update_relatime(f->fs, md);
     f->offset = read_sofar;
     if (r < 0 && written_sofar == 0)
         rv = -EINVAL;


### PR DESCRIPTION
With this policy, when a file is accessed, the file access time is updated only if its current value is less than or equal to the file modification time (or if it is more than 1 day old). This is the default behavior on Linux, and makes file reads more efficient by avoiding frequent file metadata updates.
In addition, the file access time update is being removed from the filesystem_get_node() function, because the access time should be updated only when file contents are accessed (or, in the case of directories, when directory contents are listed).