### PR TITLE
PCI add support for multiple root bridges

### DIFF
--- a/src/kernel/pci.h
+++ b/src/kernel/pci.h
@@ -184,7 +184,7 @@ void pci_bar_write_8(struct pci_bar *b, u64 offset, u64 val);
 u32 pci_find_cap(pci_dev dev, u8 cap);
 u32 pci_find_next_cap(pci_dev dev, u8 cap, u32 cp);
 
-void pci_bus_set_iomem(int bus, id_heap iomem);
+void pci_bridge_set_iomem(range window, id_heap iomem);
 id_heap pci_bus_get_iomem(int bus);
 void pci_discover();
 void pci_probe_device(pci_dev dev);


### PR DESCRIPTION
A PCI root bridge is a bridge that does not sit downstream another bridge, and as such cannot be detected by probing the host bridge. PCI root bridges are listed in the ACPI tables, where a bridge device handle contains information not only on the memory ranges managed by a given bridge, but also on the "bridge window", i.e. the range of PCI bus numbers managed (directly or indirectly) by the bridge.
This commit amends the ACPI code so that it retrieves both the memory ranges and the bridge windows for all PCI root bridges, and amends the PCI code so that it stores (instead of a vector of PCI buses) a map of bus number ranges (with I/O memory associated to the corresponding root bridge).
The pci_discover() function probes, beside the host bridge, any additional bridges that have been detected via ACPI; the pci_bus_get_iomem() function has been amended so that it can retrieve the I/O memory to be assigned to a given PCI device even if the device is on a different bus than the primary bus of its root bridge.
These changes allow the kernel to detect the  network adapter on AWS instances with multiple root bridges, such as m7a instance types.