### PR TITLE
ESXi: add support for booting via UEFI

### DIFF
--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -249,8 +249,12 @@ static void __attribute__((noinline)) init_service_new_stack()
     init_symbols(allocate_tagged_region(kh, tag_symbol, pagesize), heap_locked(kh));
 
     for_regions(e) {
-        if (e->type == REGION_SMBIOS) {
+        switch (e->type) {
+        case REGION_SMBIOS:
             smbios_entry_point = e->base;
+            break;
+        case REGION_RSDP:
+            acpi_save_rsdp(e->base);
             break;
         }
     }

--- a/src/drivers/acpi.h
+++ b/src/drivers/acpi.h
@@ -155,6 +155,7 @@ typedef closure_type(spcr_handler, void, u8, u64);
 
 void init_acpi(kernel_heaps kh);
 void init_acpi_tables(kernel_heaps kh);
+void acpi_save_rsdp(u64 rsdp);
 boolean acpi_walk_madt(madt_handler mh);
 boolean acpi_walk_mcfg(mcfg_handler mh);
 boolean acpi_parse_spcr(spcr_handler h);

--- a/src/kernel/region.h
+++ b/src/kernel/region.h
@@ -17,6 +17,8 @@ typedef struct region *region;
 #define REGION_KERNIMAGE         13 /* location of kernel elf image loaded by stage2 */
 #define REGION_RECLAIM           14 /* areas to be unmapped and reclaimed in stage3 (only stage2 stack presently) */
 #define REGION_SMBIOS            15 /* SMBIOS entry point */
+#define REGION_RSDP              16 /* location of the ACPI RSDP */
+
 
 static inline region create_region(u64 base, u64 length, int type)
 {

--- a/src/tfs/tlog.c
+++ b/src/tfs/tlog.c
@@ -120,7 +120,9 @@ define_closure_function(1, 0, void, log_ext_free,
     if (ext->staging)
         deallocate_buffer(ext->staging);
     heap h = ext->tl->h;
+#ifndef TLOG_READ_ONLY
     refcount_release(&ext->tl->refcount);
+#endif
     deallocate(h, ext, sizeof(struct log_ext));
 }
 
@@ -149,8 +151,8 @@ static log_ext open_log_extension(log tl, range sectors)
         rmnode_init(n, sectors);
         rangemap_insert(tl->extensions, n);
     }
-#endif
     refcount_reserve(&tl->refcount);
+#endif
     return ext;
 #ifndef TLOG_READ_ONLY
   fail_dealloc_staging:

--- a/src/vmware/vmxnet3_net.c
+++ b/src/vmware/vmxnet3_net.c
@@ -359,6 +359,7 @@ static void vmxnet3_net_attach(heap general, heap page_allocator, pci_dev d)
     pci_bar_init(dev->dev, &dev->bar1, 1, 0, -1);
 
     pci_set_bus_master(dev->dev);
+    pci_enable_io_and_memory(d);
     pci_enable_msix(dev->dev);
 
     dev->general = general;

--- a/src/x86_64/crt0.s
+++ b/src/x86_64/crt0.s
@@ -373,7 +373,14 @@ install_gdt64_and_tss:
         mov [rdi + 8], eax ; base [63:32]
         sub rdi, rdx	; calculate offset of TSS descriptor in GDT
         ltr di
-        ret
+        mov rax, 0x10   ; assumes kernel data segment is at offset 0x10
+        mov ss, rax
+        mov ds, rax
+        mov es, rax
+        pop rax
+        push 0x08       ; assumes kernel code segment is at offset 0x08
+        push rax
+        o64 retf
 .end:
 
 ;; hypercall page used by xen and hyper-v

--- a/src/x86_64/uefi.c
+++ b/src/x86_64/uefi.c
@@ -83,10 +83,10 @@ void uefi_start_kernel(void *image_handle, efi_system_table system_table, buffer
     rsvd_mem_add(irangel(kern_base, kern_len));
     for (int i = 0; i < system_table->number_of_table_entries; i++) {
         efi_configuration_table table = &system_table->configuration_table[i];
-        if (!runtime_memcmp(&table->guid, &uefi_smbios_table, sizeof(table->guid))) {
+        if (!runtime_memcmp(&table->guid, &uefi_smbios_table, sizeof(table->guid)))
             create_region(u64_from_pointer(table->table), SMBIOS_EP_SIZE, REGION_SMBIOS);
-            break;
-        }
+        else if (!runtime_memcmp(&table->guid, &uefi_acpi20_table, sizeof(table->guid)))
+            create_region(u64_from_pointer(table->table), sizeof(u64), REGION_RSDP);
     }
     struct uefi_mem_map map;
     uefi_exit_bs(&map);


### PR DESCRIPTION
This change set allows Nanos to run on ESXi instances configured to boot via UEFI instead of BIOS. Tested on ESXi v7.0.
Note: the VGA console does not work on UEFI instances, because the video device, although being VGA-compatible, is not configured in text mode by the UEFI firmware, and the the kernel VGA console driver supports text mode only. The serial console continues to work as before.

Credits go to @sanderssj for the GDT- and ACPI-related changes.