### PR TITLE
Kernel heaps: add page heap

### DIFF
--- a/platform/pc/boot/stage2.c
+++ b/platform/pc/boot/stage2.c
@@ -267,7 +267,7 @@ void newstack()
 
     setup_page_tables();
 
-    init_pagecache(h, h, 0, PAGESIZE);
+    init_pagecache(h, h, PAGESIZE);
     create_filesystem(h,
                       SECTOR_SIZE,
                       infinity,

--- a/src/boot/uefi.c
+++ b/src/boot/uefi.c
@@ -280,7 +280,7 @@ efi_status efi_main(void *image_handle, efi_system_table system_table)
             continue;
         uefi_debug("found boot filesystem at LBA 0x%lx, length 0x%lx sectors",
                    bootfs_part->lba_start, bootfs_part->nsectors);
-        init_pagecache(&general, &general, 0, PAGESIZE);
+        init_pagecache(&general, &general, PAGESIZE);
         create_filesystem(&general, SECTOR_SIZE, bootfs_part->nsectors * SECTOR_SIZE,
                           closure(&general, uefi_blkdev_read, block_io, bootfs_part->lba_start), true, 0,
                           closure(&general, uefi_bootfs_complete, &general, &aligned_heap, &options));

--- a/src/config.h
+++ b/src/config.h
@@ -65,12 +65,11 @@
 #define MEM_CLEAN_THRESHOLD (64 * MB)
 #define MEM_CLEAN_THRESHOLD_SHIFT   6
 #define PAGECACHE_SCAN_PERIOD_SECONDS 5
-#define PAGECACHE_MEMORY_RESERVE        (8 * MB)
-#define PAGECACHE_LOWMEM_MEMORY_RESERVE (4 * MB)
-#define USER_MEMORY_RESERVE (4 * MB)
+#define PAGEHEAP_MEMORY_RESERVE         (8 * MB)
+#define PAGEHEAP_LOWMEM_MEMORY_RESERVE  (4 * MB)
+#define PAGEHEAP_LOWMEM_PAGESIZE        (128*KB)
 #define LOW_MEMORY_THRESHOLD   (64 * MB)
 #define SG_FRAG_BYTE_THRESHOLD (128*KB)
-#define PAGECACHE_LOWMEM_CONTIGUOUS_PAGESIZE (128*KB)
 #define PAGECACHE_MAX_SG_ENTRIES    8192
 
 /* don't go below this minimum amount of physical memory when inflating balloon */

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -800,6 +800,7 @@ static inline u64 phys_from_linear_backed_virt(u64 virt)
 }
 
 void unmap_and_free_phys(u64 virtual, u64 length);
+void page_free_phys(u64 phys);
 
 #if !defined(BOOT)
 

--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -544,6 +544,27 @@ void unmap(u64 virtual, u64 length)
     unmap_pages(virtual, length);
 }
 
+closure_function(1, 1, boolean, page_dealloc,
+                 heap, pageheap,
+                 range, r)
+{
+    u64 virt = pagemem.pagevirt.start + r.start;
+    deallocate_u64(bound(pageheap), virt, range_span(r));
+    return true;
+}
+
+void unmap_and_free_phys(u64 virtual, u64 length)
+{
+    unmap_pages_with_handler(virtual, length,
+                             stack_closure(page_dealloc, (heap)get_kernel_heaps()->pages));
+}
+
+void page_free_phys(u64 phys)
+{
+    u64 virt = pagemem.pagevirt.start + phys;
+    deallocate_u64((heap)get_kernel_heaps()->pages, virt, PAGESIZE);
+}
+
 static boolean init_page_map(range phys, range *curr_virt, id_heap virt_heap, pageflags flags)
 {
     if (phys.end > range_span(*curr_virt)) {

--- a/src/kernel/pagecache.h
+++ b/src/kernel/pagecache.h
@@ -56,4 +56,4 @@ void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node
 pagecache_volume pagecache_allocate_volume(u64 length, int block_order);
 void pagecache_dealloc_volume(pagecache_volume pv);
 
-void init_pagecache(heap general, heap contiguous, heap physical, u64 pagesize);
+void init_pagecache(heap general, heap contiguous, u64 pagesize);

--- a/src/kernel/pagecache_internal.h
+++ b/src/kernel/pagecache_internal.h
@@ -28,7 +28,6 @@ typedef struct pagecache {
     int page_order;
     heap h;
     heap contiguous;
-    heap physical;
     heap completions;
     heap pp_heap;
 

--- a/src/runtime/kernel_heaps.h
+++ b/src/runtime/kernel_heaps.h
@@ -34,6 +34,10 @@ typedef struct kernel_heaps {
        of DMA memory. */
     backed_heap linear_backed;
 
+    /* Caching heap for allocations of single pages. Avoids complete exhaustion of physical memory,
+     * and minimizes memory fragmentation. */
+    caching_heap pages;
+
     /* The general heap is an mcache used for allocations of arbitrary
        sizes from 32B to 1MB. It is the heap that is closest to being
        a general-purpose allocator. Compatible with a malloc/free

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -981,15 +981,18 @@ closure_function(3, 1, boolean, vmap_remove_intersection,
     } else {
         /* tail only: move node start back */
         vmap_assert(rangemap_reinsert(pvmap, node, irange(ri.end, rn.end)));
-        match->node_offset += ri.end - rn.start;
     }
     if (bound(unmap)) {
         struct vmap k = altered_vmap_key(match, match->flags, ri.start - rn.start);
         k.node.r = ri;
         apply(bound(unmap), &k);
     }
-    if (!head && !tail)
-        deallocate_vmap_locked(pvmap, match);
+    if (!head) {
+        if (tail)
+            match->node_offset += ri.end - rn.start;
+        else
+            deallocate_vmap_locked(pvmap, match);
+    }
     vmap_paranoia_locked(pvmap);
     return true;
 }

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -330,7 +330,8 @@ void vmap_iterator(process p, vmap_handler vmh)
     vmap_lock(p);
     vmap vm = (vmap) rangemap_first_node(p->vmaps);
     while (vm != INVALID_ADDRESS) {
-        apply(vmh, vm);
+        if (!apply(vmh, vm))
+            break;
         vm = (vmap) rangemap_next_node(p->vmaps, &vm->node);
     }
     vmap_unlock(p);
@@ -1012,11 +1013,12 @@ static void vmap_unmap_page_range(process p, vmap k)
     }
 }
 
