### PR TITLE
virtio-net: cap objcache pagesizes at PAGESIZE_2M

### DIFF
--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -280,7 +280,7 @@ static err_t virtioif_init(struct netif *netif)
 static inline u64 find_page_size(bytes each, int n)
 {
     /* extra element to cover objcache meta */
-    return 1ul << find_order(each * (n + 1));
+    return MIN(1ul << find_order(each * (n + 1)), PAGESIZE_2M);
 }
 
 static void virtio_net_attach(vtdev dev)
@@ -307,6 +307,8 @@ static void virtio_net_attach(vtdev dev)
     virtio_alloc_virtqueue(dev, "virtio net tx", 1, &vn->txq);
     virtqueue_set_polling(vn->txq, true);
     virtio_alloc_virtqueue(dev, "virtio net rx", 0, &vn->rxq);
+    virtio_net_debug("%s: rx q entries %d, tx q entries %d\n", __func__,
+                     virtqueue_entries(vn->rxq), virtqueue_entries(vn->txq));
     bytes rx_allocsize = vn->rxbuflen + sizeof(struct xpbuf);
     bytes rxbuffers_pagesize = find_page_size(rx_allocsize, virtqueue_entries(vn->rxq));
     bytes tx_handler_size = sizeof(closure_struct_type(tx_complete));


### PR DESCRIPTION
Commit 3eb8533b introduced a bug whereby large virtio-net queue sizes (e.g. 4096 on gce) would result in an objcache pagesize being greater than the maximum guaranteed alignment of the parent (linear backed) heap. This could result in an assertion failure in the objcache code when allocating a parent page that is not aligned to the objcache pagesize.

While the id heap aligns allocations to the rounded power-of-2 of the allocation size (a property that ought to be parameterized...), the physical id heap ranges themselves are only guaranteed to be aligned to 2M. Thus, allocations from the physical id heap or linear backed heap may also only be aligned up to a size of 2M.

The problem is avoided in this case by capping the objcache pagesize at PAGESIZE_2M when setting up the virtio-net caches; a larger pagesize is unnecessary anyhow, as the objcache meta accounts for less than .1% of a PAGESIZE_2M.

Closes #1892 
