### PR TITLE
X86_64: PVH entry point: add stack memory configuration

### DIFF
--- a/src/x86_64/crt0.s
+++ b/src/x86_64/crt0.s
@@ -414,6 +414,10 @@ bits 32
         mov dword [edx + esi], ecx
         or dword [edx + esi], 0x83
         mov dword [edx + esi + 4], 0
+        ; set stack pointer to INITIAL_MAP_SIZE, and map stack memory
+        mov esp, 0xa000
+        mov dword [edx], 0x83
+        mov dword [edx + 4], 0
         ; map kernel code
         mov dword [edx + 8], 0x200000 | 0x83
         mov dword [edx + 12], 0


### PR DESCRIPTION
The pvh_start32 assembly code is a 32-bit entry point for the kernel, used by hypervisors such as QEMU (with the microvm machine type) and cloud-hypervisor (https://github.com/cloud-hypervisor/cloud-hypervisor). The current code was missing the initialization of the stack, which prevents the kernel from booting under cloud-hypervisor.
This change adds the code to set the stack pointer register and to map the memory area to be used as initial stack during boot; this allows booting under cloud-hypervisor.

Closes #1838.