### PR TITLE
fault in user program pages

### DIFF
--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -3,6 +3,7 @@ PROGRAMS=	stage2.elf
 SRCS-stage2.elf= \
 	$(CURDIR)/stage2.c \
 	$(CURDIR)/service32.s \
+	$(SRCDIR)/boot/elf.c \
 	$(SRCDIR)/drivers/ata.c \
 	$(SRCDIR)/kernel/elf.c \
 	$(SRCDIR)/kernel/page.c \
@@ -59,6 +60,7 @@ msg_objcopy=	OBJCOPY	$@
 cmd_objcopy=	$(OBJCOPY) $(OBJCOPYFLAGS) $(OBJCOPYFLAGS_$(@F)) $< $@
 
 SRCS-uefi= \
+	$(SRCDIR)/boot/elf.c \
 	$(SRCDIR)/boot/uefi.c \
 	$(SRCDIR)/kernel/elf.c \
 	$(SRCDIR)/kernel/page.c \

--- a/src/boot/boot.h
+++ b/src/boot/boot.h
@@ -56,3 +56,4 @@ static inline value_tag tagof(value v)
 }
 
 extern heap boot_buffer_heap;
+void *load_kernel_elf(buffer b, heap bss_heap);

--- a/src/boot/elf.c
+++ b/src/boot/elf.c
@@ -1,0 +1,58 @@
+#include <runtime.h>
+#include <page.h>
+#include <elf64.h>
+
+//#define BOOT_ELF_DEBUG
+#ifdef BOOT_ELF_DEBUG
+#define boot_elf_debug rprintf
+#else
+#define boot_elf_debug(...) do { } while(0)
+#endif
+
+closure_function(2, 5, boolean, kernel_elf_map,
+                 buffer, b, heap, bss_heap,
+                 u64, vaddr, u64, offset, u64, data_size, u64, bss_size, pageflags, flags)
+{
+    boot_elf_debug("%s: vaddr 0x%lx, offset 0x%lx, data_size 0x%lx, bss_size 0x%lx, flags 0x%lx\n",
+                   __func__, vaddr, offset, data_size, bss_size, flags);
+    u64 map_start = vaddr & ~PAGEMASK;
+    data_size += vaddr & PAGEMASK;
+
+    u64 tail_copy = bss_size > 0 ? data_size & PAGEMASK : 0;
+    if (tail_copy > 0)
+        data_size -= tail_copy;
+    else
+        data_size = pad(data_size, PAGESIZE);
+
+    offset &= ~PAGEMASK;
+    if (data_size > 0) {
+        u64 paddr = physical_from_virtual(buffer_ref(bound(b), offset));
+        map(map_start, paddr, data_size, flags);
+        map_start += data_size;
+    }
+    if (bss_size > 0) {
+        u64 maplen = pad(bss_size + tail_copy, PAGESIZE);
+        u64 paddr = allocate_u64(bound(bss_heap), maplen);
+        if (paddr == INVALID_PHYSICAL)
+            goto alloc_fail;
+        map(map_start, paddr, maplen, flags);
+        if (tail_copy > 0) {
+            void *src = buffer_ref(bound(b), offset + data_size);
+            boot_elf_debug("   tail copy at 0x%lx, %ld bytes, offset 0x%lx, from %p\n",
+                           map_start, tail_copy, data_size, src);
+            runtime_memcpy(pointer_from_u64(paddr), src, tail_copy);
+        }
+        boot_elf_debug("   zero at 0x%lx, len 0x%lx\n", map_start + tail_copy, maplen - tail_copy);
+        zero(pointer_from_u64(paddr + tail_copy), maplen - tail_copy);
+    }
+    return true;
+  alloc_fail:
+    msg_err("failed to allocate kernel bss mapping\n");
+    return false;
+}
+
+void *load_kernel_elf(buffer b, heap bss_heap)
+{
+    boot_elf_debug("%s: b %p, bss_heap %p\n", __func__, b, bss_heap);
+    return load_elf(b, 0, stack_closure(kernel_elf_map, b, bss_heap));
+}

