### PR TITLE
Aarch64: init_mmu(): fix check for support of 4KB granule size

### DIFF
--- a/src/aarch64/page.c
+++ b/src/aarch64/page.c
@@ -54,7 +54,7 @@ void init_mmu(range init_pt, u64 vtarget)
     page_init_debug_u64(mmfr0);
     page_init_debug("\n");
 
-    if (field_from_u64(mmfr0, ID_AA64MMFR0_EL1_TGran4) != 0)
+    if (field_from_u64(mmfr0, ID_AA64MMFR0_EL1_TGran4) == 15)
         halt("%s: 4KB granule not supported\n", __func__);
 
     page_set_allowed_levels(0xe); /* mapping at levels 1-3 always allowed */


### PR DESCRIPTION
With the implementation of new MMU features such as LPA and LPA2, the `Tgran4` field of the ID_AA64MMFR0_EL1 register can have a non-zero value and still indicate that the 4KB memory translation granule size is supported (e.g. a value of 1 indicates that this granule size is supported with 52-bit addresses). The only value of this field that indicates lack of support for 4KB granule size is 15.
This change fixes the init_mmu() function so that it works when running on Aarch64 machines that implement the LPA2 feature, such as the "virt" machine on Qemu version 8 and later with the `-cpu max` command line option.