### PR TITLE
Kernel command line: add support for arbitrary configuration settings

### DIFF
--- a/klib/cloud_init.c
+++ b/klib/cloud_init.c
@@ -82,7 +82,7 @@ static enum cloud cloud_detect(void)
 
 static int cloud_init_parse_vector(value config, int (*parse_each)(tuple, vector), vector tasks)
 {
-    if (!(is_tuple(config) || is_vector(config)))
+    if (!is_composite(config))
         return KLIB_INIT_FAILED;
     /* allow parsing either tuple or vector for backward compatibility with older ops/tfs... */
     value v;

--- a/klib/firewall.c
+++ b/klib/firewall.c
@@ -555,7 +555,7 @@ int init(status_handler complete)
     value rules = get(config, sym(rules));
     if (!rules)
         return KLIB_INIT_OK;
-    if (!(is_tuple(rules) || is_vector(rules))) {
+    if (!is_composite(rules)) {
         rprintf("invalid firewall rules\n");
         return KLIB_INIT_FAILED;
     }

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -243,16 +243,6 @@ static void __attribute__((noinline)) init_service_new_stack()
 {
     kernel_heaps kh = get_kernel_heaps();
     early_init_debug("in init_service_new_stack");
-    bytes pagesize = is_low_memory_machine() ? PAGESIZE : PAGESIZE_2M;
-    init_integers(locking_heap_wrapper(heap_general(kh),
-                  allocate_tagged_region(kh, tag_integer, pagesize)));
-    init_tuples(locking_heap_wrapper(heap_general(kh),
-                allocate_tagged_region(kh, tag_table_tuple, pagesize)));
-    init_symbols(allocate_tagged_region(kh, tag_symbol, pagesize), heap_locked(kh));
-    heap vh = allocate_tagged_region(kh, tag_vector, pagesize);
-    init_vectors(locking_heap_wrapper(heap_general(kh), vh), heap_locked(kh));
-    heap sh = allocate_tagged_region(kh, tag_string, pagesize);
-    init_strings(locking_heap_wrapper(heap_general(kh), sh), heap_locked(kh));
 
     for_regions(e) {
         switch (e->type) {
@@ -265,7 +255,6 @@ static void __attribute__((noinline)) init_service_new_stack()
         }
     }
 
-    init_management(allocate_tagged_region(kh, tag_function_tuple, pagesize), heap_general(kh));
     early_init_debug("init_hwrand");
     init_hwrand();
 

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -332,15 +332,10 @@ id_heap init_physical_id_heap(heap h)
     early_init_debug("physical memory:");
     for_regions(e) {
 	if (e->type == REGION_PHYSICAL) {
-	    /* Align for 2M pages */
 	    u64 base = e->base;
-	    u64 end = base + e->length;
-	    u64 page2m_mask = MASK(PAGELOG_2M);
-	    base = (base + page2m_mask) & ~page2m_mask;
-	    end &= ~MASK(PAGELOG);
-	    if (base >= end)
+	    u64 length = e->length;
+	    if (length == 0)
 		continue;
-	    u64 length = end - base;
 #ifdef INIT_DEBUG
 	    early_debug("INIT:  [");
 	    early_debug_u64(base);

--- a/platform/riscv-virt/service.c
+++ b/platform/riscv-virt/service.c
@@ -47,7 +47,7 @@ id_heap init_physical_id_heap(heap h)
     u64 end = PHYSMEM_BASE + mem_size;
     u64 bootstrap_size = init_bootstrap_heap(end - base);
     map(BOOTSTRAP_BASE, base, bootstrap_size, pageflags_writable(pageflags_memory()));
-    base = pad(base + bootstrap_size, PAGESIZE_2M);
+    base += bootstrap_size;
     init_debug("\nfree base ");
     init_debug_u64(base);
     init_debug("\nend ");

--- a/platform/riscv-virt/service.c
+++ b/platform/riscv-virt/service.c
@@ -102,17 +102,6 @@ static void __attribute__((noinline)) init_service_new_stack(void)
 {
     init_debug("in init_service_new_stack\n");
     kernel_heaps kh = get_kernel_heaps();
-    bytes pagesize = is_low_memory_machine() ? PAGESIZE : PAGESIZE_2M;
-    init_integers(locking_heap_wrapper(heap_general(kh),
-                  allocate_tagged_region(kh, tag_integer, pagesize)));
-    init_tuples(locking_heap_wrapper(heap_general(kh),
-                allocate_tagged_region(kh, tag_table_tuple, pagesize)));
-    init_symbols(allocate_tagged_region(kh, tag_symbol, pagesize), heap_locked(kh));
-    heap vh = allocate_tagged_region(kh, tag_vector, pagesize);
-    init_vectors(locking_heap_wrapper(heap_general(kh), vh), heap_locked(kh));
-    heap sh = allocate_tagged_region(kh, tag_string, pagesize);
-    init_strings(locking_heap_wrapper(heap_general(kh), sh), heap_locked(kh));
-    init_management(allocate_tagged_region(kh, tag_function_tuple, pagesize), heap_general(kh));
     init_debug("calling runtime init\n");
     kernel_runtime_init(kh);
     while(1);

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -110,9 +110,6 @@ static void add_heap_range_internal(id_heap h, range r, range *remainder)
         r = *remainder;
         *remainder = tmp;
     }
-    r.start = pad(r.start, PAGESIZE_2M);
-    if (r.start >= r.end)
-        return;
     init_debug("adding range [0x");
     init_debug_u64(r.start);
     init_debug(" 0x");
@@ -198,7 +195,7 @@ id_heap init_physical_id_heap(heap h)
         u64 end = base + get_memory_size(pointer_from_u64(DEVICETREE_BLOB_BASE));
         u64 bootstrap_size = init_bootstrap_heap(end - base);
         map(BOOTSTRAP_BASE, base, bootstrap_size, pageflags_writable(pageflags_memory()));
-        base = pad(base + bootstrap_size, PAGESIZE_2M);
+        base += bootstrap_size;
         init_debug("\nfree base ");
         init_debug_u64(base);
         init_debug("\nend ");

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -244,17 +244,6 @@ static void __attribute__((noinline)) init_service_new_stack(void)
 {
     init_debug("in init_service_new_stack\n");
     kernel_heaps kh = get_kernel_heaps();
-    bytes pagesize = is_low_memory_machine() ? PAGESIZE : PAGESIZE_2M;
-    init_integers(locking_heap_wrapper(heap_general(kh),
-                  allocate_tagged_region(kh, tag_integer, pagesize)));
-    init_tuples(locking_heap_wrapper(heap_general(kh),
-                allocate_tagged_region(kh, tag_table_tuple, pagesize)));
-    init_symbols(allocate_tagged_region(kh, tag_symbol, pagesize), heap_locked(kh));
-    heap vh = allocate_tagged_region(kh, tag_vector, pagesize);
-    init_vectors(locking_heap_wrapper(heap_general(kh), vh), heap_locked(kh));
-    heap sh = allocate_tagged_region(kh, tag_string, pagesize);
-    init_strings(locking_heap_wrapper(heap_general(kh), sh), heap_locked(kh));
-    init_management(allocate_tagged_region(kh, tag_function_tuple, pagesize), heap_general(kh));
     init_debug("calling runtime init\n");
     kernel_runtime_init(kh);
     while(1);

--- a/src/aarch64/kernel_machine.c
+++ b/src/aarch64/kernel_machine.c
@@ -45,7 +45,7 @@ static u64 tag_alloc(heap h, bytes s)
     return a;
 }
 
-heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize)
+heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize, boolean locking)
 {
     heap h = heap_locked(kh);
     struct tagheap *th = allocate(h, sizeof(struct tagheap));

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -205,6 +205,9 @@ static inline void wait_for_interrupt(void)
     enable_interrupts();
 }
 
+#define cmdline_consume(o, h)   (void)(h)
+#define boot_params_apply(t)
+
 /* locking constructs */
 #include <mutex.h>
 

--- a/src/drivers/console.c
+++ b/src/drivers/console.c
@@ -104,7 +104,7 @@ void config_console(tuple root)
     value v = get(root, sym(consoles));
     if (v == 0)
         return;
-    if (!(is_vector(v) || is_tuple(v))) {
+    if (!is_composite(v)) {
         msg_err("consoles config is neither vector nor tuple\n");
         return;
     }

--- a/src/fs/tlog.c
+++ b/src/fs/tlog.c
@@ -499,7 +499,7 @@ closure_function(2, 1, void, log_switch_complete,
     if (is_ok(s))
         table_foreach(old_tl->dictionary, k, v) {
             (void)v;
-            if ((is_tuple(k) || is_vector(k)) && !table_find(new_tl->dictionary, k)) {
+            if (is_composite(k) && !table_find(new_tl->dictionary, k)) {
                 tlog_debug("  destroying value %p\n", __func__, k);
                 destruct_value(k, false);
             }
@@ -842,7 +842,7 @@ closure_function(4, 1, void, log_read_complete,
         table newdict = allocate_table(tl->h, identity_key, pointer_equal);
         table_foreach(tl->dictionary, k, v) {
             tlog_debug("   dict swap: k %p, v %p, type %d\n", k, v, tagof(v));
-            assert(is_tuple(v) || is_symbol(v) || is_vector(v));
+            assert(is_composite(v) || is_symbol(v));
             table_set(newdict, v, k);
         }
         deallocate_table(tl->dictionary);

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -613,7 +613,7 @@ static boolean vm_exit_match(u8 exit_code, tuple config, symbol option, boolean 
             return (((action_code == exit_code) && !neq) ||
                     ((action_code != exit_code) && neq));
         }
-    } else if (is_vector(config_option)) {
+    } else if (is_composite(config_option)) {
         for (int i = 0; get_u64(config_option, intern_u64(i), &action_code); i++) {
             if (action_code == exit_code)
                 return true;

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -189,10 +189,10 @@ closure_function(2, 2, void, fsstarted,
     root_fs = fs;
     storage_set_root_fs(fs);
 
-    wrapped_root = tuple_notifier_wrap(filesystem_getroot(fs));
+    tuple fs_root = filesystem_getroot(fs);
+    wrapped_root = tuple_notifier_wrap(fs_root, true);
     assert(wrapped_root != INVALID_ADDRESS);
-    // XXX use wrapped_root after root fs is separate
-    tuple root = filesystem_getroot(root_fs);
+    tuple root = (tuple)wrapped_root;
     tuple mounts = get_tuple(root, sym(mounts));
     if (mounts)
         storage_set_mountpoints(mounts);
@@ -227,7 +227,7 @@ closure_function(2, 2, void, fsstarted,
     closure_finish();
     symbol booted = sym(booted);
     if (!get(root, booted))
-        filesystem_write_eav((tfs)fs, root, booted, null_value, false);
+        filesystem_write_eav((tfs)fs, fs_root, booted, null_value, false);
     config_console(root);
 }
 
@@ -331,12 +331,11 @@ filesystem get_root_fs(void)
 
 tuple get_root_tuple(void)
 {
-    return root_fs ? filesystem_getroot(root_fs) : 0;
+    return (tuple)wrapped_root;
 }
 
 void register_root_notify(symbol s, set_value_notify n)
 {
-    // XXX to be restored when root fs tuple is separated from root tuple
     tuple_notifier_register_set_notify(wrapped_root, s, n);
 }
 

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -5,6 +5,8 @@
 #include <debug.h>
 #endif
 
+typedef closure_type(cmdline_handler, void, const char *, int);
+
 #ifdef KERNEL
 void runloop_target(void) __attribute__((noreturn));
 #endif
@@ -750,6 +752,9 @@ void init_cpuinfo_machine(cpuinfo ci, heap backed);
 void kernel_runtime_init(kernel_heaps kh);
 void read_kernel_syms(void);
 void reclaim_regions(void);
+
+int cmdline_parse(char *cmdline_start, int cmdline_len, const char *opt_name, cmdline_handler h);
+void cmdline_apply(char *cmdline_start, int cmdline_len, tuple t);
 
 boolean breakpoint_insert(heap h, u64 a, u8 type, u8 length, thunk completion);
 boolean breakpoint_remove(heap h, u32 a, thunk completion);

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -798,7 +798,7 @@ void unmap_and_free_phys(u64 virtual, u64 length);
 
 #if !defined(BOOT)
 
-heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize);
+heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize, boolean locking);
 heap locking_heap_wrapper(heap meta, heap parent);
 
 #endif

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -296,7 +296,7 @@ void init_klib(kernel_heaps kh, void *fs, tuple config_root, status_handler comp
     heap h = heap_locked(kh);
     klib_kh = kh;
     klib_fs = (filesystem)fs;
-    klib_loaded = allocate_vector(heap_general(kh), 4);
+    klib_loaded = allocate_vector(h, 4);
     assert(klib_loaded != INVALID_ADDRESS);
 
     extern u8 END;

--- a/src/kernel/region.h
+++ b/src/kernel/region.h
@@ -13,6 +13,7 @@ typedef struct region *region;
 #define REGION_PHYSICAL          1 /* available physical memory */
 #define REGION_DEVICE            2 /* e820 physical region configured for i/o */
 #define REGION_INITIAL_PAGES     10 /* for page table allocations in stage2 and early stage3 */
+#define REGION_CMDLINE           11 /* kernel command line */
 #define REGION_FILESYSTEM        12 /* offset on disk for the filesystem, see if we can get disk info from the bios */
 #define REGION_KERNIMAGE         13 /* location of kernel elf image loaded by stage2 */
 #define REGION_RECLAIM           14 /* areas to be unmapped and reclaimed in stage3 (only stage2 stack presently) */

--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -90,7 +90,6 @@ static void init_kernel_heaps_management(tuple root)
     set(heaps, sym(physical), heap_management((heap)heap_physical(kh)));
     set(heaps, sym(general), heap_management((heap)heap_general(kh)));
     set(heaps, sym(locked), heap_management((heap)heap_locked(kh)));
-    set(heaps, sym(no_encode), null_value);
     set(root, sym(heaps), heaps);
 }
 
@@ -135,7 +134,7 @@ closure_function(6, 0, void, startup,
         filesystem_set_readonly(fs);
     value p = get(root, sym(program));
     assert(p && is_string(p));
-    tuple pro = resolve_path(root, split(general, p, '/'));
+    tuple pro = resolve_path(filesystem_getroot(fs), split(general, p, '/'));
     if (!pro)
         halt("unable to resolve program path \"%b\"\n", p);
     program_set_perms(root, pro);

--- a/src/kernel/storage.c
+++ b/src/kernel/storage.c
@@ -40,7 +40,6 @@ static struct {
 static void notify_mount_change_locked(void);
 
 /* Called with mutex locked. */
-// XXX this won't work with wrapped root...
 static volume storage_get_volume(tuple root)
 {
     list_foreach(&storage.volumes, e) {

--- a/src/kernel/tracelog.c
+++ b/src/kernel/tracelog.c
@@ -155,7 +155,7 @@ closure_function(1, 2, boolean, match_attrs,
     value tv = get(bound(attrs), a);
     if (!tv)
         return false;
-    if (is_tuple(v) || is_vector(v)) {
+    if (is_composite(v)) {
         /* We support either a single value for this attribute or a set of
            acceptable values (as a tuple-encoded vector). */
         boolean match = false;

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -2630,12 +2630,13 @@ boolean netsyscall_init(unix_heaps uh, tuple cfg)
     else
         so_rcvbuf = DEFAULT_SO_RCVBUF;
     kernel_heaps kh = (kernel_heaps)uh;
-    caching_heap socket_cache = allocate_objcache(heap_general(kh), (heap)heap_page_backed(kh),
+    heap h = heap_locked(kh);
+    caching_heap socket_cache = allocate_objcache(h, (heap)heap_page_backed(kh),
                                                   sizeof(struct netsock), PAGESIZE, true);
     if (socket_cache == INVALID_ADDRESS)
 	return false;
     uh->socket_cache = socket_cache;
-    net_loop_poll = closure(heap_general(kh), netsock_poll);
+    net_loop_poll = closure(h, netsock_poll);
     netlink_init();
     vsock_init();
     return true;

--- a/src/riscv64/kernel_machine.c
+++ b/src/riscv64/kernel_machine.c
@@ -9,7 +9,7 @@
 #define tag_debug(x, ...)
 #endif
 
-heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize)
+heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize, boolean locking)
 {
     heap h = heap_locked(kh);
     heap p = (heap)heap_physical(kh);
@@ -25,7 +25,9 @@ heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize)
     /* reserve area in virtual_huge */
     assert(id_heap_set_area(heap_virtual_huge(kh), tag_base, tag_length, true, true));
 
-    return allocate_mcache(h, backed, 5, find_order(pagesize) - 1, pagesize, false);
+    heap mc = allocate_mcache(h, backed, 5, find_order(pagesize) - 1, pagesize, false);
+    assert(mc != INVALID_ADDRESS);
+    return locking ? locking_heap_wrapper(h, mc) : mc;
 }
 
 extern void *trap_handler;

--- a/src/riscv64/kernel_machine.h
+++ b/src/riscv64/kernel_machine.h
@@ -135,6 +135,9 @@ static inline void wait_for_interrupt(void)
     disable_interrupts();
 }
 
+#define cmdline_consume(o, h)   (void)(h)
+#define boot_params_apply(t)
+
 /* locking constructs */
 #include <mutex.h>
 

--- a/src/runtime/bitmap.h
+++ b/src/runtime/bitmap.h
@@ -1,3 +1,7 @@
+#define BITMAP_WORDLEN_LOG      6
+#define BITMAP_WORDLEN          (1 << BITMAP_WORDLEN_LOG)
+#define BITMAP_WORDMASK         (BITMAP_WORDLEN - 1)
+
 /* XXX keep allocs small for now; rolling heap allocations more than a
    page are b0rked */
 #define ALLOC_EXTEND_BITS	U64_FROM_BIT(12)

--- a/src/runtime/extra_prints.c
+++ b/src/runtime/extra_prints.c
@@ -158,7 +158,7 @@ static boolean is_binary_buffer(buffer b)
 
 static void print_value_internal(buffer dest, value v, table *visited, s32 indent, s32 depth)
 {
-    if (is_tuple(v) || is_vector(v)) {
+    if (is_composite(v)) {
         if (!*visited) {
             *visited = allocate_table(transient, identity_key, pointer_equal);
             assert(visited != INVALID_ADDRESS);

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -453,7 +453,7 @@ static value id_management(heap h)
     symbol s;
     tuple t = timm("type", "id", "pagesize", "%d", i->h.pagesize);
     assert(t != INVALID_ADDRESS);
-    tuple_notifier n = tuple_notifier_wrap(t);
+    tuple_notifier n = tuple_notifier_wrap(t, false);
     assert(n != INVALID_ADDRESS);
     register_stat(i, n, t, allocated);
     register_stat(i, n, t, total);

--- a/src/runtime/heap/mcache.c
+++ b/src/runtime/heap/mcache.c
@@ -282,7 +282,7 @@ static value mcache_management(heap h)
     symbol s;
     tuple t = timm("type", "mcache", "pagesize", "%d", m->h.pagesize);
     assert(t != INVALID_ADDRESS);
-    tuple_notifier n = tuple_notifier_wrap(t);
+    tuple_notifier n = tuple_notifier_wrap(t, false);
     assert(n != INVALID_ADDRESS);
     register_stat(m, n, t, allocated);
     register_stat(m, n, t, total);

--- a/src/runtime/heap/objcache.c
+++ b/src/runtime/heap/objcache.c
@@ -439,7 +439,7 @@ static value objcache_management(heap h)
     symbol s;
     tuple t = timm("type", "objcache", "pagesize", "%d", object_size(o));
     assert(t != INVALID_ADDRESS);
-    tuple_notifier n = tuple_notifier_wrap(t);
+    tuple_notifier n = tuple_notifier_wrap(t, false);
     assert(n != INVALID_ADDRESS);
     register_stat(o, n, t, allocated);
     register_stat(o, n, t, total);

--- a/src/runtime/heap/reserve.c
+++ b/src/runtime/heap/reserve.c
@@ -83,7 +83,7 @@ static value reservelock_management(heap h)
     symbol s;
     tuple t = timm("type", "reservelock", "pagesize", "%d", rl->h.pagesize);
     assert(t != INVALID_ADDRESS);
-    tuple_notifier n = tuple_notifier_wrap(t);
+    tuple_notifier n = tuple_notifier_wrap(t, false);
     assert(n != INVALID_ADDRESS);
     register_stat(rl, n, t, allocated);
     register_stat(rl, n, t, total);

--- a/src/runtime/management.h
+++ b/src/runtime/management.h
@@ -9,7 +9,7 @@ typedef struct tuple_notifier *tuple_notifier;
 typedef closure_type(set_value_notify, boolean, value);
 typedef closure_type(get_value_notify, value);
 
-tuple_notifier tuple_notifier_wrap(tuple parent);
+tuple_notifier tuple_notifier_wrap(value parent, boolean copy_on_write);
 void tuple_notifier_unwrap(tuple_notifier tn);
 void tuple_notifier_register_get_notify(tuple_notifier tn, symbol s, get_value_notify n);
 void tuple_notifier_register_set_notify(tuple_notifier tn, symbol s, set_value_notify n);

--- a/src/runtime/memops.c
+++ b/src/runtime/memops.c
@@ -204,3 +204,11 @@ int runtime_memcmp(const void *a, const void *b, bytes len)
     }
     return memcmp_8(a + len - end_len, p_long_b, end_len);
 }
+
+void *runtime_memchr(const void *a, int c, bytes len)
+{
+    for (const char *p = a; len > 0; p++, len--)
+        if (*p == c)
+            return (void *)p;
+    return 0;
+}

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -87,6 +87,7 @@ void runtime_memcpy(void *a, const void *b, bytes len);
 void runtime_memset(u8 *a, u8 b, bytes len);
 
 int runtime_memcmp(const void *a, const void *b, bytes len);
+void *runtime_memchr(const void *a, int c, bytes len);
 
 static inline int runtime_strlen(const char *a)
 {

--- a/src/runtime/tuple.c
+++ b/src/runtime/tuple.c
@@ -125,6 +125,18 @@ boolean iterate(value e, binding_handler h)
     }
 }
 
+boolean is_composite(value v)
+{
+    switch (tagof(v)) {
+    case tag_table_tuple:
+    case tag_function_tuple:
+    case tag_vector:
+        return true;
+    default:
+        return false;
+    }
+}
+
 closure_function(1, 2, boolean, tuple_count_each,
                  int *, count,
                  value, s, value, v)
@@ -227,7 +239,7 @@ closure_function(2, 2, boolean, destruct_value_each,
                  value, v, boolean, recursive,
                  value, s, value, v)
 {
-    if (is_tuple(v) || is_vector(v)) {
+    if (is_composite(v)) {
         if (bound(recursive))
             destruct_value(v, true);
     } else if (v != null_value) {
@@ -238,7 +250,7 @@ closure_function(2, 2, boolean, destruct_value_each,
 
 void destruct_value(value v, boolean recursive)
 {
-    if (is_tuple(v) || is_vector(v))
+    if (is_composite(v))
         iterate(v, stack_closure(destruct_value_each, v, recursive));
     deallocate_value(v);
 }

--- a/src/runtime/tuple.h
+++ b/src/runtime/tuple.h
@@ -74,6 +74,8 @@ static inline boolean is_integer(value v)
     return tagof(v) == tag_integer;
 }
 
+boolean is_composite(value v);
+
 /* we're lax about typing here as these are sometimes used on alloca-wrapped buffers */
 static inline boolean u64_from_value(value v, u64 *result)
 {

--- a/src/unix/coredump.c
+++ b/src/unix/coredump.c
@@ -221,7 +221,7 @@ void coredump(thread t, struct siginfo *si, status_handler complete)
         return;
     }
     u64 doff = 0;
-    heap h = heap_general(get_kernel_heaps());
+    heap h = heap_locked(get_kernel_heaps());
     process p = t->p;
     status s = STATUS_OK;
 

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2871,7 +2871,7 @@ closure_function(1, 1, boolean, notrace_notify,
                  value, v)
 {
     notrace_configure(bound(p), false);
-    if (is_tuple(v) || is_vector(v))
+    if (is_composite(v))
         iterate(v, stack_closure(notrace_each, bound(p), true));
     return true;
 }
@@ -2881,7 +2881,7 @@ closure_function(1, 1, boolean, tracelist_notify,
                  value, v)
 {
     notrace_configure(bound(p), true);
-    if (is_tuple(v) || is_vector(v))
+    if (is_composite(v))
         iterate(v, stack_closure(notrace_each, bound(p), false));
     return true;
 }

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -533,7 +533,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     }
     filesystem_reserve(fs); /* because it hosts the current working directory */
     p->root_fs = p->cwd_fs = fs;
-    p->cwd = fs->get_inode(fs, root);
+    p->cwd = fs->get_inode(fs, filesystem_getroot(fs));
     p->process_root = root;
     p->fdallocator = create_id_heap(locked, locked, 0, infinity, 1, false);
     p->files = allocate_vector(locked, 64);
@@ -658,7 +658,7 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
     ftrace_enable();
 
     register_special_files(kernel_process);
-    init_syscalls(kernel_process->process_root);
+    init_syscalls(kernel_process);
     register_file_syscalls(linux_syscalls);
 #ifdef NET
     register_net_syscalls(linux_syscalls);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -1021,7 +1021,7 @@ static inline u64 iov_total_len(struct iovec *iov, int iovcnt)
 
 #define resolve_fd(__p, __fd) ({void *f ; if (!(f = fdesc_get(__p, __fd))) return set_syscall_error(current, EBADF); f;})
 
-void init_syscalls(tuple root);
+void init_syscalls(process p);
 void init_threads(process p);
 void init_futices(process p);
 

--- a/src/virtio/virtio.h
+++ b/src/virtio/virtio.h
@@ -6,5 +6,4 @@ void init_virtio_rng(kernel_heaps kh);
 void init_virtio_scsi(kernel_heaps kh, storage_attach a);
 void init_virtio_socket(kernel_heaps kh);
 
-void virtio_mmio_parse(kernel_heaps kh, const char *str, int len);
 void virtio_mmio_enum_devs(kernel_heaps kh);

--- a/src/virtio/virtio_mmio.c
+++ b/src/virtio/virtio_mmio.c
@@ -51,7 +51,9 @@ closure_function(1, 1, void, vtmmio_new_dev,
     list_push_back(&vtmmio_devices, &dev->l);
 }
 
-void virtio_mmio_parse(kernel_heaps kh, const char *str, int len)
+closure_function(1, 2, void, vtmmio_cmdline_parse,
+                 kernel_heaps, kh,
+                 const char *, str, int, len)
 {
     buffer b = alloca_wrap_buffer(str, len);
     int optname_len = buffer_strchr(b, '=');
@@ -86,12 +88,13 @@ void virtio_mmio_parse(kernel_heaps kh, const char *str, int len)
             .memsize = memsize,
             .irq = irq,
         };
-        apply(stack_closure(vtmmio_new_dev, kh), &adev);
+        apply(stack_closure(vtmmio_new_dev, bound(kh)), &adev);
     }
 }
 
 void virtio_mmio_enum_devs(kernel_heaps kh)
 {
+    cmdline_consume("virtio_mmio", stack_closure(vtmmio_cmdline_parse, kh));
     acpi_get_vtmmio_devs(stack_closure(vtmmio_new_dev, kh));
 }
 

--- a/src/x86_64/kernel_machine.c
+++ b/src/x86_64/kernel_machine.c
@@ -36,7 +36,7 @@ void interrupt_exit(void)
     lapic_eoi();
 }
 
-heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize)
+heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize, boolean locking)
 {
     heap h = heap_locked(kh);
     heap p = (heap)heap_physical(kh);
@@ -52,7 +52,9 @@ heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize)
     /* reserve area in virtual_huge */
     assert(id_heap_set_area(heap_virtual_huge(kh), tag_base, tag_length, true, true));
 
-    return allocate_mcache(h, backed, 5, find_order(pagesize) - 1, pagesize, false);
+    heap mc = allocate_mcache(h, backed, 5, find_order(pagesize) - 1, pagesize, false);
+    assert(mc != INVALID_ADDRESS);
+    return locking ? locking_heap_wrapper(h, mc) : mc;
 }
 
 void clone_frame_pstate(context_frame dest, context_frame src)

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -170,6 +170,9 @@ void install_gdt64_and_tss(void *tss_desc, void *tss, void *gdt, void *gdt_point
 #ifdef KERNEL
 /* locking constructs */
 #include <mutex.h>
+
+void cmdline_consume(const char *opt_name, cmdline_handler h);
+void boot_params_apply(tuple t);
 #endif
 
 /* device mmio region access */


### PR DESCRIPTION
This patch set adds support for changing arbitrary settings in the root tuple via the kernel command line (which is retrieved by the kernel when booting under AWS Firecracker on x86).
With these changes, it is possible for example to override the network settings when starting an instance from a given image (without modifying the image itself) by specifying those settings in the kernel command line ("boot_args" parameter in the Firecracker configuration file), as in the following example:
"en1.ipaddr=10.3.3.6 en1.netmask=255.255.0.0 en1.gateway=10.3.0.1".
In the above example, "en1" identifies the first network interface; if multiple interfaces are used (en2, en3, etc.), each of them can be configured independently.
Example to configure a static IPv6 address on the first network interface:
"en1.ip6addr=20::A8FC:FF:7600:AA"
Example to add an environment variable (or override its value if the variable is already present in the image):
"environment.VAR_NAME=VAR_VALUE"
Example to modify the program arguments:
"arguments.0=/bin/my-program arguments.1=--my-option"

The first 3 commits are fixes for issues that have been exposed by the last 2 commits; the fix in the first commit allows all available physical memory ranges to be used by the kernel, without requiring 2MB alignment of the range start.

Closes #1976