### PR TITLE
Additional tests for optional nanos features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
             OPS_DIR=$HOME/.ops
             PATH=$HOME/.ops/bin:$PATH
             make test-noaccel
+      - run: test/extended_tests.py
       - run:
           command: |
             if [[ ! -v GCLOUD_SERVICE_KEY ]]; then

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -300,7 +300,7 @@ ifeq ($(IMAGE),)
 endif
 	@ echo "MKFS	$@"
 	@ $(MKDIR) $(dir $(IMAGE))
-	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) -t "(debug_exit:t)" $(TRACELOG_MKFS_OPTS) $(IMAGE)
+	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) -t "(debug_exit:t)" $(TRACELOG_MKFS_OPTS) $(EXTRA_MKFS_OPTS) $(IMAGE)
 
 release: mkfs boot kernel
 	$(Q) $(RM) -r release

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -52,8 +52,9 @@ void print_frame_trace_from_here();
 #define assert(x)                                   \
     do {                                            \
         if (!(x)) {                                 \
+            __label__ __here;                       \
             print_frame_trace_from_here();          \
-            halt("assertion " #x " failed at " __FILE__ ":%d  in %s(); halt\n", __LINE__, __func__); \
+            __here: halt("assertion " #x " failed at " __FILE__ ":%d (IP %p)  in %s(); halt\n", __LINE__, &&__here, __func__); \
         }                                           \
     } while(0)
 #endif

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -1105,6 +1105,7 @@ static void default_signal_action(thread t, queued_signal qs)
     case SIGXCPU:
     case SIGXFSZ:
         coredump(t, &qs->si, closure(h, after_dump_halt, t, signum));
+        clear_fault_handler();
         runloop();
         return;
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2719,8 +2719,6 @@ closure_function(0, 2, void, print_syscall_stats_cfn,
     deallocate_pqueue(pq);
 }
 
-static boolean syscall_defer;
-
 static char *missing_files_exclude[] = {
     "ld.so.cache",
 };
@@ -2855,13 +2853,6 @@ closure_function(0, 1, boolean, debugsyscalls_notify,
     return true;
 }
 
-closure_function(0, 1, boolean, syscall_defer_notify,
-                 value, v)
-{
-    syscall_defer = !!v;
-    return true;
-}
-
 closure_function(1, 1, boolean, notrace_notify,
                  process, p,
                  value, v)
@@ -2886,7 +2877,6 @@ void configure_syscalls(process p)
 {
     heap h = heap_locked(&p->uh->kh);
     register_root_notify(sym(debugsyscalls), closure(h, debugsyscalls_notify));
-    register_root_notify(sym(syscall_defer), closure(h, syscall_defer_notify));
     register_root_notify(sym(notrace), closure(h, notrace_notify, p));
     register_root_notify(sym(tracelist), closure(h, tracelist_notify, p));
 }

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -842,7 +842,7 @@ void count_syscall(thread t, sysreturn rv);
 extern boolean do_syscall_stats;
 static inline void count_syscall_save(thread t)
 {
-    if (do_syscall_stats && !t->syscall_complete && t->syscall_enter_ts) {
+    if (do_syscall_stats && t && !t->syscall_complete && t->syscall_enter_ts) {
         t->syscall_time += usec_from_timestamp(now(CLOCK_ID_MONOTONIC_RAW) - t->syscall_enter_ts);
         t->syscall_enter_ts = 0;
     }
@@ -850,7 +850,7 @@ static inline void count_syscall_save(thread t)
 
 static inline void count_syscall_resume(thread t)
 {
-    if (do_syscall_stats && !t->syscall_complete && t->syscall_enter_ts == 0)
+    if (do_syscall_stats && t && !t->syscall_complete && t->syscall_enter_ts == 0)
         t->syscall_enter_ts = now(CLOCK_ID_MONOTONIC_RAW);
 }
 

--- a/test/extended_tests.py
+++ b/test/extended_tests.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+import os
+import sys
+import subprocess
+import socket
+from threading import Thread
+import ast
+import re
+import tempfile
+
+ip4_addr = "127.0.0.1"
+repo_directory = "."
+
+TEST_TIMEOUT = 120.0
+
+###############################################################################
+NETCONS_LISTEN_PORT = 8888
+
+
+def udp_reader(ctx):
+    while True:
+        try:
+            s, _ = ctx['sock'].recvfrom(512)
+            if 'data' in ctx:
+                ctx['data'] = ctx['data'] + s
+            else:
+                ctx['data'] = s
+        except:
+            return
+
+
+def netcons_pre(ctx):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((ip4_addr, NETCONS_LISTEN_PORT))
+    ctx['sock'] = sock
+    ctx['thread'] = Thread(target=udp_reader, args=(ctx, ))
+    ctx['thread'].start()
+
+
+def netcons_post(ctx):
+    try:
+        ctx['sock'].shutdown(socket.SHUT_RDWR)
+    except Exception:
+        pass
+    try:
+        ctx['sock'].close()
+    except Exception:
+        pass
+    if 'data' not in ctx or len(ctx['data']) == 0:
+        return (-1, 'no udp console messages received')
+
+
+def coredump_post(ctx):
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            subprocess.run([
+                repo_directory + '/output/tools/bin/dump', '-d', tmp,
+                repo_directory + '/output/image/disk.raw'
+            ],
+                           capture_output=True,
+                           check=True)
+        except:
+            return (-1, 'dump failed')
+        if not os.path.isfile(tmp + '/coredumps/core'):
+            return (-1, 'coredump not generated')
+
+
+def notrace_post(ctx):
+    if re.search('    2 arch_prctl', ctx['output'], re.M) != None:
+        return (-1, 'syscall was not excluded')
+
+
+def tracelist_post(ctx):
+    if re.search('    2 arch_prctl', ctx['output'], re.M) == None:
+        return (-1, 'syscall was not found')
+    if re.search('    2 [^arch_prctl]', ctx['output'], re.M) != None:
+        return (-1, 'other syscalls were not excluded')
+
+
+def debugsyscalls_post(ctx):
+    if ctx['output'].find('direct return') == -1:
+        return (-1, 'debugsyscalls does not appear to be activated')
+
+
+def ltrace_post(ctx):
+    if ctx['output'].find('[LTRACE]') == -1:
+        return (-1, 'ltrace does not appear to be activated')
+
+
+###############################################################################
+
+
+def run_test(program, option):
+    child = subprocess.Popen([
+        'make', '-C' + repo_directory, 'TARGET=' + program,
+        'EXTRA_MKFS_OPTS=-t \(%s\)' % (option), 'run-noaccel'
+    ],
+                             stdout=subprocess.PIPE,
+                             encoding='utf-8')
+    try:
+        returncode = child.wait(timeout=TEST_TIMEOUT)
+    except:
+        raise TimeoutError
+    out = child.stdout.read()
+    return (returncode, out)
+
+
+def test_basic_options():
+    basic_programs = [{
+        'name':
+        'mmap',
+        'option':
+        'consoles:[+net]\ netconsole_ip:%s\ netconsole_port:%d' %
+        (ip4_addr, NETCONS_LISTEN_PORT),
+        'pre':
+        netcons_pre,
+        'post':
+        netcons_post
+    }, {
+        'name': 'mmap',
+        'option': 'missing_files:t'
+    }, {
+        'name': 'mmap',
+        'option': 'syscall_summary:t'
+    }, {
+        'name': 'sigoverflow',
+        'option': 'coredumplimit:32M',
+        'post': coredump_post
+    }, {
+        'name': 'hws',
+        'option': 'trace:t\ notrace:[arch_prctl]',
+        'post': notrace_post
+    }, {
+        'name': 'hws',
+        'option': 'trace:t\ tracelist:[arch_prctl]',
+        'post': tracelist_post
+    }, {
+        'name': 'hws',
+        'option': 'trace:t\ debugsyscalls:t',
+        'post': debugsyscalls_post
+    }, {
+        'name': 'hw',
+        'option': 'ltrace:t',
+        'post': ltrace_post
+    }]
+
+    for p in basic_programs:
+        ctx = dict()
+        if 'pre' in p:
+            p['pre'](ctx)
+        try:
+            rc, out = run_test(p['name'], p['option'])
+        except TimeoutError:
+            print('FAILED: %s timed out' % (p['name']))
+            raise RuntimeError
+        if rc != 0:
+            print('%s\nFAILED: "%s" failed with option "%s"' %
+                  (out, p['name'], p['option']))
+            raise RuntimeError
+        ctx['output'] = out
+        if 'post' in p:
+            try:
+                t = p['post'](ctx)
+            except Exception as err:
+                print(
+                    'FAILED: "%s" with option "%s" post check exception: %s' %
+                    (p['name'], p['option'], err))
+                raise RuntimeError
+            if t != None:
+                rc, out = t
+                if rc != 0:
+                    print('FAILED: "%s" with option "%s" post check: %s' %
+                          (p['name'], p['option'], out))
+                    raise RuntimeError
+        print('PASSED: "%s" with option "%s"' % (p['name'], p['option']))
+
+
+def test_aslr():
+
+    def run(option):
+        exp = re.compile('^\{ \'.*$', re.M)
+        try:
+            rc, out = run_test('aslr', option)
+        except TimeoutError:
+            print('FAILED: aslr program timed out')
+            raise TimeoutError
+        if rc != 0:
+            print('%s\nFAILED: aslr program failed to run' % (out))
+            raise RuntimeError
+        g = exp.search(out)
+        try:
+            d = ast.literal_eval(g.group(0))
+        except:
+            print("FAILED: error parsing rd aslr output")
+            raise RuntimeError
+        return d
+
+    rd = run('')
+    nd = run('')
+    if rd['main'] == nd['main'] or rd['library'] == nd['library'] or rd[
+            'heap'] == nd['heap'] or rd['stack'] == nd['stack']:
+        print('FAILED: aslr locations did not change between runs: %s vs %s' %
+              (rd, nd))
+        raise RuntimeError
+    rd = run('noaslr:t')
+    nd = run('noaslr:t')
+    if rd['main'] != nd['main'] or rd['library'] != nd['library'] or rd[
+            'heap'] != nd['heap']:
+        print('FAILED: noaslr locations changed between runs: %s vs %s' %
+              (rd, nd))
+        raise RuntimeError
+    print('PASSED: aslr and noaslr')
+
+
+def get_ip4():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(0)
+    try:
+        s.connect(('8.8.8.8', 1))
+        ip = s.getsockname()[0]
+    except Exception:
+        ip = '127.0.0.1'
+    finally:
+        s.close()
+    return ip
+
+
+def main():
+    global ip4_addr, repo_directory
+    ip4_addr = get_ip4()
+    repo_directory = os.path.dirname(os.path.realpath(sys.argv[0])) + "/.."
+    try:
+        test_basic_options()
+        test_aslr()
+    except:
+        return -1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -2,6 +2,7 @@
 DEBUG_STRIP=y
 PROGRAMS= \
 	aio \
+	aslr \
 	dup \
 	creat \
 	epoll \
@@ -56,6 +57,10 @@ SRCS-aio= \
 	$(CURDIR)/aio.c \
 	$(SRCDIR)/unix_process/ssp.c
 LDFLAGS-aio=	-static
+
+SRCS-aslr= \
+	$(CURDIR)/aslr.c \
+	$(SRCDIR)/unix_process/ssp.c
 
 SRCS-dup= \
 	$(CURDIR)/dup.c \

--- a/test/runtime/aslr.c
+++ b/test/runtime/aslr.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv)
+{
+    volatile int stack_variable;
+    void *heap_pointer = malloc(64);
+    printf("{ 'main':%p, 'library':%p, 'heap':%p, 'stack':%p }\n", main, malloc, heap_pointer, &stack_variable);
+    return 0;
+}

--- a/test/runtime/aslr.manifest
+++ b/test/runtime/aslr.manifest
@@ -1,0 +1,15 @@
+(
+    children:(
+            #user program
+	        aslr:(contents:(host:output/test/runtime/bin/aslr))
+	        TEST-LIBS)
+    # filesystem path to elf for kernel to run
+    program:/aslr
+#    trace:t
+#    debugsyscalls:t
+#    futex_trace:t
+#    noaslr:t
+    fault:t
+    arguments:[aslr]
+    environment:(USER:bobby PWD:/)
+)


### PR DESCRIPTION
Nanos has a number of behaviors that are only activated when explicitly configured in the manifest. Many of these are informational or related to debugging, so they are not exercised in normal testing. Sometimes major changes in nanos can break these features and without testing coverage the problem goes unnoticed.

This PR creates a python script that performs tests on some of these features, and fixes some bugs that were discovered by doing this testing:

- The syscall_defer option was found to be obsolete and no longer did anything.
- The syscall_summary option was panicking and needed a thread pointer check
- The coredump feature had an assert failure because the failing context's fault handler wasn't cleared while waiting for the coredump to be written out
- The netconsole feature had a deadlock when trying to send a message from an lwip callback

Other changes include printing the IP in an assert failure message to make it easier to identify failed asserts in inlined functions, and an aslr runtime test that prints out addresses in order to verify the noaslr option. The test script has also been included in the build-pc CI checks.

