### PR TITLE
epoll: add EPOLLEXCLUSIVE support

### DIFF
--- a/src/unix/notify.h
+++ b/src/unix/notify.h
@@ -4,7 +4,12 @@ typedef struct notify_entry *notify_entry;
 /* Notify handlers receive event changes, including falling edges;
    if the last argument is a non-zero thread pointer, event changes
    are relevant only for waiters on that thread. */
-typedef closure_type(event_handler, boolean, u64 events, void *arg);
+typedef closure_type(event_handler, u64, u64 events, void *arg);
+
+#define NOTIFY_FLAGS_EXCLUSIVE  U64_FROM_BIT(0)
+
+#define NOTIFY_RESULT_CONSUMED  U64_FROM_BIT(0)
+#define NOTIFY_RESULT_RELEASE   U64_FROM_BIT(1)
 
 /* NOTIFY_EVENTS_RELEASE is a special value of events to signal to the
    event_handler that a notify_set is being deallocated.
@@ -16,7 +21,9 @@ notify_set allocate_notify_set(heap h);
 
 void deallocate_notify_set(notify_set s);
 
-notify_entry notify_add(notify_set s, u64 eventmask, event_handler eh);
+notify_entry notify_add_with_flags(notify_set s, u64 eventmask, u64 flags, event_handler eh);
+
+#define notify_add(s, e, h)  notify_add_with_flags(s, e, 0, h)
 
 void notify_remove(notify_set s, notify_entry e, boolean release);
 

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -791,7 +791,7 @@ sysreturn rt_sigtimedwait(const u64 * set, siginfo_t * info, const struct timesp
     return blockq_check_timeout(current->thread_bq, ba, false, CLOCK_ID_MONOTONIC, t, false);
 }
 
-declare_closure_struct(0, 2, boolean, signalfd_notify,
+declare_closure_struct(0, 2, u64, signalfd_notify,
                        u64, events, void *, t);
 typedef struct signal_fd {
     struct fdesc f; /* must be first */
@@ -949,7 +949,7 @@ closure_function(1, 2, sysreturn, signalfd_close,
     return io_complete(completion, 0);
 }
 
-define_closure_function(0, 2, boolean, signalfd_notify,
+define_closure_function(0, 2, u64, signalfd_notify,
                         u64, events, void *, t)
 {
     signal_fd sfd = struct_from_field(closure_self(), signal_fd, notify);
@@ -958,7 +958,7 @@ define_closure_function(0, 2, boolean, signalfd_notify,
 
     if ((events & sfd->mask) == 0) {
         sig_debug("%d spurious notify\n", sfd->fd);
-        return false;
+        return 0;
     }
 
     /* null thread on notify set release (thread dealloc) */
@@ -968,7 +968,7 @@ define_closure_function(0, 2, boolean, signalfd_notify,
             blockq_wake_one_for_thread(sfd->bq, &ctx->uc, false);
     }
     notify_dispatch_for_thread(sfd->f.ns, EPOLLIN, t);
-    return false;
+    return 0;
 }
 
 static sysreturn allocate_signalfd(const u64 *mask, int flags)

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -6,7 +6,7 @@
 declare_closure_struct(1, 0, void, sharedbuf_free,
     struct sharedbuf *, shb);
 
-declare_closure_struct(1, 2, boolean, unixsock_event_handler,
+declare_closure_struct(1, 2, u64, unixsock_event_handler,
                        struct unixsock *, s,
                        u64, events, void *, arg);
 declare_closure_struct(1, 0, void, unixsock_free,
@@ -76,7 +76,7 @@ static boolean unixsock_is_conn_oriented(unixsock s)
     return (s->sock.type != SOCK_DGRAM);
 }
 
-define_closure_function(1, 2, boolean, unixsock_event_handler,
+define_closure_function(1, 2, u64, unixsock_event_handler,
                         unixsock, s,
                         u64, events, void *, arg)
 {
@@ -84,7 +84,7 @@ define_closure_function(1, 2, boolean, unixsock_event_handler,
     if (events == NOTIFY_EVENTS_RELEASE)    /* the peer socket is being closed */
         s->notify_handle = INVALID_ADDRESS;
     fdesc_notify_events(&s->sock.f);
-    return false;
+    return 0;
 }
 
 define_closure_function(1, 0, void, unixsock_free,

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -76,6 +76,7 @@ SRCS-epoll= \
 	$(CURDIR)/epoll.c \
 	$(SRCDIR)/unix_process/ssp.c
 LDFLAGS-epoll=		-static
+LIBS-epoll=			-lpthread
 
 SRCS-eventfd= \
 	$(CURDIR)/eventfd.c \


### PR DESCRIPTION
This change adds support for the EPOLLEXCLUSIVE flag in the epoll implementation, which allows limiting the number of threads waiting on a file descriptor that are woken up when an event set is notified. The EPOLLEXCLUSIVE flag works on a per file descriptor basis, not on a per epoll instance basis, so it can be used with threads waiting on a given file descriptor via one or more epoll instances.
The event_handler closure type in the notify subsystem has been changed to return a u64 value instead of a boolean value, so the event handlers can indicate whether they have "consumed" the events being reported. A notify entry is now associated to a set of flags, used to indicate whether a handler is exclusive. When an event set is notified, the notify subsystem calls all non-exclusive handlers, plus it calls the exclusive handlers until the event set is "consumed" (by any previously invoked handler, exclusive or non-exclusive).
The notify subsystem is agnostic of the logic to determine whether an event set is consumed; in the epoll implementation, an event set is consumed when one or more waiting threads are unblocked. In addition, the epoll_wait() implementation has been enhanced so that a single event notification can wake up multiple threads blocked on the same epoll instance.