### PR TITLE
RTM_GETADDR: report multiple ipv6 addresses

### DIFF
--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -564,8 +564,12 @@ static boolean nl_rtm_getaddr6(struct netif *n, void *priv)
 {
     nl_rtm_netif_priv data = priv;
     nlsock s = data->s;
-    nl_enqueue_ifaddr6(s, RTM_NEWADDR, NLM_F_MULTI, data->hdr->nlmsg_seq, s->addr.nl_pid, n,
-                       *netif_ip6_addr(n, 0));
+    for (int i = 0; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
+        if (!ip6_addr_isinvalid(netif_ip6_addr_state(n, i))) {
+            nl_enqueue_ifaddr6(s, RTM_NEWADDR, NLM_F_MULTI, data->hdr->nlmsg_seq, s->addr.nl_pid, n,
+                               *netif_ip6_addr(n, i));
+        }
+    }
     return false;
 }
 


### PR DESCRIPTION
This changes the behavior of nl_rtm_getaddr6() to iterate through all IPv6 addresses on an interface and enqueue an RTM_NEWADDR entry for each valid one.