### PR TITLE
Unix syscalls: implement utimensat(2)

### DIFF
--- a/src/aarch64/unix_machine.c
+++ b/src/aarch64/unix_machine.c
@@ -275,7 +275,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, sync_file_range, 0, 0);
     register_syscall(map, vmsplice, 0, 0);
     register_syscall(map, move_pages, 0, 0);
-    register_syscall(map, utimensat, 0, 0);
     register_syscall(map, preadv, 0, 0);
     register_syscall(map, pwritev, 0, 0);
     register_syscall(map, perf_event_open, 0, 0);

--- a/src/riscv64/unix_machine.c
+++ b/src/riscv64/unix_machine.c
@@ -220,7 +220,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, sync_file_range, 0, 0);
     register_syscall(map, vmsplice, 0, 0);
     register_syscall(map, move_pages, 0, 0);
-    register_syscall(map, utimensat, 0, 0);
     register_syscall(map, preadv, 0, 0);
     register_syscall(map, pwritev, 0, 0);
     register_syscall(map, perf_event_open, 0, 0);

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -39,6 +39,7 @@ sysreturn symlinkat(const char *target, int dirfd, const char *linkpath);
 
 sysreturn utime(const char *filename, const struct utimbuf *times);
 sysreturn utimes(const char *filename, const struct timeval times[2]);
+sysreturn utimensat(int dirfd, const char *filename, const struct timespec times[2], int flags);
 
 sysreturn statfs(const char *path, struct statfs *buf);
 sysreturn fstatfs(int fd, struct statfs *buf);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2419,6 +2419,7 @@ void register_file_syscalls(struct syscall *map)
     register_syscall(map, unlinkat, unlinkat, SYSCALL_F_SET_FILE|SYSCALL_F_SET_DESC);
     register_syscall(map, renameat, renameat, SYSCALL_F_SET_FILE|SYSCALL_F_SET_DESC);
     register_syscall(map, renameat2, renameat2, SYSCALL_F_SET_FILE|SYSCALL_F_SET_DESC);
+    register_syscall(map, utimensat, utimensat, SYSCALL_F_SET_FILE|SYSCALL_F_SET_DESC);
     register_syscall(map, close, close, SYSCALL_F_SET_DESC);
     register_syscall(map, sched_yield, sched_yield, 0);
     register_syscall(map, brk, brk, SYSCALL_F_SET_MEM);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -249,6 +249,9 @@ typedef int clockid_t;
 #define ITIMER_VIRTUAL 1
 #define ITIMER_PROF    2
 
+#define UTIME_NOW   ((1ull << 30) - 1)
+#define UTIME_OMIT  ((1ull << 30) - 2)
+
 struct timespec {
     u64 tv_sec;
     u64 tv_nsec;

--- a/src/x86_64/unix_machine.c
+++ b/src/x86_64/unix_machine.c
@@ -385,7 +385,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, sync_file_range, 0, 0);
     register_syscall(map, vmsplice, 0, 0);
     register_syscall(map, move_pages, 0, 0);
-    register_syscall(map, utimensat, 0, 0);
     register_syscall(map, preadv, 0, 0);
     register_syscall(map, pwritev, 0, 0);
     register_syscall(map, perf_event_open, 0, 0);


### PR DESCRIPTION
This change adds to the kernel an implementation of the utimensat syscall, which allows programs to use the utimensat() and futimens() POSIX functions.
The new code is being exercised in the runtime tests.