### PR TITLE
remove unused GNU_STACK ELF program header

### DIFF
--- a/platform/pc/linker_script
+++ b/platform/pc/linker_script
@@ -9,7 +9,6 @@ PHDRS
     text PT_LOAD FLAGS(5);          /* R E */
     rodata PT_LOAD FLAGS(4);        /* R */
     data PT_LOAD FLAGS(6);          /* RW */
-    stack PT_GNU_STACK FLAGS(7);    /* RWE */
     note PT_NOTE FLAGS(4);          /* R */
 }
 


### PR DESCRIPTION
The PT_GNU_STACK header in the pc linker script is unused and benign, but its presence may cause confusion. This removes it.