### PR TITLE
CircleCI build-virt: fix job failure when triggered from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,11 @@ jobs:
             PATH=$HOME/.ops/bin:$PATH
             make test-noaccel
 
+      - run:
+          command: |
+            if [[ ! -v GCLOUD_SERVICE_KEY ]]; then
+              circleci-agent step halt
+            fi
       - run: echo "deb http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
       - run: curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
       - run: sudo apt-get update && sudo apt-get install google-cloud-sdk


### PR DESCRIPTION
In the build-virt CircleCI job, after a successful run of the test suite, build artifacts should be uploaded to Google Cloud only if the GCLOUD_SERVICE_KEY environment variable is set, otherwise the job fails when triggered by pull requests from forked repositories.