### PR TITLE
VDSO linker script: move .text section to end of PT_LOAD segment

### DIFF
--- a/src/aarch64/vdso.lds
+++ b/src/aarch64/vdso.lds
@@ -13,6 +13,10 @@ SECTIONS
     .gnu.version_d : { *(.gnu.version_d) } : text
     .gnu.version_r : { *(.gnu.version_r) } : text
 
+    .plt : { *(.plt) } : text
+    .got : { *(.got) } : text
+    .got.plt : { *(.got.plt) } : text
+
     /* The presence of eh_frame_hdr in vdso - and presumably incomplete CFI
        directives - was leading libgcc to spin endlessly when unwinding after
        a sigcancel_handler. The nuances of this process are murky (see the

--- a/src/riscv64/vdso.lds
+++ b/src/riscv64/vdso.lds
@@ -13,6 +13,11 @@ SECTIONS
     .gnu.version_d : { *(.gnu.version_d) } : text
     .gnu.version_r : { *(.gnu.version_r) } : text
 
+    .plt : { *(.plt) } : text
+    .rela.dyn : { *(.rela.dyn) } : text
+    .got : { *(.got) } : text
+    .got.plt : { *(.got.plt) } : text
+
     .eh_frame_hdr : { *(.eh_frame_hdr) } : eh_frame_hdr : text
     .eh_frame : { *(.eh_frame) } : text
     .text : { *(.text*) } : text


### PR DESCRIPTION
The vvar_page location in the VDSO linker script follows the .text section, after a 4KB alignment. However, the kernel maps the vvar page after the entire vdso.so ELF file contents, which means that in order for the user program to correctly access the VDSO variables (e.g. vdso_dat), the end of the .text section must be within the last 4 KB of the VDSO ELF file.
The above constraint is not being satisfied in the RISC-V CI builds, which causes VDSO functions that access VDSO variables to behave incorrectly.
This change adds the declaration of a few more sections for the text PT_LOAD segment in the VDSO linker script for aarch64 and risc-v, so that these sections are placed before the .text section, which is then placed at the end of the PT_LOAD segment; this decreases the likelihood of the above constraint not being satisfied, and allows the RISC-V CI tests to succeed. For aarch64, the .rela.dyn section is not placed before the .text section because doing so would cause the .eh_frame_hdr section to also go before the .text section, which according to the comment in the linker script would create problems with the sigcancel handler.