### PR TITLE
TFS create_extent(): fix assignment of file range

### DIFF
--- a/src/tfs/tfs.c
+++ b/src/tfs/tfs.c
@@ -627,6 +627,8 @@ static fs_status create_extent(filesystem fs, range blocks, boolean uninited, ex
 
     range storage_blocks = irangel(start_block, nblocks);
     tfs_debug("   storage_blocks %R\n", storage_blocks);
+    if ((nblocks < range_span(blocks)))
+        blocks.end = blocks.start + nblocks;
     *ex = allocate_extent(h, blocks, storage_blocks);
     if (*ex == INVALID_ADDRESS)
         return FS_STATUS_NOMEM;


### PR DESCRIPTION
When a request to create an extent of a certain size cannot be fulfilled due to missing free contiguous storage space, and the extent is created with a smaller size than requested, the existing code is assigning the originally requested file range (instead of the range actually allocated) to the extent being created, which leads to filesystem corruption.
Regression introduced in commit 65434ad7 (#1765).