### PR TITLE
Support building with ARM-based Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,38 @@ This installs the correct toolchain and will install an up-to-date qemu.
 It is highly recommended to be running the latest qemu otherwise you
 might run into issues.
 
+For Intel-based Macs:
 ```
 brew update && brew install nasm go wget ent
-brew tap nanovms/homebrew-x86_64-elf
+brew tap nanovms/homebrew-toolchains
 brew install x86_64-elf-binutils
 brew tap nanovms/homebrew-qemu
 brew install nanovms/homebrew-qemu/qemu
 ```
 
+For ARM-based Macs (M1/M2):
+```
+brew update && brew install go wget ent qemu aarch64-elf-gcc aarch64-elf-binutils
+# To build and link runtime tests or aarch64 linux user programs:
+brew tap nanovms/homebrew-toolchains
+brew install aarch64-linux-binutils
+```
+
 Create a Chroot:
 (this isn't absolutely necessary)
+
+For Intel-based Macs:
 ```
 mkdir target-root && cd target-root && wget
 https://storage.googleapis.com/testmisc/target-root.tar.gz && tar xzf target-root.tar.gz
 ```
+
+For ARM-based Macs (M1/M2):
+```
+mkdir target-root && cd target-root && wget
+https://storage.googleapis.com/testmisc/arm64-target-root-new.tar.gz && tar xzf arm64-target-root-new.tar.gz
+```
+
 You should also set the environment variable NANOS_TARGET_ROOT to the path of 
 target-root created above in order to create the example and test images.
 

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -181,15 +181,11 @@ $(KLIB_SYMS): $(PROGRAM_BINARIES)
 # delete linker script backup file
 	$(Q) $(RM) $(KLIB_SYMS).bak
 
-ifeq ($(UNAME_s),Darwin)
-ELF_TARGET=     -target x86_64-elf
+ifeq ($(findstring clang,$(COMPILER_VERSION)),clang)
+ELF_TARGET=     -target $(ARCH)-elf
 CFLAGS+=        $(ELF_TARGET)
-LD=             x86_64-elf-ld
-OBJDUMP=        x86_64-elf-objdump
-STRIP=          x86_64-elf-strip
-else
-LD=             $(CROSS_COMPILE)ld
 endif
+LD=             $(CROSS_COMPILE)ld
 
 INCLUDES= \
 	-I$(CURDIR) \

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -379,8 +379,14 @@ $(UEFI_LOADER):	$(BOOT_OBJDIR)/uefi.so
 	$(call cmd,uefi_objcopy)
 
 LD=             $(CROSS_COMPILE)ld
+ifeq ($(UNAME_s),Darwin)
+REL_OS=		darwin
+QEMU_ACCEL=	-accel $(ACCEL) -cpu host
+ACCEL?=		hvf
+else
 REL_OS=		linux
 QEMU_ACCEL=	-enable-kvm -cpu host
+endif
 
 ##############################################################################
 # run

--- a/src/aarch64/machine.h
+++ b/src/aarch64/machine.h
@@ -45,8 +45,10 @@ typedef u64 bytes;
 #define mask_and_set_field(u, f, v) (clear_field(u, f) | u64_from_field(f, v))
 
 #define DIV(__x, __by, __q, __r) \
-    do { asm("udiv %0, %2, %3; msub %1, %0, %3, %2" :           \
-             "=&r"(__q), "=r"(__r) : "r"(__x), "r"(__by)); } while(0)
+    do { asm("udiv %0, %1, %2" :           \
+            "=r"(__q): "r"(__x), "r"((u64)__by)); \
+        asm("msub %0, %2, %3, %1" :           \
+            "=r"(__r) : "r"(__x), "r"(__q),"r"((u64)__by)); } while(0)
 
 #if 0
 #define ROL(__x, __b)\

--- a/src/unix_process/socket_user.c
+++ b/src/unix_process/socket_user.c
@@ -493,8 +493,10 @@ closure_function(4, 0, void, accepting,
     socklen_t len = sizeof(struct sockaddr_in);
     int s = accept(bound(c), (struct sockaddr *)&where, &len);
     if (s < 0 ) halt("accept %s\n", strerror(errno));
+#ifndef __APPLE__
     int en = 1;
     setsockopt(s, SOL_TCP, TCP_NODELAY, &en, sizeof(en));
+#endif
     register_conn_descriptor(h, n, s, bound(nc));
 }
 

--- a/src/unix_process/unix_process_runtime.c
+++ b/src/unix_process/unix_process_runtime.c
@@ -7,7 +7,7 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 
-#ifdef __aarch64__
+#if defined(__aarch64__) && !defined(__APPLE__)
 #include <sys/prctl.h>
 #endif
 
@@ -135,7 +135,7 @@ static u64 tag_alloc(heap h, bytes s)
 
 static heap allocate_tagged_region(heap h, u64 tag)
 {
-#ifdef __aarch64__
+#if defined(__aarch64__) && !defined(__APPLE__)
 #define PR_SET_TAGGED_ADDR_CTRL      55
 #define PR_TAGGED_ADDR_ENABLE        (1UL << 0)
     static boolean abi_init = false;

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -328,20 +328,41 @@ dummy:
 
 include ../../rules.mk
 
+TARGET_ROOT=	$(NANOS_TARGET_ROOT)
+ifeq ($(UNAME_s),Darwin)
+ifeq ($(ARCH),x86_64)
+GCC_VER=	6
+OBJS_CRTBEGIN_D=-dynamic-linker /lib64/ld-linux-x86-64.so.2
+LD=			x86_64-elf-ld
+else ifeq ($(ARCH),aarch64)
+GCC_VER=	12
+OBJS_CRTBEGIN_D=-dynamic-linker /lib/ld-linux-aarch64.so.1
+LD=			aarch64-linux-ld
+endif
+# crtbegin/crtend for dynamically linked executables
+OBJS_CRTBEGIN_D+= $(TARGET_ROOT)/usr/lib/$(ARCH)-linux-gnu/Scrt1.o $(TARGET_ROOT)/usr/lib/$(ARCH)-linux-gnu/crti.o $(TARGET_ROOT)/usr/lib/gcc/$(ARCH)-linux-gnu/$(GCC_VER)/crtbeginS.o
+OBJS_CRTEND_D=	-L=/usr/lib/$(ARCH)-linux-gnu -L=/usr/lib/gcc/$(ARCH)-linux-gnu/$(GCC_VER) -lc $(TARGET_ROOT)/usr/lib/gcc/$(ARCH)-linux-gnu/$(GCC_VER)/crtendS.o $(TARGET_ROOT)/usr/lib/$(ARCH)-linux-gnu/crtn.o
+# crtbegin/crtend for statically linked executables
+OBJS_CRTBEGIN=	$(TARGET_ROOT)/usr/lib/$(ARCH)-linux-gnu/crt1.o $(TARGET_ROOT)/usr/lib/$(ARCH)-linux-gnu/crti.o $(TARGET_ROOT)/usr/lib/gcc/$(ARCH)-linux-gnu/$(GCC_VER)/crtbeginT.o
+OBJS_CRTEND=	-L=/usr/lib/$(ARCH)-linux-gnu -L=/usr/lib -L=/lib/$(ARCH)-linux-gnu -L=/lib -L=/usr/lib/gcc/$(ARCH)-linux-gnu/$(GCC_VER) --start-group -lgcc -lgcc_eh -lc --end-group $(TARGET_ROOT)/usr/lib/gcc/$(ARCH)-linux-gnu/$(GCC_VER)/crtend.o $(TARGET_ROOT)/usr/lib/$(ARCH)-linux-gnu/crtn.o
+endif
+
 ifneq ($(CROSS_COMPILE),)
+LDFLAGS+=	--sysroot=$(TARGET_ROOT)
+ifeq ($(findstring clang,$(COMPILER_VERSION)),clang)
+CFLAGS+=	-target x86_64-elf --sysroot $(TARGET_ROOT) -I $(TARGET_ROOT)/usr/include
+else
 CFLAGS+=	--sysroot $(TARGET_ROOT) -isystem $(TARGET_ROOT)/usr/include -isystem $(TARGET_ROOT)/usr/include/$(ARCH)-linux-gnu
-LDFLAGS+=	--sysroot=$(TARGET_ROOT) -B$(TARGET_ROOT)/usr/lib/$(ARCH)-linux-gnu
+ifeq ($(CC),$(LD))
+LDFLAGS+=	-B$(TARGET_ROOT)/usr/lib/$(ARCH)-linux-gnu
+endif
+endif
 ifeq ($(ARCH),riscv64)
 LDFLAGS+=	-Wl,--eh-frame-hdr
 endif
-else
 ifeq ($(UNAME_s),Darwin)
-CFLAGS+=	-target x86_64-elf --sysroot $(TARGET_ROOT) -I $(TARGET_ROOT)/usr/include
-LD=		x86_64-elf-ld
-LDFLAGS+=	--sysroot=$(TARGET_ROOT)
 OBJS_BEGIN=	$(OBJS_CRTBEGIN)
 OBJS_END=	$(OBJS_CRTEND)
-GO_ENV=		GOOS=linux GOARCH=amd64
 
 $(PROG-hw): OBJS_BEGIN=$(OBJS_CRTBEGIN_D)
 $(PROG-hw): OBJS_END=$(OBJS_CRTEND_D)
@@ -355,6 +376,8 @@ ifneq ($(CROSS_COMPILE),)
 GO_ENV=		GOOS=linux
 ifeq ($(ARCH),aarch64)
 GO_ENV+=	GOARCH=arm64
+else ifeq ($(ARCH),x86_64)
+GO_ENV+=	GOARCH=amd64
 else
 GO_ENV+=	GOARCH=$(ARCH)
 endif

--- a/test/runtime/signal.c
+++ b/test/runtime/signal.c
@@ -1495,7 +1495,7 @@ void test_smp_sig_handling(void)
 static void test_fault(void)
 {
     sigset_t ss;
-    union sigval sv;
+    union sigval sv = {0};
     siginfo_t info;
     int fd;
 

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -1,3 +1,9 @@
+override ARCH=$(shell uname -m)
+override CROSS_COMPILE=
+ifeq ($(shell uname -s),Darwin)
+override CC=cc
+endif
+
 PROGRAMS= \
 	bitmap_test \
 	buffer_test \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,5 +1,8 @@
 override ARCH=$(shell uname -m)
 override CROSS_COMPILE=
+ifeq ($(shell uname -s),Darwin)
+override CC=cc
+endif
 CONTGEN=$(OBJDIR)/bin/contgen
 PROGRAMS=dump mkfs vdsogen
 ADDITIONAL_PROGRAMS=tfs-fuse


### PR DESCRIPTION
This adds support for building nanos on an M1 or M2 based Mac. Several rules
have been rewritten to be more friendly for cross compiling or for determining
CFLAGS based on compiler type and not just platform.

Aarch64 apple clang has several warnings and errors when processing nanos
code and some of them did not have a reasonable solution for making the compiler
happy. Most of these problems were related to the inline assembly. Since homebrew
provides an up-to-date aarch64-elf-gcc, this change uses that instead of clang to
compile the kernel.

While aarch64-elf-binutils works fine for working with the kernel, the linker
appears to have a problem compiling the static runtime tests where the
automatic symbol __ehdr_start is not found. For this reason, a custom
aarch64-linux-binutils formula is provided which allows proper linking of
those static user programs.

The OBJS_CRT definitions that were removed in a previous change have
been restored as they are required for linking user programs on either
architecture of Macs, but they have been relocated to the runtime
Makefile as that is the only place they are used.

A handful of small changes were necessary to silence new compiler warnings.