### PR TITLE
E2E tests: ruby: remove sinatra gem install and GEM_HOME env var

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -81,14 +81,6 @@ func cloudPrebuild(t *testing.T) {
 	}()
 }
 
-func rubyPrebuild(t *testing.T) {
-	effect, err := exec.Command("/bin/bash", "-c", "mkdir -p .ruby && export GEM_HOME=.ruby && if (gem install --help | grep -q -- \"--no-document\"); then gem install sinatra --no-document; else gem install sinatra --no-rdoc --no-ri; fi").CombinedOutput()
-	if err != nil {
-		t.Log(effect)
-		t.Fatal(err)
-	}
-}
-
 func rustPrebuild(t *testing.T) {
 	effect, err := exec.Command("/bin/bash", "-c", "rustc http_server.rs -o main").CombinedOutput()
 	if err != nil {
@@ -140,7 +132,7 @@ func testPackages(t *testing.T) {
 		{name: "node_v11.5.0", pkg: "eyberg/node:v11.5.0", dir: "node_v11.5.0", request: "http://0.0.0.0:8083"},
 		{name: "nginx_1.15.6", pkg: "eyberg/nginx:1.15.6", dir: "nginx_1.15.6", request: "http://0.0.0.0:8084"},
 		{name: "php_7.3.5", pkg: "eyberg/php:7.3.5", dir: "php_7.3.5", request: "http://0.0.0.0:9501"},
-		{name: "ruby_3.1.2", pkg: "eyberg/ruby:3.1.2", dir: "ruby_3.1.2", request: "http://0.0.0.0:4567", prebuild: rubyPrebuild},
+		{name: "ruby_3.1.2", pkg: "eyberg/ruby:3.1.2", dir: "ruby_3.1.2", request: "http://0.0.0.0:4567"},
 		{name: "go", dir: "go", request: "http://0.0.0.0:8080", elf: "main", prebuild: goPrebuild},
 		{name: "rust", dir: "rust", request: "http://0.0.0.0:8080", elf: "main", prebuild: rustPrebuild, nocross: true},
 	}

--- a/test/e2e/ruby_3.1.2/config.json
+++ b/test/e2e/ruby_3.1.2/config.json
@@ -1,9 +1,5 @@
 {
     "Args": ["myapp.rb"],
-    "Dirs": [".ruby"],
-    "ENV": {
-        "GEM_HOME": ".ruby"
-    },
     "RunConfig": {
         "Ports": ["4567"]
     },


### PR DESCRIPTION
The ruby_3.1.2 package already includes the sinatra gem, thus it is not necessary to install it locally in order to run a Ruby web server. This change removes the sinatra gem installation step in the Rubty e2e test; in addition, the GEM_HOME environment variable is being removed from the Ops configuration file because the Ruby package already provides a correct value for this variable (consistent with the contents of the package).
This change fixes a 'Sinatra could not start, the "rackup" gem was not found' error that occurs when trying to run the (locally installed) latest release of the sinatra gem during the e2e tests.