### PR TITLE
test/go: run 'go mod tidy' in post-clean rule

### DIFF
--- a/test/go/Makefile
+++ b/test/go/Makefile
@@ -20,6 +20,7 @@ test: build
 CLEANFILES+=	$(OBJDIR)/kernel.img $(OBJDIR)/boot.img
 
 post-clean:
+	$(Q) $(GOMOD) tidy
 	$(Q) $(GOCLEAN)
 	$(Q) $(RM) -rf .staging
 	$(Q) $(RM) -f $(BINARY_NAME) image ../runtime/soop.data


### PR DESCRIPTION
Running a 'make clean' on a clean tree, or a tree that hasn't executed the test/go tests, may result in an error such as:

   go: github.com/nanovms/ops@v0.0.0-20210408190622-0dc76ec84cd2: missing go.sum entry; to add it:
   	go mod download github.com/nanovms/ops

To avoid this, the post-clean rule now runs 'go mod tidy' prior to 'go clean'.

[I'm not certain if this is the right fix; does anyone know if there's a simpler way to bypass the above error?]
