### PR TITLE
feat(shutdown): record shutdown sources

### DIFF
--- a/src/aarch64/interrupt.c
+++ b/src/aarch64/interrupt.c
@@ -287,7 +287,7 @@ void irq_handler(void)
     }
 
     /* enqueue interrupted user thread */
-    if (is_thread_context(ctx) && !shutting_down) {
+    if (is_thread_context(ctx) && !(shutting_down & SHUTDOWN_ONGOING)) {
         int_debug("int sched thread %p\n", ctx);
         context_schedule_return(ctx);
     }

--- a/src/drivers/acpi.c
+++ b/src/drivers/acpi.c
@@ -222,12 +222,10 @@ static UINT32 acpi_sleep(void *context)
     return ACPI_INTERRUPT_HANDLED;
 }
 
-void unix_shutdown(void);
-
 static UINT32 acpi_shutdown(void *context)
 {
     acpi_debug("shutdown");
-    unix_shutdown();
+    kernel_powerdown();
     return ACPI_INTERRUPT_HANDLED;
 }
 

--- a/src/hyperv/utilities/vmbus_shutdown.c
+++ b/src/hyperv/utilities/vmbus_shutdown.c
@@ -50,8 +50,6 @@ closure_function(0, 1, void, hv_sync_complete,
     HV_SHUTDOWN();
 }
 
-void unix_shutdown(void);
-
 static void vmbus_shutdown_cb(struct vmbus_channel *chan, void *xsc)
 {
    struct vmbus_ic_softc *sc = xsc;
@@ -117,7 +115,7 @@ static void vmbus_shutdown_cb(struct vmbus_channel *chan, void *xsc)
    vmbus_ic_sendresp(sc, chan, data, dlen, xactid);
 
    if (do_shutdown)
-       unix_shutdown();
+       kernel_powerdown();
 }
 
 

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -249,6 +249,12 @@ void halt_with_code(u8 code, char *format, ...)
     kernel_shutdown(code);
 }
 
