### PR TITLE
Unix exec_elf(): improve support for static PIE programs

### DIFF
--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -266,7 +266,7 @@ process exec_elf(buffer ex, process kp)
         exec_debug("interp: %p\n", interp);
 
     u64 load_offset = 0;
-    if (e->e_type == ET_DYN && interp) {
+    if (e->e_type == ET_DYN) {
         /* Have some PIE */
         load_offset = DEFAULT_PROG_ADDR;
         if (aslr) {


### PR DESCRIPTION
In an ELF file, an ET_DYN type value in the ELF header indicates that the file has position-independent code, regardless of whether the file has to be executed directly or through an interpreter; hence, the file can be loaded at an arbitrary address, and the ASLR feature can be used to randomize the load address. This change adds ASLR support to programs built with gcc's `-static-pie` option. In addition, this allows running programs whose load range as derived from the PT_LOAD sections starts at 0 and whose glibc initialization code does mmap() operations on (parts of) the address range where the program has been loaded; for example, the initialization code in the binary release 0.24.0 of miniserve (https://github.com/svenstaro/miniserve) does an mmap() with the MAP_FIXED flag on the address range where the first PT_LOAD segment has been loaded, which fails with the current code because the segment is loaded at address 0 and by default the kernel does not allow doing mmap on the zero page.