### PR TITLE
Unix signals: fix polling for blocked signals via signalfd, fix handling of ignored signals

### DIFF
--- a/src/unix/coredump.c
+++ b/src/unix/coredump.c
@@ -128,7 +128,7 @@ static boolean add_thread_status(buffer b, thread t, struct siginfo *si)
     prs->pr_info.si_code = si->si_code;
     prs->pr_info.si_errno = si->si_errno;
     prs->pr_sigpend = t->signals.pending;
-    prs->pr_sighold = t->signals.ignored; // XXX is this right?
+    prs->pr_sighold = t->signal_mask;
     prs->pr_cursig = si->si_signo;
     prs->pr_pid = t->tid;
     prs->pr_ppid = t->p->pid;

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -102,6 +102,7 @@ typedef struct iovec {
 #define ECANCELED       125             /* Used for timer cancel on RTC shift */
 
 #define ERESTARTSYS     512
+#define ERESTARTNOHAND  514
 
 #define O_RDONLY	00000000
 #define O_WRONLY	00000001

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -404,7 +404,6 @@ define_closure_function(1, 0, void, free_thread,
     if (t->cpu_timers)
         deallocate_timerqueue(t->cpu_timers);
     deallocate_bitmap(t->affinity);
-    deallocate_notify_set(t->signalfds);
     /* XXX only free tids from non-leader threads. Leader threads will
      * need different handling */
     if (t->p->pid != t->tid)
@@ -431,10 +430,6 @@ thread create_thread(process p, u64 tid)
     t->thread_bq = allocate_blockq(h, "thread");
     if (t->thread_bq == INVALID_ADDRESS)
         goto fail_bq;
-
-    t->signalfds = allocate_notify_set(h);
-    if (t->signalfds == INVALID_ADDRESS)
-        goto fail_sfds;
 
     t->p = p;
     t->syscall = 0;
@@ -499,8 +494,6 @@ thread create_thread(process p, u64 tid)
 #endif
     return t;
   fail_affinity:
-    deallocate_notify_set(t->signalfds);
-  fail_sfds:
     deallocate_blockq(t->thread_bq);
   fail_bq:
     destruct_context(&t->context);

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -544,6 +544,8 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     p->syscalls = linux_syscalls;
     init_sigstate(&p->signals);
     zero(p->sigactions, sizeof(p->sigactions));
+    p->signalfds = allocate_notify_set(locked);
+    assert(p->signalfds != INVALID_ADDRESS);
     p->posix_timer_ids = create_id_heap(locked, locked, 0, U32_MAX, 1, false);
     p->posix_timers = allocate_vector(locked, 8);
     p->itimers = allocate_vector(locked, 3);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -255,7 +255,6 @@ static inline sysreturn blockq_check(blockq bq, blockq_action a, boolean in_bh)
 typedef struct sigstate {
     /* these should be bitmaps, but time is of the essence, and presently NSIG=64 */
     u64         pending;        /* pending and not yet dispatched */
-    u64         ignored;        /* mask of signals set to SIG_IGN */
     u64         interest;       /* signals of interest, regardless of mask or ignored */
     struct spinlock   ss_lock;
     struct list heads[NSIG];

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -342,7 +342,6 @@ typedef struct thread {
     struct sigstate signals;
     u64 signal_mask;
     u64 saved_signal_mask;      /* for rt_sigsuspend */
-    notify_set signalfds;
     boolean interrupting_syscall;
     void *signal_stack;
     u64 signal_stack_length;
@@ -536,6 +535,7 @@ typedef struct process {
     struct spinlock   faulting_lock;
     struct sigstate   signals;
     struct sigaction  sigactions[NSIG];
+    notify_set        signalfds;
     id_heap           posix_timer_ids;
     vector            posix_timers; /* unix_timer by timerid */
     vector            itimers;      /* unix_timer by ITIMER_ type */


### PR DESCRIPTION
This change set fixes two issues in the Unix signal implementation:

- If a poll request is issued on a signalfd file descriptor to poll for the delivery of a blocked signal (i.e. a signal that is in the process signal mask), the poll syscall does not return when the signal is raised
- Ignored signals are not detectable via sigwaitinfo(), sigtimedwait() or sigwait(), nor via signalfd