### PR TITLE
tfs_rename(): fix writing of metadata to TFS log

### DIFF
--- a/src/fs/tfs.c
+++ b/src/fs/tfs.c
@@ -1278,11 +1278,11 @@ static fs_status tfs_rename(filesystem fs, tuple old_parent, string old_name, tu
     }
     tfs tfs = (struct tfs *)fs;
     set(old_md, sym_this(".."), 0);
-    fs_status s = filesystem_write_eav(tfs, new_parent, intern(new_name), old_md);
+    fs_status s = filesystem_write_eav(tfs, children(new_parent), intern(new_name), old_md);
     if (s == FS_STATUS_OK) {
         if (exchange && new_md)
             set(new_md, sym_this(".."), 0);
-        s = filesystem_write_eav(tfs, old_parent, intern(old_name), exchange ? new_md : 0);
+        s = filesystem_write_eav(tfs, children(old_parent), intern(old_name), exchange ? new_md : 0);
     }
     if ((s == FS_STATUS_OK) && !exchange && new_md)
         *destruct_md = tfs_file_unlink(tfs, new_md);


### PR DESCRIPTION
A directory entry corresponds to an attribute in the `children` tuple of the directory tuple, not in the directory tuple itself. This change fixes an error that causes a filesystem corruption when a file is renamed (this corruption is only detected after a reboot).
Regression introduced in a4afaa317f88e1406432f5dc691fb6b9e448b025