### PR TITLE
File-backed mappings: request pagecache fill asynchronously

### DIFF
--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -267,6 +267,8 @@ struct ftrace_graph_entry;
 #include <notify.h>
 
 struct pending_fault;
+declare_closure_struct(3, 0, void, pending_fault_demand_file_page,
+                       struct vmap *, vm, u64, node_offset, pageflags, flags);
 declare_closure_struct(1, 1, void, pending_fault_complete,
                        struct pending_fault *, pf,
                        status, s);
@@ -278,6 +280,7 @@ typedef struct pending_fault {
     process p;
     vector dependents;
     struct list l_free;
+    closure_struct(pending_fault_demand_file_page, demand_file_page);
     closure_struct(pending_fault_complete, complete);
 } *pending_fault;
 


### PR DESCRIPTION
Requesting a pagecache fill to resolve a page fault for a file-backed mapping can cause the current context to be suspended, e.g. to acquire the filesystem mutex. The context_switch() function, which is called to switch to a kernel context before calling pagecache_map_page(), does not move the stack pointer to the stack of the kernel context; instead, the context will run on the exception/interrupt stack of the current CPU; if the context is suspended, the current CPU can pick up and run a user thread, which can cause a new exception, whose handler will run on the same stack; as a result, when the suspended context is later resumed, it will run on a corrupted stack, leading to a kernel crash.
This change fixes the above issue by removing the use of the context_switch() function (which is unnecessary because a switch to a kernel context happens when kern_yield() is called) when resolving a page fault, and using an asynchronous thunk instead of calling pagecache_map_page() directly.