### PR TITLE
x86: add AMD SEV (Secure Encrypted Virtualization) support

### DIFF
--- a/klib/mbedtls.c
+++ b/klib/mbedtls.c
@@ -273,7 +273,7 @@ int tls_connect(ip_addr_t *addr, u16 port, connection_handler ch)
 
 int init(status_handler complete)
 {
-    tls.h = heap_locked(get_kernel_heaps());
+    tls.h = heap_malloc();
     mbedtls_ssl_config_init(&tls.conf);
     mbedtls_ctr_drbg_init(&tls.ctr_drbg);
     mbedtls_entropy_init(&tls.entropy);

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -17,6 +17,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/drivers/ata-pci.c \
 	$(SRCDIR)/drivers/console.c \
 	$(SRCDIR)/drivers/dmi.c \
+	$(SRCDIR)/drivers/gve.c \
 	$(SRCDIR)/drivers/nvme.c \
 	$(SRCDIR)/drivers/netconsole.c \
 	$(SRCDIR)/drivers/vga.c \

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -24,6 +24,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/gdb/gdbtcp.c \
 	$(SRCDIR)/gdb/gdbutil.c \
 	$(SRCDIR)/http/http.c \
+	$(SRCDIR)/kernel/dma.c \
 	$(SRCDIR)/kernel/elf.c \
 	$(SRCDIR)/kernel/clock.c \
 	$(SRCDIR)/kernel/flush.c \
@@ -185,6 +186,7 @@ AFLAGS+=-I$(ARCHDIR)/
 CFLAGS+=$(KERNCFLAGS) -DKERNEL -O3 -fno-pic -mcmodel=kernel
 CFLAGS+=-Wno-address # lwIP build sadness
 CFLAGS+=-DCONFIG_LTRACE
+CFLAGS+=-DDMA_BUFFERING	# required by memory encryption
 CFLAGS+=$(INCLUDES)
 
 # Enable tracing by specifying TRACE=ftrace on command line

--- a/platform/pc/boot/stage2.c
+++ b/platform/pc/boot/stage2.c
@@ -80,6 +80,11 @@ void klog_write(const char *s, bytes count)
 {
 }
 
+heap heap_dma(void)
+{
+    return general;
+}
+
 closure_function(1, 1, void, stage2_bios_read,
                  u64, offset,
                  storage_req, req)

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -242,7 +242,6 @@ static void __attribute__((noinline)) init_service_new_stack()
 {
     kernel_heaps kh = get_kernel_heaps();
     early_init_debug("in init_service_new_stack");
-    init_page_tables((heap)heap_linear_backed(kh));
     bytes pagesize = is_low_memory_machine() ? PAGESIZE : PAGESIZE_2M;
     init_integers(locking_heap_wrapper(heap_general(kh),
                   allocate_tagged_region(kh, tag_integer, pagesize)));

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -431,8 +431,7 @@ extern void *READONLY_END;
 static int setup_initmap(region temp_pages_r)
 {
     /* Set up initial mappings in the same way as stage2 does. */
-    /* Enable NXE bit now to avoid page faults when mapping a noexec page. */
-    write_msr(EFER_MSR, read_msr(EFER_MSR) | EFER_NXE);
+    init_mmu();
     struct region_heap rh;
     region_heap_init(&rh, PAGESIZE, REGION_PHYSICAL);
     u64 initial_pages_base = allocate_u64(&rh.h, INITIAL_PAGES_SIZE);
@@ -508,7 +507,8 @@ void init_service(u64 rdi, u64 rsi)
     early_init_debug("init_service");
 
     find_initial_pages();
-    init_mmu();
+    if (!pagebase)
+        init_mmu();
     init_page_initial_map(pointer_from_u64(PAGES_BASE), initial_pages);
     init_kernel_heaps();
     if (cmdline)

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -10,6 +10,7 @@
 #include <drivers/ata-pci.h>
 #include <drivers/console.h>
 #include <drivers/dmi.h>
+#include <drivers/gve.h>
 #include <drivers/nvme.h>
 #include <drivers/vga.h>
 #include <hyperv_platform.h>
@@ -603,6 +604,7 @@ void detect_devices(kernel_heaps kh, storage_attach sa)
         init_virtio_network(kh);
         init_vmxnet3_network(kh);
         init_aws_ena(kh);
+        init_gve(kh);
 
         /* storage */
         init_virtio_blk(kh, sa);

--- a/platform/riscv-virt/service.c
+++ b/platform/riscv-virt/service.c
@@ -68,6 +68,8 @@ void read_kernel_syms(void)
 
 void reclaim_regions(void)
 {
+    /* mmu init complete; unmap temporary identity map */
+    unmap(PHYSMEM_BASE, INIT_IDENTITY_SIZE);
 }
 
 static inline void virt_shutdown(u64 code)
@@ -100,9 +102,6 @@ static void __attribute__((noinline)) init_service_new_stack(void)
 {
     init_debug("in init_service_new_stack\n");
     kernel_heaps kh = get_kernel_heaps();
-    init_page_tables((heap)heap_linear_backed(kh));
-    /* mmu init complete; unmap temporary identity map */
-    unmap(PHYSMEM_BASE, INIT_IDENTITY_SIZE);
     bytes pagesize = is_low_memory_machine() ? PAGESIZE : PAGESIZE_2M;
     init_integers(locking_heap_wrapper(heap_general(kh),
                   allocate_tagged_region(kh, tag_integer, pagesize)));

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -247,7 +247,6 @@ static void __attribute__((noinline)) init_service_new_stack(void)
 {
     init_debug("in init_service_new_stack\n");
     kernel_heaps kh = get_kernel_heaps();
-    init_page_tables((heap)heap_linear_backed(kh));
     bytes pagesize = is_low_memory_machine() ? PAGESIZE : PAGESIZE_2M;
     init_integers(locking_heap_wrapper(heap_general(kh),
                   allocate_tagged_region(kh, tag_integer, pagesize)));

--- a/src/aarch64/kernel_machine.c
+++ b/src/aarch64/kernel_machine.c
@@ -138,7 +138,7 @@ static void ap_start(void)
 {
     int cpuid = cpuid_from_mpid(read_mpid());
     assert(cpuid >= 0);
-    cpuinfo ci = init_cpuinfo((heap)heap_linear_backed(get_kernel_heaps()), cpuid);
+    cpuinfo ci = init_cpuinfo(heap_locked(get_kernel_heaps()), cpuid);
     assert(ci != INVALID_ADDRESS);
     context_frame f = ci->m.kernel_context->frame;
     switch_stack_1(frame_get_stack_top(f), ap_start_newstack, cpuid);

--- a/src/aarch64/page_machine.h
+++ b/src/aarch64/page_machine.h
@@ -232,6 +232,11 @@ static inline pageflags pageflags_device(void)
             | PAGE_DEFAULT_PERMISSIONS};
 }
 
+static inline pageflags pageflags_dma(void)
+{
+    return (pageflags){.w = pageflags_memory().w & ~PAGE_READONLY};
+}
+
 static inline pageflags pageflags_writable(pageflags flags)
 {
     return (pageflags){.w = flags.w & ~PAGE_READONLY};

--- a/src/boot/uefi.c
+++ b/src/boot/uefi.c
@@ -33,6 +33,7 @@ struct efi_guid uefi_acpi20_table = {
 
 static void *uefi_image_handle;
 static efi_system_table uefi_system_table;
+static struct heap general;
 
 /* UEFI Boot Services */
 #define UBS uefi_system_table->boot_services
@@ -98,6 +99,11 @@ void halt_with_code(u8 code, char *format, ...)
     buffer_print(b);
     UBS->exit(uefi_image_handle, EFI_LOAD_ERROR, 0, 0); /* does not return */
     while(1);   /* to honor "noreturn" attribute */
+}
+
+heap heap_dma(void)
+{
+    return &general;
 }
 
 static u64 uefi_alloc(heap h, bytes b)
@@ -228,7 +234,6 @@ efi_status efi_main(void *image_handle, efi_system_table system_table)
 {
     uefi_image_handle = image_handle;
     uefi_system_table = system_table;
-    struct heap general;
     zero(&general, sizeof(general));
     general.alloc = uefi_alloc;
     general.dealloc = uefi_dealloc;

--- a/src/drivers/acpi.c
+++ b/src/drivers/acpi.c
@@ -440,13 +440,15 @@ ACPI_STATUS AcpiOsInitialize(void)
 
 void *AcpiOsAllocate(ACPI_SIZE size)
 {
-    void *p = allocate(acpi_heap, size);
+    heap h = heap_malloc();
+    void *p = allocate(h, size);
     return (p != INVALID_ADDRESS) ? p : 0;
 }
 
 void AcpiOsFree(void *memory)
 {
-    deallocate(acpi_heap, memory, -1ull);
+    heap h = heap_malloc();
+    deallocate(h, memory, -1ull);
 }
 
 void *AcpiOsMapMemory(ACPI_PHYSICAL_ADDRESS where, ACPI_SIZE length)

--- a/src/drivers/acpi.c
+++ b/src/drivers/acpi.c
@@ -603,7 +603,7 @@ ACPI_STATUS AcpiOsPredefinedOverride(const ACPI_PREDEFINED_NAMES *init_val, ACPI
 ACPI_STATUS AcpiOsCreateCache(char *cache_name, UINT16 object_size, UINT16 max_depth,
                               ACPI_CACHE_T **return_cache)
 {
-    caching_heap h = allocate_objcache(acpi_heap, (heap)heap_linear_backed(get_kernel_heaps()),
+    caching_heap h = allocate_objcache(acpi_heap, (heap)heap_page_backed(get_kernel_heaps()),
                                        object_size, PAGESIZE, false);
     if (h == INVALID_ADDRESS)
         return AE_NO_MEMORY;

--- a/src/fs/tfs.c
+++ b/src/fs/tfs.c
@@ -1,4 +1,5 @@
 #include <tfs_internal.h>
+#include <dma.h>
 
 //#define TFS_DEBUG
 #if defined(TFS_DEBUG)
@@ -1526,6 +1527,7 @@ void create_filesystem(heap h,
         runtime_memcpy(fs->label, label, label_len);
         fs->label[label_len] = '\0';
     }
+    fs->dma = heap_dma();
     fs->next_extend_log_offset = INVALID_PHYSICAL;
     fs->next_new_log_offset = INVALID_PHYSICAL;
     fs->tl = log_create(h, fs, label != 0, closure(h, log_complete, complete, fs));

--- a/src/kernel/dma.c
+++ b/src/kernel/dma.c
@@ -1,0 +1,65 @@
+#include <kernel.h>
+#include <dma.h>
+
+BSS_RO_AFTER_INIT static struct {
+    heap general;
+    heap io;
+    boolean bounce_buffering;
+} dma;
+
+void dma_init(kernel_heaps kh)
+{
+    dma.general = heap_locked(kh);
+    dma.io = kh->dma;
+    dma.bounce_buffering = (dma.io != dma.general);
+}
+
+closure_function(6, 1, void, dma_sg_io_complete,
+                 sg_list, sg, sg_list, dma_sg, void *, buf, u64, buf_size, boolean, write, status_handler, completion,
+                 status, s)
+{
+    sg_list sg = bound(sg);
+    sg_list dma_sg = bound(dma_sg);
+    void *buf = bound(buf);
+    u64 buf_size = bound(buf_size);
+    if (!bound(write) && is_ok(s))
+        sg_copy_from_buf(buf, sg, buf_size - dma_sg->count);
+    deallocate(dma.io, buf, buf_size);
+    deallocate_sg_list(dma_sg);
+    apply(bound(completion), s);
+    closure_finish();
+}
+
+void dma_sg_io(sg_io op, sg_list sg, range r, boolean write, status_handler completion)
+{
+    if (!dma.bounce_buffering) {
+        apply(op, sg, r, completion);
+        return;
+    }
+    sg_list dma_sg = allocate_sg_list();
+    if (dma_sg == INVALID_ADDRESS)
+        goto oom;
+    u64 len = sg->count;
+    void *buf = allocate(dma.io, len);
+    if (buf == INVALID_ADDRESS)
+        goto err_buf;
+    status_handler dma_completion = closure(dma.general, dma_sg_io_complete, sg, dma_sg, buf, len,
+                                            write, completion);
+    if (dma_completion == INVALID_ADDRESS)
+        goto err_closure;
+    sg_buf sgb = sg_list_tail_add(dma_sg, len);
+    sgb->buf = buf;
+    sgb->size = len;
+    sgb->offset = 0;
+    sgb->refcount = 0;
+    if (write)
+        sg_copy_to_buf(buf, sg, len);
+    apply(op, dma_sg, r, dma_completion);
+    return;
+  err_closure:
+    deallocate(dma.io, buf, len);
+  err_buf:
+    deallocate_sg_list(dma_sg);
+  oom:
+    apply(completion, timm_oom);
+}

--- a/src/kernel/dma.h
+++ b/src/kernel/dma.h
@@ -1,0 +1,33 @@
+#ifndef DMA_H_
+#define DMA_H_
+
+heap heap_dma(void);
+
+#ifdef DMA_BUFFERING
+
+void dma_init(kernel_heaps kh);
+void dma_sg_io(sg_io op, sg_list sg, range r, boolean write, status_handler completion);
+
+#else
+
+static inline void dma_init(void *arg) {}
+
+static inline void dma_sg_io(sg_io op, sg_list sg, range r, boolean write,
+                             status_handler completion)
+{
+    apply(op, sg, r, completion);
+}
+
+#endif
+
+static inline void dma_sg_read(sg_io op, sg_list sg, range r, status_handler completion)
+{
+    dma_sg_io(op, sg, r, false, completion);
+}
+
+static inline void dma_sg_write(sg_io op, sg_list sg, range r, status_handler completion)
+{
+    dma_sg_io(op, sg, r, true, completion);
+}
+
+#endif

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -68,10 +68,9 @@ void init_kernel_heaps(void)
     heaps.physical = init_physical_id_heap(&bootstrap);
     assert(heaps.physical != INVALID_ADDRESS);
 
+    heaps.linear_backed = allocate_linear_backed_heap(&bootstrap, heaps.physical, irange(0, 0));
 #if defined(MEMDEBUG_BACKED) || defined(MEMDEBUG_ALL)
-    heaps.linear_backed = mem_debug_backed(&bootstrap, allocate_linear_backed_heap(&bootstrap, heaps.physical), PAGESIZE_2M, true);
-#else
-    heaps.linear_backed = allocate_linear_backed_heap(&bootstrap, heaps.physical);
+    heaps.linear_backed = mem_debug_backed(&bootstrap, heaps.linear_backed, PAGESIZE_2M, true);
 #endif
     assert(heaps.linear_backed != INVALID_ADDRESS);
 

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -79,7 +79,7 @@ void init_kernel_heaps(void)
     int max_mcache_order = is_lowmem ? MAX_LOWMEM_MCACHE_ORDER : MAX_MCACHE_ORDER;
     bytes pagesize = is_lowmem ? U64_FROM_BIT(max_mcache_order + 1) : PAGESIZE_2M;
     heaps.general = allocate_mcache(&bootstrap, (heap)heaps.linear_backed, 5, max_mcache_order,
-                                    pagesize);
+                                    pagesize, false);
     assert(heaps.general != INVALID_ADDRESS);
 
     heaps.locked = locking_heap_wrapper(heaps.general, heaps.general);
@@ -97,6 +97,12 @@ void init_kernel_heaps(void)
     heaps.page_backed = allocate_page_backed_heap(heaps.general, (heap)heaps.virtual_page,
                                                   (heap)heaps.physical, PAGESIZE, true);
     assert(heaps.page_backed != INVALID_ADDRESS);
+
+    heaps.malloc = allocate_mcache(heaps.locked, (heap)heaps.linear_backed, 5, max_mcache_order,
+                                   pagesize, true);
+    assert(heaps.malloc != INVALID_ADDRESS);
+    heaps.malloc = locking_heap_wrapper(heaps.general, heaps.malloc);
+    assert(heaps.malloc != INVALID_ADDRESS);
 }
 
 closure_function(2, 1, void, offset_req_handler,

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -79,7 +79,7 @@ define_closure_function(2, 0, void, free_kernel_context,
 
     bound(queued) = false;
     if (!enqueue(bound(free_ctx_q), kc))
-        deallocate((heap)heap_linear_backed(get_kernel_heaps()), kc, kc->size);
+        deallocate(heap_locked(get_kernel_heaps()), kc, kc->size);
 }
 
 static void kernel_context_pause(context c)
@@ -133,7 +133,7 @@ void init_kernel_context(kernel_context kc, int type, int size, queue free_ctx_q
 kernel_context allocate_kernel_context(cpuinfo ci)
 {
     build_assert((KERNEL_CONTEXT_SIZE & (KERNEL_CONTEXT_SIZE - 1)) == 0);
-    kernel_context kc = allocate((heap)heap_linear_backed(get_kernel_heaps()),
+    kernel_context kc = allocate(heap_locked(get_kernel_heaps()),
                                  KERNEL_CONTEXT_SIZE);
     if (kc == INVALID_ADDRESS)
         return kc;

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -847,6 +847,8 @@ boolean mm_register_mem_cleaner(mem_cleaner cleaner);
 
 kernel_heaps get_kernel_heaps(void);
 
+#define heap_malloc()  (get_kernel_heaps()->malloc)
+
 static inline boolean is_low_memory_machine(void)
 {
     return (heap_total((heap)heap_physical(get_kernel_heaps())) < LOW_MEMORY_THRESHOLD);

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -766,7 +766,7 @@ backed_heap allocate_page_backed_heap(heap meta, heap virtual, heap physical,
                                       u64 pagesize, boolean locking);
 void page_backed_dealloc_virtual(backed_heap bh, u64 x, bytes length);
 
-backed_heap allocate_linear_backed_heap(heap meta, id_heap physical);
+backed_heap allocate_linear_backed_heap(heap meta, id_heap physical, range mapped_virt);
 
 static inline boolean is_linear_backed_address(u64 address)
 {

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -259,7 +259,7 @@ closure_function(3, 2, boolean, autoload_klib_each,
         klib_handler kl_complete = closure(h, autoload_klib_complete, bound(pending),
             bound(retry_klibs), sh, 0);
         assert(kl_complete != INVALID_ADDRESS);
-        filesystem_read_entire(klib_fs, v, (heap)heap_linear_backed(klib_kh),
+        filesystem_read_entire(klib_fs, v, (heap)heap_page_backed(klib_kh),
                                closure(h, load_klib_complete, symbol_string(s), kl_complete, sh),
                                closure(h, load_klib_failed, kl_complete));
     }

--- a/src/kernel/kvm_platform.c
+++ b/src/kernel/kvm_platform.c
@@ -24,7 +24,7 @@
 static boolean probe_kvm_pvclock(kernel_heaps kh, u32 cpuid_fn)
 {
     kvm_debug("probing for KVM pvclock...");
-    heap backed = (heap)heap_page_backed(kh);
+    heap backed = (heap)heap_linear_backed(kh);
     u32 v[4];
     cpuid(cpuid_fn + KVM_CPUID_FEATURES, 0, v);
     if ((v[0] & (1 << 3)) == 0) {

--- a/src/kernel/linear_backed_heap.c
+++ b/src/kernel/linear_backed_heap.c
@@ -87,7 +87,7 @@ static void add_linear_backed_page(linear_backed_heap hb, int index)
         u64 length = U64_FROM_BIT(LINEAR_BACKED_PAGELOG);
         u64 vbase = linear_backed_base_from_index(hb, index);
         u64 pbase = index * length;
-        map(vbase, pbase, length, pageflags_writable(pageflags_memory()));
+        map(vbase, pbase, length, pageflags_dma());
         bitmap_set(hb->mapped, index, 1);
     }
 }

--- a/src/kernel/lockstats.c
+++ b/src/kernel/lockstats.c
@@ -305,7 +305,7 @@ init_http_listener(void)
 void lockstats_init(kernel_heaps kh)
 {
     heap h = heap_general(kh);
-    heap backed = (heap)heap_linear_backed(kh);
+    heap backed = (heap)heap_page_backed(kh);
     lockstats_heap = h;
     cpuinfo ci;
     vector_foreach(cpuinfos, ci) {

--- a/src/kernel/page.h
+++ b/src/kernel/page.h
@@ -18,6 +18,7 @@ typedef struct pageflags {
 } pageflags;
 
 void init_page_initial_map(void *initial_map, range phys);
+range init_page_map_all(id_heap phys, id_heap virt_heap);
 void init_page_tables(heap pageheap);
 
 /* tlb shootdown */
@@ -61,6 +62,11 @@ static inline void unmap_pages(u64 virtual, u64 length)
 }
 
 #include <page_machine.h>
+
+static inline pageflags pageflags_kernel_data(void)
+{
+    return pageflags_writable(pageflags_memory());
+}
 
 /* table traversal */
 typedef closure_type(entry_handler, boolean /* success */, int /* level */,

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -16,9 +16,6 @@
 #include <lwip/mld6.h>
 #include <lwip/nd6.h>
 
-#define MAX_LWIP_ALLOC_ORDER 16
-#define MAX_LOWMEM_LWIP_ALLOC_ORDER 11
-
 status direct_connect(heap h, ip_addr_t *addr, u16 port, connection_handler ch);
 
 u16 ifflags_from_netif(struct netif *netif);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -431,15 +431,7 @@ extern void lwip_init();
 
 void init_net(kernel_heaps kh)
 {
-    heap h = heap_general(kh);
-    heap backed = (heap)heap_linear_backed(kh);
-    boolean is_lowmem = is_low_memory_machine();
-    int lwip_alloc_order = is_lowmem ? MAX_LOWMEM_LWIP_ALLOC_ORDER : MAX_LWIP_ALLOC_ORDER;
-    bytes pagesize = is_lowmem ? U64_FROM_BIT(lwip_alloc_order + 1) : PAGESIZE_2M;
-    lwip_heap = allocate_mcache(h, backed, 5, lwip_alloc_order, pagesize);
-    assert(lwip_heap != INVALID_ADDRESS);
-    lwip_heap = locking_heap_wrapper(h, lwip_heap);
-    assert(lwip_heap != INVALID_ADDRESS);
+    lwip_heap = kh->malloc;
     list_init(&net_complete_list);
     lwip_init();
     BSS_RO_AFTER_INIT NETIF_DECLARE_EXT_CALLBACK(netif_callback);

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -2617,7 +2617,7 @@ boolean netsyscall_init(unix_heaps uh, tuple cfg)
     else
         so_rcvbuf = DEFAULT_SO_RCVBUF;
     kernel_heaps kh = (kernel_heaps)uh;
-    caching_heap socket_cache = allocate_objcache(heap_general(kh), (heap)heap_linear_backed(kh),
+    caching_heap socket_cache = allocate_objcache(heap_general(kh), (heap)heap_page_backed(kh),
                                                   sizeof(struct netsock), PAGESIZE, true);
     if (socket_cache == INVALID_ADDRESS)
 	return false;

--- a/src/riscv64/kernel_machine.c
+++ b/src/riscv64/kernel_machine.c
@@ -25,7 +25,7 @@ heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize)
     /* reserve area in virtual_huge */
     assert(id_heap_set_area(heap_virtual_huge(kh), tag_base, tag_length, true, true));
 
-    return allocate_mcache(h, backed, 5, find_order(pagesize) - 1, pagesize);
+    return allocate_mcache(h, backed, 5, find_order(pagesize) - 1, pagesize, false);
 }
 
 extern void *trap_handler;

--- a/src/riscv64/kernel_machine.c
+++ b/src/riscv64/kernel_machine.c
@@ -16,7 +16,7 @@ heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize)
     assert(tag < U64_FROM_BIT(VA_TAG_WIDTH));
     u64 tag_base = KMEM_BASE | (tag << VA_TAG_OFFSET);
     u64 tag_length = U64_FROM_BIT(VA_TAG_OFFSET);
-    heap v = (heap)create_id_heap(h, (heap)heap_linear_backed(kh), tag_base, tag_length, p->pagesize, false);
+    heap v = (heap)create_id_heap(h, h, tag_base, tag_length, p->pagesize, false);
     assert(v != INVALID_ADDRESS);
     heap backed = (heap)allocate_page_backed_heap(h, v, p, p->pagesize, false);
     if (backed == INVALID_ADDRESS)
@@ -98,7 +98,7 @@ void ap_start(u64 hartid)
     u64 cpuid = cpuid_from_hartid(hartid);
     assert(cpuid != INVALID_PHYSICAL);
     assert(cpuid > 0);
-    cpuinfo ci = init_cpuinfo((heap)heap_linear_backed(get_kernel_heaps()), cpuid);
+    cpuinfo ci = init_cpuinfo(heap_locked(get_kernel_heaps()), cpuid);
     assert(ci != INVALID_ADDRESS);
     ci->m.hartid = hartid;
     context_frame f = ci->m.kernel_context->frame;

--- a/src/riscv64/page_machine.h
+++ b/src/riscv64/page_machine.h
@@ -53,6 +53,11 @@ static inline pageflags pageflags_device(void)
     return (pageflags){.w = PAGE_DEFAULT_PERMISSIONS}; // PMAs are hardwired
 }
 
+static inline pageflags pageflags_dma(void)
+{
+    return (pageflags){.w = PAGE_DEFAULT_PERMISSIONS | PAGE_WRITABLE};
+}
+
 static inline pageflags pageflags_writable(pageflags flags)
 {
     return (pageflags){.w = flags.w | PAGE_WRITABLE};

--- a/src/runtime/heap/heap.h
+++ b/src/runtime/heap/heap.h
@@ -58,7 +58,8 @@ caching_heap allocate_wrapped_objcache(heap meta, heap parent, bytes objsize, by
 caching_heap allocate_objcache_preallocated(heap meta, heap parent, bytes objsize, bytes pagesize, u64 prealloc_count, boolean prealloc_only);
 boolean objcache_validate(heap h);
 heap objcache_from_object(u64 obj, bytes parent_pagesize);
-heap allocate_mcache(heap meta, heap parent, int min_order, int max_order, bytes pagesize);
+heap allocate_mcache(heap meta, heap parent, int min_order, int max_order, bytes pagesize,
+                     boolean malloc_style);
 heap reserve_heap_wrapper(heap meta, heap parent, bytes reserved);
 backed_heap reserve_backed_heap_wrapper(heap meta, backed_heap parent, bytes reserved);
 

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -466,6 +466,20 @@ boolean id_heap_range_foreach(id_heap i, range_handler rh)
             RM_MATCH);
 }
 
+closure_function(1, 1, boolean, prealloc_foreach_handler,
+                 id_heap, i,
+                 range, r)
+{
+    return set_area(bound(i), r.start, range_span(r), false, false);
+}
+
+/* Pre-allocate all internal data structures so that no future allocations will be requested from
+ * the meta or map heaps when operating the id heap. */
+boolean id_heap_prealloc(id_heap i)
+{
+    return id_heap_range_foreach(i, stack_closure(prealloc_foreach_handler, i));
+}
+
 #ifdef KERNEL
 id_heap clone_id_heap(id_heap source)
 {

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -461,8 +461,9 @@ closure_function(2, 1, boolean, node_foreach_handler,
 
 boolean id_heap_range_foreach(id_heap i, range_handler rh)
 {
-    return rangemap_range_lookup(i->ranges, (range){0, infinity},
-                                 stack_closure(node_foreach_handler, rh, page_order(i)));
+    return (rangemap_range_lookup(i->ranges, (range){0, infinity},
+                                  stack_closure(node_foreach_handler, rh, page_order(i))) ==
+            RM_MATCH);
 }
 
 #ifdef KERNEL

--- a/src/runtime/heap/id.h
+++ b/src/runtime/heap/id.h
@@ -37,3 +37,5 @@ static inline u64 id_heap_alloc_gte(id_heap i, bytes count, u64 min)
     id_heap_set_next(i, count, min);
     return id_heap_alloc_subrange(i, count, min, infinity);
 }
+
+boolean id_heap_prealloc(id_heap i);

--- a/src/runtime/heap/mcache.c
+++ b/src/runtime/heap/mcache.c
@@ -56,6 +56,7 @@ u64 mcache_alloc(heap h, bytes b)
             m->fallbacks = allocate_table(m->meta, fallback_key, pointer_equal);
             if (m->fallbacks == INVALID_ADDRESS) {
                 rputs("mcache_alloc: failed to allocate fallbacks table\n");
+                m->fallbacks = 0;
                 return INVALID_PHYSICAL;
             }
         }

--- a/src/runtime/kernel_heaps.h
+++ b/src/runtime/kernel_heaps.h
@@ -50,6 +50,10 @@ typedef struct kernel_heaps {
        interrupt handlers are generally discouraged, they should be safe on
        the locked heap. */
     heap locked;
+
+    /* mcache for "malloc-style" allocations, i.e. to be used by vendor code where deallocation
+     * requests are made without a size argument. Protected by spinlock. */
+    heap malloc;
 } *kernel_heaps;
 
 static inline id_heap heap_physical(kernel_heaps heaps)

--- a/src/runtime/sg.h
+++ b/src/runtime/sg.h
@@ -92,6 +92,7 @@ void deallocate_sg_list(sg_list sg);
 void init_sg(heap h);
 void sg_consume(sg_list sg, u64 length);
 u64 sg_copy_to_buf(void *target, sg_list sg, u64 length);
+u64 sg_copy_from_buf(void *src, sg_list sg, u64 length);
 u64 sg_copy_to_buf_and_release(void *dest, sg_list src, u64 limit);
 u64 sg_move(sg_list dest, sg_list src, u64 n);
 u64 sg_zero_fill(sg_list sg, u64 n);

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -1895,7 +1895,7 @@ ftrace_init(unix_heaps uh, filesystem fs)
     cpuinfo ci;
 
     ftrace_heap = heap_locked(&(uh->kh));
-    rbuf_heap = (heap)heap_linear_backed(&(uh->kh));
+    rbuf_heap = (heap)heap_page_backed(&(uh->kh));
 
     cpu_rbufs = allocate_vector(ftrace_heap, total_processors);
     if (cpu_rbufs == INVALID_ADDRESS) {

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -50,7 +50,7 @@ struct pipe {
 boolean pipe_init(unix_heaps uh)
 {
     heap h = heap_locked((kernel_heaps)uh);
-    heap backed = (heap)heap_linear_backed((kernel_heaps)uh);
+    heap backed = (heap)heap_page_backed((kernel_heaps)uh);
 
     uh->pipe_cache = allocate_objcache(h, backed, sizeof(struct pipe), PAGESIZE, true);
     return (uh->pipe_cache == INVALID_ADDRESS ? false : true);

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2538,7 +2538,7 @@ static void syscall_context_pre_suspend(context ctx)
 syscall_context allocate_syscall_context(cpuinfo ci)
 {
     build_assert((SYSCALL_CONTEXT_SIZE & (SYSCALL_CONTEXT_SIZE - 1)) == 0);
-    syscall_context sc = allocate((heap)heap_linear_backed(get_kernel_heaps()),
+    syscall_context sc = allocate(heap_locked(get_kernel_heaps()),
                                   SYSCALL_CONTEXT_SIZE);
     if (sc == INVALID_ADDRESS)
         return sc;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -491,7 +491,7 @@ process_context get_process_context(void)
         refcount_set_count(&pc->uc.kc.context.refcount, 1);
         return pc;
     }
-    pc = allocate((heap)heap_linear_backed(get_kernel_heaps()), PROCESS_CONTEXT_SIZE);
+    pc = allocate(heap_locked(get_kernel_heaps()), PROCESS_CONTEXT_SIZE);
     if (pc == INVALID_ADDRESS)
         return pc;
     init_unix_context(&pc->uc, CONTEXT_TYPE_PROCESS, PROCESS_CONTEXT_SIZE,
@@ -623,7 +623,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     u_heap = uh;
     uh->kh = *kh;
     uh->processes = locking_heap_wrapper(h, (heap)create_id_heap(h, h, 1, 65535, 1, false));
-    uh->file_cache = allocate_objcache(h, (heap)heap_linear_backed(kh), sizeof(struct file),
+    uh->file_cache = allocate_objcache(h, (heap)heap_page_backed(kh), sizeof(struct file),
                                        PAGESIZE, true);
     if (uh->file_cache == INVALID_ADDRESS)
 	goto alloc_fail;

--- a/src/unix/vdso.c
+++ b/src/unix/vdso.c
@@ -51,7 +51,8 @@ void init_vdso(process p)
 #endif
         if (paddr != INVALID_PHYSICAL) {
             __vdso_dat->pvclock_offset = paddr & PAGEMASK;
-            map(vaddr, paddr & ~PAGEMASK, size, pageflags_noexec(flags));
+            map(vaddr, paddr & ~PAGEMASK, size,
+                pageflags_user(pageflags_readonly(pageflags_dma())));
         }
     }
 

--- a/src/unix_process/unix_process_runtime.c
+++ b/src/unix_process/unix_process_runtime.c
@@ -41,6 +41,7 @@ u64 hw_get_seed()
     return random();
 }
 
+static heap malloc_heap;
 static u64 bytes_allocated;
 
 static u64 allocated(heap h)
@@ -96,8 +97,14 @@ heap malloc_allocator()
     h->allocated = allocated;
     h->total = 0;
     h->management = 0;
+    malloc_heap = h;
     bytes_allocated = 0;
     return h;
+}
+
+heap heap_dma(void)
+{
+    return malloc_heap;
 }
 
 void halt_with_code(u8 code, char *format, ...)

--- a/src/x86_64/kernel_machine.c
+++ b/src/x86_64/kernel_machine.c
@@ -52,7 +52,7 @@ heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize)
     /* reserve area in virtual_huge */
     assert(id_heap_set_area(heap_virtual_huge(kh), tag_base, tag_length, true, true));
 
-    return allocate_mcache(h, backed, 5, find_order(pagesize) - 1, pagesize);
+    return allocate_mcache(h, backed, 5, find_order(pagesize) - 1, pagesize, false);
 }
 
 void clone_frame_pstate(context_frame dest, context_frame src)

--- a/src/x86_64/kernel_machine.c
+++ b/src/x86_64/kernel_machine.c
@@ -43,7 +43,7 @@ heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize)
     assert(tag < U64_FROM_BIT(VA_TAG_WIDTH));
     u64 tag_base = KMEM_BASE | (tag << VA_TAG_OFFSET);
     u64 tag_length = U64_FROM_BIT(VA_TAG_OFFSET);
-    heap v = (heap)create_id_heap(h, (heap)heap_linear_backed(kh), tag_base, tag_length, p->pagesize, false);
+    heap v = (heap)create_id_heap(h, h, tag_base, tag_length, p->pagesize, false);
     assert(v != INVALID_ADDRESS);
     heap backed = (heap)allocate_page_backed_heap(h, v, p, p->pagesize, false);
     if (backed == INVALID_ADDRESS)

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -49,6 +49,9 @@
 #define KERNEL_GS_MSR    0xc0000102
 #define TSC_AUX_MSR      0xc0000103
 
+#define SEV_STATUS_MSR   0xc0010131
+#define SEV_ENABLED      (1 << 0)
+
 #define C0_MP   0x00000002
 #define C0_EM   0x00000004
 #define C0_WP   0x00010000
@@ -217,6 +220,13 @@ extern void write_xmsr(u64, u64);
 #define CPUID_FN_EXT_PROC_INFO  0x80000001
 /* EDX */
 #define CPUID_PDPE1GB           (1 << 26)
+
+/* Encrypted memory capabilities */
+#define CPUID_FN_ENCR_MEM   0x8000001f
+/* EAX */
+#define CPUID_SEV           (1 << 1)
+/* EBX */
+#define CPUID_SME_C_BIT(v)  ((v) & 0x3f)
 
 static inline void cpuid(u32 fn, u32 ecx, u32 * v)
 {

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -213,9 +213,21 @@ extern void write_xmsr(u64, u64);
 /* CPUID level 7 (EBX) */
 #define CPUID_FSGSBASE  (1 << 0)
 
+/* Extended processor info and feature bits */
+#define CPUID_FN_EXT_PROC_INFO  0x80000001
+/* EDX */
+#define CPUID_PDPE1GB           (1 << 26)
+
 static inline void cpuid(u32 fn, u32 ecx, u32 * v)
 {
     asm volatile("cpuid" : "=a" (v[0]), "=b" (v[1]), "=c" (v[2]), "=d" (v[3]) : "0" (fn), "2" (ecx));
+}
+
+static inline u32 cpuid_highest_fn(boolean extended)
+{
+    u32 v[4];
+    cpuid(extended ? 0x80000000 : 0, 0, v);
+    return v[0];
 }
 
 static inline void xsetbv(u32 ecx, u32 eax, u32 edx)

--- a/src/x86_64/page_machine.h
+++ b/src/x86_64/page_machine.h
@@ -48,6 +48,11 @@ static inline pageflags pageflags_device(void)
     return (pageflags){.w = PAGE_DEFAULT_PERMISSIONS | PAGE_CACHE_DISABLE};
 }
 
+static inline pageflags pageflags_dma(void)
+{
+    return (pageflags){.w = PAGE_DEFAULT_PERMISSIONS | PAGE_WRITABLE};
+}
+
 static inline pageflags pageflags_writable(pageflags flags)
 {
     return (pageflags){.w = flags.w | PAGE_WRITABLE};

--- a/src/x86_64/page_machine.h
+++ b/src/x86_64/page_machine.h
@@ -263,7 +263,7 @@ physical physical_from_virtual(void *x);
 #endif
 
 void *bootstrap_page_tables(heap initial);
-#ifdef KERNEL
+#if defined(KERNEL) || defined(UEFI)
 void map_setup_2mbpages(u64 v, physical p, int pages, pageflags flags,
                         u64 *pdpt, u64 *pdt);
 void init_mmu(void);

--- a/src/x86_64/page_machine.h
+++ b/src/x86_64/page_machine.h
@@ -33,9 +33,11 @@
 #define PT_SHIFT_L3 21
 #define PT_SHIFT_L4 12
 
+extern u64 page_encr_mask;
+
 static inline pageflags pageflags_memory(void)
 {
-    return (pageflags){.w = PAGE_DEFAULT_PERMISSIONS};
+    return (pageflags){.w = PAGE_DEFAULT_PERMISSIONS | page_encr_mask};
 }
 
 static inline pageflags pageflags_memory_writethrough(void)
@@ -144,7 +146,7 @@ static inline boolean pte_is_block_mapping(pte entry)
 
 static inline u64 flags_from_pte(u64 pte)
 {
-    return pte & PAGE_FLAGS_MASK;
+    return pte & (PAGE_FLAGS_MASK | page_encr_mask);
 }
 
 static inline pageflags pageflags_from_pte(pte pte)
@@ -164,7 +166,7 @@ static inline u64 block_pte(u64 phys, u64 flags)
 
 static inline u64 new_level_pte(u64 tp_phys)
 {
-    return tp_phys | PAGE_WRITABLE | PAGE_USER | PAGE_PRESENT;
+    return tp_phys | PAGE_WRITABLE | PAGE_USER | PAGE_PRESENT | page_encr_mask;
 }
 
 static inline boolean flags_has_minpage(u64 flags)
@@ -224,7 +226,7 @@ static inline boolean pte_is_dirty(pte entry)
 static inline u64 page_from_pte(pte p)
 {
     /* page directory pointer base address [51:12] */
-    return p & (MASK(52) & ~PAGEMASK);
+    return p & (MASK(52) & ~PAGEMASK & ~page_encr_mask);
 }
 
 static inline void pt_pte_clean(pteptr pp)

--- a/src/x86_64/uefi-crt0.s
+++ b/src/x86_64/uefi-crt0.s
@@ -31,6 +31,15 @@ _start:
     add rsp, 8
     ret
 
+global read_msr
+read_msr:
+    mov rcx, rdi
+    mov rax, 0
+    rdmsr
+    shl rdx, 0x20
+    or rax, rdx
+    ret
+
 global write_msr
 write_msr:
     mov rcx, rdi

--- a/src/x86_64/uefi-crt0.s
+++ b/src/x86_64/uefi-crt0.s
@@ -31,6 +31,15 @@ _start:
     add rsp, 8
     ret
 
+global write_msr
+write_msr:
+    mov rcx, rdi
+    mov rax, rsi
+    mov rdx, rsi
+    shr rdx, 0x20
+    wrmsr
+    ret
+
 ;; The .reloc section contains the fixup table; it must be present and non-emtpy
 ;; even if there are no fixups to be applied
 section .reloc

--- a/src/x86_64/uefi.c
+++ b/src/x86_64/uefi.c
@@ -55,6 +55,7 @@ void uefi_arch_setup(heap general, heap aligned, uefi_arch_options options)
     assert(initial_pages != INVALID_PHYSICAL);
     create_region(initial_pages, INITIAL_PAGES_SIZE, REGION_INITIAL_PAGES);
     rsvd_mem_add(irangel(initial_pages, INITIAL_PAGES_SIZE));
+    init_mmu();
     pgdir = bootstrap_page_tables(region_allocator(general, PAGESIZE, REGION_INITIAL_PAGES));
     map(0, 0, INITIAL_MAP_SIZE, pageflags_writable(pageflags_exec(pageflags_memory())));
     map(PAGES_BASE, initial_pages, INITIAL_PAGES_SIZE, pageflags_writable(pageflags_memory()));


### PR DESCRIPTION
This changeset adds support for confidential computing, by making the kernel able to run on AMD CPUs where the hypervisor enables SEV (memory encryption with a guest-private key).
Use of kernel heaps has been revised in order to differentiate between DMA-compatible and non-DMA-compatible memory (when running with SEV enabled, kernel and userspace memory is encrypted, while memory used for DMA transfers cannot be encrypted).
In addition, the gVNIC (Google Virtual Ethernet) device driver is being added to the x86 build of the kernel, because confidential VM instances in Google Cloud Platform are equipped with a gVNIC network adapter.