### PR TITLE
virt/riscv-virt: use virtio-scsi-pci as QEMU virtio SCSI device

### DIFF
--- a/platform/riscv-virt/Makefile
+++ b/platform/riscv-virt/Makefile
@@ -336,7 +336,7 @@ QEMU_DISPLAY=	-display none
 QEMU_SERIAL=	-serial stdio
 QEMU_STORAGE=	-drive if=none,id=hd0,format=raw,file=$(IMAGE)
 ifeq ($(STORAGE),virtio-scsi)
-QEMU_STORAGE+=	-device virtio-scsi-device,id=scsi0 -device scsi-hd,bus=scsi0.0,drive=hd0
+QEMU_STORAGE+=	-device virtio-scsi-pci$(STORAGE_BUS),id=scsi0 -device scsi-hd,bus=scsi0.0,drive=hd0
 else ifeq ($(STORAGE),pvscsi)
 QEMU_STORAGE+=	-device pvscsi$(STORAGE_BUS),id=scsi0 -device scsi-hd,bus=scsi0.0,drive=hd0
 else ifeq ($(STORAGE),virtio-blk)

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -409,7 +409,7 @@ QEMU_DISPLAY=	-display none
 QEMU_SERIAL=	-serial stdio
 QEMU_STORAGE=	-drive if=none,id=hd0,format=raw,file=$(IMAGE)
 ifeq ($(STORAGE),virtio-scsi)
-QEMU_STORAGE+=	-device virtio-scsi-device,id=scsi0 -device scsi-hd,bus=scsi0.0,drive=hd0
+QEMU_STORAGE+=	-device virtio-scsi-pci$(STORAGE_BUS),id=scsi0 -device scsi-hd,bus=scsi0.0,drive=hd0
 else ifeq ($(STORAGE),pvscsi)
 QEMU_STORAGE+=	-device pvscsi$(STORAGE_BUS),id=scsi0 -device scsi-hd,bus=scsi0.0,drive=hd0
 else ifeq ($(STORAGE),virtio-blk)


### PR DESCRIPTION
The virtio-scsi-device QEMU device sits on the virtio bus, and since the virtio_scsi driver in the kernel does not register itself as a virtio-mmio driver, the root volume is not detected when an image is run with `STORAGE=virtio-scsi`.
This change modifies the virt and riscv-virt platform Makefiles so that a virtio SCSI device is instantiated with the virtio-scsi-pci command line option (which creates a device sitting on the PCI bus) instead of virtio-scsi-device: this allows the root volume to be properly detected when `STORAGE=virtio-scsi` is specified in the `make` command line.
Closes #1482.