### PR TITLE
Syscalls: add support for preadv and pwritev

### DIFF
--- a/src/aarch64/unix_machine.c
+++ b/src/aarch64/unix_machine.c
@@ -275,8 +275,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, sync_file_range, 0, 0);
     register_syscall(map, vmsplice, 0, 0);
     register_syscall(map, move_pages, 0, 0);
-    register_syscall(map, preadv, 0, 0);
-    register_syscall(map, pwritev, 0, 0);
     register_syscall(map, perf_event_open, 0, 0);
     register_syscall(map, fanotify_init, 0, 0);
     register_syscall(map, fanotify_mark, 0, 0);

--- a/src/riscv64/unix_machine.c
+++ b/src/riscv64/unix_machine.c
@@ -220,8 +220,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, sync_file_range, 0, 0);
     register_syscall(map, vmsplice, 0, 0);
     register_syscall(map, move_pages, 0, 0);
-    register_syscall(map, preadv, 0, 0);
-    register_syscall(map, pwritev, 0, 0);
     register_syscall(map, perf_event_open, 0, 0);
     register_syscall(map, fanotify_init, 0, 0);
     register_syscall(map, fanotify_mark, 0, 0);

--- a/src/x86_64/unix_machine.c
+++ b/src/x86_64/unix_machine.c
@@ -385,8 +385,6 @@ void register_other_syscalls(struct syscall *map)
     register_syscall(map, sync_file_range, 0, 0);
     register_syscall(map, vmsplice, 0, 0);
     register_syscall(map, move_pages, 0, 0);
-    register_syscall(map, preadv, 0, 0);
-    register_syscall(map, pwritev, 0, 0);
     register_syscall(map, perf_event_open, 0, 0);
     register_syscall(map, fanotify_init, 0, 0);
     register_syscall(map, fanotify_mark, 0, 0);

--- a/test/runtime/readv.c
+++ b/test/runtime/readv.c
@@ -63,6 +63,18 @@ int main()
     int curpos = rv;
     EXPECT_LONG_EQUAL(startpos + bytes_read, curpos);
 
+    rv = preadv(fd, iovs, 3, -1);   /* invalid offset */
+    EXPECT_LONG_EQUAL(rv, -1);
+    EXPECT_LONG_EQUAL(errno, EINVAL);
+
+    bytes_read = preadv(fd, iovs, 3, 0);
+    EXPECT_LONG_EQUAL(bytes_read, 12);
+    EXPECT_STRN_EQUAL("pad ", iovs[0].iov_base, 4);
+    EXPECT_STRN_EQUAL("one ", iovs[1].iov_base, 4);
+    EXPECT_STRN_EQUAL("six ", iovs[2].iov_base, 4);
+    rv = lseek(fd, 0, SEEK_CUR);
+    EXPECT_LONG_EQUAL(rv, curpos);
+
     if (lseek(fd, 0, SEEK_END) < 0) {
         perror("lseek(end)");
         exit(EXIT_FAILURE);

--- a/test/runtime/writev.c
+++ b/test/runtime/writev.c
@@ -101,6 +101,36 @@ int main()
         exit(EXIT_FAILURE);
     }
 
+    rv = pwritev(fd, iovs, 3, -1);
+    if ((rv != -1) || (errno != EINVAL)) {
+        printf("pwritev with invalid offset returned %ld (errno %d)\n", rv, errno);
+        exit(EXIT_FAILURE);
+    }
+
+    startpos += 10;
+    rv = pwritev(fd, iovs, 3, startpos);
+    if (rv != total_write_len) {
+        printf("Bytes written with pwritev: %ld (expected %d)\n", rv, total_write_len);
+        exit(EXIT_FAILURE);
+    }
+    rv = lseek(fd, 0, SEEK_CUR);
+    if (rv != endpos) {
+        printf("File offset at the end of pwritev: %ld (expected %d)\n", rv, endpos);
+        exit(EXIT_FAILURE);
+    }
+    _LSEEK(startpos, SEEK_SET);
+    _READ(buf, total_write_len);
+    if (rv != total_write_len) {
+        printf("read after pwritev fail: expecting %d bytes, rv: %ld \n", total_write_len, rv);
+        exit(EXIT_FAILURE);
+    }
+    if (strncmp(str, buf, strlen(str))) {
+        printf("pwritev fail: string mismatch\n");
+        buf[rv] = '\0';
+        printf("Expected: \"%s\", actual: \"%s\"\n", str, buf);
+        exit(EXIT_FAILURE);
+    }
+
     close(fd);
 
     fd = open("hello", O_RDONLY);


### PR DESCRIPTION
These syscalls are analogous to readv and writev, but take an additional file offset argument and do not change the internal file offset.
The existing readv and writev functions have been refactored to de- duplicate code, with a new iov_internal() function which is now called by readv, writev, preadv and pwritev.
The readv and writev runtime tests have been amended to exercise preadv and pwritev as well.