### PR TITLE
Vsock fixes

### DIFF
--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -129,4 +129,5 @@ typedef struct vqmsg *vqmsg;
 vqmsg allocate_vqmsg(virtqueue vq);
 void deallocate_vqmsg(virtqueue vq, vqmsg m);
 void vqmsg_push(virtqueue vq, vqmsg m, u64 phys_addr, u32 len, boolean write);
-void vqmsg_commit(virtqueue vq, vqmsg m, vqfinish completion);
+void vqmsg_commit_seqno(virtqueue vq, vqmsg m, vqfinish completion, u32 *seqno);
+#define vqmsg_commit(vq, m, completion) vqmsg_commit_seqno(vq, m, completion, 0)


### PR DESCRIPTION
This changeset fiexs two issues in the vsock code when run in multi-processor machines:

1. A lock inversion problem could cause deadlocks when a vsock file descriptor was registered in an epoll instance operated by multiple threads
2. The requirement of the stream socket type that guarantees delivery of ordered packets during a connection was not satisfied 