--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -174,6 +174,8 @@ closure_function(6, 0, void, startup,
     value p = get(root, sym(program));
     assert(p);
     tuple pro = resolve_path(root, split(general, p, '/'));
+    if (!pro)
+        halt("unable to resolve program path \"%b\"\n", p);
     program_set_perms(root, pro);
     init_network_iface(root);
     filesystem_read_entire(fs, pro, (heap)heap_page_backed(kh), pg, closure(general, read_program_fail));

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -203,57 +203,141 @@ void start_process(thread t, void *start)
     }
 }
 
-closure_function(0, 1, void, load_interp_fail,
-                 status, s)
+closure_function(4, 5, boolean, static_map,
+                 process, p, kernel_heaps, kh, u32, allowed_flags, buffer, b,
+                 u64, vaddr, u64, offset, u64, data_size, u64, bss_size, pageflags, flags)
 {
-    rputs("interp fail\n");
-    closure_finish();
-    halt("read interp failed %v\n", s);
-}
+    exec_debug("%s: vaddr 0x%lx, offset 0x%lx, data_size 0x%lx, bss_size 0x%lx, flags 0x%lx\n",
+               __func__, vaddr, offset, data_size, bss_size, flags);
+    u64 map_start = vaddr & ~PAGEMASK;
+    data_size += vaddr & PAGEMASK;
 
