### PR TITLE
Signal user program when receiving shutdown notification

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -92,6 +92,9 @@
 #define FRAME_TRACE_DEPTH 32
 #define STACK_TRACE_DEPTH 32
 
+/* how long to wait for program to exit on sigterm */
+#define UNIX_SHUTDOWN_TIMEOUT_SECS 30
+
 /* net parameters (not covered by lwipopts.h) */
 
 /* number of iterations to spin for lwip lock acquire before suspending context */

--- a/src/drivers/acpi.c
+++ b/src/drivers/acpi.c
@@ -213,10 +213,12 @@ static UINT32 acpi_sleep(void *context)
     return ACPI_INTERRUPT_HANDLED;
 }
 
+void unix_shutdown(void);
+
 static UINT32 acpi_shutdown(void *context)
 {
     acpi_debug("shutdown");
-    kernel_shutdown(0);
+    unix_shutdown();
     return ACPI_INTERRUPT_HANDLED;
 }
 

--- a/src/hyperv/utilities/vmbus_shutdown.c
+++ b/src/hyperv/utilities/vmbus_shutdown.c
@@ -50,6 +50,8 @@ closure_function(0, 1, void, hv_sync_complete,
     HV_SHUTDOWN();
 }
 
+void unix_shutdown(void);
+
 static void vmbus_shutdown_cb(struct vmbus_channel *chan, void *xsc)
 {
    struct vmbus_ic_softc *sc = xsc;
@@ -115,7 +117,7 @@ static void vmbus_shutdown_cb(struct vmbus_channel *chan, void *xsc)
    vmbus_ic_sendresp(sc, chan, data, dlen, xactid);
 
    if (do_shutdown)
-       kernel_shutdown(0);
+       unix_shutdown();
 }
 
 

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -1119,14 +1119,16 @@ static void default_signal_action(thread t, queued_signal qs)
         /* ignore */
         return;
     }
-    dump_sig_info(t, qs);
-    if (frame_is_full(t->context.frame)) {
-        rprintf("\n*** Thread context:\n");
-        dump_context(&t->context);
-    }
-    if (t->syscall && frame_is_full(t->syscall->uc.kc.context.frame)) {
-        rprintf("\n*** Syscall context:\n");
-        dump_context(&t->syscall->uc.kc.context);
+    if (signum != SIGTERM) {
+        dump_sig_info(t, qs);
+        if (frame_is_full(t->context.frame)) {
+            rprintf("\n*** Thread context:\n");
+            dump_context(&t->context);
+        }
+        if (t->syscall && frame_is_full(t->syscall->uc.kc.context.frame)) {
+            rprintf("\n*** Syscall context:\n");
+            dump_context(&t->syscall->uc.kc.context);
+        }
     }
     thread_log(t, fate);
     halt_with_code(VM_EXIT_SIGNAL(signum), "%s\n", fate);

--- a/src/unix/unix.h
+++ b/src/unix/unix.h
@@ -8,6 +8,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs);
 void process_get_cwd(process p, filesystem *cwd_fs, inode *cwd);
 thread create_thread(process p, u64 tid);
 process exec_elf(buffer ex, process kernel_process);
+void unix_shutdown(void);
 
 void program_set_perms(tuple root, tuple prog);
 

--- a/src/xen/xen_internal.h
+++ b/src/xen/xen_internal.h
@@ -51,6 +51,7 @@ status xenbus_set_state(u32 tx_id, buffer path, XenbusState newstate);
 status xenbus_watch_state(buffer path, xenstore_watch_handler handler, boolean watch);
 
 status xenstore_read_u64(u32 tx_id, buffer path, const char *node, u64 *result);
+status xenstore_read_string(u32 tx_id, buffer path, const char *node, buffer result);
 status xenstore_sync_request(u32 tx_id, enum xsd_sockmsg_type type, buffer request, buffer response);
 status xenstore_sync_printf(u32 tx_id, buffer path, const char *node, const char *format, ...);
 status xenstore_transaction_start(u32 *tx_id);


### PR DESCRIPTION
When an external shutdown notification is received, such as the acpi poweroff event, nanos
should signal the user program to exit before shutting down to allow it time to quiesce. This
PR implements this with a new unix_shutdown() function that sends a SIGTERM to the user
process. Programs that handle SIGTERM can perform shutdown tasks for up to 
UNIX_SHUTDOWN_TIMEOUT_SECS seconds, and programs without a SIGTERM handler will
be shut down immediately. The kernel_shutdown() is called when the user program exits or
when the timer expires.

Support has also been added to Xen for receiving shutdown notifications so the unix_shutdown
can be performed there as well.