### PR TITLE
Create only dual-stack udp pcbs

### DIFF
--- a/klib/syslog.c
+++ b/klib/syslog.c
@@ -484,7 +484,7 @@ int init(status_handler complete)
         syslog.max_hdr_len = 1 + sizeof(__XSTRING(SYSLOG_PRIORITY)) + sizeof(SYSLOG_VERSION) +
                 sizeof("YYYY-MM-ddThh:mm:ss.uuuuuuZ") + sizeof(syslog.local_ip) +
                 buffer_length(syslog.program) + 7;
-        syslog.udp_pcb = udp_new();
+        syslog.udp_pcb = udp_new_ip_type(IPADDR_TYPE_ANY);
         if (!syslog.udp_pcb) {
             rprintf("syslog: unable to create UDP PCB\n");
             return KLIB_INIT_FAILED;

--- a/src/drivers/netconsole.c
+++ b/src/drivers/netconsole.c
@@ -52,7 +52,7 @@ static void netconsole_write(void *_d, const char *s, bytes count)
 static void netconsole_config(void *_d, tuple r)
 {
     netconsole_driver nd = _d;
-    nd->pcb = udp_new();
+    nd->pcb = udp_new_ip_type(IPADDR_TYPE_ANY);
     if (!nd->pcb) {
         msg_err("failed to allocate pcb\n");
         return;

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1423,7 +1423,8 @@ sysreturn socket(int domain, int type, int protocol)
         net_debug("new tcp fd %d, pcb %p\n", fd, p);
         return fd;
     } else if (type == SOCK_DGRAM) {
-        struct udp_pcb *p = udp_new();
+        struct udp_pcb *p = udp_new_ip_type((domain == AF_INET) ?
+                                            IPADDR_TYPE_V4: IPADDR_TYPE_ANY);
         if (!p)
             return -ENOMEM;
 


### PR DESCRIPTION
If a udp pcb is created with udp_new(), it appears to default to being an ip4 pcb, which will then reject sending any ip6 traffic with an invalid argument because the pcb doesn't support ip6. This changes all udp_new calls to udp_new_ip_type(IPADDR_TYPE_ANY) which makes the pcb dual-stack. Ip6 udp sockets will now properly transmit
ip6 traffic. This also allows the udp netconsole and syslog to work with ip6 addresses.