### PR TITLE
Aarch64: enable CPU cache operation from user program

### DIFF
--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -150,6 +150,7 @@
 #define SCTLR_EL1_WXN     U64_FROM_BIT(19) /* write implies execute never */
 #define SCTLR_EL1_nTWE    U64_FROM_BIT(18) /* no trap on WFE */
 #define SCTLR_EL1_nTWI    U64_FROM_BIT(16) /* no trap on WFI */
+#define SCTLR_EL1_UCT     U64_FROM_BIT(15) /* no trap on CTR_EL0 access */
 #define SCTLR_EL1_I       U64_FROM_BIT(12) /* instruction cacheability (no effect) */
 #define SCTLR_EL1_CP15BEN U64_FROM_BIT(5) /* memory barrier enable from EL0 */
 #define SCTLR_EL1_SA0     U64_FROM_BIT(4) /* SP alignment fault enable for EL0 */

--- a/src/aarch64/page.c
+++ b/src/aarch64/page.c
@@ -144,6 +144,8 @@ void enable_mmu(u64 vtarget)
     u64 sctlr = (SCTLR_EL1_SPAN |
                  SCTLR_EL1_nTWE |
                  SCTLR_EL1_nTWI |
+                 SCTLR_EL1_UCI |
+                 SCTLR_EL1_UCT |
                  SCTLR_EL1_I |
                  SCTLR_EL1_C |
                  SCTLR_EL1_M);


### PR DESCRIPTION
Frameworks such as Node.js expect to be able to retrieve CPU cache characteristics such as cache line sizes, and execute cache maintenance operations (e.g. flushing the instruction cache). This change modifies the settings of the SCTLR_EL1 register so that cache access instructions from the user program do not generate exceptions.