### PR TITLE
Pagecache nodes: replace dirty_commits queue with operation list

### DIFF
--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -16,8 +16,6 @@ SRCS-stage2.elf= \
 	$(SRCDIR)/runtime/range.c \
 	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \
-	$(SRCDIR)/runtime/queue.c \
-	$(SRCDIR)/runtime/pqueue.c \
 	$(SRCDIR)/runtime/sg.c \
 	$(SRCDIR)/runtime/string.c \
 	$(SRCDIR)/runtime/symbol.c \
@@ -69,7 +67,6 @@ SRCS-uefi= \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
-	$(SRCDIR)/runtime/queue.c \
 	$(SRCDIR)/runtime/range.c \
 	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -215,7 +215,6 @@ UEFI_SRCS= \
 	$(SRCDIR)/runtime/format.c \
 	$(SRCDIR)/runtime/memops.c \
 	$(SRCDIR)/runtime/merge.c \
-	$(SRCDIR)/runtime/queue.c \
 	$(SRCDIR)/runtime/range.c \
 	$(SRCDIR)/runtime/rbtree.c \
 	$(SRCDIR)/runtime/runtime_init.c \

--- a/src/runtime/range.h
+++ b/src/runtime/range.h
@@ -110,6 +110,11 @@ static inline void rangemap_remove_node(rangemap rm, rmnode n)
     rbtree_remove_node(&(rm->t), &n->n);
 }
 
+static inline u64 rangemap_count(rangemap rm)
+{
+    return rbtree_get_count(&rm->t);
+}
+
 static inline range range_intersection(range a, range b)
 {
     range dest = {MAX(a.start, b.start), MIN(a.end, b.end)};


### PR DESCRIPTION
Using a limited-size queue to store pagecache node sync requests can lead to a failure to enqueue a request if the user program issues many parallel fsync() syscalls on a given file. In addition, using this queue to store both commit closures and sync completion status handlers can cause failure to clear the `committing` flag in the pagecache_node struct (because a completion status handler will not call the commit_dirty_node_complete() function, which is where the flag is cleared), which can lead to a deadlock where fsync() calls by the user program will never return.
This change replaces the limited-size queue and the `committing` flag with an operation list where commit closures and completion status handlers are stored (wrapped in a struct which contains information on the type of operation); a commit operation is only removed from the list when the operation is completed.

Closes #1937