### PR TITLE
x86_64 compiler options: disable use of MMX instructions

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -117,8 +117,7 @@ KERNCFLAGS=	-nostdinc \
 		-ffunction-sections
 
 ifeq ($(ARCH),x86_64)
-KERNCFLAGS+=    -mno-sse \
-		-mno-sse2
+KERNCFLAGS+=	-mno-mmx -mno-sse -mno-sse2
 endif
 
 ifeq ($(ARCH),aarch64)


### PR DESCRIPTION
Since the kernel code does not contain any floating point operations, it assumes the FPU is in a "clean" state when creating a context frame for a user thread. However, in the x86 architecture, MMX registers are aliases for the floating point registers, thus execution of any MMX instruction might modify the FPU state.
The gcc 12 compiler generates MMX instructions when compiling the AcpiUtInitGlobals() function in the acpica code; this is causing the FPU to enter a state that results in an invalid operation FPU exception and leads to wrong computation results when the user program executes floating point instructions.
This change adds the `-mno-mmx` flag to the compiler options for x86, so that generation of MMX instructions is avoided.

Closes #1884.