### PR TITLE
map(): call flush_tlb() after mapping a virtual address

### DIFF
--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -503,6 +503,7 @@ physical map_with_complete(u64 v, physical p, u64 length, pageflags flags, statu
     }
     page_init_debug("map_level done\n");
     pagetable_unlock();
+    flush_tlb(false);
     if (complete)
         apply(complete, STATUS_OK);
 #ifdef PAGE_DUMP_ALL


### PR DESCRIPTION
Even though there is no need to invalidate TLB entries and invoke a TLB shootdown after mapping a virtual address that was previously not mapped, invalidation of newly mapped pages on the local CPU is being retained in the map_level() function to avoid the possibility of a CPU having a stale mapping in its TLB as a result of a not yet executed TLB shootdown handler triggered by a previous unmapping from another CPU. However, in order for a TLB invalidation to be complete, the flush_tlb() function needs to be called, which is not being done in the current code.
This change adds a call to flush_tlb() in the map_with_complete() function, at the end of a mapping operation.
This fixes an issue observed when running on Mac M1 (ARM64) hosts, where a data abort exception occurs when a virtual memory location is accessed just after mapping the relevant address. Since this address was not previously mapped, this issue is apparently caused by a non-standard TLB implementation in Mac M1 processors, which apparently do negative caching, even though the ARM Architecture Reference Manual states that "the architecture guarantees that a translation table entry that generates a Translation fault, an Address size fault, or an Access flag fault is not held in the TLB" (ARM DDI 0487H.a, section D5.9.2), i.e. negative caching in the TLB is not allowed.

Closes #1965.