### PR TITLE
AWS: add support for PTP hardware clock

### DIFF
--- a/src/aarch64/clock.c
+++ b/src/aarch64/clock.c
@@ -15,7 +15,9 @@ closure_function(0, 0, timestamp, arm_clock_now)
 {
     u64 t = rdtsc();
     u64 f = cntfrq();
-    return seconds(t / f) | truncate_seconds((t << 32) / f);
+    u64 secs = t / f;
+    u64 frac = t - secs * f;
+    return seconds(secs) | ((frac << 32) / f);
 }
 
 closure_function(0, 1, void, arm_deadline_timer,

--- a/src/aarch64/gic.c
+++ b/src/aarch64/gic.c
@@ -466,6 +466,7 @@ int init_gic(void)
     case ID_AA64PFR0_EL1_GIC_GICC_SYSREG_NONE:
         break;
     case ID_AA64PFR0_EL1_GIC_GICC_SYSREG_3_0_4_0:
+    case ID_AA64PFR0_EL1_GIC_GICC_SYSREG_4_1:
         gic.v3_iface = true;
         break;
     default:

--- a/src/aws/ena/ena_com/ena_com.h
+++ b/src/aws/ena/ena_com/ena_com.h
@@ -277,6 +277,17 @@ struct ena_com_mmio_read {
     ena_spinlock_t lock;
 };
 
+struct ena_com_phc_info {
+    struct ena_admin_phc_resp *virt_addr;
+    dma_addr_t phys_addr;
+    timestamp block_end;
+    u32 doorbell_offset;
+    u32 expire_timeout_usec;
+    u32 block_timeout_usec;
+    u16 req_id;
+    ena_spinlock_t lock;
+};
+
 struct ena_rss {
     /* Indirect table */
     u16 *host_rss_ind_tbl;
@@ -330,6 +341,7 @@ struct ena_com_dev {
     u16 stats_queue; /* Selected queue for extended statistic dump */
 
     struct ena_com_mmio_read mmio_read;
+    struct ena_com_phc_info phc;
 
     struct ena_rss rss;
     u32 supported_features;
@@ -395,6 +407,12 @@ extern "C" {
  * @return - 0 on success, negative value on failure.
  */
 int ena_com_mmio_reg_read_request_init(struct ena_com_dev *ena_dev);
+
+bool ena_com_phc_supported(struct ena_com_dev *ena_dev);
+int ena_com_phc_init(struct ena_com_dev *ena_dev);
+int ena_com_phc_config(struct ena_com_dev *ena_dev);
+int ena_com_phc_get_timestamp(struct ena_com_dev *ena_dev, u64 *ts);
+void ena_com_phc_destroy(struct ena_com_dev *ena_dev);
 
 /* ena_com_set_mmio_read_mode - Enable/disable the indirect mmio reg read mechanism
  * @ena_dev: ENA communication layer struct

--- a/src/drivers/ns16550.c
+++ b/src/drivers/ns16550.c
@@ -6,7 +6,7 @@ typedef struct ns16550_console {
     u8 *addr;
 } *ns16550_console;
 
-static boolean tx_empty(u8 *addr) {
+static boolean tx_empty(volatile u8 *addr) {
     return *(addr + 5) & 0x20;
 }
 

--- a/src/kernel/clock.c
+++ b/src/kernel/clock.c
@@ -11,6 +11,8 @@ extern void notify_unix_timers_of_rtc_change(void);
 /* These should happen in pairs such that odd indicates update in-progress */
 #define vdso_update_gen() fetch_and_add((word *)&__vdso_dat->vdso_gen, 1)
 
+BSS_RO_AFTER_INIT clock_now ptp_clock_now;
+
 void kernel_delay(timestamp delta)
 {
     timestamp end = now(CLOCK_ID_MONOTONIC) + delta;

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -61,7 +61,7 @@ u64 init_bootstrap_heap(u64 phys_length)
      * works, when an id heap is pre-allocated, its bitmap allocates twice the amount of memory
      * needed; thus, the bootstrap heap needs twice the theoretical amount of memory.
      * In addition, we need some extra space for various initial allocations. */
-    u64 bootstrap_size = 4 * PAGESIZE + pad(page_count >> 2, PAGESIZE);
+    u64 bootstrap_size = 8 * PAGESIZE + pad(page_count >> 2, PAGESIZE);
 
     bootstrap_limit = BOOTSTRAP_BASE + bootstrap_size;
     return bootstrap_size;

--- a/src/runtime/clock.h
+++ b/src/runtime/clock.h
@@ -28,6 +28,10 @@ typedef enum {
 typedef closure_type(clock_now, timestamp);
 extern clock_now platform_monotonic_now;
 
+#define PTP_CLOCK_PRECISION -9  /* expressed in seconds as power of two */
+
+extern clock_now ptp_clock_now;
+
 #if defined(KERNEL) || defined(BUILD_VDSO)
 #include <vdso.h>
 #define __vdso_dat (&(VVAR_REF(vdso_dat)))


### PR DESCRIPTION
This change set enhances the AWS ENA network interface driver to add support for retrieving the current time from a PTP hardware clock, when supported by the network interface.
In addition, the NTP klib has been enhanced to be able to retrieve time from the PTP clock alternatively to using NTP; if the root tuple contains a "chrony" tuple that has a "refclock" attribute with "ptp" value, then the NTP klib uses the PTP clock for synchronizing the system time; if a PTP clock is not available, the klib falls back to NTP.
These features can be used on selected AWS instances (currently, from the R7g (ARM Graviton3) instance family in the Asia Pacific (Tokyo) region) to synchronize the system time with the PTP clock.
The first 5 commits fix a few issues encountered when running on AWS R7g instances, thus making the kernel able to run on ARM instances equipped with Graviton3 processors.
Example Ops configuration to enable synchronization of system time with the PTP hardware clock:
```
{
  "Klibs": ["ntp"]
  },
  "CloudConfig" : {
    "ProjectID": "my-project",
    "Zone": "ap-northeast-1a",
    "BucketName": "my-bucket",
    "Flavor": "r7g.medium"
  },
  "ManifestPassthrough": {
    "chrony": {"refclock": "ptp"}
  }
}
```