### PR TITLE
vmxnet3: fix allocation size for rx queue completion descriptors

### DIFF
--- a/src/vmware/vmxnet3_net.c
+++ b/src/vmware/vmxnet3_net.c
@@ -503,7 +503,7 @@ void vmxnet3_receive(vmxnet3 vdev, struct list *l)
             break;
         read_barrier();
 
-        assert(rxcd->qid <= 2);
+        assert(rxcd->qid < VMXNET3_RXRINGS_PERQ);
 
         if (++rxc->vxcr_next == rxc->vxcr_ndesc) {
             rxc->vxcr_next = 0;

--- a/src/vmware/vmxnet3_queue.c
+++ b/src/vmware/vmxnet3_queue.c
@@ -134,7 +134,7 @@ void vmxnet3_rx_queues_alloc(vmxnet3_pci dev)
     // alignment
     assert((u64)dev->rx_desc_mem == pad((u64)dev->rx_desc_mem, VMXNET_ALIGN_QUEUES_DESC));
 
-    u64 rx_compdesc_size = sizeof(struct vmxnet3_rxcompdesc) * VMXNET3_MAX_RX_NDESC * VMXNET3_DEF_RX_QUEUES;
+    u64 rx_compdesc_size = sizeof(struct vmxnet3_rxcompdesc) * VMXNET3_MAX_RX_NCOMPDESC * VMXNET3_DEF_RX_QUEUES;
     dev->rx_compdesc_mem = allocate_zero(dev->contiguous, rx_compdesc_size);
     assert(dev->rx_compdesc_mem != INVALID_ADDRESS);
     // alignment


### PR DESCRIPTION
The memory allocated for the rx queue completion ring was half the size required for the number of completion descriptors as set in the comp_ring_len field of the vmxnet3_rxq_shared struct. This was causing memory corruption as the vmxnet3 device would write past the memory range allocated for the completion ring.

In addition, this change set fixes the assert() statement in vmxnet3_receive() to check the rx queue ID.

Closes https://github.com/nanovms/ops/issues/1454 