### PR TITLE
Unix file paths: properly enforce NAME_MAX and PATH_MAX limits

### DIFF
--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -104,7 +104,8 @@ static inline boolean buffer_is_wrapped(buffer b)
 
 static inline bytes buffer_set_capacity(buffer b, bytes len)
 {
-    buffer_assert(!buffer_is_wrapped(b));  /* wrapped buffers can't be resized */
+    if (buffer_is_wrapped(b))   /* wrapped buffers can't be resized */
+        return b->length;
     if (len < b->end - b->start)
         len = b->end - b->start;
     if (len != b->length) {

--- a/src/runtime/text.h
+++ b/src/runtime/text.h
@@ -85,41 +85,25 @@ static inline character utf8_decode(const u8 *x, int *count)
     return *x;
 }
 
-static inline void push_character(string s, character c)
+static inline boolean push_character(string s, character c)
 {
     if (c<0x80) {
-        buffer_write_byte(s, c);
+        return buffer_write_byte(s, c);
     } else if (c<0x800) {
-        buffer_write_byte(s, 0xc0 | (c>>6));
-        buffer_write_byte(s, 0x80 | (c&0x3f));
+        return buffer_write_byte(s, 0xc0 | (c>>6)) &&
+               buffer_write_byte(s, 0x80 | (c&0x3f));
     } else if (c<0x10000) {
-        buffer_write_byte(s, 0xe0 | (c>>12));
-        buffer_write_byte(s, 0x80 | ((c>>6) & 0x3f));
-        buffer_write_byte(s, 0x80 | (c&0x3f));
+        return buffer_write_byte(s, 0xe0 | (c>>12)) &&
+               buffer_write_byte(s, 0x80 | ((c>>6) & 0x3f)) &&
+               buffer_write_byte(s, 0x80 | (c&0x3f));
     } else if (c<0x110000) {
-        buffer_write_byte(s, 0xf0 | (c>>18));
-        buffer_write_byte(s, 0x80 | ((c>>12)&0x3f));
-        buffer_write_byte(s, 0x80 | ((c>>6)&0x3f));
-        buffer_write_byte(s, 0x80 | (c&0x3f));
+        return buffer_write_byte(s, 0xf0 | (c>>18)) &&
+               buffer_write_byte(s, 0x80 | ((c>>12)&0x3f)) &&
+               buffer_write_byte(s, 0x80 | ((c>>6)&0x3f)) &&
+               buffer_write_byte(s, 0x80 | (c&0x3f));
     }
+    return false;
 }
-
-/**
- * Push an UTF-8 character from a sequence of bytes p and return the
- * number of bytes consumed from p.
- */
-static inline int push_utf8_character(string s, const char *p)
-{
-    int nbytes = 0;
-    u32 crt_char;
-
-    crt_char = utf8_decode((const u8 *)p, &nbytes);
-
-    push_character(s, crt_char);
-
-    return nbytes;
-}
-
 
 // xxx - check
 #define CHARACTER_INVALID 0xfffffffful

--- a/test/runtime/creat.c
+++ b/test/runtime/creat.c
@@ -1,3 +1,4 @@
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -64,6 +65,7 @@ void check(const char *path, int expect)
 int main(int argc, char **argv)
 {
     int fd;
+    char name_too_long[NAME_MAX + 2];
 
     fd = creat((char *)0xbadf0000, 0);
     if ((fd != -1) || (errno != EFAULT)) {
@@ -76,6 +78,11 @@ int main(int argc, char **argv)
     check("/test", 0);
     _creat("/blurb/test/deep", 0, ENOENT);
     check("/blurb/test/deep", ENOENT);
+
+    memset(name_too_long, '-', sizeof(name_too_long) - 1);
+    name_too_long[sizeof(name_too_long) - 1] = '\0';
+    _creat(name_too_long, 0, ENAMETOOLONG);
+
     printf("test passed\n");
     return EXIT_SUCCESS;
 }

--- a/test/runtime/inotify.c
+++ b/test/runtime/inotify.c
@@ -123,6 +123,7 @@ static void inotify_test_basic(int flags, struct inotify_event *expected, const 
 {
     int fd;
     int nbytes;
+    char name_too_long[NAME_MAX + 2];
     int wd[4];
     uint32_t event_mask = IN_ACCESS | IN_CREATE | IN_OPEN | IN_CLOSE | IN_DELETE | IN_MODIFY |
                           IN_MOVE_SELF;
@@ -147,6 +148,9 @@ static void inotify_test_basic(int flags, struct inotify_event *expected, const 
     /* Invalid path name */
     test_assert((inotify_add_watch(fd, NULL, IN_ACCESS) == -1) && (errno == EFAULT));
     test_assert((inotify_add_watch(fd, "abc", IN_ACCESS) == -1) && (errno == ENOENT));
+    memset(name_too_long, '-', sizeof(name_too_long) - 1);
+    name_too_long[sizeof(name_too_long) - 1] = '\0';
+    test_assert((inotify_add_watch(fd, name_too_long, IN_ACCESS) == -1) && (errno == ENAMETOOLONG));
 
     /* Invalid event mask */
     test_assert((inotify_add_watch(fd, INOTIFY_TEST_DIR1, 0) == -1) && (errno == EINVAL));

--- a/test/runtime/mkdir.c
+++ b/test/runtime/mkdir.c
@@ -335,6 +335,16 @@ int main(int argc, char **argv)
     listdir(TEST_DIR "/",TEST_DIR "/");
     listdir(TEST_DIR "/test", TEST_DIR "/test");
 
+    char name_too_long[NAME_MAX + 2];
+    memset(name_too_long, '-', sizeof(name_too_long) - 1);
+    name_too_long[sizeof(name_too_long) - 1] = '\0';
+    _mkdirat(AT_FDCWD, name_too_long, DEFAULT_MODE, ENAMETOOLONG);
+    r = chdir(name_too_long);
+    if (r != -1 || errno != ENAMETOOLONG) {
+        printf("ERROR - chdir on invalid path didn't return ENAMETOOLONG\n");
+        exit(EXIT_FAILURE);
+    }
+
     _chdir(TEST_DIR);
     _creat("root_newfile", DEFAULT_MODE, 0);
     listdir(TEST_DIR "/",".");

--- a/test/runtime/rename.c
+++ b/test/runtime/rename.c
@@ -3,6 +3,7 @@
 #include <linux/fs.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -101,6 +102,7 @@ static void test_renameat2(int olddirfd, int newdirfd)
 int main(int argc, char **argv)
 {
     int fd1, fd2;
+    char name_too_long[NAME_MAX + 2];
 
     test_rename("/file1", "/file2");
 
@@ -145,6 +147,11 @@ int main(int argc, char **argv)
             (errno == ENOENT));
     test_assert((rename("/my_file", "") < 0) && (errno == ENOENT));
     test_assert((rename("", "/my_file") < 0) && (errno == ENOENT));
+
+    memset(name_too_long, '-', sizeof(name_too_long) - 1);
+    name_too_long[sizeof(name_too_long) - 1] = '\0';
+    test_assert((rename("/my_file", name_too_long) == -1) && (errno == ENAMETOOLONG));
+    test_assert((rename(name_too_long, "foo") == -1) && (errno == ENAMETOOLONG));
 
     printf("Test passed\n");
     return EXIT_SUCCESS;

--- a/test/runtime/unlink.c
+++ b/test/runtime/unlink.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
@@ -110,6 +111,7 @@ static void test_tmpfile()
 int main(int argc, char **argv)
 {
     int fd;
+    char name_too_long[NAME_MAX + 2];
     struct stat s;
 
     if ((unlink(FAULT_ADDR) != -1) || (errno != EFAULT)) {
@@ -119,6 +121,17 @@ int main(int argc, char **argv)
     if ((unlink("") != -1) || (errno != ENOENT)) {
         printf("empty path unlink test failed\n");
         exit(EXIT_FAILURE);
+    }
+
+    memset(name_too_long, '-', sizeof(name_too_long) - 1);
+    name_too_long[sizeof(name_too_long) - 1] = '\0';
+    if ((unlink(name_too_long) != -1) || (errno != ENAMETOOLONG)) {
+        printf("name too long unlink test failed\n");
+        return EXIT_FAILURE;
+    }
+    if ((rmdir(name_too_long) != -1) || (errno != ENAMETOOLONG)) {
+        printf("name too long rmdir test failed\n");
+        return EXIT_FAILURE;
     }
 
     test_unlink("/file");

--- a/test/runtime/write.c
+++ b/test/runtime/write.c
@@ -308,6 +308,7 @@ void sync_write_test(void)
 
 void truncate_test(const char *prog)
 {
+    char name_too_long[NAME_MAX + 2];
     unsigned char tmp[BUFLEN];
     ssize_t rv;
     struct stat s;
@@ -317,6 +318,15 @@ void truncate_test(const char *prog)
         printf("truncate() with faulting path failed (%ld, %d)\n", rv, errno);
         exit(EXIT_FAILURE);
     }
+
+    memset(name_too_long, '-', sizeof(name_too_long) - 1);
+    name_too_long[sizeof(name_too_long) - 1] = '\0';
+    rv = truncate(name_too_long, 0);
+    if ((rv != -1) || (errno != ENAMETOOLONG)) {
+        printf("truncate() with name too long failed (%ld, %d)\n", rv, errno);
+        exit(EXIT_FAILURE);
+    }
+
     int fd = open("new_file", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
     if (fd < 0) {
         perror("open");


### PR DESCRIPTION
This change set fixes handling of file names whose length exceeds NAME_MAX, so that -ENAMETOOLONG is returned when appropriate, and allows using symlinks whose target path length is within the PATH_MAX limit.