### PR TITLE
Aarch64 init_mmu(): call a non-locking version of map()

### DIFF
--- a/src/aarch64/page.c
+++ b/src/aarch64/page.c
@@ -89,14 +89,14 @@ void init_mmu(range init_pt, u64 vtarget)
     page_init_debug("kernel_size ");
     page_init_debug_u64(kernel_size);
     page_init_debug("\n");
-    map(KERNEL_BASE, KERNEL_PHYS, kernel_size, pageflags_writable(pageflags_exec(pageflags_memory())));
+    map_nolock(KERNEL_BASE, KERNEL_PHYS, kernel_size, pageflags_writable(pageflags_exec(pageflags_memory())));
 #endif
 
     page_init_debug("map devices\n");
-    map(DEVICE_BASE, 0, DEV_MAP_SIZE, pageflags_writable(pageflags_device()));
+    map_nolock(DEVICE_BASE, 0, DEV_MAP_SIZE, pageflags_writable(pageflags_device()));
 
     page_init_debug("map temporary identity mapping\n");
-    map(PHYSMEM_BASE, PHYSMEM_BASE, INIT_IDENTITY_SIZE, pageflags_writable(pageflags_memory()));
+    map_nolock(PHYSMEM_BASE, PHYSMEM_BASE, INIT_IDENTITY_SIZE, pageflags_writable(pageflags_memory()));
 
     enable_mmu(vtarget);
 }

--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -512,6 +512,15 @@ physical map_with_complete(u64 v, physical p, u64 length, pageflags flags, statu
     return p - length;
 }
 
+/* Set up a mapping, like the map() function but without acquiring the page table lock; this
+ * function is meant to be called by init code, when there is only one CPU running. */
+void map_nolock(u64 v, physical p, u64 length, pageflags flags)
+{
+    range r = irangel(v, pad(length, PAGESIZE));
+    u64 *table_ptr = pointer_from_pteaddr(get_pagetable_base(v));
+    map_level(table_ptr, PT_FIRST_LEVEL, r, &p, flags.w, 0);
+}
+
 void remap(u64 v, physical p, u64 length, pageflags flags)
 {
     range r = irangel(v, pad(length, PAGESIZE));

--- a/src/kernel/page.h
+++ b/src/kernel/page.h
@@ -38,6 +38,8 @@ static inline void map(u64 v, physical p, u64 length, pageflags flags)
     map_with_complete(v, p, length, flags, 0);
 }
 
+void map_nolock(u64 v, physical p, u64 length, pageflags flags);
+
 void update_map_flags_with_complete(u64 vaddr, u64 length, pageflags flags, status_handler complete);
 
 static inline void update_map_flags(u64 vaddr, u64 length, pageflags flags)


### PR DESCRIPTION
When a new mapping is set up via the map() function, the page table spinlock is acquired in order to protect the page tables from concurrent access. On aarch64, spinlock operations are implemented by using the Load-Exclusive/Store-Exclusive mechanism; the Arm architecture reference manual (version H.a, section B2.9.2 "Exclusive access instructions and Shareable memory locations") says that support for this mechanism when address translation is disabled is not an architectural requirement, and architecturally compliant software must not rely on using it.
The init_mmu() function sets up some mappings before enabling the MMU (i.e. when address translation is disabled); in order for this code to run on machines where exclusive access instructions don't work without address translation (such as Apple M2, where the `ldxr` instruction triggers an exception), the page table lock must not be acquired. This change introduces a map_nolock() function, which is a variant of the map() function that does not acquire the page table lock; init_mmu() now calls map_nolock() instead of map(), which is safe because this code is only run during initialization by the boot CPU, when any additional CPUs have not been enabled yet.
This allows Nanos to run on Apple silicon with HVF acceleration.