### PR TITLE
Page faults: fix handling of OOM conditions

### DIFF
--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1598,7 +1598,7 @@ void pagecache_map_page(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags
                     __func__, pn, node_offset, vaddr, flags, complete, pp);
     if (pp == INVALID_ADDRESS) {
         pagecache_unlock_node(pn);
-        apply(complete, timm("result", "%s: unable to allocate pagecache page", __func__));
+        apply(complete, timm_oom);
         return;
     }
     merge m = allocate_merge(pc->h, closure(pc->h, map_page_finish,

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -896,6 +896,7 @@ boolean unix_timers_init(unix_heaps uh);
 extern sysreturn syscall_ignore();
 u64 new_zeroed_pages(u64 v, u64 length, pageflags flags, status_handler complete);
 status do_demand_page(process p, context ctx, u64 vaddr, vmap vm);
+void demand_page_done(context ctx, u64 vaddr, status s);
 vmap vmap_from_vaddr(process p, u64 vaddr);
 void vmap_iterator(process p, vmap_handler vmh);
 boolean vmap_validate_range(process p, range q, u32 flags);


### PR DESCRIPTION
This change set fixes two issues that have been introduced by #1904:

1. A call to storage_sync() may suspend the current context, e.g. to acquire the filesystem mutex. Therefore, this function cannot be called directly from the code that handles a page fault exception; instead, an asynchronous thunk should be used. This change modifies the mmap_anon_page() closure function so that it calls storage_sync() first, and the demand_anonymous_page() function so that it invokes the above closure via async_apply_bh(). Closes #1933.
2. Commit https://github.com/nanovms/nanos/commit/3e73a8fb6b32c5bcaa58e160001109f2a2eb379c implemented an OOM killer that sends a SIGKILL to the user program if enough OOM page faults have occurred in a short amount of time. However, the OOM killer is only triggered if an OOM condition is detected synchronously during a call to do_demand_page(). Since commit https://github.com/nanovms/nanos/commit/2b3e2d4bcec65c35618af174dd4fec011dcd0742, a failure to allocate an anonymous page no longer causes do_demand_page() to return an error status: instead, an OOM condition is only handled asynchronously, after flushing the page cache to disk. In addition, failure to allocate pages for file-backed mappings is also handled asynchronously, and as such is not detected by the OOM killer. This change moves the OOM killer logic to a new demand_page_done() function, which is called by both the Unix fault handler (to detect any OOM condition that may be reported by the do_demand_page() function) and the pending fault completion (to properly handle OOM conditions detected asynchronously). The pagecache_map_page() function has been modified to return an error status that is recognized by the OOM killer as an OOM condition. This fixes CI test failures that have been occurring when running the ruby_alloc e2e test.