### PR TITLE
mmap(): fix handling of MAP_32BIT flag for x86_64

### DIFF
--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -1155,6 +1155,9 @@ static sysreturn mmap(void *addr, u64 length, int prot, int flags, int fd, u64 o
         MAP_GROWSDOWN | MAP_DENYWRITE | MAP_EXECUTABLE | MAP_LOCKED | MAP_NORESERVE |
         MAP_POPULATE | MAP_NONBLOCK | MAP_STACK | MAP_HUGETLB | MAP_SYNC |
         MAP_FIXED_NOREPLACE | MAP_UNINITIALIZED |
+#ifdef __x86_64__
+        MAP_32BIT |
+#endif
         (HUGETLB_FLAG_ENCODE_MASK << HUGETLB_FLAG_ENCODE_SHIFT);
     int unknown_flags = flags & ~valid_flags;
     if (unknown_flags) {


### PR DESCRIPTION
In the x86_64 architecture, MAP_32BIT is a valid flag for the mmap() syscall. This change brings back support for this flag, which was dropped by mistake in commit 770cbfb8e5b48ec20ff87678e570816eb521a074.
Credits go to @rinor.

Closes #497