### PR TITLE
Sockets/eventfd: fix memory leaks

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -683,6 +683,7 @@ closure_function(6, 1, sysreturn, socket_write_tcp_bh,
                 rv = -EAGAIN;
                 goto out;
             }
+            tcp_unref(tcp_lw);
             net_debug(" send buf full, sleep\n");
             return blockq_block_required((unix_context)ctx, bqflags);
         }
@@ -755,6 +756,7 @@ closure_function(6, 1, sysreturn, socket_write_tcp_bh,
   out_unlock:
     netsock_unlock(s);
   out:
+    tcp_unref(tcp_lw);
     closure_finish();
     net_debug("   completion %p, rv %ld\n", completion, rv);
     apply(completion, rv);
@@ -1124,6 +1126,7 @@ closure_func_basic(fdesc_close, sysreturn, socket_close,
             tcp_close(tcp_lw);
             tcp_arg(tcp_lw, 0);
             netsock_tcp_put(tcp_lw);
+            tcp_unref(tcp_lw);
             netsock_check_loop();
         }
         break;

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -43,6 +43,8 @@ struct _closure_common {
 
 #define init_closure(__p, __name, ...)                                  \
     __closure(0, (__p), sizeof(struct _closure_##__name), __name, ##__VA_ARGS__)
+#define init_closure_func(__p, __name, __func, ...)                     \
+    __closure(0, (__p), sizeof(struct _closure_##__name), __func, ##__VA_ARGS__)
 
 #define closure_struct_type(__name)     struct _closure_##__name
 #define closure_struct(__name, __field) struct _closure_##__name __field;
@@ -67,6 +69,18 @@ struct _closure_common {
 #define define_closure_function(nl, nr, ...)            \
     __closure_function_declare(nl, nr)(__VA_ARGS__)     \
     __closure_define(nl, nr)(__VA_ARGS__)
+
+/* a basic closure has a struct without any closure-specific fields */
+#define closure_func_basic(__name, __ret, __func, ...)                              \
+    static __ret __func(struct _closure_##__name *__self, ##__VA_ARGS__);           \
+    static __name _fill_##__func(u64 ctx, struct _closure_##__name *p, bytes s) {   \
+        p->__apply = __func;                                                        \
+        p->__c.name = #__func;                                                      \
+        p->__c.ctx = ctx;                                                           \
+        p->__c.size = s;                                                            \
+        return (__name)p;                                                           \
+    }                                                                               \
+    static __ret __func(struct _closure_##__name *__self, ##__VA_ARGS__)
 
 /* use this for closures allocated and filled separately */
 #define simple_closure_function(nl, nr, ...)            \

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -358,8 +358,27 @@ struct vmap;
 
 typedef closure_type(file_io, sysreturn, void *buf, u64 length, u64 offset, context ctx,
         boolean bh, io_completion completion);
+declare_closure_struct(0, 6, sysreturn, file_io,
+                       void *, buf, u64, length, u64, offset, context, ctx, boolean, bh, io_completion, completion);
 typedef closure_type(sg_file_io, sysreturn, sg_list sg, u64 length, u64 offset, context ctx,
         boolean bh, io_completion completion);
+declare_closure_struct(0, 6, sysreturn, sg_file_io,
+                       sg_list, sg, u64, length, u64, offset, context, ctx, boolean, bh, io_completion, completion);
+typedef closure_type(fdesc_events, u32, thread t);
+declare_closure_struct(0, 1, u32, fdesc_events,
+                       thread, t);
+typedef closure_type(fdesc_ioctl, sysreturn, unsigned long request, vlist ap);
+declare_closure_struct(0, 2, sysreturn, fdesc_ioctl,
+                       unsigned long, request, vlist, ap);
+typedef closure_type(fdesc_mmap, sysreturn, struct vmap *vm, u64 offset);
+declare_closure_struct(0, 2, sysreturn, fdesc_mmap,
+                       struct vmap *, vm, u64, offset);
+typedef closure_type(fdesc_close, sysreturn, context ctx, io_completion completion);
+declare_closure_struct(0, 2, sysreturn, fdesc_close,
+                       context, ctx, io_completion, completion);
+typedef closure_type(fdesc_et_handler, u64, u64 events, u64 lastevents);
+declare_closure_struct(0, 2, u64, fdesc_et_handler,
+                       u64, events, u64, lastevents);
 
 #define FDESC_TYPE_REGULAR      1
 #define FDESC_TYPE_DIRECTORY    2
@@ -382,11 +401,11 @@ declare_closure_struct(1, 1, void, fdesc_io_complete,
 typedef struct fdesc {
     file_io read, write;
     sg_file_io sg_read, sg_write;
-    closure_type(events, u32, thread);
-    closure_type(ioctl, sysreturn, unsigned long request, vlist ap);
-    closure_type(mmap, sysreturn, struct vmap *vm, u64 offset);
-    closure_type(close, sysreturn, context ctx, io_completion completion);
-    closure_type(edge_trigger_handler, u64, u64 events, u64 lastevents);
+    fdesc_events events;
+    fdesc_ioctl ioctl;
+    fdesc_mmap mmap;
+    fdesc_close close;
+    fdesc_et_handler edge_trigger_handler;
     closure_struct(fdesc_io_complete, io_complete);
 
     u64 refcnt;


### PR DESCRIPTION
This change set fixes memory leaks occurring when some types of file descriptors (network and Unix domain sockets and eventfd) are closed and when network packets are sent on a TCP socket.
New macros have been defined to allow attaching different functions to different instantiations of a closure, and some heap-allocated closures have been converted to closures (declared is in unix_internal.h but instantiated with file descriptor-specific functions) embedded in other structs.