### PR TITLE
TFS: fix directory cleanup when writing directory entries to log

### DIFF
--- a/src/fs/tfs.h
+++ b/src/fs/tfs.h
@@ -25,7 +25,7 @@ fsfile fsfile_from_node(filesystem fs, tuple n);
 tfsfile allocate_fsfile(tfs fs, tuple md);
 
 fs_status filesystem_write_tuple(tfs fs, tuple t);
-fs_status filesystem_write_eav(tfs fs, tuple t, symbol a, value v);
+fs_status filesystem_write_eav(tfs fs, tuple t, symbol a, value v, boolean cleanup);
 
 fs_status filesystem_mkentry(filesystem fs, tuple cwd, const char *fp, tuple entry,
     boolean persistent, boolean recursive);

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -176,7 +176,7 @@ closure_function(2, 2, void, fsstarted,
     closure_finish();
     symbol booted = sym(booted);
     if (!get(root, booted))
-        filesystem_write_eav((tfs)fs, root, booted, null_value);
+        filesystem_write_eav((tfs)fs, root, booted, null_value, false);
     config_console(root);
 }
 

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -393,8 +393,8 @@ closure_function(4, 2, void, fsc,
                 if (!off)
                     off = wrap_buffer_cstring(h, "0");
                 /* make an empty file */
-                filesystem_write_eav(tfs, f, sym(extents), allocate_tuple());
-                filesystem_write_eav(tfs, f, sym(filelength), off);
+                filesystem_write_eav(tfs, f, sym(extents), allocate_tuple(), false);
+                filesystem_write_eav(tfs, f, sym(filelength), off, false);
             }
         }
     }


### PR DESCRIPTION
When a TFS metadata tuple is written to the TFS log, if it refers to a directory entry it should be cleaned up (recursively if the entry is a directory itself) by temporarily removing references to parent directories, otherwise the log will contain useless entries. This is not being done in the current code by the tfs_rename() function, which is not doing the cleanup recursively, with the result that renaming a non-empty directory produces spurious TFS log entries. In addition, if a TFS log rebuild is triggered during the first call to log_write_eav() by filesystem_write_eav(), the filesystem_log_rebuild() function fixes up the entire filesystem tree, which may cause the second call to log_write_eav() to attempt a log write of a tuple with a reference to the parent.

This change fixes the above two issues by adding the logic to clean up and fix up a directory tree to the filesystem_write_eav() function, which now takes an additional boolean argument indicating whether a cleanup (and subsequent fixup) should be performed. The rename runtime test is being amended with a new test case that would produce spurious TFS log entries without this fix.