### PR TITLE
getsockopt(): add support for SO_DOMAIN

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -2494,6 +2494,9 @@ static sysreturn netsock_getsockopt(struct sock *sock, int level,
         case SO_PROTOCOL:
             ret_optval.val = s->sock.type == SOCK_STREAM ? IP_PROTO_TCP : IP_PROTO_UDP;
             break;
+        case SO_DOMAIN:
+            ret_optval.val = s->sock.domain;
+            break;
         default:
             goto unimplemented;
         }

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -833,6 +833,7 @@ struct io_uring_params {
 #define SO_TIMESTAMP    29
 #define SO_ACCEPTCONN   30
 #define SO_PROTOCOL     38
+#define SO_DOMAIN       39
 
 #define IP_TOS              1
 #define IP_TTL              2


### PR DESCRIPTION
This socket option at the SOL_SOCKET level contains the socket domain value (e.g. AF_INET or AF_INET6).