### PR TITLE
Miscellaneous features for new Nvidia GPU klib

### DIFF
--- a/klib/Makefile
+++ b/klib/Makefile
@@ -144,10 +144,14 @@ SRCS-mbedtls-tls= \
 
 ADDITIONAL_PROGRAMS= \
 	test/klib \
+	test/lock \
 	test/page_table \
 
 SRCS-test/klib= \
 	$(CURDIR)/test/klib.c
+
+SRCS-test/lock= \
+	$(CURDIR)/test/lock.c
 
 SRCS-test/page_table= \
 	$(CURDIR)/test/page_table.c

--- a/klib/test/lock.c
+++ b/klib/test/lock.c
@@ -1,0 +1,45 @@
+#include <kernel.h>
+
+static boolean klib_test_rw_spinlock(void)
+{
+    struct rw_spinlock l;
+    spin_rw_lock_init(&l);
+    if (!spin_tryrlock(&l)) {
+        msg_err("couldn't rlock unlocked spinlock\n");
+        return false;
+    }
+    if (spin_trywlock(&l)) {
+        msg_err("could wlock rlocked spinlock\n");
+        return false;
+    }
+#if defined(SMP_ENABLE)
+    if (!spin_tryrlock(&l)) {
+        msg_err("couldn't rlock rlocked spinlock\n");
+        return false;
+    }
+    spin_runlock(&l);
+#endif
+    spin_runlock(&l);
+    if (!spin_trywlock(&l)) {
+        msg_err("couldn't wlock unlocked spinlock\n");
+        return false;
+    }
+    if (spin_tryrlock(&l)) {
+        msg_err("could rlock wlocked spinlock\n");
+        return false;
+    }
+    if (spin_trywlock(&l)) {
+        msg_err("could wlock wlocked spinlock\n");
+        return false;
+    }
+    spin_wunlock(&l);
+    return true;
+}
+
+int init(status_handler complete)
+{
+    if (!klib_test_rw_spinlock())
+        return KLIB_INIT_FAILED;
+    rprintf("Lock test OK\n");
+    return KLIB_INIT_OK;
+}

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -13,11 +13,6 @@ typedef struct special_file {
     u64 alloc_size;
 } special_file;
 
-typedef struct special_file_wrapper {
-    struct file f;
-    u64 alloc_size;
-} *special_file_wrapper;
-
 static sysreturn urandom_read(file f, void *dest, u64 length, u64 offset)
 {
     buffer b = alloca_wrap_buffer(dest, length);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -1066,6 +1066,11 @@ sysreturn inotify_rm_watch(int fd, int wd);
 
 int do_eventfd2(unsigned int count, int flags);
 
+typedef struct special_file_wrapper {
+    struct file f;
+    u64 alloc_size;
+} *special_file_wrapper;
+
 typedef closure_type(spec_file_open, sysreturn, file f);
 
 void register_special_files(process p);

--- a/test/runtime/ktest.manifest
+++ b/test/runtime/ktest.manifest
@@ -4,6 +4,7 @@
                     klib:(children:(
                         test:(children:(
                             klib:(contents:(host:output/klib/bin/test/klib))
+                            lock:(contents:(host:output/klib/bin/test/lock))
                             page_table:(contents:(host:output/klib/bin/test/page_table))
                             ))
                         ))


### PR DESCRIPTION
This change set allows building and running the latest version of the Nvidia GPU klib (https://github.com/nanovms/gpu-nvidia/):

1. the spin_tryrlock() and spin_trywlock() functions have been added to the R/W spinlock implementation 
2. for Unix special files, the special_file_wrapper struct definition has been moved to a header file so that it can be used by klib code
3. the VGA console driver has been amended to check whether the device being probed is configured in VGA mode 3