### PR TITLE
Klibs: cloud_init: properly initialize attribute_path vector

### DIFF
--- a/klib/cloud_init.c
+++ b/klib/cloud_init.c
@@ -627,6 +627,8 @@ static int cloud_download_env_parse(tuple config, vector tasks)
             return KLIB_INIT_FAILED;
         }
         cfg->attribute_path = split(cloud_heap, path, '/');
+    } else {
+        cfg->attribute_path = 0;
     }
     return KLIB_INIT_OK;
 }


### PR DESCRIPTION
If no "path" property is found in a "download_env" tuple in the cloud_init klib configuration, the current code is failing to initialize the `attribute_path` field of the cloud_download_env structure, which may cause cloud_download_env_set() to access invalid memory.