### PR TITLE
Volumes: print console message when a filesystem cannot be probed

### DIFF
--- a/src/fs/tfs.h
+++ b/src/fs/tfs.h
@@ -9,7 +9,7 @@ extern io_status_handler ignore_io_status;
 #define MAX_EXTENT_SIZE (PAGECACHE_MAX_SG_ENTRIES * PAGESIZE)
 #define MIN_EXTENT_ALLOC_SIZE   (1 * MB)
 
-boolean filesystem_probe(u8 *first_sector, u8 *uuid, char *label);
+status filesystem_probe(u8 *first_sector, u8 *uuid, char *label);
 const char *filesystem_get_label(filesystem fs);
 void filesystem_get_uuid(filesystem fs, u8 *uuid);
 

--- a/src/fs/tlog.c
+++ b/src/fs/tlog.c
@@ -873,14 +873,10 @@ static void log_read(log tl, status_handler sh)
     apply((sg_io)&ext->read, sg, r, tlc);
 }
 
-boolean filesystem_probe(u8 *first_sector, u8 *uuid, char *label)
+status filesystem_probe(u8 *first_sector, u8 *uuid, char *label)
 {
     u64 len;
-    status s = log_hdr_parse(0, alloca_wrap_buffer(first_sector, SECTOR_SIZE),
-        true, &len, uuid, label);
-    boolean success = is_ok(s);
-    timm_dealloc(s);
-    return success;
+    return log_hdr_parse(0, alloca_wrap_buffer(first_sector, SECTOR_SIZE), true, &len, uuid, label);
 }
 
 log log_create(heap h, tfs fs, boolean initialize, status_handler sh)

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -336,7 +336,8 @@ closure_function(4, 1, void, mbr_read,
     if (!rootfs_part) {
         u8 uuid[UUID_LEN];
         char label[VOLUME_LABEL_MAX_LEN];
-        if (filesystem_probe(mbr, uuid, label)) {
+        s = filesystem_probe(mbr, uuid, label);
+        if (is_ok(s)) {
             storage_req_handler req_handler = bound(req_handler);
             fs_init_handler fs_init = closure(heap_locked(init_heaps), volume_fs_init, req_handler,
                                               bound(length));
@@ -345,7 +346,8 @@ closure_function(4, 1, void, mbr_read,
             else
                 msg_err("failed to allocate closure, skipping volume\n");
         } else {
-            init_debug("unformatted storage device, ignoring");
+            msg_err("failed to probe filesystem: %v\n", get(s, sym_this("result")));
+            timm_dealloc(s);
         }
         deallocate((heap)heap_linear_backed(init_heaps), mbr, PAGESIZE);
     } else {


### PR DESCRIPTION
Instead of silently ignoring volumes whose filesystem cannot be probed, a message is now printed on the console, which makes it easier to identify the reason why an attached volume is not mounted by the kernel (e.g. tfs magic mismatch, tfs version mismatch, or invalid label).
Closes #1926.