### PR TITLE
Network: add support for starting program after IPv6 initialization

### DIFF
--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -139,21 +139,13 @@ closure_function(6, 0, void, startup,
     if (!pro)
         halt("unable to resolve program path \"%b\"\n", p);
     program_set_perms(root, pro);
-    init_network_iface(root);
+    init_network_iface(root, bound(m));
     closure_member(program_start, start, path) = (string)p;
     if (trace_get_flags(get(root, sym(trace))) & TRACE_OTHER) {
         rprintf("read program complete: %p ", root);
         rprintf("gitversion: %s\n", gitversion);
     }
     storage_when_ready(apply_merge(bound(m)));
-    value v;
-    if ((v = get(root, sym(exec_wait_for_ip4_secs)))) {
-        u64 ts;
-        if (u64_from_value(v, &ts))
-            ip4_when_ready(apply_merge(bound(m)), seconds(ts));
-        else
-            rprintf("exec_wait_for_ip4_secs has invalid time, ignoring\n");
-    }
   out:
     apply(bound(completion), s);
     closure_finish();

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -2,6 +2,5 @@
 #define NET_SYSCALLS 1
 
 void init_net(kernel_heaps kh);
-void init_network_iface(tuple root);
-void ip4_when_ready(status_handler complete, timestamp timeout);
+void init_network_iface(tuple root, merge m);
 status listen_port(heap h, u16 port, connection_handler c);


### PR DESCRIPTION
This change implements a new kernel configuration option "exec_wait_for_ip6_secs", which instructs the kernel to wait for an IPv6 address to be acquired before starting the user program; the value of this option indicates a timeout, expressed in seconds, after which the kernel starts the program even without an IPv6 address.
IPv6 address acquisition is considered complete when one of the IPv6 addresses associated to a network interface is a global address in a valid state. Both dynamic address acquisition via DHCPv6 and static configuration via the "ip6addr" option lead the network interface to reach a state which allows the kernel to start the user program.
In addition, this change allows both the "exec_wait_for_ip6_secs" option and the already existing "exec_wait_for_ip4_secs" option to be associated to a specific network interface; this is useful in instances with multiple network interfaces where the user program has to be started following address assignment to an interface different from the default interface.
Example Ops configuration to wait for both IPv4 and IPv6 addresses (with a 10-second timeout) on the default network interface:
```
  "ManifestPassthrough": {
    "exec_wait_for_ip4_secs": "10",
    "exec_wait_for_ip6_secs": "10"
  }
```
Example Ops configuration to wait for an IPv6 addresses (with a 5-second timeout) on the second network interface:
```
  "ManifestPassthrough": {
    "en2": {
      "exec_wait_for_ip6_secs": "5"
    }
  }
```