### PR TITLE
vm_exit(): fix parsing of multiple expected exit codes

### DIFF
--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -526,11 +526,10 @@ void vm_exit(u8 code)
         value expected = get(root, sym(expected_exit_code));
         if (expected) {
             u64 expected_code;
-            if ((is_string(expected) || is_integer(expected)) &&
-                u64_from_value(expected, &expected_code) &&
+            if (u64_from_value(expected, &expected_code) &&
                 expected_code == code) {
                 code = 0;               
-            } else if (is_tuple(expected)) {
+            } else if (is_vector(expected)) {
                 for (int i = 0; get_u64(expected, intern_u64(i), &expected_code); i++) {
                     if (expected_code == code) {
                         code = 0;


### PR DESCRIPTION
The current version of Ops encodes vector values using the new vector type introduced in TFS version 5; therefore, if multiple expected exit values are specified in the manifest of a given image, the corresponding value decoded by the kernel from the root tuple is a vector.
This change modifies the vm_exit() function so that it can correctly retrieve the expected exit codes when there are multiple such codes; in addition, the checks for string and integer values are being removed because they are redundant: if a value is not a string nor an integer, u64_from_value() returns false.