### PR TITLE
fix double free in each_http_request()

### DIFF
--- a/src/http/http.c
+++ b/src/http/http.c
@@ -392,7 +392,7 @@ closure_function(2, 1, void, each_http_request,
 
     buffer ver = vector_get(vsl, 2);
     if (ver) {
-        get_http_ver(ver, &hr->http_version);
+        get_http_ver(alloca_wrap(ver), &hr->http_version);
         if (hr->http_version > HTTP_VER(1, 1))
             goto bad_ver;
 
@@ -418,7 +418,7 @@ closure_function(2, 1, void, each_http_request,
         if (!hl->default_handler)
             goto not_found;
         apply(hl->default_handler, method, hr, v);
-        goto out;
+        return;
     }
 
     buffer rel_uri = clone_buffer(hl->h, uri);
@@ -453,19 +453,13 @@ closure_function(2, 1, void, each_http_request,
 
     if (match)
         apply(match->each, method, hr, v);
-out:
-    deallocate_vector(vsl);
     return;
   not_found:
-    if (vsl != INVALID_ADDRESS)
-        deallocate_vector(vsl);
     send_http_response(hr, timm("status", "404 Not Found"),
                        aprintf(hl->h, "<html><head><title>404 Not Found</title></head>"
                                "<body><h1>Not Found</h1></body></html>\r\n"));
     return;
   bad_ver:
-    if (vsl != INVALID_ADDRESS)
-        deallocate_vector(vsl);
     send_http_response(hr, timm("status", "505 HTTP Version Not Supported"),
                        aprintf(hl->h, "<html><head><title>505 HTTP Version Not Supported</title></head>"
                                "<body><h1>Use HTTP/1.1</h1></body></html>\r\n"));


### PR DESCRIPTION
Commit 5301c6a7 introduced a regression whereby the "start_line" vector attribute of an http request would be explicitly freed, which would then later cause a double free during parser cleanup. This change corrects this issue by treating the vector as an immutable value (whereas previously it was cloned and thus consumable).