### PR TITLE
Fault in process stack and heap pages

### DIFF
--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -301,7 +301,8 @@ process exec_elf(buffer ex, process kp)
     proc->brk = pointer_from_u64(brk);
     proc->heap_base = brk;
     proc->heap_map = allocate_vmap(proc, irange(brk, brk),
-                                   ivmap(VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE, 0, 0, 0, 0));
+                                   ivmap(VMAP_FLAG_HEAP | VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE,
+                                         0, 0, 0, 0));
     assert(proc->heap_map != INVALID_ADDRESS);
     exec_debug("entry %p, brk %p (offset 0x%lx)\n", entry, proc->brk, brk_offset);
 

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -238,7 +238,7 @@ boolean do_demand_page(process p, context ctx, u64 vaddr, vmap vm)
 {
     u64 page_addr = vaddr & ~PAGEMASK;
 
-    if ((vm->flags & VMAP_FLAG_MMAP) == 0) {
+    if ((vm->flags & (VMAP_FLAG_MMAP | VMAP_FLAG_STACK)) == 0) {
         msg_err("vaddr 0x%lx matched vmap with invalid flags (0x%x)\n",
                 vaddr, vm->flags);
         return false;
@@ -262,14 +262,19 @@ boolean do_demand_page(process p, context ctx, u64 vaddr, vmap vm)
         pf = new_pending_fault_locked(p, page_addr);
         spin_unlock_irq(&p->faulting_lock, flags);
         pf_debug("   new pending_fault %p\n", pf);
-        int mmap_type = vm->flags & VMAP_MMAP_TYPE_MASK;
-        switch (mmap_type) {
-        case VMAP_MMAP_TYPE_ANONYMOUS:
+        if (vm->flags & VMAP_FLAG_MMAP) {
+            int mmap_type = vm->flags & VMAP_MMAP_TYPE_MASK;
+            switch (mmap_type) {
+            case VMAP_MMAP_TYPE_ANONYMOUS:
+                return demand_anonymous_page(pf, vm, vaddr);
+            case VMAP_MMAP_TYPE_FILEBACKED:
+                return demand_filebacked_page(p, ctx, vm, vaddr, pf);
+            default:
+                halt("%s: invalid vmap type %d, flags 0x%lx\n", __func__, mmap_type, vm->flags);
+            }
+        } else {
+            pf_debug("   stack page fault\n");
             return demand_anonymous_page(pf, vm, vaddr);
-        case VMAP_MMAP_TYPE_FILEBACKED:
-            return demand_filebacked_page(p, ctx, vm, vaddr, pf);
-        default:
-            halt("%s: invalid vmap type %d, flags 0x%lx\n", __func__, mmap_type, vm->flags);
         }
     }
     kern_yield();

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -238,7 +238,7 @@ boolean do_demand_page(process p, context ctx, u64 vaddr, vmap vm)
 {
     u64 page_addr = vaddr & ~PAGEMASK;
 
-    if ((vm->flags & (VMAP_FLAG_MMAP | VMAP_FLAG_STACK)) == 0) {
+    if ((vm->flags & (VMAP_FLAG_MMAP | VMAP_FLAG_STACK | VMAP_FLAG_HEAP)) == 0) {
         msg_err("vaddr 0x%lx matched vmap with invalid flags (0x%x)\n",
                 vaddr, vm->flags);
         return false;
@@ -273,7 +273,7 @@ boolean do_demand_page(process p, context ctx, u64 vaddr, vmap vm)
                 halt("%s: invalid vmap type %d, flags 0x%lx\n", __func__, mmap_type, vm->flags);
             }
         } else {
-            pf_debug("   stack page fault\n");
+            pf_debug("   stack / heap page fault\n");
             return demand_anonymous_page(pf, vm, vaddr);
         }
     }

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1886,11 +1886,6 @@ static sysreturn brk(void *addr)
         if (!validate_user_memory(pointer_from_u64(old_end), alloc, true) ||
             !adjust_process_heap(p, irange(p->heap_base, new_end)))
             goto out;
-        pageflags flags = pageflags_writable(pageflags_noexec(pageflags_user(pageflags_memory())));
-        if (new_zeroed_pages(old_end, alloc, flags, 0) == INVALID_PHYSICAL) {
-            adjust_process_heap(p, irange(p->heap_base, old_end));
-            goto out;
-        }
     }
     p->brk = addr;
   out:

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -13,6 +13,7 @@
 
 #define VMAP_FLAG_MMAP     0x0010
 #define VMAP_FLAG_SHARED   0x0020 /* vs private; same semantics as unix */
+#define VMAP_FLAG_STACK    0x0040
 
 #define VMAP_MMAP_TYPE_MASK       0x0f00
 #define VMAP_MMAP_TYPE_ANONYMOUS  0x0100
@@ -37,6 +38,7 @@
 #define PROCESS_VIRTUAL_32BIT_RANGE (irange(2ull * GB, 4ull * GB))
 
 #define PROCESS_STACK_SIZE          (2 * MB)
+#define PROCESS_STACK_PREALLOC_SIZE PAGESIZE
 
 /* restrict the area in which ELF segments can be placed */
 #define PROCESS_ELF_LOAD_END        (3ull * GB) /* 3gb hard upper limit */

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -14,6 +14,7 @@
 #define VMAP_FLAG_MMAP     0x0010
 #define VMAP_FLAG_SHARED   0x0020 /* vs private; same semantics as unix */
 #define VMAP_FLAG_STACK    0x0040
+#define VMAP_FLAG_HEAP     0x0080
 
 #define VMAP_MMAP_TYPE_MASK       0x0f00
 #define VMAP_MMAP_TYPE_ANONYMOUS  0x0100


### PR DESCRIPTION
Up to now, Nanos would allocate and map an unnecessarily physically-contiguous
2MB chunk of memory for the userspace stack. This could be wasteful for
low-memory configurations both in terms of allocated but potentially unused
stack space as well as memory fragmentation created by the large, contiguous
allocation. Similarly, extensions of the process heap, made via a call to brk(2), would
also result in physically-contiguous allocations and mappings of the extended area.

With this change, only a single page (PROCESS_STACK_PREALLOC_SIZE) is
allocated for stack usage at first, allowing further stack pages to be faulted
in as needed. A new vmap flag, VMAP_FLAG_STACK, has been added to identify the
stack mapping, a fault on which is handled in the same way as an anonymous
mmap. Following in suit, heap extensions in brk(2) result only in an extending of the
heap vmap (now marked with VMAP_FLAG_HEAP), and heap pages are faulted
in on demand.

These changes save over 2MB (2172KB) of memory allocated, compared to master,
when running the webs test in a low memory configuration (16MB). The instance is
still not able to load with only 14MB of system memory, however, possibly due to
memory fragmentation and alignment of other large allocations (e.g. program binary).
