### PR TITLE
UEFI fixes

### DIFF
--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -74,9 +74,11 @@ SRCS-uefi= \
 	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/sg.c \
+	$(SRCDIR)/runtime/string.c \
 	$(SRCDIR)/runtime/symbol.c \
 	$(SRCDIR)/runtime/table.c \
 	$(SRCDIR)/runtime/tuple.c \
+	$(SRCDIR)/runtime/vector.c \
 	$(SRCDIR)/fs/fs.c \
 	$(SRCDIR)/fs/tfs.c \
 	$(SRCDIR)/fs/tlog.c \

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -220,9 +220,11 @@ UEFI_SRCS= \
 	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \
 	$(SRCDIR)/runtime/sg.c \
+	$(SRCDIR)/runtime/string.c \
 	$(SRCDIR)/runtime/symbol.c \
 	$(SRCDIR)/runtime/table.c \
 	$(SRCDIR)/runtime/tuple.c \
+	$(SRCDIR)/runtime/vector.c \
 	$(SRCDIR)/fs/fs.c \
 	$(SRCDIR)/fs/tfs.c \
 	$(SRCDIR)/fs/tlog.c \


### PR DESCRIPTION
This change set fixes a couple of issues preventing the kernel from booting on UEFI-enabled machines.

1. Since the addition of the string and vector tag types, the UEFI bootloader needs to include the code from the string.c and vector.c source files
2. The existing code in the pci_platform_init_bar() function for the PC platform is not handling 64-bit addresses, thus fails to properly read and assign addresses when the 64-bit flag is set for a given PCI BAR