### PR TITLE
trim cache parameters for low memory operation

### DIFF
--- a/klib/mbedtls.c
+++ b/klib/mbedtls.c
@@ -295,13 +295,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len )
 
 void *mbedtls_calloc(size_t n, size_t s)
 {
-    /* To maintain the malloc/free interface with mcache, allocations must stay
-       within the range of objcaches and not fall back to parent allocs. */
     size_t total = n * s;
-    if (total > U64_FROM_BIT(MAX_MCACHE_ORDER)) {
-        rprintf("%s: %ld bytes exceeds max alloc order\n", __func__, total);
-        return 0;
-    }
     void *p = allocate(tls.h, total);
     if (p != INVALID_ADDRESS) {
         runtime_memset(p, 0, total);

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -243,7 +243,7 @@ static void __attribute__((noinline)) init_service_new_stack()
     kernel_heaps kh = get_kernel_heaps();
     early_init_debug("in init_service_new_stack");
     init_page_tables((heap)heap_linear_backed(kh));
-    bytes pagesize = is_low_memory_machine(kh) ? PAGESIZE : PAGESIZE_2M;
+    bytes pagesize = is_low_memory_machine() ? PAGESIZE : PAGESIZE_2M;
     init_tuples(locking_heap_wrapper(heap_general(kh),
                 allocate_tagged_region(kh, tag_table_tuple, pagesize)));
     init_symbols(allocate_tagged_region(kh, tag_symbol, pagesize), heap_locked(kh));

--- a/platform/riscv-virt/service.c
+++ b/platform/riscv-virt/service.c
@@ -103,7 +103,7 @@ static void __attribute__((noinline)) init_service_new_stack(void)
     init_page_tables((heap)heap_linear_backed(kh));
     /* mmu init complete; unmap temporary identity map */
     unmap(PHYSMEM_BASE, INIT_IDENTITY_SIZE);
-    bytes pagesize = is_low_memory_machine(kh) ? PAGESIZE : PAGESIZE_2M;
+    bytes pagesize = is_low_memory_machine() ? PAGESIZE : PAGESIZE_2M;
     init_tuples(locking_heap_wrapper(heap_general(kh),
                 allocate_tagged_region(kh, tag_table_tuple, pagesize)));
     init_symbols(allocate_tagged_region(kh, tag_symbol, pagesize), heap_locked(kh));

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -254,7 +254,7 @@ static void __attribute__((noinline)) init_service_new_stack(void)
     init_debug("in init_service_new_stack\n");
     kernel_heaps kh = get_kernel_heaps();
     init_page_tables((heap)heap_linear_backed(kh));
-    bytes pagesize = is_low_memory_machine(kh) ? PAGESIZE : PAGESIZE_2M;
+    bytes pagesize = is_low_memory_machine() ? PAGESIZE : PAGESIZE_2M;
     init_tuples(locking_heap_wrapper(heap_general(kh),
                 allocate_tagged_region(kh, tag_table_tuple, pagesize)));
     init_symbols(allocate_tagged_region(kh, tag_symbol, pagesize), heap_locked(kh));

--- a/rules.mk
+++ b/rules.mk
@@ -248,6 +248,8 @@ ifeq ($1,kernel.elf)
 	$(call cmd,mvdis)
 endif
 else
+LDFLAGS-$1.dbg= $$(LDFLAGS-$1)
+LIBS-$1.dbg= $$(LIBS-$1)
 $$(PROG-$1).dbg: $$(OBJS-$1)
 	@$(MKDIR) $$(dir $$@)
 	$$(call cmd,ld)

--- a/src/config.h
+++ b/src/config.h
@@ -69,6 +69,7 @@
 #define USER_MEMORY_RESERVE (4 * MB)
 #define LOW_MEMORY_THRESHOLD   (64 * MB)
 #define SG_FRAG_BYTE_THRESHOLD (128*KB)
+#define PAGECACHE_LOWMEM_CONTIGUOUS_PAGESIZE (128*KB)
 
 /* don't go below this minimum amount of physical memory when inflating balloon */
 #define BALLOON_MEMORY_MINIMUM (16 * MB)
@@ -81,6 +82,7 @@
 
 /* must be large enough for vendor code that use malloc/free interface */
 #define MAX_MCACHE_ORDER 16
+#define MAX_LOWMEM_MCACHE_ORDER 11
 
 /* ftrace buffer size */
 #define DEFAULT_TRACE_ARRAY_SIZE        (512ULL << 20)

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -75,9 +75,10 @@ void init_kernel_heaps(void)
 #endif
     assert(heaps.linear_backed != INVALID_ADDRESS);
 
-    bytes pagesize = is_low_memory_machine(&heaps) ?
-                     U64_FROM_BIT(MAX_MCACHE_ORDER + 1) : PAGESIZE_2M;
-    heaps.general = allocate_mcache(&bootstrap, (heap)heaps.linear_backed, 5, MAX_MCACHE_ORDER,
+    boolean is_lowmem = is_low_memory_machine();
+    int max_mcache_order = is_lowmem ? MAX_LOWMEM_MCACHE_ORDER : MAX_MCACHE_ORDER;
+    bytes pagesize = is_lowmem ? U64_FROM_BIT(max_mcache_order + 1) : PAGESIZE_2M;
+    heaps.general = allocate_mcache(&bootstrap, (heap)heaps.linear_backed, 5, max_mcache_order,
                                     pagesize);
     assert(heaps.general != INVALID_ADDRESS);
 

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -808,9 +808,9 @@ boolean mm_register_mem_cleaner(mem_cleaner cleaner);
 
 kernel_heaps get_kernel_heaps(void);
 
-static inline boolean is_low_memory_machine(kernel_heaps kh)
+static inline boolean is_low_memory_machine(void)
 {
-    return (heap_total((heap)heap_physical(kh)) < LOW_MEMORY_THRESHOLD);
+    return (heap_total((heap)heap_physical(get_kernel_heaps())) < LOW_MEMORY_THRESHOLD);
 }
 
 struct filesystem *get_root_fs(void);

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1780,7 +1780,10 @@ void init_pagecache(heap general, heap contiguous, heap physical, u64 pagesize)
     assert(pagesize == U64_FROM_BIT(pc->page_order));
     pc->h = general;
 #ifdef KERNEL
-    pc->contiguous = (heap)allocate_objcache(general, contiguous, PAGESIZE, PAGESIZE_2M, true);
+    pc->contiguous = (heap)allocate_objcache(general, contiguous, PAGESIZE,
+                                             is_low_memory_machine() ?
+                                             PAGECACHE_LOWMEM_CONTIGUOUS_PAGESIZE :
+                                             PAGESIZE_2M, true);
 #else
     pc->contiguous = contiguous;
 #endif

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -17,6 +17,7 @@
 #include <lwip/nd6.h>
 
 #define MAX_LWIP_ALLOC_ORDER 16
+#define MAX_LOWMEM_LWIP_ALLOC_ORDER 11
 
 status direct_connect(heap h, ip_addr_t *addr, u16 port, connection_handler ch);
 

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -12,7 +12,6 @@
 
 BSS_RO_AFTER_INIT static heap lwip_heap;
 BSS_RO_AFTER_INIT int (*net_ip_input_filter)(struct pbuf *pbuf, struct netif *input_netif);
-BSS_RO_AFTER_INIT int lwip_alloc_order;
 
 declare_closure_struct(0, 2, void, net_timeout_handler, u64, expiry, u64, overruns);
 
@@ -86,9 +85,6 @@ void lwip_debug(char * format, ...)
 
 void *lwip_allocate(u64 size)
 {
-    /* To maintain the malloc/free interface with mcache, allocations must stay
-       within the range of objcaches and not fall back to parent allocs. */
-    assert(size <= U64_FROM_BIT(lwip_alloc_order));
     void *p = allocate(lwip_heap, size);
     return ((p != INVALID_ADDRESS) ? p : 0);
 }
@@ -390,7 +386,7 @@ void init_net(kernel_heaps kh)
     heap h = heap_general(kh);
     heap backed = (heap)heap_linear_backed(kh);
     boolean is_lowmem = is_low_memory_machine();
-    lwip_alloc_order = is_lowmem ? MAX_LOWMEM_LWIP_ALLOC_ORDER : MAX_LWIP_ALLOC_ORDER;
+    int lwip_alloc_order = is_lowmem ? MAX_LOWMEM_LWIP_ALLOC_ORDER : MAX_LWIP_ALLOC_ORDER;
     bytes pagesize = is_lowmem ? U64_FROM_BIT(lwip_alloc_order + 1) : PAGESIZE_2M;
     lwip_heap = allocate_mcache(h, backed, 5, lwip_alloc_order, pagesize);
     assert(lwip_heap != INVALID_ADDRESS);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -12,6 +12,7 @@
 
 BSS_RO_AFTER_INIT static heap lwip_heap;
 BSS_RO_AFTER_INIT int (*net_ip_input_filter)(struct pbuf *pbuf, struct netif *input_netif);
+BSS_RO_AFTER_INIT int lwip_alloc_order;
 
 declare_closure_struct(0, 2, void, net_timeout_handler, u64, expiry, u64, overruns);
 
@@ -87,7 +88,7 @@ void *lwip_allocate(u64 size)
 {
     /* To maintain the malloc/free interface with mcache, allocations must stay
        within the range of objcaches and not fall back to parent allocs. */
-    assert(size <= U64_FROM_BIT(MAX_LWIP_ALLOC_ORDER));
+    assert(size <= U64_FROM_BIT(lwip_alloc_order));
     void *p = allocate(lwip_heap, size);
     return ((p != INVALID_ADDRESS) ? p : 0);
 }
@@ -388,9 +389,10 @@ void init_net(kernel_heaps kh)
 {
     heap h = heap_general(kh);
     heap backed = (heap)heap_linear_backed(kh);
-    bytes pagesize = is_low_memory_machine(kh) ?
-                     U64_FROM_BIT(MAX_LWIP_ALLOC_ORDER + 1) : PAGESIZE_2M;
-    lwip_heap = allocate_mcache(h, backed, 5, MAX_LWIP_ALLOC_ORDER, pagesize);
+    boolean is_lowmem = is_low_memory_machine();
+    lwip_alloc_order = is_lowmem ? MAX_LOWMEM_LWIP_ALLOC_ORDER : MAX_LWIP_ALLOC_ORDER;
+    bytes pagesize = is_lowmem ? U64_FROM_BIT(lwip_alloc_order + 1) : PAGESIZE_2M;
+    lwip_heap = allocate_mcache(h, backed, 5, lwip_alloc_order, pagesize);
     assert(lwip_heap != INVALID_ADDRESS);
     lwip_heap = locking_heap_wrapper(h, lwip_heap);
     assert(lwip_heap != INVALID_ADDRESS);

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -1,4 +1,5 @@
 # these are built for the target platform (Linux x86_64)
+DEBUG_STRIP=y
 PROGRAMS= \
 	aio \
 	dup \


### PR DESCRIPTION
This change reduces baseline memory requirements for various memory caches
under "low memory" conditions. If the function is_low_memory_machine() returns
true, then the following parameters are minimized:

- the pagecache will use PAGECACHE_LOWMEM_CONTIGUOUS_PAGESIZE (default 128KB)
  as its objcache pagesize instead of PAGESIZE_2M
- the mcache high order is lowered to 11 (2KB), thus forcing PAGESIZE or
  larger allocations to be made directly from the backing heap - and thus not
  cached, nor available for situations that implement a malloc/free interface
- similiarly, allocations for lwIP are limited to a maximum size of 2KB

In addition:
- the runtime tests are stripped by default, saving the unstripped binaries
  under the ".dbg" extension
- in virtio-net, the size of the backing page allocations for the rx buffer and
  tx completion caches is set according to the rx and tx queue sizes

With these changes, it is possible to run a nanos instance capable of running the
'webs' web server in as little as 16MB of system memory.