### PR TITLE
reduce stage2 size

### DIFF
--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -114,6 +114,11 @@ CLEANDIRS+=     $(OBJDIR)/platform/pc $(OBJDIR)/platform $(OBJDIRS-uefi)
 boot: $(OBJDIR)/boot.img $(OBJDIR)/bootx64.efi
 
 $(OBJDIR)/boot.img: $(OBJDIR)/stage1 $(OBJDIR)/stage2.pad
+ifeq ($(MEMDEBUG),)
+ifeq ($(UBSAN),)
+	$(Q) test `$(SIZE_CMD) $(OBJDIR)/stage2.pad` -le 65536 || ($(ECHO) stage2 exceeds 64KB && exit 1)
+endif
+endif
 	$(call cmd,cat)
 
 $(OBJDIR)/stage1: stage1.s $(OBJDIR)/stage2.pad

--- a/platform/pc/boot/stage2.c
+++ b/platform/pc/boot/stage2.c
@@ -330,7 +330,9 @@ void centry()
     /* given our rewind tag, all values must be tagged - even untyped buffers */
     boot_buffer_heap = allocate_tagged_region(&working_heap, tag_unknown);
     init_sg(&working_heap);
+#ifdef STAGE2_DEBUG
     init_extra_prints();
+#endif
     stage2_debug("%s\n", __func__);
 
     /* Validate support for no-exec (NX) bits in ptes. */

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -73,7 +73,7 @@ void print_frame_trace_from_here();
         if (!(x)) {                                 \
             __label__ __here;                       \
             print_frame_trace_from_here();          \
-            __here: halt("assertion " #x " failed at " __FILE__ ":%d (IP %p)  in %s(); halt\n", __LINE__, &&__here, __func__); \
+            __here: halt("assertion " #x " failed at %s:%d (IP %p)  in %s(); halt\n", __FILE__, __LINE__, &&__here, __func__); \
         }                                           \
     } while(0)
 #endif


### PR DESCRIPTION
Changes introduced in #1903 caused the size of the stage2 bootloader to increase, exceeding 64KB in some build environments. As described in commit ed5a2f77, stage2 binaries larger than this size may cause boot failures when running under Xen (e.g. AWS EC2).

This PR includes a few commits that ameliorate this inflation. A build-time check is also added which causes the build to fail if the stage2 binary size exceeds 64KB. (This is disabled when building debug images with MEMDEBUG or UBSAN enabled.)
