### PR TITLE
pagecache_finish_pending_writes(): apply completion asynchronously

### DIFF
--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -822,7 +822,11 @@ static void pagecache_finish_pending_writes(pagecache pc, pagecache_volume pv, p
         }
     }
     pagecache_unlock_state(pc);
+#ifdef KERNEL
+    async_apply_status_handler(complete, STATUS_OK);
+#else
     apply(complete, STATUS_OK);
+#endif
 }
 
 #ifdef KERNEL


### PR DESCRIPTION
This function is called by pagecache_sync_volume(), which is used to commit all dirty pages to disk before shutting down the kernel. If there are no pages to be committed, the completion is invoked immediately; when shutting down the kernel, this completion is the filesystem sync_handler closure, which needs to lock the filesystem; since the filesystem lock is now a mutex, it cannot be acquired in interrupt context, therefore the completion has to be run asynchronously; this prevents errors like "assertion !frame_is_full(ctx->frame) failed at /usr/src/nanos/src/kernel/mutex.c:109  in mutex_lock_internal()" when a kernel shutdown is triggered in interrupt context, such as if an assert failure happens in interrupt context, or if a VM instance is stopped via ACPI.

Closes #1874.