### PR TITLE
utime/utimes: fix handling of non-existent files

### DIFF
--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -172,9 +172,9 @@ static sysreturn utime_internal(const char *filename, timestamp actime,
     } else {
         filesystem_set_atime(fs, t, actime);
         filesystem_set_mtime(fs, t, modtime);
+        filesystem_put_node(fs, t);
         rv = 0;
     }
-    filesystem_put_node(fs, t);
     filesystem_release(cwd_fs);
     return rv;
 }

--- a/test/runtime/time.c
+++ b/test/runtime/time.c
@@ -816,6 +816,9 @@ static void test_utime(void)
     rv = utimensat(-1, filename, NULL, 0);
     if ((rv != -1) || (errno != EBADF))
         fail_error("failed at %d (%d, %d)\n", __LINE__, rv, errno);
+    rv = utimes(filename, NULL);
+    if ((rv != -1) || (errno != ENOENT))
+        fail_error("failed at %d (%d, %d)\n", __LINE__, rv, errno);
     fd = creat(filename, S_IRUSR | S_IWUSR);
     if (fd < 0)
         fail_perror("creat(\"%s\")", filename);


### PR DESCRIPTION
If the program calls utime() or utimes() with a non-existent file path argument, the kernel crashes with "assertion ctx == m->turn failed at src/kernel/mutex.c:263 (IP 0xffffffff800491af)  in mutex_unlock(); halt".
This commit fixes the above issue and adds a test case that would fail without this fix.