-closure_function(3, 4, u64, exec_elf_map,
-                 process, p, kernel_heaps, kh, u32, allowed_flags,
-                 u64, vaddr, u64, paddr, u64, size, pageflags, flags)
-{
-    kernel_heaps kh = bound(kh);
-    u64 vmflags = VMAP_FLAG_READABLE;
-    if (pageflags_is_exec(flags))
-        vmflags |= VMAP_FLAG_EXEC;
-    if (pageflags_is_writable(flags))
-        vmflags |= VMAP_FLAG_WRITABLE;
+    u64 tail_copy = bss_size > 0 ? data_size & PAGEMASK : 0;
+    if (tail_copy > 0)
+        data_size -= tail_copy;
+    else
+        data_size = pad(data_size, PAGESIZE);
 
-    range r = irangel(vaddr, size);
-    boolean is_bss = paddr == INVALID_PHYSICAL;
-    exec_debug("%s: add to vmap: %R vmflags 0x%lx%s\n",
-               __func__, r, vmflags, is_bss ? " bss" : "");
-    assert(allocate_vmap(bound(p), r, ivmap(vmflags, bound(allowed_flags), 0, 0, 0)) !=
-           INVALID_ADDRESS);
-    if (is_bss) {
-        /* bss */
-        paddr = allocate_u64((heap)heap_physical(kh), size);
-        assert(paddr != INVALID_PHYSICAL);
+    offset &= ~PAGEMASK;
+    if (data_size > 0) {
+        u64 paddr = physical_from_virtual(buffer_ref(bound(b), offset));
+        u64 vmflags = VMAP_FLAG_READABLE | VMAP_FLAG_PROG;
+        if (pageflags_is_exec(flags))
+            vmflags |= VMAP_FLAG_EXEC;
+        if (pageflags_is_writable(flags))
+            vmflags |= VMAP_FLAG_WRITABLE;
+        range r = irangel(map_start, data_size);
+        exec_debug("   add %s to vmap: %R vmflags 0x%lx, paddr 0x%lx\n",
+                   pageflags_is_exec(flags) ? "text" : "data", r, vmflags, paddr);
+        struct vmap k = ivmap(vmflags, bound(allowed_flags), 0, 0, 0);
+        if (allocate_vmap(bound(p), r, k) == INVALID_ADDRESS)
+            goto alloc_fail;
+        map(map_start, paddr, data_size, pageflags_user(pageflags_minpage(flags)));
+        map_start += data_size;
     }
-    map(vaddr, paddr, size, pageflags_user(pageflags_minpage(flags)));
-    if (is_bss)
-        zero(pointer_from_u64(vaddr), size);
-    return vaddr;
+    if (bss_size > 0) {
+        u64 maplen = pad(bss_size + tail_copy, PAGESIZE);
+        u64 paddr = allocate_u64((heap)heap_physical(bound(kh)), maplen);
+        if (paddr == INVALID_PHYSICAL)
+            goto alloc_fail;
+        map(map_start, paddr, maplen, pageflags_user(pageflags_minpage(flags)));
+        u64 vmflags = VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE | VMAP_FLAG_BSS;
+        range r = irangel(map_start, maplen);
+        exec_debug("   add bss vmap: %R vmflags 0x%lx\n", r, vmflags);
+        struct vmap k = ivmap(vmflags, bound(allowed_flags), 0, 0, 0);
+        if (allocate_vmap(bound(p), r, k) == INVALID_ADDRESS)
+            goto alloc_fail;
+        if (tail_copy > 0) {
+            void *src = buffer_ref(bound(b), offset + data_size);
+            exec_debug("   tail copy at 0x%lx, %ld bytes, offset 0x%lx, from %p\n",
+                       map_start, tail_copy, data_size, src);
+            runtime_memcpy(pointer_from_u64(map_start), src, tail_copy);
+        }
+        exec_debug("   zero at 0x%lx, len 0x%lx\n", map_start + tail_copy, maplen - tail_copy);
+        zero(pointer_from_u64(map_start + tail_copy), maplen - tail_copy);
+    }
+    return true;
+  alloc_fail:
+    msg_err("failed to allocate interp vmap\n");
+    return false;
 }
 
-closure_function(2, 1, status, load_interp_complete,
-                 thread, t, kernel_heaps, kh,
-                 buffer, b)
+closure_function(4, 5, boolean, faulting_map,
+                 process, p, kernel_heaps, kh, u32, allowed_flags, fsfile, f,
+                 u64, vaddr, u64, offset, u64, data_size, u64, bss_size, pageflags, flags)
+{
+    exec_debug("%s: vaddr 0x%lx, offset 0x%lx, data_size 0x%lx, bss_size 0x%lx, flags 0x%lx\n",
+               __func__, vaddr, offset, data_size, bss_size, flags);
+    u64 map_start = vaddr & ~PAGEMASK;
+    if (data_size > 0) {
+        offset &= ~PAGEMASK;
+        data_size += vaddr & PAGEMASK;
+        u64 data_map_size = pad(data_size, PAGESIZE);
+        u64 tail_bss = MIN(data_map_size - data_size, bss_size);
+        u64 vmflags = VMAP_FLAG_READABLE | VMAP_FLAG_PROG;
+        if (pageflags_is_exec(flags))
+            vmflags |= VMAP_FLAG_EXEC;
+        if (pageflags_is_writable(flags))
+            vmflags |= VMAP_FLAG_WRITABLE;
+        if (tail_bss > 0)
+            vmflags |= VMAP_FLAG_TAIL_BSS;
+        range r = irangel(map_start, data_map_size);
+        exec_debug("%s: add %s to vmap: %R vmflags 0x%lx, offset 0x%lx, data_size 0x%lx, tail_bss 0x%lx\n",
+                   __func__, pageflags_is_exec(flags) ? "text" : "data",
+                   r, vmflags, offset, data_size, tail_bss);
+        struct vmap k = ivmap(vmflags, bound(allowed_flags), offset,
+                              fsfile_get_cachenode(bound(f)), 0);
+        if (tail_bss > 0)
+            k.bss_offset = data_size;
+        if (allocate_vmap(bound(p), r, k) == INVALID_ADDRESS)
+            goto alloc_fail;
+        map_start += data_map_size;
+        bss_size -= tail_bss;
+    }
+    if (bss_size > 0) {
+        u64 vmflags = VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE | VMAP_FLAG_BSS;
+        range r = irangel(map_start, pad(bss_size, PAGESIZE));
+        exec_debug("%s: add bss vmap: %R vmflags 0x%lx\n", __func__, r, vmflags);
+        struct vmap k = ivmap(vmflags, bound(allowed_flags), 0, 0, 0);
+        if (allocate_vmap(bound(p), r, k) == INVALID_ADDRESS)
+            goto alloc_fail;
+    }
+    return true;
+  alloc_fail:
+    msg_err("failed to allocate vmap\n");
+    return false;
+}
+
+closure_function(6, 2, void, load_interp_complete,
+                 thread, t, kernel_heaps, kh, buffer, b, fsfile, f, boolean, static_map, boolean, ingest_symbols,
+                 status, s, bytes, length)
 {
     thread t = bound(t);
+    process p = t->p;
     kernel_heaps kh = bound(kh);
+    buffer b = bound(b);
 
-    exec_debug("interpreter load complete, reading elf\n");
-    u64 where = process_get_virt_range(t->p, HUGE_PAGESIZE, PROCESS_VIRTUAL_MMAP_RANGE);
+    if (!is_ok(s))
+        halt("read interp failed %v\n", s);
+    exec_debug("interpreter load complete, length %ld, reading elf\n", length);
+    buffer_produce(b, length);
+    u64 where = process_get_virt_range(p, HUGE_PAGESIZE, PROCESS_VIRTUAL_MMAP_RANGE);
     assert(where != INVALID_PHYSICAL);
-    void * start = load_elf(b, where, stack_closure(exec_elf_map, t->p, kh, 0));
+    if (bound(ingest_symbols)) {
+        exec_debug("ingesting interp symbols\n");
+        add_elf_syms(b, where);
+    }
+    elf_map_handler emh;
+    if (bound(static_map))
+        emh = stack_closure(static_map, p, kh, 0, b);
+    else
+        emh = stack_closure(faulting_map, p, kh, 0, bound(f));
+    void *start = load_elf(b, where, emh);
+    if (!bound(static_map))
+        deallocate_buffer(b);
     exec_debug("starting process tid %d, start %p\n", t->tid, start);
     start_process(t, start);
     closure_finish();
-    return STATUS_OK;
 }
 
 closure_function(1, 1, boolean, trace_notify,
@@ -264,43 +348,36 @@ closure_function(1, 1, boolean, trace_notify,
     return true;
 }
 
-process exec_elf(buffer ex, process kp)
+static void exec_elf_finish(buffer ex, fsfile f, process kp,
+                            range load_range, const char *interp_path, boolean ingest_symbols,
+                            status_handler complete)
 {
-    // is process md always root?
+    status s = STATUS_OK;
     unix_heaps uh = kp->uh;
-    kernel_heaps kh = (kernel_heaps)uh;
     tuple root = kp->process_root;
     filesystem fs = kp->root_fs;
+    kernel_heaps kh = (kernel_heaps)uh;
     process proc = create_process(uh, root, fs);
     thread t = create_thread(proc, proc->pid);
-    tuple interp = 0;
+    fsfile interp;
     Elf64_Ehdr *e = (Elf64_Ehdr *)buffer_ref(ex, 0);
     boolean aslr = get(root, sym(noaslr)) == 0;
-
-    proc->brk = 0;
+    heap general = heap_locked(kh);
 
     exec_debug("exec_elf enter\n");
 
-    range load_range = irange(infinity, 0);
-    foreach_phdr(e, p) {
-        if (p->p_type == PT_INTERP) {
-            char *n = (void *)e + p->p_offset;
-            interp = resolve_path(root, split(heap_locked(kh), alloca_wrap_buffer(n, runtime_strlen(n)), '/'));
-            if (!interp) 
-                halt("couldn't find program interpreter %s\n", n);
-        } else if (p->p_type == PT_LOAD) {
-            if (p->p_vaddr < load_range.start)
-                load_range.start = p->p_vaddr;
-            u64 segend = p->p_vaddr + p->p_memsz;
-            if (segend > load_range.end)
-                load_range.end = segend;
+    if (interp_path) {
+        buffer ib = alloca_wrap_buffer(interp_path, runtime_strlen(interp_path));
+        interp = fsfile_open(ib);
+        if (!interp) {
+            s = timm("result", "couldn't find program interpreter %s", interp_path);
+            goto out;
         }
-    }
-
-    exec_debug("range of loadable segments prior to adjustment: %R\n", load_range);
-
-    if (interp)
         exec_debug("interp: %p\n", interp);
+    } else {
+        interp = 0;
+    }
+    exec_debug("range of loadable segments prior to adjustment: %R\n", load_range);
 
     u64 load_offset = 0;
     if (e->e_type == ET_DYN) {
@@ -314,16 +391,23 @@ process exec_elf(buffer ex, process kp)
     }
 
     if (load_range.end > PROCESS_ELF_LOAD_END) {
-        halt("exec_elf failed: elf segment load range (%R) exceeds hard limit 0x%lx\n",
+        s = timm("result", "exec_elf failed: elf segment load range (%R) exceeds hard limit 0x%lx",
              load_range, PROCESS_ELF_LOAD_END);
+        goto out;
     }
 
     exec_debug("offset 0x%lx, range after adjustment: %R, span 0x%lx\n",
                load_offset, load_range, range_span(load_range));
     u32 allowed_flags = proc_is_exec_protected(proc) ? 0 :
             (VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE | VMAP_FLAG_EXEC);
-    void * entry = load_elf(ex, load_offset, stack_closure(exec_elf_map, proc, kh, allowed_flags));
-
+    elf_map_handler emh;
+    boolean static_map = get(proc->process_root, sym(ltrace)) ||
+        get(proc->process_root, sym(static_map_program));
+    if (static_map)
+        emh = stack_closure(static_map, proc, kh, allowed_flags, ex);
+    else
+        emh = stack_closure(faulting_map, proc, kh, allowed_flags, f);
+    void * entry = load_elf(ex, load_offset, emh);
     u64 brk_offset = aslr ? get_aslr_offset(PROCESS_HEAP_ASLR_RANGE) : 0;
     u64 brk = pad(load_range.end, PAGESIZE) + brk_offset;
     proc->brk = pointer_from_u64(brk);
@@ -339,10 +423,9 @@ process exec_elf(buffer ex, process kp)
     //current_cpu()->current_thread = (nanos_thread)t;
     build_exec_stack(proc, t, e, entry, load_range.start, root, aslr);
 
-    if (get(proc->process_root, sym(ingest_program_symbols))) {
-        exec_debug("ingesting symbols...\n");
+    if (ingest_symbols) {
+        exec_debug("ingesting program symbols\n");
         add_elf_syms(ex, load_offset);
-        exec_debug("...done\n");
     }
 
     value ltrace = get(proc->process_root, sym(ltrace));
@@ -354,24 +437,131 @@ process exec_elf(buffer ex, process kp)
     register_root_notify(sym(trace), closure(heap_locked(kh), trace_notify, proc));
 
     if (interp) {
-        program_set_perms(root, interp);
+        program_set_perms(root, interp->md);
         exec_debug("reading interp...\n");
-        filesystem_read_entire(fs, interp, (heap)heap_page_backed(kh),
-                               closure(heap_locked(kh), load_interp_complete, t, kh),
-                               closure(heap_locked(kh), load_interp_fail));
-        return proc;
+        /* check if we neeed a full program read */
+        boolean load_entire = static_map || ingest_symbols;
+        u64 length = load_entire ? fsfile_get_length(interp) : ELF_PROGRAM_LOAD_MIN_SIZE;
+        buffer b = allocate_buffer(general, pad(length, PAGESIZE));
+        assert(b != INVALID_ADDRESS);
+        io_status_handler sh = closure(general, load_interp_complete, t, kh, b,
+                                       interp, static_map, ingest_symbols);
+        filesystem_read_linear(interp, buffer_ref(b, 0), irangel(0, length), sh);
+        goto out;
     }
 
     string cwd = get_string(root, sym(cwd));
     if (cwd) {
         buffer tmpbuf = little_stack_buffer(NAME_MAX + 1);
         fs_status fss = filesystem_chdir(proc, cstring(cwd, tmpbuf));
-        if (fss != FS_STATUS_OK)
-            halt("unable to change cwd to \"%b\"; %s\n", cwd, string_from_fs_status(fss));
+        if (fss != FS_STATUS_OK) {
+            s = timm("result", "unable to change cwd to \"%b\"; %s", cwd, string_from_fs_status(fss));
+            goto out;
+        }
     }
 
-    exec_debug("starting process...\n");
+    if (!static_map)
+        deallocate_buffer(ex);
+    exec_debug("starting process tid %d, start %p\n", t->tid, entry);
     start_process(t, entry);
-    return proc;    
+  out:
+    apply(complete, s);
 }
 
+static boolean elf_check_extend(u64 req_len, fsfile f, buffer b, io_status_handler self)
+{
+    u64 curr = buffer_length(b);
+    exec_debug("%s: req_len %ld, curr %ld\n", __func__, req_len, curr);
+    if (req_len <= curr)
+        return false;
+    u64 readlen = req_len - curr;
+    assert(buffer_extend(b, readlen));
+    exec_debug("%s: curr %ld, readlen %ld\n", __func__, curr, readlen);
+    filesystem_read_linear(f, buffer_ref(b, curr), irangel(curr, readlen), self);
+    return true;
+}
+
+closure_function(4, 2, void, exec_elf_read,
+                 fsfile, f, buffer, b, process, kp, status_handler, complete,
+                 status, s, bytes, length)
+{
+    fsfile f = bound(f);
+    buffer b = bound(b);
+    process kp = bound(kp);
+    status_handler complete = bound(complete);
+    exec_debug("%s: status %v, read %ld bytes\n", __func__, s, length);
+    if (!is_ok(s)) {
+        apply(complete, timm_up(s, "result", "failed to read elf file"));
+        closure_finish();
+        return;
+    }
+    buffer_produce(b, length);
+    exec_debug("buffer length %ld\n", buffer_length(b));
+    Elf64_Ehdr *e = (Elf64_Ehdr *)buffer_ref(b, 0);
+    const char *interp_path = 0;
+    boolean ingest_symbols = !!get(kp->process_root, sym(ingest_program_symbols));
+
+    /* This procedure will repeat until we have all the ELF info we need. */
+    range load_range = irange(infinity, 0);
+    foreach_phdr(e, p) {
+        if (p->p_type == PT_INTERP) {
+            interp_path = (void *)e + p->p_offset;
+            exec_debug("interp offset p->p_offset %ld, p->p_filesz %ld\n", p->p_offset, p->p_filesz);
+            if (elf_check_extend(p->p_offset + p->p_filesz, f, b, (io_status_handler)closure_self()))
+                return;
+        } else if (p->p_type == PT_LOAD) {
+            if (p->p_vaddr < load_range.start)
+                load_range.start = p->p_vaddr;
+            u64 segend = p->p_vaddr + p->p_memsz;
+            if (segend > load_range.end)
+                load_range.end = segend;
+        }
+    }
+    if (ingest_symbols) {
+        if (elf_check_extend(e->e_shoff + (e->e_shnum * e->e_shentsize), f, b,
+                             (io_status_handler)closure_self()))
+            return;
+        u64 req_size = 0;
+        foreach_shdr(e, shdr) {
+            if (shdr->sh_type == SHT_SYMTAB || shdr->sh_type == SHT_STRTAB) {
+                u64 sz = shdr->sh_offset + shdr->sh_size;
+                if (sz > req_size)
+                    req_size = sz;
+            }
+        }
+        if (elf_check_extend(req_size, f, b, (io_status_handler)closure_self()))
+            return;
+    }
+    exec_debug("finished reading ELF data, buffer length %ld\n", buffer_length(b));
+    closure_finish();
+    exec_elf_finish(b, f, kp, load_range, interp_path, ingest_symbols, complete);
+}
+
+void exec_elf(process kp, string program_path, status_handler complete)
+{
+    exec_debug("%s: path \"%b\", complete %p (%F)\n", __func__, program_path, complete, complete);
+    kernel_heaps kh = (kernel_heaps)(kp->uh);
+    heap general = heap_locked(kh);
+    tuple root = kp->process_root;
+    fsfile f = fsfile_open(program_path);
+    if (!f) {
+        apply(complete, timm("result", "unable to open program file %v", program_path));
+        return;
+    }
+
+    /* any of these options force a full program read */
+    boolean static_map = get(root, sym(ltrace)) || get(root, sym(static_map_program));
+    u64 length = static_map ? fsfile_get_length(f) : ELF_PROGRAM_LOAD_MIN_SIZE;
+    u64 alloc = pad(length, PAGESIZE);
+    buffer b = allocate_buffer(general, alloc);
+    if (b == INVALID_ADDRESS) {
+        apply(complete, timm("result", "unable to allocate memory for program read"));
+        return;
+    }
+    if (static_map && alloc > length) {
+        /* clear area past unaligned end */
+        zero(buffer_ref(b, length), alloc - length);
+    }
+    io_status_handler sh = closure(general, exec_elf_read, f, b, kp, complete);
+    filesystem_read_linear(f, buffer_ref(b, 0), irange(0, length), sh);
+}

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -451,7 +451,22 @@ void file_release(file f)
         unix_cache_free(get_unix_heaps(), file, f);
 }
 
-/* file_path is treated as an absolute path. */
+/* file_path is treated as an absolute path for fsfile_open() and fsfile_open_or_create() */
+fsfile fsfile_open(buffer file_path)
+{
+    tuple file;
+    fsfile fsf;
+    filesystem fs = get_root_fs();
+    fs_status s = filesystem_get_node(&fs, fs->get_inode(fs, filesystem_getroot(fs)),
+                                      buffer_to_cstring(file_path),
+                                      true, false, false, false, &file, &fsf);
+    if (s == FS_STATUS_OK) {
+        filesystem_put_node(fs, file);
+        return fsf;
+    }
+    return 0;
+}
+
 fsfile fsfile_open_or_create(buffer file_path, boolean truncate)
 {
     tuple file;

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -52,6 +52,7 @@ sysreturn fs_rename(buffer oldpath, buffer newpath);
 
 void file_release(file f);
 
+fsfile fsfile_open(buffer file_path);
 fsfile fsfile_open_or_create(buffer file_path, boolean truncate);
 fs_status fsfile_truncate(fsfile f, u64 len);
 

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -250,8 +250,8 @@ define_closure_function(0, 1, context, unix_fault_handler,
             vm = vmap_from_vaddr(p, vaddr);
         else
             vm = INVALID_ADDRESS;
-        pf_debug("page fault, vaddr 0x%lx, vmap %p, ctx %p, type %d, pc 0x%lx",
-                 vaddr, vm, ctx, ctx->type, fault_pc);
+        pf_debug("page fault, vaddr 0x%lx, vmap %p, ctx %p, type %d, pc 0x%lx, user %d",
+                 vaddr, vm, ctx, ctx->type, fault_pc, user);
         if (vm == INVALID_ADDRESS) {
             /* We're assuming here that an unhandled fault on a user page from
                within a syscall context is actually a program bug - though

--- a/src/unix/unix.h
+++ b/src/unix/unix.h
@@ -7,7 +7,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs);
 process create_process(unix_heaps uh, tuple root, filesystem fs);
 void process_get_cwd(process p, filesystem *cwd_fs, inode *cwd);
 thread create_thread(process p, u64 tid);
-process exec_elf(buffer ex, process kernel_process);
+void exec_elf(process kp, string program_path, status_handler complete);
 void unix_shutdown(void);
 
 void program_set_perms(tuple root, tuple prog);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -15,6 +15,9 @@
 #define VMAP_FLAG_SHARED   0x0020 /* vs private; same semantics as unix */
 #define VMAP_FLAG_STACK    0x0040
 #define VMAP_FLAG_HEAP     0x0080
+#define VMAP_FLAG_PROG     0x1000
+#define VMAP_FLAG_BSS      0x2000
+#define VMAP_FLAG_TAIL_BSS 0x4000
 
 #define VMAP_MMAP_TYPE_MASK       0x0f00
 #define VMAP_MMAP_TYPE_ANONYMOUS  0x0100
@@ -271,6 +274,7 @@ declare_closure_struct(1, 1, void, pending_fault_complete,
 typedef struct pending_fault {
     struct rbnode n;            /* must be first */
     u64 addr;
+    u64 bss_start;              /* u16? */
     process p;
     vector dependents;
     struct list l_free;
@@ -445,7 +449,10 @@ typedef struct vmap {
     u32 allowed_flags;
     pagecache_node cache_node;
     u64 node_offset;
-    fdesc fd;
+    union {
+        fdesc fd;
+        u64 bss_offset;
+    };
 } *vmap;
 
 #define ivmap(__f, __af, __o, __c, __fd) (struct vmap) {    \


### PR DESCRIPTION
Until this point, user program executables have been loaded and mapped, in their entirety, using physically-contiguous backed allocations. This practice has the effect of creating pressure on the memory system in the form of fragmentation, which is especially problematic in low memory configurations.

With this change, the user program file and program loader, if any, are now demand paged. Rather than reading the program with filesystem_read_entire(), a small portion is read, which is enough to contain the ELF program headers. The program headers are parsed using load_elf(), but instead of mapping loaded data directly into user memory, the elf_map_handlers instead add pagecache node information to the vmaps covering program text and data, allowing pages for these areas to be faulted in. BSS mappings are flagged as such and treated as anonymous mappings (like stack and heap mappings).

To support this change, load_elf() now passes only file offsets (instead of buffer physical addresses) to elf_map_handlers as the second argument. The handlers must find the buffer physical address by enclosing the buffer start and finding the physical address based on the given offset. The logic for handling non-page-aligned starts to bss sections has been moved from load_elf() to the handlers themselves, and the bss portion of any loadable segment is expressed with a new 'bss_size' argument, rather than handled in two separate invocations of the elf_map_handler.

Note that this feature is disabled (in favor of a statically-mapped load in entirety) when ltrace is in use, because the ltrace code needs to be able to make instruction-level modifications to the program in memory. It may also be disabled with the 'static_map_program' config option.

exec_elf() now takes a path string for the program file and performs the file loading itself. If 'ltrace' or 'static_map_program' are specified, the whole program binary is loaded at once and kept resident in memory. Otherwise, only a minimum necessary to read the program headers (ELF_PROGRAM_LOAD_MIN_SIZE, or one page) is loaded at first. Additional ELF data may be subsequently read as necessary, for instance to access the path string for the program loader, or to read in symbol data if 'ingest_program_symbols' is specified. When running in the fault-in mode, buffered file data is released after ELF header parsing has completed.