### PR TITLE
Unix clocks: add support for {clock,pthread}_getcpuclockid()

### DIFF
--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -253,6 +253,13 @@ typedef int clockid_t;
 #define UTIME_NOW   ((1ull << 30) - 1)
 #define UTIME_OMIT  ((1ull << 30) - 2)
 
+#define CPUCLOCK_PERTHREAD_MASK 0x4
+#define CPUCLOCK_CLOCK_MASK     0x3
+
+#define CPUCLOCK_PROF   0
+#define CPUCLOCK_VIRT   1
+#define CPUCLOCK_SCHED  2
+
 struct timespec {
     u64 tv_sec;
     u64 tv_nsec;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -1006,6 +1006,8 @@ static inline void __attribute__((noreturn)) syscall_finish(boolean exit)
     kern_yield();
 }
 
+boolean clockid_get(process p, clockid_t id, boolean timer, clock_id *res, thread *cputime_thread);
+
 void iov_op(fdesc f, boolean write, struct iovec *iov, int iovcnt, u64 offset,
             context ctx, boolean blocking, io_completion completion);
 


### PR DESCRIPTION
The clock_gettime(), clock_getres() and timer_create() syscalls can be invoked with clock id values returned by the
clock_getcpuclockid() and pthread_getcpuclockid() C library functions.
This change modifies the logic of the above syscalls so that they can properly decode such clock id values. For POSIX timers, in case a timer is created with a clock id corresponding to the CPU time of an arbitrary thread, a reference to this thread is kept in the timer struct, because the thread's timer queue must not be deallocated until the timer is closed.

Closes #1946