### PR TITLE
Unix resolve_dir(): fix handling of non-directory dirfd values

### DIFF
--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -10,6 +10,10 @@
         process_get_cwd(p, &__fs, &cwd);    \
     } else { \
         file f = resolve_fd(p, __dirfd);    \
+        if (f->f.type != FDESC_TYPE_DIRECTORY) {    \
+            fdesc_put(&f->f);                       \
+            return -ENOTDIR;                        \
+        }                                           \
         __fs = f->fs;               \
         filesystem_reserve(__fs);   \
         cwd = f->n;                 \

--- a/test/runtime/mkdir.c
+++ b/test/runtime/mkdir.c
@@ -331,6 +331,7 @@ int main(int argc, char **argv)
     r = open(TEST_DIR "/zip", O_WRONLY | O_CREAT, 0644);
     _mkdirat(r, "zipa", DEFAULT_MODE, ENOTDIR);
     close(r);
+    _mkdirat(STDOUT_FILENO, "zipa", DEFAULT_MODE, ENOTDIR);
     listdir(TEST_DIR "/",TEST_DIR "/");
     listdir(TEST_DIR "/test", TEST_DIR "/test");
 

--- a/test/runtime/rename.c
+++ b/test/runtime/rename.c
@@ -115,6 +115,8 @@ int main(int argc, char **argv)
     close(fd1);
     test_assert((syscall(SYS_renameat2, fd1, "file", fd2, "file", 0) < 0) &&
             (errno == EBADF));
+    test_assert((syscall(SYS_renameat2, STDOUT_FILENO, "file", fd2, "file", 0) < 0) &&
+                (errno == ENOTDIR));
     close(fd2);
 
     fd2 = open("/dir2/my_file", O_CREAT, S_IRWXU);

--- a/test/runtime/symlink.c
+++ b/test/runtime/symlink.c
@@ -38,6 +38,7 @@ int main(int argc, char **argv)
     test_assert((symlink("target", "link") == -1) && (errno == EEXIST));
     test_assert((readlink("link", FAULT_ADDR, 1) == -1) && (errno == EFAULT));
     test_assert((readlinkat(AT_FDCWD, "link", FAULT_ADDR, 1) == -1) && (errno == EFAULT));
+    test_assert((readlinkat(STDOUT_FILENO, "link", buf, sizeof(buf)) == -1) && (errno == ENOTDIR));
     memset(buf, 0, sizeof(buf));
     test_assert((readlink("link", buf, 1) == 1) && (buf[0] == 't'));
     test_assert((readlinkat(AT_FDCWD, "link", buf, 1) == 1) && (buf[0] == 't'));

--- a/test/runtime/unlink.c
+++ b/test/runtime/unlink.c
@@ -45,6 +45,10 @@ static void test_unlinkat(int dirfd)
         exit(EXIT_FAILURE);
     }
     close(fd);
+    if ((unlinkat(STDOUT_FILENO, "file", 0) != -1) || (errno != ENOTDIR)) {
+        printf("unlinkat test with invalid dir fd failed\n");
+        exit(EXIT_FAILURE);
+    }
     if (unlinkat(dirfd, "file", 0) < 0) {
         perror("unlinkat");
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Filesystem-related syscalls that take a directory file descriptor and a file path should return -ENOTDIR if the supplied file descriptor is an open descriptor but does not correspond to a directory. The current code is assuming that if the file descriptor can be resolved it refers to an open directory; this may cause access to invalid memory addresses if the above assumption does not hold.
This change adds a check for the file descriptor type in the resolve_dir() macro, which returns -ENOTDIR if the check fails. A few runtime tests have been amended with test cases that would cause the kernel to misbehave (e.g. try to access a filesystem struct through an invalid pointer) without this fix.