### PR TITLE
Klog: Ensure sufficient alignment for dump

### DIFF
--- a/src/kernel/log.c
+++ b/src/kernel/log.c
@@ -41,14 +41,14 @@ declare_closure_struct(2, 1, void, klog_load_sh,
     status, s);
 
 static struct {
+    struct klog_dump dump;
     char buf[KLOG_BUF_SIZE];
     bytes count;
     struct spinlock lock;
     u64 disk_offset;
     storage_req_handler disk_handler;
     closure_struct(klog_load_sh, load_sh);
-    struct klog_dump dump;
-} klog;
+} klog __attribute__ ((aligned(SECTOR_SIZE)));
 
 #define klog_lock()     u64 _irqflags = spin_lock_irq(&klog.lock)
 #define klog_unlock()   spin_unlock_irq(&klog.lock, _irqflags)


### PR DESCRIPTION
The klog_dump used by the kernel is a buffer passed directly to a storage handler, but some storage drivers like xen require at least sector alignment for the transaction's buffer. The dump was located in the bss at the end of the klog struct, so it had no alignment guarantees. This change moves it to the front of the struct and adds a 512-byte alignment requirement to the struct. This fixes an assertion failure when running klog_save on a xen instance.