### PR TITLE
Real-time clock: add support for running without an RTC peripheral

### DIFF
--- a/src/aarch64/clock.c
+++ b/src/aarch64/clock.c
@@ -35,7 +35,7 @@ BSS_RO_AFTER_INIT closure_struct(arm_timer_percpu_init, _timer_percpu_init);
 
 void init_clock(void)
 {
-    register_platform_clock_now(init_closure(&_clock_now, arm_clock_now), VDSO_CLOCK_SYSCALL);
+    register_platform_clock_now(init_closure(&_clock_now, arm_clock_now), VDSO_CLOCK_SYSCALL, 0);
     register_platform_clock_timer(init_closure(&_deadline_timer, arm_deadline_timer),
                                   init_closure(&_timer_percpu_init, arm_timer_percpu_init));
 }

--- a/src/hyperv/vmbus/hyperv.c
+++ b/src/hyperv/vmbus/hyperv.c
@@ -252,7 +252,7 @@ hyperv_detect(kernel_heaps kh) {
     }
 
     hyperv_init_clock();
-    register_platform_clock_now(closure(hyperv_info.general, hyperv_clock_now), 0);
+    register_platform_clock_now(closure(hyperv_info.general, hyperv_clock_now), 0, 0);
 
     clock_timer ct;
     thunk per_cpu_init;

--- a/src/kernel/clock.c
+++ b/src/kernel/clock.c
@@ -94,6 +94,7 @@ void clock_reset_rtc(timestamp wallclock_now)
     rtc_settimeofday(sec_from_timestamp(wallclock_now));
     notify_unix_timers_of_rtc_change();
     timer_adjust_begin(kernel_timers);
+    __vdso_dat->rtc_offset = wallclock_now - now(CLOCK_ID_MONOTONIC_RAW);
     reset_clock_vdso_dat();
     timer_adjust_end(kernel_timers, stack_closure(timer_adjust_handler, wallclock_now - n));
 }

--- a/src/kernel/pvclock.h
+++ b/src/kernel/pvclock.h
@@ -17,5 +17,5 @@ struct pvclock_wall_clock {
 
 u64 pvclock_now_ns(void);
 boolean init_tsc_deadline_timer(clock_timer *ct, thunk *per_cpu_init);
-void init_pvclock(heap h, struct pvclock_vcpu_time_info *pvclock);
+void init_pvclock(heap h, struct pvclock_vcpu_time_info *pvclock, struct pvclock_wall_clock *wc);
 physical pvclock_get_physaddr(void);

--- a/src/riscv64/clock.c
+++ b/src/riscv64/clock.c
@@ -56,7 +56,7 @@ closure_struct(riscv_timer_percpu_init, _timer_percpu_init);
 
 void init_clock(void)
 {
-    register_platform_clock_now(init_closure(&_clock_now, riscv_clock_now), VDSO_CLOCK_SYSCALL);
+    register_platform_clock_now(init_closure(&_clock_now, riscv_clock_now), VDSO_CLOCK_SYSCALL, 0);
     register_platform_clock_timer(init_closure(&_deadline_timer, riscv_deadline_timer),
                                   init_closure(&_timer_percpu_init, riscv_timer_percpu_init));
 }

--- a/src/x86_64/clock.c
+++ b/src/x86_64/clock.c
@@ -70,7 +70,7 @@ boolean init_tsc_timer(kernel_heaps kh)
     u64 tsc_scaling = tsc_calibrate();
     if (tsc_scaling) {
         register_platform_clock_now(closure(heap_general(kh), tsc_now, tsc_scaling),
-                                    VDSO_CLOCK_TSC_STABLE);
+                                    VDSO_CLOCK_TSC_STABLE, 0);
         thunk percpu_init;
         boolean success = init_lapic_timer(&platform_timer, &percpu_init);
         if (success)

--- a/src/x86_64/hpet.c
+++ b/src/x86_64/hpet.c
@@ -207,7 +207,7 @@ boolean init_hpet(kernel_heaps kh) {
     for (int i = 0; i < 10; i ++) {
         if (prev == hpet_main_counter())
             continue;
-        register_platform_clock_now(closure(heap_general(kh), hpet_now), VDSO_CLOCK_HPET);
+        register_platform_clock_now(closure(heap_general(kh), hpet_now), VDSO_CLOCK_HPET, 0);
         register_platform_clock_timer(closure(heap_general(kh), hpet_runloop_timer), 0 /* no per-cpu init */);
         return true;
     }

--- a/src/xen/xen.c
+++ b/src/xen/xen.c
@@ -520,7 +520,8 @@ boolean xen_detect(kernel_heaps kh)
     register_platform_clock_timer(closure(xen_info.h, xen_runloop_timer), closure(xen_info.h, xen_per_cpu_init, shared_info_phys));
 
     /* register pvclock (feature verified above) */
-    init_pvclock(xen_info.h, (struct pvclock_vcpu_time_info *)&xen_info.shared_info->vcpu_info[0].time);
+    init_pvclock(xen_info.h, (struct pvclock_vcpu_time_info *)&xen_info.shared_info->vcpu_info[0].time,
+                 (struct pvclock_wall_clock *)&xen_info.shared_info->wc_version);
 
     xen_debug("unmasking xenstore event channel");
     spin_lock_init(&xen_info.xenstore_lock);


### PR DESCRIPTION
Nanos can run on platforms where the RTC peripheral is read-only (e.g. riscv-virt), is not initialized with the system time from the host (e.g. cloud-hypervisor), or is not available at all (e.g. AWS Firecracker). This change set allows the system time to be retrieved during boot from an alternative source (e.g. the wall clock time made available by the paravirtualized clock), and allows changing the system time even when the RTC peripheral is unavailable (in this case, the time update will not persist across a VM reset).
The register_platform_clock_now() function now takes an additional parameter with the value of the offset between the system time and the monotonic time: if such offset is available (i.e. non-zero), it is used to initialize the rtc_offset field of the VDSO structure, otherwise the kernel falls back to trying to derive the offset from the RTC time. On platforms with the pvclock peripheral, the RTC offset is available via the wall clock time.
The x86 RTC driver is being amended to be able to handle cases where the RTC is not available: in these cases, rtc_gettimeofday() returns 0, and rtc_settimeofday() is a no-op.

Closes #1869