### PR TITLE
ACPI: add support for clean VM shutdown on cloud-hypervisor

### DIFF
--- a/src/aarch64/acpi.c
+++ b/src/aarch64/acpi.c
@@ -3,6 +3,11 @@
 #include <boot/uefi.h>
 #include <drivers/acpi.h>
 
+void acpi_register_irq_handler(int irq, thunk t, const char *name)
+{
+    register_interrupt(irq, t, name);
+}
+
 /* OS services layer */
 
 ACPI_PHYSICAL_ADDRESS AcpiOsGetRootPointer(void)
@@ -44,15 +49,4 @@ ACPI_STATUS AcpiOsWritePort(ACPI_IO_ADDRESS address, UINT32 value, UINT32 width)
         return AE_BAD_PARAMETER;
     }
     return AE_OK;
-}
-
-UINT32 AcpiOsInstallInterruptHandler(UINT32 interrupt_number, ACPI_OSD_HANDLER service_routine,
-                                     void *context)
-{
-    return AE_NOT_IMPLEMENTED;
-}
-
-ACPI_STATUS AcpiOsRemoveInterruptHandler(UINT32 interrupt_number, ACPI_OSD_HANDLER service_routine)
-{
-    return AE_NOT_IMPLEMENTED;
 }

--- a/src/drivers/acpi.c
+++ b/src/drivers/acpi.c
@@ -324,7 +324,6 @@ static void acpi_powerdown_init(kernel_heaps kh)
     rv = AcpiEvaluateObjectTyped(NULL, "\\_S5", NULL, &retb, ACPI_TYPE_PACKAGE);
     if (ACPI_FAILURE(rv)) {
         acpi_debug("failed to get _S5 object (%d)", rv);
-        AcpiGetDevices("PNP0C0C", acpi_pwrbtn_probe, NULL, NULL);
         return;
     }
     ACPI_OBJECT *obj = retb.Pointer;
@@ -355,6 +354,7 @@ void init_acpi(kernel_heaps kh)
     }
     acpi_powerdown_init(kh);
     AcpiGetDevices("ACPI0013", acpi_ged_probe, NULL, NULL);
+    AcpiGetDevices("PNP0C0C", acpi_pwrbtn_probe, NULL, NULL);
     rv = AcpiInstallFixedEventHandler(ACPI_EVENT_POWER_BUTTON, acpi_shutdown, 0);
     if (ACPI_FAILURE(rv))
         acpi_debug("cannot install power button hander: %d", rv);

--- a/src/drivers/acpi.h
+++ b/src/drivers/acpi.h
@@ -156,6 +156,7 @@ typedef closure_type(spcr_handler, void, u8, u64);
 void init_acpi(kernel_heaps kh);
 void init_acpi_tables(kernel_heaps kh);
 void acpi_save_rsdp(u64 rsdp);
+void acpi_register_irq_handler(int irq, thunk t, const char *name);
 boolean acpi_walk_madt(madt_handler mh);
 boolean acpi_walk_mcfg(mcfg_handler mh);
 boolean acpi_parse_spcr(spcr_handler h);

--- a/src/drivers/acpi.h
+++ b/src/drivers/acpi.h
@@ -13,6 +13,10 @@
 #define ACPI_PM1_SLP_TYP(typ)   (typ << 10)
 #define ACPI_PM1_SCI_EN         (1 << 0)
 
+/* Sleep Control Register */
+#define ACPI_SLEEPCTRL_SLP_EN       (1 << 5)
+#define ACPI_SLEEPCTRL_SLP_TYP(typ) ((typ) << 2)
+
 #define ACPI_SCI_IRQ    9
 
 /* MADT controller types */


### PR DESCRIPTION
This PR contains the following ACPI changes:
- GED interrupt handler registration has been fixed on x86_64
- probing of the power button device has been decoupled from probing of the _S5 object
- support for powering down the machine via the Sleep Control Register has been added

These changes allow the kernel to cleanly shut down (via the ACPI power button) a machine running on cloud-hypervisor.