+void unix_shutdown(void);
+void kernel_powerdown(void) {
+    shutting_down |= SHUTDOWN_POWER;
+    unix_shutdown();
+}
+
 #ifndef CONFIG_TRACELOG
 void tprintf(symbol tag, tuple attrs, const char *format, ...)
 {

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -55,7 +55,12 @@ void init_kernel_context(kernel_context kc, int type, int size, queue free_ctx_q
 #define cpu_interrupt 3
 #define cpu_user 4
 
-extern boolean shutting_down;
+extern u32 shutting_down;
+
+#define SHUTDOWN_POWER   (1<<0) // shutdown triggered externally
+#define SHUTDOWN_ONGOING (1<<1) // process termination already triggered
+
+void kernel_powerdown(void);
 
 typedef struct sched_task {
     thunk t;

--- a/src/riscv64/interrupt.c
+++ b/src/riscv64/interrupt.c
@@ -258,7 +258,7 @@ void trap_interrupt(void)
     }
 
     /* enqueue interrupted user thread */
-    if (is_thread_context(ctx) && !shutting_down) {
+    if (is_thread_context(ctx) && !(shutting_down & SHUTDOWN_ONGOING)) {
         int_debug("int sched %p\n", ctx);
         context_schedule_return(ctx);
     }
@@ -447,4 +447,3 @@ void __attribute__((noreturn)) __stack_chk_fail(void)
     dump_context(ctx);
     vm_exit(VM_EXIT_FAULT);
 }
-

--- a/src/unix/coredump.c
+++ b/src/unix/coredump.c
@@ -225,10 +225,6 @@ void coredump(thread t, struct siginfo *si, status_handler complete)
     process p = t->p;
     status s = STATUS_OK;
 
-    /* stop running any other user threads */
-    shutting_down = true;
-    wakeup_or_interrupt_cpu_all();
-
     fsfile f = fsfile_open_or_create(alloca_wrap_cstring(CORE_PATH), true);
     if (f == INVALID_ADDRESS) {
         core_debug("failed to open core file\n");

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -17,7 +17,7 @@ sysreturn set_tid_address(int *a)
 
 #ifdef __x86_64__
 sysreturn arch_prctl(int code, unsigned long addr)
-{    
+{
     thread_log(current, "arch_prctl: code 0x%x, addr 0x%lx", code, addr);
 
     /* just validate the word at base */
@@ -227,7 +227,7 @@ static void thread_cputime_update(thread t)
 
 static void thread_pause(context ctx)
 {
-    if (shutting_down)
+    if (shutting_down & SHUTDOWN_ONGOING)
         return;
     thread t = (thread)ctx;
     context_frame f = thread_frame(t);
@@ -441,7 +441,7 @@ thread create_thread(process p, u64 tid)
     t->name[0] = '\0';
 
     init_thread_fault_handler(t);
-    
+
     t->scheduling_queue = &current_cpu()->thread_queue;
     context_frame f = thread_frame(t);
 #ifdef __x86_64__
@@ -503,7 +503,7 @@ thread create_thread(process p, u64 tid)
     return INVALID_ADDRESS;
 }
 
-NOTRACE 
+NOTRACE
 void exit_thread(thread t)
 {
     thread_log(current, "exit_thread");

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -64,7 +64,7 @@ u64 allocate_fd_gte(process p, u64 min, void *f)
 void deallocate_fd(process p, int fd)
 {
     process_lock(p);
-    assert(vector_set(p->files, fd, 0)); 
+    assert(vector_set(p->files, fd, 0));
     deallocate_u64((heap)p->fdallocator, fd, 1);
     process_unlock(p);
 }
@@ -515,7 +515,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     kernel_heaps kh = (kernel_heaps)uh;
     heap locked = heap_locked(kh);
     process p = allocate(locked, sizeof(struct process));
-    assert(p != INVALID_ADDRESS); 
+    assert(p != INVALID_ADDRESS);
 
     spin_lock_init(&p->lock);
     p->uh = uh;
@@ -703,7 +703,7 @@ closure_function(1, 2, void, shutdown_timeout,
     closure_finish();
     if (overruns == timer_disabled)
         return;
-    if (!shutting_down)
+    if (!(shutting_down & SHUTDOWN_ONGOING))
         kernel_shutdown(0);
 }
 
@@ -726,7 +726,7 @@ void unix_shutdown(void)
     struct timer shutdown_timer = {0};
     init_timer(&shutdown_timer);
     timer_handler th = closure(h, shutdown_timeout, shutdown_timer);
-    register_timer(kernel_timers, &closure_member(shutdown_timeout, th, shutdown_timer), 
+    register_timer(kernel_timers, &closure_member(shutdown_timeout, th, shutdown_timer),
         CLOCK_ID_MONOTONIC, seconds(UNIX_SHUTDOWN_TIMEOUT_SECS), false, 0, th);
 }
 

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -169,7 +169,7 @@ void dump_context(context ctx)
         rputs("\n   address: ");
         print_u64_with_sym(f[FRAME_CR2]);
     }
-    
+
     rputs("\n\n");
     for (int j = 0; j < 24; j++) {
         rputs(register_name(j));
@@ -233,7 +233,7 @@ void common_handler()
             lapic_eoi();
 
         /* enqueue interrupted user thread */
-        if (is_thread_context(ctx) && !shutting_down) {
+        if (is_thread_context(ctx) && !(shutting_down & SHUTDOWN_ONGOING)) {
             int_debug("int sched thread %p\n", ctx);
             context_schedule_return(ctx);
         }
@@ -399,7 +399,7 @@ void init_interrupts(kernel_heaps kh)
     u64 vector_base = u64_from_pointer(&interrupt_vectors);
     for (int i = 0; i < INTERRUPT_VECTOR_START; i++)
         write_idt(i, vector_base + i * interrupt_vector_size, IST_EXCEPTION);
-    
+
     for (int i = INTERRUPT_VECTOR_START; i < n_interrupt_vectors; i++)
         write_idt(i, vector_base + i * interrupt_vector_size, IST_INTERRUPT);
 

--- a/src/xen/xen.c
+++ b/src/xen/xen.c
@@ -388,8 +388,6 @@ closure_function(1, 0, void, xen_per_cpu_init,
     xen_setup_vcpu(current_cpu()->id, bound(shared_info_phys));
 }
 
-void unix_shutdown(void);
-
 define_closure_function(1, 0, void, xen_shutdown_handler,
                  buffer, b)
 {
@@ -406,7 +404,7 @@ define_closure_function(1, 0, void, xen_shutdown_handler,
 out:
     xenstore_transaction_end(txid, is_ok(s) ? false : true);
     if (buffer_compare_with_cstring(rsp, "poweroff") || buffer_compare_with_cstring(rsp, "halt"))
-        unix_shutdown();
+        kernel_powerdown();
 }
 
 define_closure_function(0, 1, void, xen_shutdown_watcher,
@@ -1137,4 +1135,3 @@ void register_xen_driver(const char *name, xen_device_probe probe)
     xd->probe = probe;
     list_insert_before(&xen_info.driver_list, &xd->l);
 }
-


### PR DESCRIPTION
Not sure if this is the best way, but it should work for clean differentiation of shutdown origin when checking/executing  hooks like `reboot_on_exit` so they don't interfere on "normal" shutdown/stop requests 