### PR TITLE
VM shutdown fixes

### DIFF
--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -322,7 +322,7 @@ ifeq ($(IMAGE),)
 endif
 	@ echo "MKFS	$@"
 	@ $(MKDIR) $(dir $(IMAGE))
-	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) $(TRACELOG_MKFS_OPTS) $(IMAGE) -t "(debug_exit:t)"
+	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) $(TRACELOG_MKFS_OPTS) -t "(debug_exit:t)" $(IMAGE)
 
 release: mkfs kernel
 	$(Q) $(RM) -r release

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -222,21 +222,15 @@ void reclaim_regions(void)
 {
 }
 
-extern filesystem root_fs;
-
-static inline void virt_shutdown(u64 code)
+closure_function(0, 1, void, psci_vm_halt,
+                 int, status)
 {
-    tuple root = get_root_tuple();
-    if (root) {
-        if (!get(root, sym(psci)))
-            angel_shutdown(code);
-    }
     psci_shutdown();
 }
 
 void vm_shutdown(u8 code)
 {
-    virt_shutdown(code);
+    angel_shutdown(code);
     while (1);
 }
 
@@ -372,4 +366,8 @@ void detect_devices(kernel_heaps kh, storage_attach sa)
     init_virtio_rng(kh);
     init_virtio_9p(kh);
     init_virtio_socket(kh);
+    if (!vm_halt) {
+        vm_halt = closure(heap_locked(kh), psci_vm_halt);
+        assert(vm_halt != INVALID_ADDRESS);
+    }
 }

--- a/src/hyperv/vmbus/hyperv.c
+++ b/src/hyperv/vmbus/hyperv.c
@@ -328,5 +328,4 @@ hyperv_probe_devices(storage_attach a, boolean *storvsc_attached)
 void HV_SHUTDOWN(void)
 {
     out16((unsigned int)PM1a_CNT, SLP_TYPa | SLP_EN);
-    while(1);
 }

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -571,8 +571,10 @@ void vm_exit(u8 code)
             machine_halt();
         }
     }
-    if (vm_halt && (!root || !get(root, sym(debug_exit))))
+    if (vm_halt && (!root || !get(root, sym(debug_exit)))) {
         apply(vm_halt, code);
+        machine_halt();
+    }
     vm_shutdown(code);
 }
 


### PR DESCRIPTION
This change set ensures that the exit status of the user program is reflected in Qemu's exit status only if the "debug_exit" option is specified in the manifest. This fixes two minor issues:
- when running on-prem instances on x86_64 machines, Ops no longer outputs the spurious "exit status 1" error message
- when running on an Aarch64 machine that does not support the Angel shutdown command (such as Apple M1 and M2 machines), the kernel no longer outputs the "QEMU exit code will not reflect program exit code" error message

In order for the exit status of the user program to be reflected in Qemu's exit status (or for an error message to be output if this is not supported), the "debug_exit" option has to be specified in the manifest. Example configuration when using Ops:
```
"ManifestPassthrough": {
  "debug_exit":"t"
}
```
