### PR TITLE
TFS log_write_internal(): fix writing to new log extension

### DIFF
--- a/src/fs/tlog.c
+++ b/src/fs/tlog.c
@@ -249,7 +249,7 @@ static log log_new(heap h, tfs fs)
 static void dump_staging(log_ext ext)
 {
 #ifdef TLOG_DEBUG_DUMP
-    buffer b = ext->staging;
+    buffer b = &ext->staging;
     u64 z = b->end;
     rprintf("staging contains:\n");
     for (int i = 0; i < 4; i++) {
@@ -422,6 +422,7 @@ static inline boolean log_write_internal(log tl, merge m)
                 if (ext == INVALID_ADDRESS)
                     return false;
                 size = log_size(ext);
+                staging = &ext->staging;
                 tlog_ext_lock(ext);
             }
             assert(staging->end + min < size);


### PR DESCRIPTION
When the current log extension of a TFS filesystem is full and a new extension is created, any log entries that could not fit in the current extension must be written to the staging buffer of the new extension.
This change fixes a regression introduced in commit d151508. In addition, it fixes a build failure when the TLOG_DEBUG_DUMP preprocessor #define is present.

Closes #1970.