-closure_function(1, 1, void, vmap_unmap,
+closure_function(1, 1, boolean, vmap_unmap,
                  process, p,
                  vmap, v)
 {
     vmap_unmap_page_range(bound(p), v);
+    return true;
 }
 
 static void process_remove_range_locked(process p, range q, boolean unmap)

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -153,7 +153,7 @@ static sysreturn mounts_read(file f, void *dest, u64 length, u64 offset)
     return length;
 }
 
-closure_function(1, 1, void, maps_handler,
+closure_function(1, 1, boolean, maps_handler,
                  buffer, b,
                  vmap, map)
 {
@@ -173,6 +173,7 @@ closure_function(1, 1, void, maps_handler,
     }
 
     buffer_write_cstring(b, "\n");
+    return true;
 }
 
 static sysreturn maps_read(file f, void *dest, u64 length, u64 offset)

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -463,7 +463,7 @@ typedef struct vmap {
     .cache_node = __c,                              \
     .fd = __fd,                                     \
 }
-typedef closure_type(vmap_handler, void, vmap);
+typedef closure_type(vmap_handler, boolean, vmap);
 
 static inline sysreturn set_syscall_return(thread t, sysreturn val)
 {

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -298,7 +298,7 @@ int main(int argc, char **argv)
         dump_klog(fd);
 
     heap h = init_process_runtime();
-    init_pagecache(h, h, 0, PAGESIZE);
+    init_pagecache(h, h, PAGESIZE);
     create_filesystem(h,
                       SECTOR_SIZE,
                       infinity,

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -729,7 +729,7 @@ int main(int argc, char **argv)
         parser_feed(p, read_stdin(h));
     }
 
-    init_pagecache(h, h, 0, PAGESIZE);
+    init_pagecache(h, h, PAGESIZE);
     mkfs_write_status = closure(h, mkfs_write_handler);
 
     if (root && !empty_fs) {

--- a/tools/tfs-fuse.c
+++ b/tools/tfs-fuse.c
@@ -927,7 +927,7 @@ int main(int argc, char **argv)
     dfd = fd;
     --argc;
     h = init_process_runtime();
-    init_pagecache(h, h, 0, PAGESIZE);
+    init_pagecache(h, h, PAGESIZE);
     u64 length;
     u64 offset = get_fs_offset(fd, partition, false, &length);
     create_filesystem(h,


### PR DESCRIPTION
This new heap is a caching heap that allows allocating single memory pages, while avoiding complete exhaustion of physical memory and minimizing memory fragmentation. It is used by both the pagecache code (instead of a pagecache-specific caching heap) and the mmap code (instead of the page_backed heap), which now avoid accessing directly the physical heap. The page heap is drained by the MM service when the kernel is running out of memory.
This change fixes a memory fragmentation issue that occurs when the user process makes heavy use of map() and unmap() system calls and may cause failure to allocate 2MB chunks of memory (https://github.com/nanovms/ops/issues/1570#issuecomment-1895947857).

The first 2 commits refactor the mmap code to remove code duplication, the third commit fixes a bug in the mmap code.