### PR TITLE
Strings: remove unbounded memory access

### DIFF
--- a/klib/Makefile
+++ b/klib/Makefile
@@ -123,7 +123,6 @@ SRCS-mbedtls-crypto= \
 	$(MBEDTLS_DIR)/library/sha512.c \
 	$(MBEDTLS_DIR)/library/threading.c \
 	$(MBEDTLS_DIR)/library/version.c \
-	$(MBEDTLS_DIR)/library/version_features.c \
 	$(MBEDTLS_DIR)/library/xtea.c \
 
 SRCS-mbedtls-x509= \

--- a/klib/aws.h
+++ b/klib/aws.h
@@ -1,16 +1,16 @@
 #define AWS_ERR_TOKEN_EXPIRED   "ExpiredTokenException"
 
 boolean aws_metadata_available(void);
-void aws_metadata_get(heap h, const char *uri, buffer_handler handler);
+void aws_metadata_get(heap h, sstring uri, buffer_handler handler);
 
 static inline void aws_region_get(heap h, buffer_handler handler)
 {
-    aws_metadata_get(h, "/latest/meta-data/placement/region", handler);
+    aws_metadata_get(h, ss("/latest/meta-data/placement/region"), handler);
 }
 
 static inline void aws_hostname_get(heap h, buffer_handler handler)
 {
-    aws_metadata_get(h, "/latest/meta-data/hostname", handler);
+    aws_metadata_get(h, ss("/latest/meta-data/hostname"), handler);
 }
 
 typedef struct aws_cred {
@@ -23,5 +23,5 @@ void aws_cred_get(heap h, aws_cred_handler handler);
 
 void aws_req_set_date(tuple req, buffer b);
 
-buffer aws_req_sign(heap h, const char *region, const char *service, const char *method,
-                    tuple req, buffer body, const char *access_key, const char *secret);
+buffer aws_req_sign(heap h, sstring region, sstring service, sstring method,
+                    tuple req, buffer body, sstring access_key, sstring secret);

--- a/klib/mbedtls.c
+++ b/klib/mbedtls.c
@@ -233,7 +233,7 @@ int tls_set_cacert(void *cert, u64 len)
     mbedtls_x509_crt_init(&tls.cacert);
     int ret = mbedtls_x509_crt_parse(&tls.cacert, cert, len);
     if (ret < 0) {
-        rprintf("%s: cannot parse certificate (%d)\n", __func__, ret);
+        msg_err("cannot parse certificate (%d)\n", ret);
         return ret;
     }
     mbedtls_ssl_conf_ca_chain(&tls.conf, &tls.cacert, NULL);
@@ -249,7 +249,7 @@ int tls_connect(ip_addr_t *addr, u16 port, connection_handler ch)
     mbedtls_ssl_init(&conn->ssl);
     int ret = mbedtls_ssl_setup(&conn->ssl, &tls.conf);
     if (ret) {
-        rprintf("%s: cannot set up SSL context\n", __func__);
+        msg_err("cannot set up SSL context\n");
         goto err_ssl_setup;
     }
     conn->app_ch = ch;

--- a/klib/mbedtls_conf.h
+++ b/klib/mbedtls_conf.h
@@ -44,9 +44,6 @@ void mbedtls_free(void *ptr);
 #ifndef memcmp
 #define memcmp  runtime_memcmp
 #endif
-#ifndef strlen
-#define strlen  runtime_strlen
-#endif
 #ifndef strcmp
 #define strcmp  runtime_strcmp
 #endif

--- a/klib/ntp.c
+++ b/klib/ntp.c
@@ -3,7 +3,7 @@
 
 //#define NTP_DEBUG
 #ifdef NTP_DEBUG
-#define ntp_debug(x, ...) do {tprintf(sym(ntp), 0, x, ##__VA_ARGS__);} while(0)
+#define ntp_debug(x, ...) do {tprintf(sym(ntp), 0, ss(x), ##__VA_ARGS__);} while(0)
 #else
 #define ntp_debug(x, ...)
 #endif
@@ -72,7 +72,7 @@ struct ntp_sample {
 };
 
 typedef struct ntp_server {
-    char *addr;
+    sstring addr;
     u16 port;
     ip_addr_t ip_addr;
     struct ntp_ts last_transmit_time;
@@ -704,7 +704,7 @@ static void ntp_input(void *z, struct udp_pcb *pcb, struct pbuf *p,
     pbuf_free(p);
 }
 
-static void ntp_dns_cb(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
+static void ntp_dns_cb(sstring name, const ip_addr_t *ipaddr, void *callback_arg)
 {
     if (ipaddr) {
         ntp_server server = callback_arg;
@@ -780,11 +780,7 @@ static void ntp_server_add(heap h, buffer addr, u16 port)
     ntp_debug("adding server %b (port %d)\n", addr, port);
     ntp_server server = allocate(h, sizeof(*server));
     assert(server != INVALID_ADDRESS);
-    bytes addr_len = buffer_length(addr);
-    server->addr = allocate(h, addr_len + 1);
-    assert(server->addr != INVALID_ADDRESS);
-    runtime_memcpy(server->addr, buffer_ref(addr, 0), addr_len);
-    server->addr[addr_len] = '\0';
+    server->addr = buffer_to_sstring(addr);
     server->port = port;
     vector_push(ntp.servers, server);
 }

--- a/klib/ntp.c
+++ b/klib/ntp.c
@@ -899,7 +899,7 @@ int init(status_handler complete)
     }
     ntp.pollmin = 4;
     ntp.pollmax = 10;
-    value pollmin = get(root, sym_intern(ntp_poll_min, intern));
+    value pollmin = get(root, sym(ntp_poll_min));
     if (pollmin) {
         u64 interval;
         if (!u64_from_value(pollmin, &interval) || (interval < NTP_QUERY_INTERVAL_MIN) ||
@@ -911,7 +911,7 @@ int init(status_handler complete)
         if (interval > ntp.pollmax)
             ntp.pollmax = interval;
     }
-    value pollmax = get(root, sym_intern(ntp_poll_max, intern));
+    value pollmax = get(root, sym(ntp_poll_max));
     if (pollmax) {
         u64 interval;
         if (!u64_from_value(pollmax, &interval) || (interval < NTP_QUERY_INTERVAL_MIN) ||
@@ -929,7 +929,7 @@ int init(status_handler complete)
         }
     }
     ntp.reset_threshold = 0;
-    value reset_thresh = get(root, sym_intern(ntp_reset_threshold, intern));
+    value reset_thresh = get(root, sym(ntp_reset_threshold));
     if (reset_thresh) {
         u64 thresh;
         if (!u64_from_value(reset_thresh, &thresh) || (thresh > 0 && thresh < NTP_RESET_THRESHOLD_MIN)) {
@@ -939,7 +939,7 @@ int init(status_handler complete)
         ntp.reset_threshold = seconds(thresh);
     }
     ntp.max_corr_freq = PPM_SCALE(DEFAULT_MAX_SLEW_PPM);
-    value corr_freq = get(root, sym_intern(ntp_max_slew_ppm, intern));
+    value corr_freq = get(root, sym(ntp_max_slew_ppm));
     if (corr_freq) {
         u64 ppm;
         if (!u64_from_value(corr_freq, &ppm) || (ppm > 0 && ppm < NTP_MAX_SLEW_LIMIT)) {
@@ -949,7 +949,7 @@ int init(status_handler complete)
         ntp.max_corr_freq = PPM_SCALE(ppm);
     }
     ntp.max_base_freq = PPM_SCALE(DEFAULT_MAX_FREQ_PPM);
-    value base_freq = get(root, sym_intern(ntp_max_freq_ppm, intern));
+    value base_freq = get(root, sym(ntp_max_freq_ppm));
     if (base_freq) {
         u64 ppm;
         if (!u64_from_value(base_freq, &ppm) || (ppm > 0 && ppm < NTP_MAX_FREQ_LIMIT)) {

--- a/klib/radar.c
+++ b/klib/radar.c
@@ -391,7 +391,7 @@ static void telemetry_stats_send(void)
 {
     buffer b = allocate_buffer(telemetry.h, 128);
     if (b == INVALID_ADDRESS) {
-        rprintf("%s: failed to allocate buffer\n", __func__);
+        msg_err("failed to allocate buffer\n");
         return;
     }
     bprintf(b, "{\"bootID\":%ld,\"memUsed\":[", telemetry.boot_id);
@@ -402,7 +402,7 @@ static void telemetry_stats_send(void)
     storage_iterate(stack_closure(telemetry_vh, b, 0));
     buffer_write_cstring(b, "]}\r\n");
     if (!telemetry_send("/api/v1/machine-stats", b, 0)) {
-        rprintf("%s: failed to send stats\n", __func__);
+        msg_err("failed to send stats\n");
         deallocate_buffer(b);
     }
 }

--- a/klib/special_files.c
+++ b/klib/special_files.c
@@ -12,11 +12,11 @@ typedef struct specfiles_disks {
 
 closure_function(1, 4, void, disks_handler,
                  buffer, b,
-                 u8 *, uuid, const char *, label, filesystem, fs, inode, mount_point)
+                 u8 *, uuid, sstring, label, filesystem, fs, inode, mount_point)
 {
     buffer b = bound(b);
     buffer_write_cstring(b, "[\n");
-    if (label[0])
+    if (!sstring_is_empty(label))
         bprintf(b, "\tNAME=%s\n", label);
     if (uuid) {
         buffer_write_cstring(b, "\tUUID=");
@@ -79,7 +79,7 @@ int init(status_handler complete)
         spec_file_open open = closure(specfiles_heap, disks_open);
         if (open == INVALID_ADDRESS)
             error = true;
-        else if (!create_special_file("/sys/devices/disks", open, 0, 0)) {
+        else if (!create_special_file(ss("/sys/devices/disks"), open, 0, 0)) {
             deallocate_closure(open);
             error = true;
         }

--- a/klib/syslog.c
+++ b/klib/syslog.c
@@ -358,12 +358,9 @@ define_closure_function(0, 2, void, syslog_shutdown_completion,
     syslog_udp_flush();
 }
 
-closure_function(2, 2, boolean, syslog_cfg,
-                 void *, intern, void *, rprintf,
+closure_function(0, 2, boolean, syslog_cfg,
                  value, s, value, v)
 {
-    symbol (*intern)(string name) = bound(intern);
-    void (*rprintf)(const char *format, ...) = bound(rprintf);
     if (s == sym(file)) {
         if (!is_string(v)) {
             rprintf("invalid syslog file\n");
@@ -463,7 +460,7 @@ int init(status_handler complete)
     syslog.file_rotate = SYSLOG_FILE_ROTATE_DEFAULT;
     syslog.server_port = SYSLOG_UDP_PORT_DEFAULT;
 
-    if (!is_tuple(cfg) || !iterate(cfg, stack_closure(syslog_cfg, intern, rprintf))) {
+    if (!is_tuple(cfg) || !iterate(cfg, stack_closure(syslog_cfg))) {
         rprintf("invalid syslog configuration\n");
         return KLIB_INIT_FAILED;
     }

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -259,7 +259,7 @@ msg_sed=	SED	$@
 cmd_sed=	$(SED) -e 's/\#/%/' <$^ >$@
 
 msg_version=	VERSION	$@
-cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "const char * const gitversion = \"$(shell $(GIT) rev-parse HEAD)\";" >$@
+cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "\#include <runtime.h>\nconst sstring gitversion = ss_static_init(\"$(shell $(GIT) rev-parse HEAD)\");" >$@
 
 include ../../rules.mk
 

--- a/platform/pc/pci.c
+++ b/platform/pc/pci.c
@@ -30,7 +30,7 @@
 static int pci_cfgenable(pci_dev dev, int reg, int bytes)
 {
     pci_plat_debug("%s: dev %p, dev->bus %d, reg %d, bytes %d\n",
-                   __func__, dev, dev->bus, reg, bytes);
+                   func_ss, dev, dev->bus, reg, bytes);
     int dataport = 0;
 
     if (dev->bus <= PCI_BUSMAX && dev->slot <= PCI_SLOTMAX && dev->function <= PCI_FUNCMAX &&
@@ -46,7 +46,7 @@ static int pci_cfgenable(pci_dev dev, int reg, int bytes)
 u32 pci_cfgread(pci_dev dev, int reg, int bytes)
 {
     pci_plat_debug("%s: dev %p, dev->bus %d, reg %d, bytes %d\n",
-                   __func__, dev, dev->bus, reg, bytes);
+                   func_ss, dev, dev->bus, reg, bytes);
     u32 data = -1;
     int port;
 
@@ -70,7 +70,7 @@ u32 pci_cfgread(pci_dev dev, int reg, int bytes)
 void pci_cfgwrite(pci_dev dev, int reg, int bytes, u32 source)
 {
     pci_plat_debug("%s: dev %p, dev->bus %d, reg %d, bytes %d, source 0x%x\n",
-                   __func__, dev, dev->bus, reg, bytes, source);
+                   func_ss, dev, dev->bus, reg, bytes, source);
     int port;
 
     port = pci_cfgenable(dev, reg, bytes);
@@ -91,13 +91,13 @@ void pci_cfgwrite(pci_dev dev, int reg, int bytes, u32 source)
 
 u8 pci_bar_read_1(struct pci_bar *b, u64 offset)
 {
-    pci_plat_debug("%s: pci_bar %p, offset 0x%lx\n", __func__, b, offset);
+    pci_plat_debug("%s: pci_bar %p, offset 0x%lx\n", func_ss, b, offset);
     return b->type == PCI_BAR_MEMORY ? *(u8 *) (b->vaddr + offset) : in8(b->addr + offset);
 }
 
 void pci_bar_write_1(struct pci_bar *b, u64 offset, u8 val)
 {
-    pci_plat_debug("%s: pci_bar %p, offset 0x%lx, val 0x%x\n", __func__, b, offset, val);
+    pci_plat_debug("%s: pci_bar %p, offset 0x%lx, val 0x%x\n", func_ss, b, offset, val);
     if (b->type == PCI_BAR_MEMORY)
         *(u8 *) (b->vaddr + offset) = val;
     else
@@ -106,13 +106,13 @@ void pci_bar_write_1(struct pci_bar *b, u64 offset, u8 val)
 
 u16 pci_bar_read_2(struct pci_bar *b, u64 offset)
 {
-    pci_plat_debug("%s: pci_bar %p, offset 0x%lx\n", __func__, b, offset);
+    pci_plat_debug("%s: pci_bar %p, offset 0x%lx\n", func_ss, b, offset);
     return b->type == PCI_BAR_MEMORY ? *(u16 *) (b->vaddr + offset) : in16(b->addr + offset);
 }
 
 void pci_bar_write_2(struct pci_bar *b, u64 offset, u16 val)
 {
-    pci_plat_debug("%s: pci_bar %p, offset 0x%lx, val 0x%x\n", __func__, b, offset, val);
+    pci_plat_debug("%s: pci_bar %p, offset 0x%lx, val 0x%x\n", func_ss, b, offset, val);
     if (b->type == PCI_BAR_MEMORY)
         *(u16 *) (b->vaddr + offset) = val;
     else
@@ -121,13 +121,13 @@ void pci_bar_write_2(struct pci_bar *b, u64 offset, u16 val)
 
 u32 pci_bar_read_4(struct pci_bar *b, u64 offset)
 {
-    pci_plat_debug("%s: pci_bar %p, offset 0x%lx\n", __func__, b, offset);
+    pci_plat_debug("%s: pci_bar %p, offset 0x%lx\n", func_ss, b, offset);
     return b->type == PCI_BAR_MEMORY ? *(u32 *) (b->vaddr + offset) : in32(b->addr + offset);
 }
 
 void pci_bar_write_4(struct pci_bar *b, u64 offset, u32 val)
 {
-    pci_plat_debug("%s: pci_bar %p, offset 0x%lx, val 0x%x\n", __func__, b, offset, val);
+    pci_plat_debug("%s: pci_bar %p, offset 0x%lx, val 0x%x\n", func_ss, b, offset, val);
     if (b->type == PCI_BAR_MEMORY)
         *(u32 *) (b->vaddr + offset) = val;
     else
@@ -147,9 +147,9 @@ void pci_bar_write_8(struct pci_bar *b, u64 offset, u64 val)
         out64(b->addr + offset, val);
 }
 
-void pci_setup_non_msi_irq(pci_dev dev, thunk h, const char *name)
+void pci_setup_non_msi_irq(pci_dev dev, thunk h, sstring name)
 {
-    pci_plat_debug("%s: h %F, name %s\n", __func__, h, name);
+    pci_plat_debug("%s: h %F, name %s\n", func_ss, h, name);
 
     /* For maximum portability, the GSI should be retrieved via the ACPI _PRT method. */
     unsigned int gsi = pci_cfgread(dev, PCIR_INTERRUPT_LINE, 1);
@@ -159,7 +159,7 @@ void pci_setup_non_msi_irq(pci_dev dev, thunk h, const char *name)
 
 void pci_platform_init_bar(pci_dev dev, int bar)
 {
-    pci_plat_debug("%s: dev %p, %d:%d:%d, bar %d\n", __func__, dev,
+    pci_plat_debug("%s: dev %p, %d:%d:%d, bar %d\n", func_ss, dev,
                    dev->bus, dev->slot, dev->function, bar);
     u64 base = pci_cfgread(dev, PCIR_BAR(bar), 4);
     boolean is_io = (base & PCI_BAR_B_TYPE_MASK) == PCI_BAR_IOPORT;
@@ -193,7 +193,7 @@ void pci_platform_init_bar(pci_dev dev, int bar)
     }
 }
 
-u64 pci_platform_allocate_msi(pci_dev dev, thunk h, const char *name, u32 *address, u32 *data)
+u64 pci_platform_allocate_msi(pci_dev dev, thunk h, sstring name, u32 *address, u32 *data)
 {
     u64 v = allocate_interrupt();
     if (v == INVALID_PHYSICAL)

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -139,7 +139,7 @@ void reclaim_regions(void)
             unmap(e->base, e->length);
             if (!id_heap_add_range(heap_physical(get_kernel_heaps()), e->base, e->length))
                 halt("%s: add range for physical heap failed (%R)\n",
-                     __func__, irange(e->base, e->base + e->length));
+                     func_ss, irange(e->base, e->base + e->length));
         }
     }
     /* we're done with looking at e820 (and our custom) regions, so
@@ -501,13 +501,13 @@ void pvh_start(hvm_start_info start_info)
     init_service(0, 0);
 }
 
+RO_AFTER_INIT static struct console_driver serial_console_driver = {
+    .name = ss_static_init("serial"),
+    .write = serial_console_write,
+};
+
 void init_platform_devices(kernel_heaps kh)
 {
-    RO_AFTER_INIT static struct console_driver serial_console_driver = {
-        .name = "serial",
-        .write = serial_console_write,
-    };
-
     attach_console_driver(&serial_console_driver);
     vga_pci_register(kh);
     pci_discover(); // early PCI discover to configure VGA console
@@ -587,7 +587,7 @@ void detect_devices(kernel_heaps kh, storage_attach sa)
     init_virtio_rng(kh);
 }
 
-void cmdline_consume(const char *opt_name, cmdline_handler h)
+void cmdline_consume(sstring opt_name, cmdline_handler h)
 {
     for_regions(e) {
         if (e->type == REGION_CMDLINE) {

--- a/platform/riscv-virt/Makefile
+++ b/platform/riscv-virt/Makefile
@@ -218,7 +218,7 @@ msg_sed=	SED	$@
 cmd_sed=	$(SED) -e 's/\#/%/' <$^ >$@
 
 msg_version=	VERSION	$@
-cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "const char *gitversion = \"$(shell $(GIT) rev-parse HEAD)\";" >$@
+cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "\#include <runtime.h>\nconst sstring gitversion = ss_static_init(\"$(shell $(GIT) rev-parse HEAD)\");" >$@
 
 msg_xxd_r=	XXD_R	$@
 cmd_xxd_r=	$(XXD) -r $< $@

--- a/platform/riscv-virt/kernel_platform.h
+++ b/platform/riscv-virt/kernel_platform.h
@@ -25,9 +25,5 @@
 
 #define mmio_base_addr(x) ((u64)(DEVICE_BASE + DEV_BASE_ ##x))
 
-void early_debug(const char *s);
-void early_debug_u64(u64 n);
-void early_dump(void *p, unsigned long length);
-
 #include "sbi_ecall_interface.h"
 #endif

--- a/platform/riscv-virt/service.c
+++ b/platform/riscv-virt/service.c
@@ -145,13 +145,13 @@ void __attribute__((noreturn)) start(void *a0, void *dtb)
     while (1);
 }
 
+RO_AFTER_INIT static struct console_driver serial_console_driver = {
+    .name = ss_static_init("serial"),
+    .write = serial_console_write,
+};
+
 void init_platform_devices(kernel_heaps kh)
 {
-    RO_AFTER_INIT static struct console_driver serial_console_driver = {
-        .name = "serial",
-        .write = serial_console_write,
-    };
-
     attach_console_driver(&serial_console_driver);
 }
 

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -264,7 +264,7 @@ msg_sed=	SED	$@
 cmd_sed=	$(SED) -e 's/\#/%/' <$^ >$@
 
 msg_version=	VERSION	$@
-cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "const char * const gitversion = \"$(shell $(GIT) rev-parse HEAD)\";" >$@
+cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "\#include <runtime.h>\nconst sstring gitversion = ss_static_init(\"$(shell $(GIT) rev-parse HEAD)\");" >$@
 
 msg_xxd_r=	XXD_R	$@
 cmd_xxd_r=	$(XXD) -r $< $@

--- a/platform/virt/kernel_platform.h
+++ b/platform/virt/kernel_platform.h
@@ -37,7 +37,4 @@
 #ifndef __ASSEMBLY__
 #define mmio_base_addr(x) ((u64)(DEVICE_BASE + DEV_BASE_ ##x))
 
-void early_debug(const char *s);
-void early_debug_u64(u64 n);
-void early_dump(void *p, unsigned long length);
 #endif

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -327,7 +327,7 @@ void init_platform_devices(kernel_heaps kh)
     acpi_parse_spcr(stack_closure(plat_spcr_handler, kh, &console_driver));
     if (!console_driver) {
         console_driver = allocate_zero(heap_general(kh), sizeof(*console_driver));
-        console_driver->name = "serial";
+        console_driver->name = ss("serial");
         console_driver->write = serial_console_write;
     }
     attach_console_driver(console_driver);

--- a/src/aarch64/acpi.c
+++ b/src/aarch64/acpi.c
@@ -3,7 +3,7 @@
 #include <boot/uefi.h>
 #include <drivers/acpi.h>
 
-void acpi_register_irq_handler(int irq, thunk t, const char *name)
+void acpi_register_irq_handler(int irq, thunk t, sstring name)
 {
     register_interrupt(irq, t, name);
 }

--- a/src/aarch64/gic.c
+++ b/src/aarch64/gic.c
@@ -6,7 +6,7 @@
 
 //#define GIC_DEBUG
 #ifdef GIC_DEBUG
-#define gic_debug(x, ...) do {rprintf("%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#define gic_debug(x, ...) do {rprintf("%s: " x, func_ss, ##__VA_ARGS__);} while(0)
 #else
 #define gic_debug(x, ...)
 #endif
@@ -470,7 +470,7 @@ int init_gic(void)
         gic.v3_iface = true;
         break;
     default:
-        halt("%s: gic type %d from ID_AA64PFR0_EL1 not supported\n", __func__, gic_iface);
+        halt("%s: gic type %d from ID_AA64PFR0_EL1 not supported\n", func_ss, gic_iface);
     }
 
     if (gic.v3_iface) {

--- a/src/aarch64/kernel_machine.c
+++ b/src/aarch64/kernel_machine.c
@@ -28,7 +28,7 @@ struct tagheap {
 static void tag_dealloc(heap h, u64 a, bytes s)
 {
     struct tagheap *th = (struct tagheap *)h;
-    tag_debug("%s: tag %d, a 0x%lx, s 0x%lx\n", __func__, th->vtag >> VA_TAG_OFFSET, a, s);
+    tag_debug("%s: tag %d, a 0x%lx, s 0x%lx\n", func_ss, th->vtag >> VA_TAG_OFFSET, a, s);
     deallocate_u64(th->mh, a & MASK(VA_TAG_OFFSET), s);
 }
 
@@ -41,7 +41,7 @@ static u64 tag_alloc(heap h, bytes s)
     u64 a = u64_from_pointer(p);
     assert((a >> VA_TAG_OFFSET) == 0);
     a |= th->vtag;
-    tag_debug("%s: tag %d, s 0x%lx, a 0x%lx\n", __func__, th->vtag >> VA_TAG_OFFSET, s, a);
+    tag_debug("%s: tag %d, s 0x%lx, a 0x%lx\n", func_ss, th->vtag >> VA_TAG_OFFSET, s, a);
     return a;
 }
 
@@ -61,7 +61,7 @@ heap allocate_tagged_region(kernel_heaps kh, u64 tag, bytes pagesize, boolean lo
     th->h.allocated = 0;
     th->h.total = 0;
     th->h.management = 0;
-    tag_debug("%s: tag %d, bits 0x%lx, heap %p\n", __func__, tag, th->vtag, th);
+    tag_debug("%s: tag %d, bits 0x%lx, heap %p\n", func_ss, tag, th->vtag, th);
     return &th->h;
 }
 

--- a/src/aarch64/page.c
+++ b/src/aarch64/page.c
@@ -55,7 +55,7 @@ void init_mmu(range init_pt, u64 vtarget)
     page_init_debug("\n");
 
     if (field_from_u64(mmfr0, ID_AA64MMFR0_EL1_TGran4) == 15)
-        halt("%s: 4KB granule not supported\n", __func__);
+        halt("%s: 4KB granule not supported\n", func_ss);
 
     page_set_allowed_levels(0xe); /* mapping at levels 1-3 always allowed */
     init_page_initial_map(pointer_from_u64(init_pt.start), init_pt);

--- a/src/aarch64/rtc.c
+++ b/src/aarch64/rtc.c
@@ -66,12 +66,12 @@ u64 rtc_gettimeofday(void) {
     if (!rtc_detect())
         return 0;
     u64 seconds = RTCDR;
-    rtc_debug("%s: returning %ld seconds\n", __func__, seconds);
+    rtc_debug("%s: returning %ld seconds\n", func_ss, seconds);
     return seconds;
 }
 
 void rtc_settimeofday(u64 seconds) {
-    rtc_debug("%s: setting rtc to %ld seconds\n", __func__, seconds);
+    rtc_debug("%s: setting rtc to %ld seconds\n", func_ss, seconds);
     if (rtc_detect())
         RTCLR = seconds;
 }

--- a/src/aws/ena/ena.c
+++ b/src/aws/ena/ena.c
@@ -98,7 +98,8 @@ static int ena_enable_msix_and_set_admin_interrupts(struct ena_adapter *);
 static void ena_update_on_link_change(void *, struct ena_admin_aenq_entry *);
 static void unimplemented_aenq_handler(void *, struct ena_admin_aenq_entry *);
 
-static const char ena_version[] = DEVICE_NAME " " DRV_MODULE_NAME " v" DRV_MODULE_VERSION;
+static const sstring ena_version =
+    ss_static_init(DEVICE_NAME " " DRV_MODULE_NAME " v" DRV_MODULE_VERSION);
 
 static const ena_vendor_info_t ena_vendor_info_array[] = {
         { PCI_VENDOR_ID_AMAZON, PCI_DEV_ID_ENA_PF, 0 },
@@ -930,7 +931,7 @@ static int ena_request_mgmnt_irq(struct ena_adapter *adapter)
     irq = &adapter->irq_tbl[ENA_MGMNT_IRQ_IDX];
 
     if (pci_setup_msix(adapter->pdev, irq->vector, init_closure(&irq->th, ena_irq_handler, irq),
-                       "ena_mgmnt") == INVALID_PHYSICAL)
+                       ss("ena_mgmnt")) == INVALID_PHYSICAL)
         return ENA_COM_FAULT;
     return 0;
 }
@@ -948,7 +949,7 @@ static int ena_request_io_irq(struct ena_adapter *adapter)
     for (i = ENA_IO_IRQ_FIRST_IDX; i < adapter->msix_vecs; i++) {
         irq = &adapter->irq_tbl[i];
         if (pci_setup_msix(adapter->pdev, irq->vector, init_closure(&irq->th, ena_irq_handler, irq),
-                           "ena_io") == INVALID_PHYSICAL)
+                           ss("ena_io")) == INVALID_PHYSICAL)
             return ENA_COM_FAULT;
         ena_trace(NULL, ENA_INFO, "queue %d\n", i - ENA_IO_IRQ_FIRST_IDX);
     }
@@ -1358,7 +1359,7 @@ int ena_up(struct ena_adapter *adapter)
         adapter->requested_rx_ring_size,
         adapter->requested_tx_ring_size,
         (adapter->ena_dev->tx_mem_queue_type == ENA_ADMIN_PLACEMENT_POLICY_DEV) ?
-                "ENABLED" : "DISABLED");
+                ss("ENABLED") : ss("DISABLED"));
 
     rc = create_queues_with_size_backoff(adapter);
     if (unlikely(rc != 0)) {
@@ -1407,7 +1408,7 @@ static err_t ena_init(struct netif *netif)
     struct ena_adapter *adapter = netif->state;
 
     netif = &adapter->ifp;
-    netif->hostname = "uniboot";
+    netif->hostname = sstring_empty();
     netif->name[0] = 'e';
     netif->name[1] = 'n';
     netif->flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP;

--- a/src/aws/ena/ena_com/ena_eth_com.c
+++ b/src/aws/ena/ena_com/ena_eth_com.c
@@ -584,7 +584,7 @@ int ena_com_rx_pkt(struct ena_com_io_cq *io_cq, struct ena_com_io_sq *io_sq,
     /* Update SQ head ptr */
     io_sq->next_to_comp += nb_hw_desc;
 
-    ena_trc_dbg(ena_com_io_cq_to_ena_dev(io_cq), "[%s][QID#%d] Updating SQ head to: %d\n", __func__,
+    ena_trc_dbg(ena_com_io_cq_to_ena_dev(io_cq), "[QID#%d] Updating SQ head to: %d\n",
         io_sq->qid, io_sq->next_to_comp);
 
     /* Get rx flags from the last pkt */
@@ -620,8 +620,7 @@ int ena_com_add_single_rx_desc(struct ena_com_io_sq *io_sq, struct ena_com_buf *
     desc->req_id = req_id;
 
     ena_trc_dbg(ena_com_io_sq_to_ena_dev(io_sq),
-                "[%s] Adding single RX desc, Queue: %d, req_id: %d\n",
-                __func__, io_sq->qid, req_id);
+                "Adding single RX desc, Queue: %d, req_id: %d\n", io_sq->qid, req_id);
 
     desc->buff_addr_lo = (u32) ena_buf->paddr;
     desc->buff_addr_hi = ((ena_buf->paddr & GENMASK_ULL(io_sq->dma_addr_bits - 1, 32)) >> 32);

--- a/src/aws/ena/ena_com/ena_plat.h
+++ b/src/aws/ena/ena_com/ena_plat.h
@@ -86,7 +86,7 @@ typedef u64 uintptr_t;
     } while (0)
 
 #define ena_trace(ctx, level, fmt, args...)                     \
-    ena_trace_raw(ctx, level, "%s(): " fmt, __func__, ##args)
+    ena_trace_raw(ctx, level, "%s(): " fmt, func_ss, ##args)
 
 #define ena_trc_dbg(ctx, format, arg...)    \
     ena_trace(ctx, ENA_DBG, format, ##arg)

--- a/src/boot/elf.c
+++ b/src/boot/elf.c
@@ -14,7 +14,7 @@ closure_function(2, 5, boolean, kernel_elf_map,
                  u64, vaddr, u64, offset, u64, data_size, u64, bss_size, pageflags, flags)
 {
     boot_elf_debug("%s: vaddr 0x%lx, offset 0x%lx, data_size 0x%lx, bss_size 0x%lx, flags 0x%lx\n",
-                   __func__, vaddr, offset, data_size, bss_size, flags);
+                   func_ss, vaddr, offset, data_size, bss_size, flags);
     u64 map_start = vaddr & ~PAGEMASK;
     data_size += vaddr & PAGEMASK;
 
@@ -53,6 +53,6 @@ closure_function(2, 5, boolean, kernel_elf_map,
 
 void *load_kernel_elf(buffer b, heap bss_heap)
 {
-    boot_elf_debug("%s: b %p, bss_heap %p\n", __func__, b, bss_heap);
+    boot_elf_debug("%s: b %p, bss_heap %p\n", func_ss, b, bss_heap);
     return load_elf(b, 0, stack_closure(kernel_elf_map, b, bss_heap));
 }

--- a/src/devicetree/devicetree.h
+++ b/src/devicetree/devicetree.h
@@ -3,9 +3,6 @@
 #define dt_string(b, x) dtb_string(b, dt_u32(x))
 #define dt_get_prop_value(b, n, nm) dtb_read_value((b), (n), dtb_get_prop((b), (n), (nm)))
 
-#define dt_stringlist_foreach(v, c) \
-    for (char *c = v.data, *__ce = c + v.dlen; c < __ce; c += runtime_strlen(c) + 1)
-
 #define dt_reg_foreach(ri, r) \
     for (range r; dtb_reg_iterate(&(ri), &(r));)
 
@@ -43,9 +40,9 @@ typedef struct dt_value {
     } u;
 } dt_value;
 
-typedef closure_type(dt_node_handler, boolean, dt_node, char *);
+typedef closure_type(dt_node_handler, boolean, dt_node, sstring);
 
-char *dtb_string(void *dtb, u64 off);
+sstring dtb_string(void *dtb, u64 off);
 
 u32 dtb_read_u32(dt_prop p);
 u64 dtb_read_u64(dt_prop p);
@@ -53,13 +50,13 @@ dt_reg_iterator dtb_read_reg(void *dtb, dt_node n, dt_prop p);
 boolean dtb_reg_iterate(dt_reg_iterator *ri, range *r);
 range dtb_read_memory_range(void *dtb);
 
-dt_node dtb_find_node_by_path(void *dtb, char *path);
+dt_node dtb_find_node_by_path(void *dtb, sstring path);
 dt_node dtb_find_node_by_phandle(void *dtb, u32 phandle);
-int dtb_walk_node_children(void *dtb, dt_node n, char *match, dt_node_handler nh);
+int dtb_walk_node_children(void *dtb, dt_node n, sstring match, dt_node_handler nh);
 u32 dtb_blob_size(void *dtb);
 dt_node dtb_get_root(void *dtb);
 dt_node dtb_get_parent(void *dtb, dt_node n);
-dt_prop dtb_get_prop(void *dtb, dt_node n, char *pname);
+dt_prop dtb_get_prop(void *dtb, dt_node n, sstring pname);
 dt_value dtb_read_value(void *dtb, dt_node n, dt_prop p);
 
 void devicetree_dump(void *dtb);

--- a/src/drivers/acpi.c
+++ b/src/drivers/acpi.c
@@ -311,7 +311,7 @@ static ACPI_STATUS acpi_ged_res_probe(ACPI_RESOURCE *resource, void *context)
             }
             thunk handler = closure(acpi_heap, acpi_ged_handler, event, gsi);
             assert(handler != INVALID_ADDRESS);
-            acpi_register_irq_handler(gsi, handler, "acpi-ged");
+            acpi_register_irq_handler(gsi, handler, ss("acpi-ged"));
         }
         break;
     }
@@ -451,7 +451,7 @@ void AcpiOsFree(void *memory)
 
 void *AcpiOsMapMemory(ACPI_PHYSICAL_ADDRESS where, ACPI_SIZE length)
 {
-    acpi_debug("%s(0x%lx, %ld)", __func__, where, length);
+    acpi_debug("%s(0x%lx, %ld)", func_ss, where, length);
     u64 page_offset = where & PAGEMASK;
     length += page_offset;
     heap vh = (heap)heap_virtual_page(get_kernel_heaps());
@@ -465,7 +465,7 @@ void *AcpiOsMapMemory(ACPI_PHYSICAL_ADDRESS where, ACPI_SIZE length)
 
 void AcpiOsUnmapMemory(void *where, ACPI_SIZE length)
 {
-    acpi_debug("%s(0x%lx, %ld)", __func__, where, length);
+    acpi_debug("%s(0x%lx, %ld)", func_ss, where, length);
     u64 page_offset = u64_from_pointer(where) & PAGEMASK;
     where -= page_offset;
     length = pad(length + page_offset, PAGESIZE);
@@ -562,7 +562,7 @@ void AcpiOsStall(UINT32 usecs)
 
 void AcpiOsSleep(UINT64 msecs)
 {
-    halt("%s not supported\n", __func__);
+    halt("%s not supported\n", func_ss);
 }
 
 ACPI_STATUS AcpiOsSignal(UINT32 function, void *info)
@@ -572,10 +572,7 @@ ACPI_STATUS AcpiOsSignal(UINT32 function, void *info)
 
 void AcpiOsPrintf(const char *fmt, ...)
 {
-    /* We can't use the printf-style functions of the kernel because they treat the %X format
-     * identifier differently from the standard printf-style functions. Just print the format
-     * string, it may still be helpful if any error messages are generated. */
-    rputs(fmt);
+    /* We don't handle null-terminated strings, so don't parse the format string. */
 }
 
 ACPI_STATUS AcpiOsTableOverride(ACPI_TABLE_HEADER *existing_table, ACPI_TABLE_HEADER **new_table)
@@ -733,7 +730,7 @@ UINT32 AcpiOsInstallInterruptHandler(UINT32 interrupt_number, ACPI_OSD_HANDLER s
     thunk irq_handler = closure(acpi_heap, acpi_irq, service_routine, context);
     if (irq_handler == INVALID_ADDRESS)
         return AE_NO_MEMORY;
-    acpi_register_irq_handler(interrupt_number, irq_handler, "ACPI");
+    acpi_register_irq_handler(interrupt_number, irq_handler, ss("ACPI"));
     return AE_OK;
 }
 

--- a/src/drivers/acpi.h
+++ b/src/drivers/acpi.h
@@ -160,7 +160,7 @@ typedef closure_type(spcr_handler, void, u8, u64);
 void init_acpi(kernel_heaps kh);
 void init_acpi_tables(kernel_heaps kh);
 void acpi_save_rsdp(u64 rsdp);
-void acpi_register_irq_handler(int irq, thunk t, const char *name);
+void acpi_register_irq_handler(int irq, thunk t, sstring name);
 boolean acpi_walk_madt(madt_handler mh);
 boolean acpi_walk_mcfg(mcfg_handler mh);
 boolean acpi_parse_spcr(spcr_handler h);

--- a/src/drivers/ata.c
+++ b/src/drivers/ata.c
@@ -87,25 +87,21 @@ struct ata {
 static inline u8 ata_in8(struct ata *dev, int reg)
 {
     u8 val = in8(dev->reg_port[reg]);
-    //ata_debug("%s: reg %d: port 0x%x -> 0x%x\n", __func__, reg, dev->reg_port[reg], val);
     return val;
 }
 
 static inline void ata_ins32(struct ata *dev, int reg, void *addr, u32 count)
 {
-    //ata_debug("%s: reg %d: port 0x%x -> %p/%d\n", __func__, reg, dev->reg_port[reg], addr, count);
     ins32(dev->reg_port[reg], addr, count);
 }
 
 static void ata_out8(struct ata *dev, int reg, u8 val)
 {
-    //ata_debug("%s: reg %d: port 0x%x <- 0x%x\n", __func__, reg, dev->reg_port[reg], val);
     out8(dev->reg_port[reg], val);
 }
 
 static void ata_outs32(struct ata *dev, int reg, const void *addr, u32 count)
 {
-    //ata_debug("%s: reg %d: port 0x%x <- %p/%d\n", __func__, reg, dev->reg_port[reg], addr, count);
     outs32(dev->reg_port[reg], addr, count);
 }
 

--- a/src/drivers/console.c
+++ b/src/drivers/console.c
@@ -78,7 +78,7 @@ closure_function(1, 2, boolean, config_console_each,
     case '-':
         list_foreach(&console_drivers, e) {
             struct console_driver *d = struct_from_list(e, struct console_driver *, l);
-            if (!buffer_compare_with_cstring(b, d->name))
+            if (buffer_compare_with_sstring(b, d->name))
                 continue;
             list_delete(e);
             if (op == '-') {

--- a/src/drivers/console.h
+++ b/src/drivers/console.h
@@ -2,7 +2,7 @@ struct console_driver {
     struct list l;
     void (*write)(void *d, const char *s, bytes count);
     void (*config)(void *d, tuple r);
-    char *name;
+    sstring name;
     boolean disabled;
 };
 

--- a/src/drivers/dmi.h
+++ b/src/drivers/dmi.h
@@ -7,4 +7,4 @@ enum dmi_field {
 
 extern u64 smbios_entry_point;
 
-const char *dmi_get_string(enum dmi_field field);
+sstring dmi_get_string(enum dmi_field field);

--- a/src/drivers/gve.c
+++ b/src/drivers/gve.c
@@ -596,10 +596,10 @@ static boolean gve_init_interrupts(gve adapter)
     if (msix_avail < 3) /* TX irq, RX irq, management irq */
         return false;
     if (pci_setup_msix(adapter->pdev, 2, init_closure(&adapter->mgmt_irq_handler, gve_mgmt_irq),
-                       "gve_mgmt") == INVALID_PHYSICAL)
+                       ss("gve_mgmt")) == INVALID_PHYSICAL)
         goto error;
     if (pci_setup_msix(adapter->pdev, 1, init_closure(&adapter->rx.irq_handler, gve_rx_irq),
-                       "gve_rx") == INVALID_PHYSICAL)
+                       ss("gve_rx")) == INVALID_PHYSICAL)
         goto err_disable_mgmt;
     return true;
   err_disable_mgmt:
@@ -828,7 +828,7 @@ static err_t gve_if_init(struct netif *netif)
 {
     gve adapter = netif->state;
     netif = &adapter->net_if;
-    netif->hostname = 0;
+    netif->hostname = sstring_empty();
     netif->name[0] = 'e';
     netif->name[1] = 'n';
     netif->mtu = adapter->mtu;

--- a/src/drivers/netconsole.c
+++ b/src/drivers/netconsole.c
@@ -59,17 +59,13 @@ static void netconsole_config(void *_d, tuple r)
     }
 
     buffer dst_ip = get(r, sym(netconsole_ip));
-    char *s = dst_ip ? buffer_ref(dst_ip, 0) : DEFAULT_IP;
-    bytes len = dst_ip ? buffer_length(dst_ip) : runtime_strlen(DEFAULT_IP);
+    sstring b = dst_ip ? buffer_to_sstring(dst_ip) : ss(DEFAULT_IP);
 
-    if (len > IPADDR_STRLEN_MAX) {
+    if (b.len > IPADDR_STRLEN_MAX) {
         msg_err("ip address too long\n");
         return;
     }
 
-    char b[IPADDR_STRLEN_MAX+1];
-    runtime_memcpy(b, s, len);
-    b[len] = 0;
     if (!ipaddr_aton(b, &nd->dst_ip)) {
         msg_err("failed to translate ip address\n");
         return;
@@ -96,7 +92,7 @@ void netconsole_register(kernel_heaps kh, console_attach a)
     assert(nd != INVALID_ADDRESS);
     nd->h = h;
     nd->c.write = netconsole_write;
-    nd->c.name = "net";
+    nd->c.name = ss("net");
     nd->c.disabled = true;
     nd->c.config = netconsole_config;
     apply(a, &nd->c);

--- a/src/drivers/netconsole.c
+++ b/src/drivers/netconsole.c
@@ -63,7 +63,7 @@ static void netconsole_config(void *_d, tuple r)
     bytes len = dst_ip ? buffer_length(dst_ip) : runtime_strlen(DEFAULT_IP);
 
     if (len > IPADDR_STRLEN_MAX) {
-        msg_err("%s: ip address too long\n");
+        msg_err("ip address too long\n");
         return;
     }
 
@@ -71,18 +71,18 @@ static void netconsole_config(void *_d, tuple r)
     runtime_memcpy(b, s, len);
     b[len] = 0;
     if (!ipaddr_aton(b, &nd->dst_ip)) {
-        msg_err("%s: failed to translate ip address\n");
+        msg_err("failed to translate ip address\n");
         return;
     }
 
     buffer dst_port = get(r, sym(netconsole_port));
     u64 port = DEFAULT_PORT;
     if (dst_port && !parse_int(dst_port, 10, &port)) {
-        msg_err("%s: failed to parse port\n");
+        msg_err("failed to parse port\n");
         return;
     }
     if (port >= U64_FROM_BIT(16)) {
-        msg_err("%s: port out of range\n");
+        msg_err("port out of range\n");
         return;
     }
     nd->port = (u16)port;

--- a/src/drivers/ns16550.c
+++ b/src/drivers/ns16550.c
@@ -25,7 +25,7 @@ struct console_driver *ns16550_console_init(kernel_heaps kh, void *base)
     ns16550_console console = allocate(heap_general(kh), sizeof(*console));
     console->addr = base;
     zero(&console->driver, sizeof(console->driver));
-    console->driver.name = "16550";
+    console->driver.name = ss("16550");
     console->driver.write = ns16550_write;
     return &console->driver;
 }

--- a/src/drivers/nvme.c
+++ b/src/drivers/nvme.c
@@ -387,7 +387,7 @@ define_closure_function(3, 3, void, nvme_io,
     nvme n = bound(n);
     u32 namespace = bound(namespace);
     boolean write = bound(write);
-    nvme_debug("[%d] %s %R", namespace, write ? "write" : "read", blocks);
+    nvme_debug("[%d] %c %R", namespace, write ? 'w' : 'r', blocks);
     nvme_ioreq req = nvme_get_ioreq(n);
     if (req == INVALID_ADDRESS) {
         apply(sh, timm("result", "request allocation failed"));

--- a/src/fs/9p.h
+++ b/src/fs/9p.h
@@ -29,7 +29,7 @@ struct p9_string {
     char str[0];
 } __attribute__((packed));
 
-#define p9_strlen(str)  (2 + runtime_strlen(str))
+#define p9_strlen(str)  (2 + (str).len)
 #define p9_buflen(buf)  (2 + buffer_length(buf))
 
 enum p9_msg_t {
@@ -370,9 +370,9 @@ union p9_write_resp {
 
 void p9_create_fs(heap h, void *transport, boolean readonly, filesystem_complete complete);
 
-void p9_strcpy(struct p9_string *dest, const char *str);
+void p9_strcpy(struct p9_string *dest, sstring str);
 void p9_bufcpy(struct p9_string *dest, buffer b);
-int p9_strcmp(struct p9_string *s1, const char *s2);
+int p9_strcmp(struct p9_string *s1, sstring s2);
 
 fs_status p9_parse_minimal_resp(u8 req_type, union p9_minimal_resp *resp, u32 resp_len);
 fs_status p9_parse_qid_resp(u8 req_type, union p9_qid_resp *resp, u32 resp_len, u64 *qid);

--- a/src/fs/fs.c
+++ b/src/fs/fs.c
@@ -183,7 +183,8 @@ void filesystem_read_linear(fsfile f, void *dest, range q, io_status_handler io_
 {
     sg_list sg = allocate_sg_list();
     if (sg == INVALID_ADDRESS) {
-        apply(io_complete, timm("result", "failed to allocate sg list",
+        status s = timm("result", "failed to allocate sg list");
+        apply(io_complete, timm_append(s,
                                 "fsstatus", "%d", FS_STATUS_NOMEM), 0);
         return;
     }
@@ -225,8 +226,10 @@ void filesystem_read_entire(filesystem fs, tuple t, heap bufheap, buffer_handler
              t, bufheap, c, sh);
     fsfile f;
     fs_status fss = fs->get_fsfile(fs, t, &f);
+    status s;
     if ((fss != FS_STATUS_OK) || !f) {
-        apply(sh, timm("result", "no such file %v", t,
+        s = timm("result", "no such file %v", t);
+        apply(sh, timm_append(s,
                        "fsstatus", "%d", fss));
         return;
     }
@@ -245,7 +248,8 @@ void filesystem_read_entire(filesystem fs, tuple t, heap bufheap, buffer_handler
                       closure(fs->h, read_entire_complete, sg, c, b, f, sh));
     return;
   alloc_fail:
-    apply(sh, timm("result", "allocation failure",
+    s = timm("result", "allocation failure");
+    apply(sh, timm_append(s,
                    "fsstatus", "%d", FS_STATUS_NOMEM));
     return;
 }
@@ -275,7 +279,8 @@ void filesystem_write_linear(fsfile f, void *src, range q, io_status_handler io_
 {
     sg_list sg = allocate_sg_list();
     if (sg == INVALID_ADDRESS) {
-        apply(io_complete, timm("result", "failed to allocate sg list",
+        status s = timm("result", "failed to allocate sg list");
+        apply(io_complete, timm_append(s,
                                 "fsstatus", "%d", FS_STATUS_NOMEM), 0);
         return;
     }
@@ -283,7 +288,8 @@ void filesystem_write_linear(fsfile f, void *src, range q, io_status_handler io_
     sg_buf sgb = sg_list_tail_add(sg, length);
     if (sgb == INVALID_ADDRESS) {
         deallocate_sg_list(sg);
-        apply(io_complete, timm("result", "failed to allocate sg buf",
+        status s = timm("result", "failed to allocate sg buf");
+        apply(io_complete, timm_append(s,
                                 "fsstatus", "%d", FS_STATUS_NOMEM), 0);
         return;
     }

--- a/src/fs/tfs.h
+++ b/src/fs/tfs.h
@@ -10,7 +10,7 @@ extern io_status_handler ignore_io_status;
 #define MIN_EXTENT_ALLOC_SIZE   (1 * MB)
 
 status filesystem_probe(u8 *first_sector, u8 *uuid, char *label);
-const char *filesystem_get_label(filesystem fs);
+sstring filesystem_get_label(filesystem fs);
 void filesystem_get_uuid(filesystem fs, u8 *uuid);
 
 void create_filesystem(heap h,
@@ -18,7 +18,7 @@ void create_filesystem(heap h,
                        u64 size,
                        storage_req_handler req_handler,
                        boolean ro,
-                       const char *label,
+                       sstring label,
                        filesystem_complete complete);
 void destroy_filesystem(filesystem fs);
 
@@ -28,7 +28,7 @@ tfsfile allocate_fsfile(tfs fs, tuple md);
 fs_status filesystem_write_tuple(tfs fs, tuple t);
 fs_status filesystem_write_eav(tfs fs, tuple t, symbol a, value v, boolean cleanup);
 
-fs_status filesystem_mkentry(filesystem fs, tuple cwd, const char *fp, tuple entry,
+fs_status filesystem_mkentry(filesystem fs, tuple cwd, sstring fp, tuple entry,
     boolean persistent, boolean recursive);
-fs_status filesystem_mkdirpath(filesystem fs, tuple cwd, const char *fp,
+fs_status filesystem_mkdirpath(filesystem fs, tuple cwd, sstring fp,
         boolean persistent);

--- a/src/gdb/gdbstub.c
+++ b/src/gdb/gdbstub.c
@@ -3,7 +3,7 @@
 
 //#define GDB_DEBUG
 #ifdef GDB_DEBUG
-#define gdb_debug(x, ...) do {tprintf(sym(gdb), 0, x, ##__VA_ARGS__);} while(0)
+#define gdb_debug(x, ...) do {tprintf(sym(gdb), 0, ss(x), ##__VA_ARGS__);} while(0)
 #else
 #define gdb_debug(...)
 #endif
@@ -77,7 +77,7 @@ static boolean return_offsets(gdb g, buffer in, string out)
 
 static boolean return_supported(gdb g, buffer in, string out)
 {
-    if (buffer_strstr(in, "multiprocess+")) {
+    if (buffer_strstr(in, ss("multiprocess+"))) {
         g->multiprocess = true;
         bprintf(out, "multiprocess+");
     }
@@ -141,10 +141,12 @@ static boolean extra_info(gdb g, buffer in, string out)
         return true;
     }
     // XXX is there a better way to communicate status?
+    sstring status;
     if (t->syscall && t->syscall->uc.blocked_on)
-        mem2hex(out, "Blocked", strlen("Blocked"));
+        status = ss("Blocked");
     else
-        mem2hex(out, "Runnable", strlen("Runnable"));
+        status = ss("Runnable");
+    mem2hex(out, status.ptr, status.len);
     return true;
 }
 static struct handler query_handler[] = {

--- a/src/gdb/gdbtcp.c
+++ b/src/gdb/gdbtcp.c
@@ -12,7 +12,7 @@ closure_function(1, 1, status, gdb_send,
     /* invoked exclusively by gdbserver_input with lwIP lock held */
     err_t err = tcp_write(bound(g)->p, buffer_ref(b, 0), buffer_length(b), TCP_WRITE_FLAG_COPY);
     if (err != ERR_OK)
-        return timm("result", "%s: tcp_write returned with error %d", __func__, err);
+        return timm("result", "%s: tcp_write returned with error %d", func_ss, err);
     return STATUS_OK;
 }
 

--- a/src/http/http.h
+++ b/src/http/http.h
@@ -26,12 +26,12 @@ status send_http_chunk(http_responder out, buffer c);
 status send_http_chunked_response(http_responder out, tuple t);
 status send_http_response(http_responder out, tuple t, buffer c);
 
-extern const char * const http_request_methods[];
+extern const sstring http_request_methods[];
 
 typedef struct http_listener *http_listener;
 typedef closure_type(http_request_handler, void, http_method, http_responder, value);
 
-void http_register_uri_handler(http_listener hl, const char *uri, http_request_handler each);
+void http_register_uri_handler(http_listener hl, sstring uri, http_request_handler each);
 void http_register_default_handler(http_listener hl, http_request_handler each);
 connection_handler connection_handler_from_http_listener(http_listener hl);
 http_listener allocate_http_listener(heap h, u16 port);

--- a/src/hyperv/netvsc/netvsc.c
+++ b/src/hyperv/netvsc/netvsc.c
@@ -211,7 +211,7 @@ retry_send:
         netvsc_xmit_completion(packet);
 
         // TODO - error code?
-        netvsc_debug("%s: hv_rf_on_send() failed %d times, giving up", __func__, retries);
+        netvsc_debug("%s: hv_rf_on_send() failed %d times, giving up", func_ss, retries);
         return ERR_TIMEOUT;
     }
 
@@ -229,7 +229,7 @@ define_closure_function(0, 1, u64, hn_mem_cleaner,
 static err_t
 vmxif_init(struct netif *netif)
 {
-    netif->hostname = "uniboot"; // from config
+    netif->hostname = sstring_empty();
 
     netif->name[0] = DEVICE_NAME[0];
     netif->name[1] = DEVICE_NAME[1];
@@ -282,7 +282,7 @@ netvsc_attach(kernel_heaps kh, hv_device* device)
               ethernet_input);
 
     mm_register_mem_cleaner(init_closure(&hn->mem_cleaner, hn_mem_cleaner));
-    netvsc_debug("%s: hwaddr %02x:%02x:%02x:%02x:%02x:%02x", __func__,
+    netvsc_debug("%s: hwaddr %02x:%02x:%02x:%02x:%02x:%02x", func_ss,
                  netif->hwaddr[0], netif->hwaddr[1], netif->hwaddr[2],
                  netif->hwaddr[3], netif->hwaddr[4], netif->hwaddr[5]);
     return STATUS_OK;

--- a/src/hyperv/vmbus/hyperv.c
+++ b/src/hyperv/vmbus/hyperv.c
@@ -262,7 +262,7 @@ hyperv_detect(kernel_heaps kh) {
     } else if (init_lapic_timer(&ct, &per_cpu_init)) {
         hyperv_debug("defaulting to (suboptimal) lapic timer\n");
     } else {
-        halt("%s: no timer available\n", __func__);
+        halt("%s: no timer available\n", func_ss);
     }
 
     register_platform_clock_timer(ct, per_cpu_init);

--- a/src/hyperv/vmbus/vmbus.c
+++ b/src/hyperv/vmbus/vmbus.c
@@ -549,7 +549,7 @@ vmbus_attach(kernel_heaps kh, vmbus_dev *result)
     dev->vmbus_idtvec = allocate_interrupt();
     vmbus_debug("interrupt vector %d; registering", dev->vmbus_idtvec);
     dev->vmbus_intr_handler = closure(dev->general, vmbus_interrupt, dev);
-    register_interrupt(dev->vmbus_idtvec, dev->vmbus_intr_handler, "vmbus");
+    register_interrupt(dev->vmbus_idtvec, dev->vmbus_intr_handler, ss("vmbus"));
 
     dev->poll_mode = true;
 

--- a/src/hyperv/vmbus/vmbus_et.c
+++ b/src/hyperv/vmbus/vmbus_et.c
@@ -65,7 +65,7 @@ hyperv_sbintime2count(timestamp time)
 void
 vmbus_et_intr(void)
 {
-    vmbus_timer_debug("%s\n", __func__);
+    vmbus_timer_debug("%s\n", func_ss);
     schedule_timer_service();
 }
 

--- a/src/kernel/clock.c
+++ b/src/kernel/clock.c
@@ -2,7 +2,7 @@
 
 //#define CLOCK_DEBUG
 #ifdef CLOCK_DEBUG
-#define clock_debug(x, ...) do {tprintf(sym(clock), 0, x, ##__VA_ARGS__);} while(0)
+#define clock_debug(x, ...) do {tprintf(sym(clock), 0, ss(x), ##__VA_ARGS__);} while(0)
 #else
 #define clock_debug(x, ...)
 #endif
@@ -91,7 +91,7 @@ void clock_step_rtc(s64 step)
 void clock_reset_rtc(timestamp wallclock_now)
 {
     clock_debug("%s: now %T, wallclock_now %T\n",
-                __func__, now(CLOCK_ID_REALTIME), wallclock_now);
+                func_ss, now(CLOCK_ID_REALTIME), wallclock_now);
     timestamp n = now(CLOCK_ID_REALTIME);
     rtc_settimeofday(sec_from_timestamp(wallclock_now));
     notify_unix_timers_of_rtc_change();

--- a/src/kernel/elf.c
+++ b/src/kernel/elf.c
@@ -34,7 +34,7 @@ void elf_symbols(buffer elf, elf_sym_handler each)
     ELF_CHECK_PTR(elfh, Elf64_Ehdr);
     Elf64_Shdr *section_names = buffer_ref(elf, elfh->e_shoff + elfh->e_shstrndx * elfh->e_shentsize);
     ELF_CHECK_PTR(section_names, Elf64_Shdr);
-    if (elf_string(elf, section_names, section_names->sh_size) > (char*)elf_end)
+    if (section_names->sh_offset + section_names->sh_size > buffer_length(elf))
         goto out_elf_fail;
 
     Elf64_Shdr *symbols =0 , *symbol_strings =0;
@@ -196,7 +196,7 @@ boolean elf_plt_get(buffer elf, u64 *addr, u64 *offset, u64 *size)
     void *elf_end = buffer_end(elf);
     Elf64_Shdr *section_names = buffer_ref(elf, e->e_shoff + e->e_shstrndx * e->e_shentsize);
     ELF_CHECK_PTR(section_names, Elf64_Shdr);
-    if (elf_string(elf, section_names, section_names->sh_size) > (char*)elf_end)
+    if (section_names->sh_offset + section_names->sh_size > buffer_length(elf))
         goto out_elf_fail;
     Elf64_Shdr *plt_section = 0;
     char *name;

--- a/src/kernel/elf64.h
+++ b/src/kernel/elf64.h
@@ -259,9 +259,9 @@ typedef closure_type(elf_map_handler, boolean, u64 /* vaddr */, u64 /* buffer va
                      u64 /* data size */, u64 /* bss size */, pageflags /* flags */);
 typedef closure_type(elf_loader, void, u64 /* offset */, u64 /* length */, void * /* dest */,
                      status_handler);
-typedef closure_type(elf_sym_handler, void, char *, u64, u64, u8);
-typedef closure_type(elf_sym_resolver, void *, const char *);
-char *elf_string(buffer elf, Elf64_Shdr *string_section, u64 offset);
+typedef closure_type(elf_sym_handler, void, sstring, u64, u64, u8);
+typedef closure_type(elf_sym_resolver, void *, sstring);
+sstring elf_string(buffer elf, Elf64_Shdr *string_section, u64 offset);
 void elf_symbols(buffer elf, elf_sym_handler each);
 boolean elf_dyn_parse(buffer elf, Elf64_Shdr **symtab, Elf64_Shdr **strtab, Elf64_Rela **reltab,
                       int *relcount);

--- a/src/kernel/flush.c
+++ b/src/kernel/flush.c
@@ -213,7 +213,7 @@ flush_entry get_page_flush_entry(void)
 void init_flush(heap h)
 {
     flush_ipi = allocate_ipi_interrupt();
-    register_interrupt(flush_ipi, closure(h, flush_handler), "flush ipi");
+    register_interrupt(flush_ipi, closure(h, flush_handler), ss("flush ipi"));
     list_init(&entries);
     flush_service = closure(h, do_flush_service);
     free_flush_entries = allocate_queue(h, MAX_FLUSH_ENTRIES + 1);

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -1,11 +1,11 @@
 #include <kernel.h>
 #include <symtab.h>
 
-const char *context_type_strings[CONTEXT_TYPE_MAX] = {
-    "undefined",
-    "kernel",
-    "syscall",
-    "thread",
+const sstring context_type_strings[CONTEXT_TYPE_MAX] = {
+    ss_static_init("undefined"),
+    ss_static_init("kernel"),
+    ss_static_init("syscall"),
+    ss_static_init("thread"),
 };
 
 struct mm_stats mm_stats;
@@ -238,12 +238,12 @@ void run_percpu_init(void)
     }
 }
 
-void halt_with_code(u8 code, char *format, ...)
+void halt_with_code(u8 code, sstring format, ...)
 {
     buffer b = little_stack_buffer(512);
     vlist a;
     vstart(a, format);
-    vbprintf(b, alloca_wrap_cstring(format), &a);
+    vbprintf(b, format, &a);
     vend(a);
     buffer_print(b);
     kernel_shutdown(code);
@@ -256,17 +256,16 @@ void kernel_powerdown(void) {
 }
 
 #ifndef CONFIG_TRACELOG
-void tprintf(symbol tag, tuple attrs, const char *format, ...)
+void tprintf(symbol tag, tuple attrs, sstring format, ...)
 {
     vlist a;
     buffer b = little_stack_buffer(256);
     vstart(a, format);
-    buffer f = alloca_wrap_buffer(format, runtime_strlen(format));
     bprintf(b, "[%T, %d, %v", now(CLOCK_ID_MONOTONIC), current_cpu()->id, tag);
     if (attrs)
         bprintf(b, " %v", attrs);
     bprintf(b, "] ");
-    vbprintf(b, f, &a);
+    vbprintf(b, format, &a);
     vend(a);
     buffer_print(b);
 }

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -54,7 +54,7 @@ closure_function(2, 5, boolean, klib_elf_map,
                  u64, vaddr, u64, offset, u64, data_size, u64, bss_size, pageflags, flags)
 {
     klib kl = bound(kl);
-    klib_debug("%s: kl %s, vaddr 0x%lx, offset 0x%lx, data_size 0x%lx, bss_size 0x%lx, flags 0x%lx\n",
+    klib_debug("%s: kl %b, vaddr 0x%lx, offset 0x%lx, data_size 0x%lx, bss_size 0x%lx, flags 0x%lx\n",
                __func__, kl->name, vaddr, offset, data_size, bss_size, flags);
     u64 map_start = vaddr & ~PAGEMASK;
     data_size += vaddr & PAGEMASK;

--- a/src/kernel/kvm_platform.c
+++ b/src/kernel/kvm_platform.c
@@ -76,7 +76,7 @@ boolean kvm_detect(kernel_heaps kh)
     } else if (init_lapic_timer(&ct, &per_cpu_init)) {
         kvm_debug("defaulting to (suboptimal) lapic timer");
     } else {
-        halt("%s: no timer available\n", __func__);
+        halt("%s: no timer available\n", func_ss);
     }
 
     register_platform_clock_timer(ct, per_cpu_init);

--- a/src/kernel/linear_backed_heap.c
+++ b/src/kernel/linear_backed_heap.c
@@ -31,7 +31,7 @@ static inline u64 linear_backed_alloc_internal(linear_backed_heap hb, bytes size
         return p;
     u64 v = p + hb->virt_base;
     linear_backed_debug("%s: size 0x%lx, len 0x%lx, p 0x%lx, v 0x%lx\n",
-                        __func__, size, len, p, v);
+                        func_ss, size, len, p, v);
     return v;
 }
 
@@ -46,7 +46,7 @@ static inline void linear_backed_dealloc_internal(linear_backed_heap hb, u64 x, 
     u64 phys = x - hb->virt_base;
     deallocate_u64((heap)hb->physical, phys, len);
     linear_backed_debug("%s: addr 0x%lx, phys 0x%lx, size 0x%lx, len 0x%lx\n",
-                        __func__, x, phys, size, len);
+                        func_ss, x, phys, size, len);
 }
 
 static void linear_backed_dealloc(heap h, u64 x, bytes size)

--- a/src/kernel/lockstats.c
+++ b/src/kernel/lockstats.c
@@ -315,5 +315,5 @@ void lockstats_init(kernel_heaps kh)
     }
     int ret = init_http_listener();
     if (ret != 0)
-        rprintf("%s: failed to start http listener\n", __func__);
+        msg_err("failed to start http listener\n");
 }

--- a/src/kernel/log.h
+++ b/src/kernel/log.h
@@ -13,11 +13,6 @@ typedef struct klog_dump {
 
 void klog_write(const char *s, bytes count);
 
-static inline void klog_print(const char *s)
-{
-    klog_write(s, runtime_strlen(s));
-}
-
 void klog_disk_setup(u64 disk_offset, storage_req_handler req_handler);
 void klog_set_boot_id(u64 id);
 void klog_load(klog_dump dest, status_handler sh);

--- a/src/kernel/ltrace.c
+++ b/src/kernel/ltrace.c
@@ -89,7 +89,7 @@ typedef struct ltrace_brkpt {
     void *plt_entry;
     u64 addr;   /* userspace instruction pointer */
     u8 insn[sizeof(swbkp_insn)];
-    const char *sym_name;
+    sstring sym_name;
 } *ltrace_brkpt;
 
 declare_closure_struct(0, 2, int, ltrace_brkpt_compare,
@@ -164,7 +164,7 @@ void ltrace_init(value cfg, buffer exe, u64 load_offset)
         runtime_memcpy(brkpt->insn, plt_entry, sizeof(swbkp_insn));
         runtime_memcpy(plt_entry, swbkp_insn, sizeof(swbkp_insn));
         brkpt->sym_name = elf_string(exe, strtab, syms[sym_index].st_name);
-        if (!brkpt->sym_name)
+        if (sstring_is_null(brkpt->sym_name))
             halt("ltrace: no name for symbol 0x%lx\n", sym_index);
         ltrace_debug("PLT entry at 0x%lx: relocation 0x%lx, symbol 0x%lx at 0x%lx (%s)", plt_addr,
                      rel_index, sym_index, sym_offset, brkpt->sym_name);

--- a/src/kernel/management_telnet.c
+++ b/src/kernel/management_telnet.c
@@ -3,7 +3,7 @@
 
 //#define MGMT_DEBUG
 #ifdef MGMT_DEBUG
-#define mgmt_debug(x, ...) do {tprintf(sym(mgmt), 0, x, ##__VA_ARGS__);} while(0)
+#define mgmt_debug(x, ...) do {tprintf(sym(mgmt), 0, ss(x), ##__VA_ARGS__);} while(0)
 #else
 #define mgmt_debug(x, ...)
 #endif
@@ -15,10 +15,10 @@ closure_function(3, 1, status, telnet_recv,
     buffer_handler out = bound(out);
     if (!b) {
         // XXX need tuple parser dealloc
-        mgmt_debug("%s: remote closed\n", __func__);
+        mgmt_debug("%s: remote closed\n", func_ss);
         return STATUS_OK;
     }
-    mgmt_debug("%s: got request \"%b\"\n", __func__, b);
+    mgmt_debug("%s: got request \"%b\"\n", func_ss, b);
     switch (*((u8*)buffer_ref(b, 0))) {
     case 0x04:                  /* EOT */
         mgmt_debug("   remote sent quit\n");

--- a/src/kernel/mutex.c
+++ b/src/kernel/mutex.c
@@ -2,7 +2,7 @@
 
 //#define MUTEX_DEBUG
 #ifdef MUTEX_DEBUG
-#define mutex_debug(x, ...) do {tprintf(sym(mutex), 0, x, ##__VA_ARGS__);} while(0)
+#define mutex_debug(x, ...) do {tprintf(sym(mutex), 0, ss(x), ##__VA_ARGS__);} while(0)
 #else
 #define mutex_debug(x, ...)
 #endif
@@ -90,7 +90,7 @@ static inline boolean mutex_lock_internal(mutex m, boolean wait)
 #endif
     /* not preemptable (could become option on allocate) */
     if (((volatile mutex)m)->turn == ctx)
-        halt("%s: lock already held - cpu %d, mutex %p, ctx %p, ra %p\n", __func__,
+        halt("%s: lock already held - cpu %d, mutex %p, ctx %p, ra %p\n", func_ss,
              ci->id, m, ctx, __builtin_return_address(0));
 
     assert(!ctx->waiting_on);

--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -225,7 +225,7 @@ closure_function(2, 3, boolean, update_pte_flags,
 void update_map_flags_with_complete(u64 vaddr, u64 length, pageflags flags, status_handler complete)
 {
     flags = pageflags_no_minpage(flags);
-    page_debug("%s: vaddr 0x%lx, length 0x%lx, flags 0x%lx\n", __func__, vaddr, length, flags.w);
+    page_debug("vaddr 0x%lx, length 0x%lx, flags 0x%lx\n", vaddr, length, flags.w);
 
     /* Catch any attempt to change page flags in a linear_backed mapping */
     assert(!intersects_linear_backed(irangel(vaddr, length)));

--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -11,7 +11,7 @@ struct spinlock pt_lock;
 //#define PAGE_DUMP_ALL
 
 #if defined(PAGE_DEBUG) && !defined(BOOT)
-#define page_debug(x, ...) do {tprintf(sym(page), 0, "%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#define page_debug(x, ...) do {tprintf(sym(page), 0, ss("%s: " x), func_ss, ##__VA_ARGS__);} while(0)
 #else
 #define page_debug(x, ...)
 #endif

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -589,7 +589,8 @@ closure_function(6, 1, void, pagecache_write_sg_finish,
         saved_ctx = bound(saved_ctx);
         use_fault_handler(saved_ctx->fault_handler);
         if (!sg_fault_in(sg, q.end - (bound(pi) << page_order) - offset)) {
-            s = timm("result", "invalid user memory", "fsstatus", "%d", FS_STATUS_FAULT);
+            s = timm("result", "invalid user memory");
+            s = timm_append(s, "fsstatus", "%d", FS_STATUS_FAULT);
             clear_fault_handler();
         }
     }

--- a/src/kernel/pci.h
+++ b/src/kernel/pci.h
@@ -160,7 +160,7 @@ void pci_bar_init(pci_dev dev, struct pci_bar *b, int bar, bytes offset, bytes l
 void pci_bar_deinit(struct pci_bar *b);
 void pci_platform_init(void);
 void pci_platform_init_bar(pci_dev dev, int bar);
-u64 pci_platform_allocate_msi(pci_dev dev, thunk h, const char *name, u32 *address, u32 *data);
+u64 pci_platform_allocate_msi(pci_dev dev, thunk h, sstring name, u32 *address, u32 *data);
 void pci_platform_deallocate_msi(pci_dev dev, u64 v);
 boolean pci_platform_has_msi(void);
 
@@ -193,10 +193,10 @@ void pci_set_bus_master(pci_dev dev);
 int pci_get_msix_count(pci_dev dev);
 int pci_enable_msix(pci_dev dev);
 void pci_enable_io_and_memory(pci_dev dev);
-u64 pci_setup_msix(pci_dev dev, int msi_slot, thunk h, const char *name);
+u64 pci_setup_msix(pci_dev dev, int msi_slot, thunk h, sstring name);
 void pci_teardown_msix(pci_dev dev, int msi_slot);
 void pci_disable_msix(pci_dev dev);
-void pci_setup_non_msi_irq(pci_dev dev, thunk h, const char *name);
+void pci_setup_non_msi_irq(pci_dev dev, thunk h, sstring name);
 
 static inline u64 pci_msix_table_addr(pci_dev dev)
 {

--- a/src/kernel/pvclock.c
+++ b/src/kernel/pvclock.c
@@ -83,7 +83,7 @@ boolean init_tsc_deadline_timer(clock_timer *ct, thunk *per_cpu_init)
 
     *ct = closure(pvclock_heap, tsc_deadline_timer);
     int irq = allocate_interrupt();
-    register_interrupt(irq, timer_interrupt_handler, "tsc deadline timer");
+    register_interrupt(irq, timer_interrupt_handler, ss("tsc deadline timer"));
     *per_cpu_init = closure(pvclock_heap, tsc_deadline_percpu_init, irq);
     apply(*per_cpu_init);
     return true;

--- a/src/kernel/schedule.c
+++ b/src/kernel/schedule.c
@@ -2,20 +2,20 @@
 
 //#define SCHED_DEBUG
 #ifdef SCHED_DEBUG
-#define sched_debug(x, ...) do {tprintf(sym(sched), 0, x, ##__VA_ARGS__);} while(0)
+#define sched_debug(x, ...) do {tprintf(sym(sched), 0, ss(x), ##__VA_ARGS__);} while(0)
 #else
 #define sched_debug(x, ...)
 #endif
 
-static const char * const state_strings_backing[] = {
-    "not present",
-    "idle",
-    "kernel",
-    "interrupt",
-    "user",
+static const sstring state_strings_backing[] = {
+    ss_static_init("not present"),
+    ss_static_init("idle"),
+    ss_static_init("kernel"),
+    ss_static_init("interrupt"),
+    ss_static_init("user"),
 };
 
-const char * const * const state_strings = state_strings_backing;
+const sstring * const state_strings = state_strings_backing;
 BSS_RO_AFTER_INIT static int wakeup_vector;
 BSS_RO_AFTER_INIT int shutdown_vector;
 u32 shutting_down = 0;
@@ -262,7 +262,7 @@ closure_function(0, 0, void, global_shutdown)
 void init_scheduler(heap h)
 {
     /* timer init */
-    kernel_timers = allocate_timerqueue(h, 0, "runloop");
+    kernel_timers = allocate_timerqueue(h, 0, ss("runloop"));
     assert(kernel_timers != INVALID_ADDRESS);
     kernel_timers->min = microseconds(RUNLOOP_TIMER_MIN_PERIOD_US);
     kernel_timers->max = microseconds(RUNLOOP_TIMER_MAX_PERIOD_US);
@@ -271,9 +271,9 @@ void init_scheduler(heap h)
 
     /* IPI init */
     wakeup_vector = allocate_ipi_interrupt();
-    register_interrupt(wakeup_vector, ignore, "wakeup ipi");
+    register_interrupt(wakeup_vector, ignore, ss("wakeup ipi"));
     shutdown_vector = allocate_ipi_interrupt();
-    register_interrupt(shutdown_vector, closure(h, global_shutdown), "shutdown ipi");
+    register_interrupt(shutdown_vector, closure(h, global_shutdown), ss("shutdown ipi"));
     assert(wakeup_vector != INVALID_PHYSICAL);
 
     /* scheduling queues init */

--- a/src/kernel/symtab.h
+++ b/src/kernel/symtab.h
@@ -1,7 +1,7 @@
 void init_symtab(kernel_heaps kh);
 boolean symtab_is_empty(void);
-void *symtab_get_addr(const char *sym_name);
+void *symtab_get_addr(sstring sym_name);
 void symtab_remove_addrs(range r);
 void add_elf_syms(buffer b, u64 load_offset);
-char * find_elf_sym(u64 a, u64 *offset, u64 *len);
+sstring find_elf_sym(u64 a, u64 *offset, u64 *len);
 void print_u64_with_sym(u64 a);

--- a/src/kernel/tracelog.c
+++ b/src/kernel/tracelog.c
@@ -405,7 +405,7 @@ static void tracelog_file_write(status_handler complete)
   fail_dealloc_sg:
     deallocate_sg_list(sg);
   fail:
-    msg_err("%s: out of memory\n", __func__);
+    msg_err("out of memory\n");
     if (complete)
         async_apply_status_handler(complete, timm("status", "out of memory"));
 }

--- a/src/kernel/tracelog.c
+++ b/src/kernel/tracelog.c
@@ -407,7 +407,7 @@ static void tracelog_file_write(status_handler complete)
   fail:
     msg_err("out of memory\n");
     if (complete)
-        async_apply_status_handler(complete, timm("status", "out of memory"));
+        async_apply_status_handler(complete, timm_oom);
 }
 
 static boolean tracelog_entry_compare(void *za, void *zb)

--- a/src/kernel/tracelog.h
+++ b/src/kernel/tracelog.h
@@ -1,4 +1,4 @@
-void tprintf(symbol tag, tuple attrs, const char *format, ...);
-void vtprintf(symbol tag, tuple attrs, const char *format, vlist *ap);
+void tprintf(symbol tag, tuple attrs, sstring format, ...);
+void vtprintf(symbol tag, tuple attrs, sstring format, vlist *ap);
 void init_tracelog_config(tuple root);
 void init_tracelog(heap h);

--- a/src/net/direct.c
+++ b/src/net/direct.c
@@ -299,7 +299,7 @@ static void direct_conn_err(void *z, err_t err)
         direct_conn_enqueue(dc, 0);
         return;
     }
-    rprintf("%s: dc %p, err %d\n", __func__, dc, err);
+    msg_err("dc %p, err %d\n", dc, err);
     dc->pending_err = err;
 }
 
@@ -342,7 +342,7 @@ static direct_conn direct_conn_alloc(direct d, struct tcp_pcb *pcb)
 static void direct_listen_err(void *z, err_t err)
 {
     direct d = z;
-    rprintf("%s: d %p, err %d\n", __func__, d, err);
+    msg_err("d %p, err %d\n", d, err);
     /* XXX TODO */
 }
 

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -20,7 +20,7 @@ status direct_connect(heap h, ip_addr_t *addr, u16 port, connection_handler ch);
 
 u16 ifflags_from_netif(struct netif *netif);
 boolean ifflags_to_netif(struct netif *netif, u16 flags); /* do not call with lwIP lock held */
-void netif_name_cpy(char *dest, struct netif *netif);
+bytes netif_name_cpy(char *dest, struct netif *netif);
 
 #define netif_is_loopback(netif)    (((netif)->name[0] == 'l') && ((netif)->name[1] == 'o'))
 

--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -9,6 +9,7 @@
 #define ARP_QUEUEING 1
 //#define LWIP_DEBUG
 #ifdef LWIP_DEBUG
+#define lwip_debug(fmt, ...)    lwip_debug_sstring(ss(fmt), ##__VA_ARGS__)
 #define LWIP_PLATFORM_DIAG(x) do {lwip_debug x;} while(0)
 #define LWIP_DBG_MIN_LEVEL		LWIP_DBG_LEVEL_ALL
 #define ETHARP_DEBUG                    LWIP_DBG_ON
@@ -141,7 +142,7 @@ struct tcpip_api_call_data
 #define SYS_LIGHTWEIGHT_PROT    0
 
 typedef unsigned long long time; 
-extern void lwip_debug(char * format, ...);
+extern void lwip_debug_sstring(sstring format, ...);
 
 #define MEM_LIBC_MALLOC 1
 
@@ -168,21 +169,18 @@ static inline void lwip_free(void *x)
     lwip_deallocate(x);
 }
 
-int lwip_atoi(const char *p);
+int lwip_atoi(sstring p);
 void lwip_memcpy(void *a, const void *b, unsigned long len);
-int lwip_strlen(char *a);
 void lwip_memset(void *x, unsigned char v, unsigned long len);
 int lwip_memcmp(const void *x, const void *y, unsigned long len);
-int lwip_strcmp(const char *x, const char *y);
 int lwip_strncmp(const char *x, const char *y, unsigned long len);
 
 #define memcpy(__a, __b, __c) lwip_memcpy(__a, __b, __c)
 #define memcmp(__a, __b, __c) lwip_memcmp(__a, __b, __c)
 #define memset(__a, __b, __c) lwip_memset((void *)(__a), __b, __c)
 #define memmove(__a, __b, __c) lwip_memcpy(__a, __b, __c)
-#define strlen(__a) lwip_strlen((void *)__a)
 #define strncmp(__a, __b, __c) lwip_strncmp(__a, __b, __c)
-#define strcmp(__a, __b) lwip_strcmp(__a, __b)
+#define strcmp(__a, __b) runtime_strcmp(__a, __b)
 #define atoi(__a) lwip_atoi(__a)
 
 static inline void *calloc(size_t n, size_t s)

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -14,7 +14,7 @@
 
 //#define NETSYSCALL_DEBUG
 #ifdef NETSYSCALL_DEBUG
-#define net_debug(x, ...) do {log_printf(" NET", "%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#define net_debug(x, ...) do {log_printf(ss(" NET"), ss("%s: " x), func_ss, ##__VA_ARGS__);} while(0)
 #else
 #define net_debug(x, ...)
 #endif
@@ -928,7 +928,7 @@ static sysreturn socket_ifreq(struct ifreq *ifreq, boolean set, socket_ifreq_han
     context ctx = get_current_context(current_cpu());
     if (!validate_user_memory(ifreq, sizeof(struct ifreq), !set) || context_set_err(ctx))
         return -EFAULT;
-    struct netif *netif = netif_find(ifreq->ifr_name);
+    struct netif *netif = netif_find(sstring_from_cstring(ifreq->ifr_name, IFNAMSIZ));
     context_clear_err(ctx);
     if (!netif)
         return -ENODEV;

--- a/src/runtime/buffer.c
+++ b/src/runtime/buffer.c
@@ -24,10 +24,38 @@ boolean buffer_append(buffer b,
     return buffer_write(b, body, length);
 }
 
-int buffer_strstr(buffer b, const char *str) {
-    int len = runtime_strlen(str);
-    for (int i = 0; b->start + i + len <= b->end; i++) {
-        if (!runtime_memcmp(buffer_ref(b, i), str, len))
+/* The string in the buffer may or may not be null-terminated. */
+int buffer_compare_with_sstring(buffer b, sstring str)
+{
+    int res = buffer_memcmp(b, str.ptr, str.len);
+    if (res)
+        return res;
+    bytes len = buffer_length(b);
+    if ((len > str.len + 1) || ((len == str.len + 1) && (byte(b, str.len) != '\0')))
+        return 1;
+    return 0;
+}
+
+/* The string in the buffer may or may not be null-terminated. */
+int buffer_compare_with_sstring_ci(buffer b, sstring str)
+{
+    bytes len = MIN(buffer_length(b), str.len);
+    for (bytes i = 0; i < len; i++) {
+        int res = tolower(byte(b, i)) - tolower(str.ptr[i]);
+        if (res)
+            return res;
+    }
+    len = buffer_length(b);
+    if (len < str.len)
+        return -1;
+    if ((len > str.len + 1) || ((len == str.len + 1) && (byte(b, str.len) != '\0')))
+        return 1;
+    return 0;
+}
+
+int buffer_strstr(buffer b, sstring str) {
+    for (int i = 0; b->start + i + str.len <= b->end; i++) {
+        if (!runtime_memcmp(buffer_ref(b, i), str.ptr, str.len))
             return i;
     }
     return -1;

--- a/src/runtime/closure.h
+++ b/src/runtime/closure.h
@@ -6,7 +6,6 @@
     _fill_##__name(__c, __p, __s, ##__VA_ARGS__)
 
 struct _closure_common {
-    char *name;
 #define CLOSURE_COMMON_CTX_IS_CONTEXT        1 /* vs heap */
 #define CLOSURE_COMMON_CTX_DEALLOC_ON_FINISH 2
 #define CLOSURE_COMMON_CTX_FLAGS_MASK        3
@@ -23,7 +22,6 @@ struct _closure_common {
     __var = allocate(__h, sizeof(struct _closure_##__name));    \
     if (__var != INVALID_ADDRESS) {                             \
         __var->__apply = __name;                                \
-        __var->__c.name = #__name;                              \
         __var->__c.ctx = ctx_from_heap(__h);                    \
         __var->__c.size = sizeof(struct _closure_##__name);     \
     }                                                           \
@@ -75,7 +73,6 @@ struct _closure_common {
     static __ret __func(struct _closure_##__name *__self, ##__VA_ARGS__);           \
     static __name _fill_##__func(u64 ctx, struct _closure_##__name *p, bytes s) {   \
         p->__apply = __func;                                                        \
-        p->__c.name = #__func;                                                      \
         p->__c.ctx = ctx;                                                           \
         p->__c.size = s;                                                            \
         return (__name)p;                                                           \

--- a/src/runtime/extra_prints.c
+++ b/src/runtime/extra_prints.c
@@ -1,4 +1,9 @@
+#ifdef KERNEL
+#include <kernel.h>
+#include <symtab.h>
+#else
 #include <runtime.h>
+#endif
 
 
 static char *hex_digit="0123456789abcdef";
@@ -309,9 +314,15 @@ static void format_range(buffer dest, struct formatter_state *s, vlist *a)
 static void format_closure(buffer dest, struct formatter_state *s, vlist *a)
 {
     // xxx - we can probably do better here?
-    void **k = varg(*a, void **);
-    struct _closure_common *c = k[1];
-    bprintf(dest, "%s", &c->name);
+    u64 *k = varg(*a, u64 *);
+#ifdef KERNEL
+    sstring name = find_elf_sym(*k, 0, 0);
+    if (!sstring_is_null(name)) {
+        bprintf(dest, "%s", name);
+        return;
+    }
+#endif
+    bprintf(dest, "%p", *k);
 }
 
 void init_extra_prints(void)

--- a/src/runtime/format.h
+++ b/src/runtime/format.h
@@ -1,7 +1,7 @@
-extern void vbprintf(buffer s, buffer fmt, vlist *ap);
+extern void vbprintf(buffer s, sstring fmt, vlist *ap);
 
-extern void log_vprintf(const char *prefix, const char *log_format, vlist *a);
-extern void log_printf(const char *prefix, const char *log_format, ...);
+extern void log_vprintf(sstring prefix, sstring log_format, vlist *a);
+extern void log_printf(sstring prefix, sstring log_format, ...);
 
 struct formatter_state {
     int state;
@@ -19,8 +19,14 @@ typedef void (*formatter)(buffer dest, struct formatter_state *s, vlist *ap);
 void register_format(character c, formatter f, int accepts_long);
 void init_extra_prints(void);
 
-buffer aprintf(heap h, const char *fmt, ...);
-void bbprintf(buffer b, buffer fmt, ...);
-void bprintf(buffer b, const char *fmt, ...);
-int rsnprintf(char *str, u64 size, const char *fmt, ...);
-void rprintf(const char *format, ...);
+buffer aprintf_sstring(heap h, sstring fmt, ...);
+#define aprintf(h, fmt, ...)    aprintf_sstring(h, ss(fmt), ##__VA_ARGS__)
+
+void bprintf_sstring(buffer b, sstring fmt, ...);
+#define bprintf(b, fmt, ...)    bprintf_sstring(b, ss(fmt), ##__VA_ARGS__)
+
+int rsnprintf_sstring(char *str, u64 size, sstring fmt, ...);
+#define rsnprintf(str, size, fmt, ...)  rsnprintf_sstring(str, size, ss(fmt), ##__VA_ARGS__)
+
+void rprintf_sstring(sstring format, ...);
+#define rprintf(fmt, ...)   rprintf_sstring(ss(fmt), ##__VA_ARGS__)

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -65,7 +65,7 @@ static id_range id_add_range(id_heap i, u64 base, u64 length)
     if (ir == INVALID_ADDRESS)
 	return ir;
     if (!rangemap_insert(i->ranges, &ir->n)) {
-        msg_err("%s: range insertion failure; conflict with range %R\n", __func__, ir->n.r);
+        msg_err("range insertion failure; conflict with range %R\n", ir->n.r);
         goto fail;
     }
 
@@ -77,7 +77,7 @@ static id_range id_add_range(id_heap i, u64 base, u64 length)
 
     ir->b = allocate_bitmap(i->meta, i->map, pages + page_start_mask);
     if (ir->b == INVALID_ADDRESS) {
-        msg_err("%s: failed to allocate bitmap for range %R\n", __func__, ir->n.r);
+        msg_err("failed to allocate bitmap for range %R\n", ir->n.r);
         goto fail;
     }
     if (page_start_mask)

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -7,7 +7,7 @@
 
 //#define ID_HEAP_DEBUG
 #ifdef ID_HEAP_DEBUG
-#define id_debug(x, ...) do {rprintf("%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#define id_debug(x, ...) do {rprintf("%s: " x, func_ss, ##__VA_ARGS__);} while(0)
 #else
 #define id_debug(x, ...)
 #endif

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -451,8 +451,8 @@ static value id_management(heap h)
         return i->mgmt;
     value v;
     symbol s;
-    tuple t = timm("type", "id", "pagesize", "%d", i->h.pagesize);
-    assert(t != INVALID_ADDRESS);
+    tuple t = timm("type", "id");
+    t = timm_append(t, "pagesize", "%d", i->h.pagesize);
     tuple_notifier n = tuple_notifier_wrap(t, false);
     assert(n != INVALID_ADDRESS);
     register_stat(i, n, t, allocated);

--- a/src/runtime/heap/mcache.c
+++ b/src/runtime/heap/mcache.c
@@ -280,8 +280,8 @@ static value mcache_management(heap h)
         return m->mgmt;
     value v;
     symbol s;
-    tuple t = timm("type", "mcache", "pagesize", "%d", m->h.pagesize);
-    assert(t != INVALID_ADDRESS);
+    tuple t = timm("type", "mcache");
+    t = timm_append(t, "pagesize", "%d", m->h.pagesize);
     tuple_notifier n = tuple_notifier_wrap(t, false);
     assert(n != INVALID_ADDRESS);
     register_stat(m, n, t, allocated);

--- a/src/runtime/heap/objcache.c
+++ b/src/runtime/heap/objcache.c
@@ -437,8 +437,8 @@ static value objcache_management(heap h)
         return o->mgmt;
     value v;
     symbol s;
-    tuple t = timm("type", "objcache", "pagesize", "%d", object_size(o));
-    assert(t != INVALID_ADDRESS);
+    tuple t = timm("type", "objcache");
+    t = timm_append(t, "pagesize", "%d", object_size(o));
     tuple_notifier n = tuple_notifier_wrap(t, false);
     assert(n != INVALID_ADDRESS);
     register_stat(o, n, t, allocated);

--- a/src/runtime/heap/reserve.c
+++ b/src/runtime/heap/reserve.c
@@ -81,8 +81,8 @@ static value reservelock_management(heap h)
         return rl->mgmt;
     value v;
     symbol s;
-    tuple t = timm("type", "reservelock", "pagesize", "%d", rl->h.pagesize);
-    assert(t != INVALID_ADDRESS);
+    tuple t = timm("type", "reservelock");
+    t = timm_append(t, "pagesize", "%d", rl->h.pagesize);
     tuple_notifier n = tuple_notifier_wrap(t, false);
     assert(n != INVALID_ADDRESS);
     register_stat(rl, n, t, allocated);

--- a/src/runtime/json.c
+++ b/src/runtime/json.c
@@ -134,12 +134,12 @@ static parser json_array_parser(heap h, parse_finish_internal c, parse_error_int
 
 static boolean char_is_whitespace(character in)
 {
-    return (runtime_strchr(" \n\r\t", in) != 0);
+    return (runtime_strchr(ss(" \n\r\t"), in) != 0);
 }
 
 static boolean char_is_numeric(character in)
 {
-    return (runtime_strchr("1234567890.", in) != 0);
+    return (runtime_strchr(ss("1234567890."), in) != 0);
 }
 
 static parser parse_literal(parser p, character in, int char_index, const char *literal,

--- a/src/runtime/management.c
+++ b/src/runtime/management.c
@@ -70,22 +70,22 @@ define_closure_function(1, 2, boolean, each_request,
                         buffer_handler, out,
                         value, k, value, args)
 {
-    char *resultstr = 0;
+    sstring resultstr = sstring_null();
     buffer b = allocate_buffer(management.h, 256);
     assert(b != INVALID_ADDRESS);
     if (k == sym(get)) {
         if (!is_tuple(args)) {
-            resultstr = "missing arguments tuple";
+            resultstr = ss("missing arguments tuple");
             goto out;
         }
         string path = get_string(args, sym(path));
         if (!path) {
-            resultstr = "could not parse path attribute";
+            resultstr = ss("could not parse path attribute");
             goto out;
         }
         value target = resolve_tuple_path(management.root, path, 0, 0);
         if (!target) {
-            resultstr = "could not resolve path";
+            resultstr = ss("could not resolve path");
             goto out;
         }
         tuple attrs = timm("indent", "3");
@@ -96,24 +96,24 @@ define_closure_function(1, 2, boolean, each_request,
         deallocate_value(attrs);
     } else if (k == sym(set)) {
         if (!is_tuple(args)) {
-            resultstr = "missing arguments tuple";
+            resultstr = ss("missing arguments tuple");
             goto out;
         }
         string path = get_string(args, sym(path));
         if (!path) {
-            resultstr = "could not parse path attribute";
+            resultstr = ss("could not parse path attribute");
             goto out;
         }
         symbol a = 0;
         tuple parent = 0;
         resolve_tuple_path(management.root, path, &parent, &a);
         if (!parent) {
-            resultstr = "could not resolve path";
+            resultstr = ss("could not resolve path");
             goto out;
         }
         value v = get(args, sym(value));
         if (!v) {
-            resultstr = "value not found";
+            resultstr = ss("value not found");
             goto out;
         }
         if (is_null_string(v))
@@ -127,13 +127,13 @@ define_closure_function(1, 2, boolean, each_request,
         } else if (is_tuple(args)) {
             tuple req = get_tuple(args, sym(request));
             if (!req) {
-                resultstr = "could not parse request";
+                resultstr = ss("could not parse request");
                 goto out;
             }
 
             u64 period;
             if (!get_u64(args, sym(period), &period)) {
-                resultstr = "could not parse period";
+                resultstr = ss("could not parse period");
                 goto out;
             }
 
@@ -150,16 +150,16 @@ define_closure_function(1, 2, boolean, each_request,
                            init_closure(&management.timer_expiry, mgmt_timer_expiry,
                                         bound(out)));
         } else {
-            resultstr = "could not parse timer tuple";
+            resultstr = ss("could not parse timer tuple");
             goto out;
         }
         bprintf(b, "()\n");
 #endif
     } else {
-        resultstr = "unknown command";
+        resultstr = ss("unknown command");
     }
   out:
-    if (resultstr)
+    if (!sstring_is_null(resultstr))
         bprintf(b, "(result:%s)\n", resultstr);
     apply(bound(out), b);
     return true;

--- a/src/runtime/rbtree.c
+++ b/src/runtime/rbtree.c
@@ -12,7 +12,7 @@
 //#define RBTREE_PARANOIA
 //#define RBTREE_DEBUG
 #ifdef RBTREE_DEBUG
-#define rbtree_debug(x, ...) do {rprintf("RBTREE %s: " x, __func__, ##__VA_ARGS__);} while(0)
+#define rbtree_debug(x, ...) do {rprintf("RBTREE %s: " x, func_ss, ##__VA_ARGS__);} while(0)
 #else
 #define rbtree_debug(x, ...)
 #endif
@@ -313,7 +313,7 @@ boolean rbtree_remove_by_key(rbtree t, rbnode k)
     {
         status s = rbtree_validate(t);
         if (!is_ok(s)) {
-            halt("%s: validate check failed: %v\n", __func__, s);
+            halt("%s: validate check failed: %v\n", func_ss, s);
         }
     }
 #endif
@@ -361,7 +361,7 @@ boolean rbtree_insert_node(rbtree t, rbnode n)
     {
         status s = rbtree_validate(t);
         if (!is_ok(s)) {
-            halt("%s: validate check failed: %v\n", __func__, s);
+            halt("%s: validate check failed: %v\n", func_ss, s);
         }
     }
 #endif
@@ -455,7 +455,7 @@ void rbtree_dump(rbtree t, int order)
 static status parent_child_check(rbtree t, rbnode p, int hand)
 {
     rbnode c = child(p, hand);
-    char *hstr = hand == left ? "left" : "right";
+    sstring hstr = hand == left ? ss("left") : ss("right");
     if (!c)
         return STATUS_OK;
     if (parent(c) != p) {

--- a/src/runtime/refcount.h
+++ b/src/runtime/refcount.h
@@ -18,8 +18,7 @@ static inline void refcount_reserve(refcount r)
 static inline boolean refcount_release(refcount r)
 {
     word n = fetch_and_add(&r->c, (word)-1);
-    if (n < 1)
-        halt("%s: invalid count %ld\n", __func__, n);
+    assert(n > 0);
     if (n == 1) {
         if (r->completion)
             apply(r->completion);

--- a/src/runtime/runtime_init.c
+++ b/src/runtime/runtime_init.c
@@ -99,16 +99,15 @@ static void format_character(buffer dest, struct formatter_state *s, vlist *a)
     push_character(dest, x);
 }
 
-static void format_cstring(buffer dest, struct formatter_state *s, vlist *a)
+static void format_sstring(buffer dest, struct formatter_state *s, vlist *a)
 {
-    char *c = varg(*a, char *);
-    if (!c) c = (char *)"(null)";
-    int len = runtime_strlen(c);
-    if (s->precision > 0)
+    sstring ss = varg(*a, sstring);
+    int len = ss.len;
+    if ((s->precision > 0) && (s->precision < len))
         len = s->precision;
     if (len < s->width && s->align == 0)
         fill(dest, s->width - len, ' ');
-    assert(buffer_write(dest, c, len));
+    assert(buffer_write(dest, ss.ptr, len));
     if (len < s->width && s->align == '-')
         fill(dest, s->width - len, ' ');
 }
@@ -132,7 +131,7 @@ void init_runtime(heap general, heap safe)
     register_format('x', format_number, 1);
     register_format('d', format_number, 1);
     register_format('u', format_number, 1);
-    register_format('s', format_cstring, 0);
+    register_format('s', format_sstring, 0);
     register_format('b', format_buffer, 0);
     register_format('n', format_spaces, 0);
     register_format('c', format_character, 0);
@@ -141,11 +140,10 @@ void init_runtime(heap general, heap safe)
     null_value = wrap_buffer(general, "", 1);
 }
 
-void rputs(const char *s)
+void rput_sstring(sstring s)
 {
-    int len = runtime_strlen(s);
-    console_write(s, len);
-    klog_write(s, len);
+    console_write(s.ptr, s.len);
+    klog_write(s.ptr, s.len);
 }
 
 #define STACK_CHK_GUARD 0x595e9fbd94fda766

--- a/src/runtime/runtime_string.h
+++ b/src/runtime/runtime_string.h
@@ -1,7 +1,8 @@
-char *runtime_strchr(const char *, int);
-char *runtime_strstr(const char *haystack, const char *needle);
-char *runtime_strtok_r(char *, const char *, char **);
-int runtime_strcmp(const char *, const char *);
+char *runtime_strchr(sstring s, int c);
+char *runtime_strrchr(sstring s, int c);
+char *runtime_strstr(sstring haystack, sstring needle);
+sstring runtime_strtok_r(sstring *str, sstring delim, sstring *saveptr);
+int runtime_strcmp(sstring string1, sstring string2);
 
 string wrap_string(void *body, bytes length);
 string allocate_string(bytes size);
@@ -9,16 +10,17 @@ void init_strings(heap h, heap init);
 
 #define deallocate_string deallocate_buffer
 
-static inline buffer wrap_string_cstring(char *x)
+static inline string string_from_buf(void *x, bytes len)
 {
-    return wrap_string(x, runtime_strlen(x));
-}
-
-static inline string string_from_cstring(const char *x)
-{
-    int len = runtime_strlen(x);
     string s = allocate_string(len);
     buffer_assert(s != INVALID_ADDRESS);
     buffer_assert(buffer_append(s, x, len));
     return s;
 }
+
+static inline string wrap_string_sstring(sstring s)
+{
+    return string_from_buf(s.ptr, s.len);
+}
+
+#define wrap_string_cstring(x)  wrap_string_sstring(ss(x))

--- a/src/runtime/sg.c
+++ b/src/runtime/sg.c
@@ -61,7 +61,7 @@ static u64 sg_copy(void *buf, sg_list sg, u64 n, boolean to_buf)
     sg_buf sgb;
     u64 remain = n;
 
-    sg_debug("%s: target %p, sg %p, length 0x%lx, count %ld\n", __func__, target, sg, length, sg->count);
+    sg_debug("%s: target %p, sg %p, length 0x%lx, count %ld\n", func_ss, target, sg, length, sg->count);
     while (remain > 0 && (sgb = sg_list_head_peek(sg)) != INVALID_ADDRESS) {
         assert(sgb->size > sgb->offset); /* invariant: no null-length bufs */
         void *sg_buf = sgb->buf + sgb->offset;
@@ -142,7 +142,7 @@ u64 sg_copy_to_buf_and_release(void *target, sg_list sg, u64 n)
     sg_buf sgb;
     u64 remain = n;
 
-    sg_debug("%s: target %p, sg %p, limit 0x%lx, count %ld\n", __func__, target, sg, limit, sg->count);
+    sg_debug("%s: target %p, sg %p, limit 0x%lx, count %ld\n", func_ss, target, sg, limit, sg->count);
     while ((sgb = sg_list_head_remove(sg)) != INVALID_ADDRESS) {
         assert(sgb->size > sgb->offset);
         u64 len = MIN(remain, sg_buf_len(sgb));
@@ -241,16 +241,16 @@ closure_function(3, 3, void, sg_wrapped_read,
     bytes padlen = pad(length, 1 << block_order);
     void *buf = allocate(bound(backed), padlen);
     sg_debug("%s: io %p, order %d, backed %p, sg %p, range %R, sh %p\n",
-             __func__, bound(block_read), block_order, bound(backed), sg, q, sh);
+             func_ss, bound(block_read), block_order, bound(backed), sg, q, sh);
 
     if (buf == INVALID_ADDRESS) {
         apply(sh, timm("result", "%s: failed to allocate backed buffer of size %ld",
-                       __func__, padlen));
+                       func_ss, padlen));
         return;
     }
     refcount refcount = allocate(sg_heap, sizeof(struct refcount));
     if (refcount == INVALID_ADDRESS) {
-        apply(sh, timm("result", "%s: alloc failed", __func__));
+        apply(sh, timm("result", "%s: alloc failed", func_ss));
         return;
     }
     init_refcount(refcount, 1, closure(sg_heap, sg_wrapped_buf_release,
@@ -269,13 +269,13 @@ closure_function(3, 3, void, sg_wrapped_read,
 
 sg_io sg_wrapped_block_reader(block_io bio, int block_order, heap backed)
 {
-    sg_debug("%s, heap %p, bio %p, order %d, backed %p\n", __func__, sg_heap, bio, block_order, backed);
+    sg_debug("%s, heap %p, bio %p, order %d, backed %p\n", func_ss, sg_heap, bio, block_order, backed);
     return closure(sg_heap, sg_wrapped_read, bio, block_order, backed);
 }
 
 void init_sg(heap h)
 {
-    sg_debug("%s\n", __func__);
+    sg_debug("%s\n", func_ss);
     sg_heap = h;
     list_init(&free_sg_lists);
     sg_lock_init();

--- a/src/runtime/sstring.h
+++ b/src/runtime/sstring.h
@@ -1,0 +1,78 @@
+/* Simple string structure that does not use NULL string terminators. */
+typedef struct sstring {
+    bytes len;
+    char *ptr;
+} sstring;
+
+#define ss(x)  ({               \
+    assert_string_literal(x);   \
+    sstring s = {               \
+        .len = sizeof(x) - 1,   \
+        .ptr = x,               \
+    };                          \
+    s;                          \
+})
+
+/* Should only be used for initialization of static variables.
+ * For all other uses, ss() is more efficient. */
+#define ss_static_init(x)   {   \
+    .len = sizeof(x) - 1,       \
+    .ptr = string_literal(x),   \
+}
+
+#define sstring_foreach(__i, __c, __s)              \
+    for (bytes __i = 0, __c, __limit = (__s).len;     \
+         (__c = (__s).ptr[__i]), (__i) < __limit;   \
+         (__i)++)
+
+#define file_ss isstring((char *)__FILE__, sizeof(__FILE__) - 1)
+#define func_ss isstring((char *)__func__, sizeof(__func__) - 1)
+
+static inline sstring isstring(char *ptr, bytes len)
+{
+    sstring s = {
+        .len = len,
+        .ptr = ptr,
+    };
+    return s;
+}
+
+static inline sstring sstring_null(void)
+{
+    sstring s = {
+        .ptr = 0,
+    };
+    return s;
+}
+
+static inline sstring sstring_empty(void)
+{
+    sstring s = {
+        .len = 0,
+        .ptr = "",
+    };
+    return s;
+}
+
+static inline sstring sstring_from_cstring(const char *cstring, bytes maxlen)
+{
+    sstring s = {
+        .ptr = (char *)cstring,
+    };
+    bytes len;
+    for (len = 0; len < maxlen; len++)
+        if (cstring[len] == '\0')
+            break;
+    s.len = len;
+    return s;
+}
+
+static inline boolean sstring_is_null(sstring s)
+{
+    return (s.ptr == 0);
+}
+
+static inline boolean sstring_is_empty(sstring s)
+{
+    return (s.len == 0);
+}

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -105,7 +105,7 @@ void storage_sync(status_handler sh);
 struct filesystem *storage_get_fs(tuple root);
 u64 storage_get_mountpoint(tuple root, struct filesystem **fs);
 
-typedef closure_type(volume_handler, void, u8 *, const char *, struct filesystem *, u64);
+typedef closure_type(volume_handler, void, u8 *, sstring, struct filesystem *, u64);
 void storage_iterate(volume_handler vh);
 
 void storage_detach(void *priv, thunk complete);

--- a/src/runtime/symbol.h
+++ b/src/runtime/symbol.h
@@ -10,13 +10,15 @@ string symbol_string(symbol s);
       if (!__s){char x[] = #name; __s = intern(alloca_wrap_buffer(x, sizeof(x)-1));} \
      __s;})              
 
-#define sym_this(name)\
-    (intern(alloca_wrap_buffer(name, runtime_strlen(name))))
+#define sym_this(name)  ({                              \
+    assert_string_literal(name);                        \
+    intern(alloca_wrap_buffer(name, sizeof(name) - 1)); \
+})
+
+#define sym_sstring(name)   ({                      \
+    sstring __n = name;                             \
+    intern(alloca_wrap_buffer(__n.ptr, __n.len));   \
+})
 
 table symbol_table();
 key key_from_symbol(void *z);
-
-static inline boolean sym_cstring_compare(symbol s, const char *c)
-{
-    return buffer_compare_with_cstring(symbol_string(s), c);
-}

--- a/src/runtime/symbol.h
+++ b/src/runtime/symbol.h
@@ -5,12 +5,10 @@ symbol intern_u64(u64);
 
 string symbol_string(symbol s);
 
-#define sym_intern(name, intern)\
+#define sym(name)           \
     ({static symbol __s = 0;\
       if (!__s){char x[] = #name; __s = intern(alloca_wrap_buffer(x, sizeof(x)-1));} \
      __s;})              
-
-#define sym(name)   sym_intern(name, intern)
 
 #define sym_this(name)\
     (intern(alloca_wrap_buffer(name, runtime_strlen(name))))

--- a/src/runtime/table.c
+++ b/src/runtime/table.c
@@ -17,12 +17,12 @@ key identity_key(void *a)
 }
 
 #ifdef TABLE_PARANOIA
-#define table_paranoia(t, n)    table_validate(t, n)
+#define table_paranoia(t, n)    table_validate(t, ss(n))
 #else
 #define table_paranoia(t, n)
 #endif
 
-void table_validate(table t, char *n)
+void table_validate(table t, sstring n)
 {
     void *last;
     for(int i = 0; i < t->buckets; i++) {

--- a/src/runtime/table.h
+++ b/src/runtime/table.h
@@ -22,7 +22,7 @@ struct table {
 table allocate_table(heap h, key (*key_function)(void *x), boolean (*equal_function)(void *x, void *y));
 table allocate_table_preallocated(heap h, heap entry_parent, key (*key_function)(void *x), boolean (*equal_function)(void *x, void *y), u64 prealloc_count);
 void deallocate_table(table t);
-void table_validate(table t, char *n);
+void table_validate(table t, sstring n);
 int table_elements(table t);
 void *table_find(table t, void *c);
 //void *table_find_key (table t, void *c, void **kr);

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -10,7 +10,7 @@
 
 //#define TIMER_DEBUG
 #ifdef TIMER_DEBUG
-#define timer_debug(x, ...) do {log_printf("TIMER", x, ##__VA_ARGS__);} while(0)
+#define timer_debug(x, ...) do {log_printf(ss("TIMER"), ss(x), ##__VA_ARGS__);} while(0)
 #else
 #define timer_debug(x, ...)
 #endif
@@ -150,7 +150,7 @@ void timer_adjust_end(timerqueue tq, pqueue_element_handler h)
     timer_unlock(tq);
 }
 
-timerqueue allocate_timerqueue(heap h, clock_now now, const char *name)
+timerqueue allocate_timerqueue(heap h, clock_now now, sstring name)
 {
     timerqueue tq = allocate(h, sizeof(struct timerqueue));
     tq->pq = allocate_pqueue(h, now ? timer_compare_simple : timer_compare);

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -47,7 +47,7 @@ typedef struct timerqueue {
     u32 service_scheduled;  /* CAS */
     u32 update;             /* CAS; timer re-programming needed */
     boolean empty;          /* indicating the queue is empty */
-    const char *name;
+    sstring name;
 } *timerqueue;
 
 struct timer {
@@ -163,7 +163,7 @@ boolean remove_timer(timerqueue tq, timer t, timestamp *remain);
 
 typedef closure_type(timer_select, boolean, timer);
 
-timerqueue allocate_timerqueue(heap h, clock_now now, const char *name);
+timerqueue allocate_timerqueue(heap h, clock_now now, sstring name);
 void deallocate_timerqueue(timerqueue tq);
 void timer_service(timerqueue tq, timestamp here);
 void timer_reorder(timerqueue tq);

--- a/src/unix/aio.c
+++ b/src/unix/aio.c
@@ -201,7 +201,7 @@ static sysreturn iocb_enqueue(struct aio *aio, struct iocb *iocb, context ctx)
 {
     if (!validate_user_memory(iocb, sizeof(struct iocb), false) || context_set_err(ctx))
         return -EFAULT;
-    thread_log(current, "%s: fd %d, op %d", __func__, iocb->aio_fildes,
+    thread_log(current, "%s: fd %d, op %d", func_ss, iocb->aio_fildes,
             iocb->aio_lio_opcode);
 
     if (iocb->aio_reserved1 || iocb->aio_reserved2 || !iocb->aio_buf ||

--- a/src/unix/eventfd.c
+++ b/src/unix/eventfd.c
@@ -198,13 +198,13 @@ int do_eventfd2(unsigned int count, int flags)
     efd->h = h;
     efd->flags = flags;
 
-    efd->read_bq = allocate_blockq(h, "eventfd read");
+    efd->read_bq = allocate_blockq(h, ss("eventfd read"));
     if (efd->read_bq == INVALID_ADDRESS) {
         msg_err("failed to allocated blockq\n");
         goto err_read_bq;
     }
 
-    efd->write_bq = allocate_blockq(h, "eventfd write");
+    efd->write_bq = allocate_blockq(h, ss("eventfd write"));
     if (efd->write_bq == INVALID_ADDRESS) {
         msg_err("failed to allocate blockq\n");
         goto err_write_bq;

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -1,5 +1,5 @@
-#define resolve_dir(__fs, __dirfd, __path) ({ \
-    if (!fault_in_user_string(__path)) return -EFAULT;  \
+#define resolve_dir(__fs, __dirfd, __path, __path_ss) ({ \
+    if (!fault_in_user_string(__path, &(__path_ss))) return -EFAULT;    \
     inode cwd; \
     process p = current->p; \
     if (*(__path) == '/') { \
@@ -30,7 +30,7 @@ sysreturn sysreturn_from_fs_status_value(status s);
  * not to the range to be read ahead. */
 void file_readahead(file f, u64 offset, u64 len);
 
-fs_status filesystem_chdir(process p, const char *path);
+fs_status filesystem_chdir(process p, sstring path);
 
 void filesystem_update_relatime(filesystem fs, tuple md);
 
@@ -48,12 +48,12 @@ sysreturn fallocate(int fd, int mode, long offset, long len);
 
 sysreturn fadvise64(int fd, s64 off, u64 len, int advice);
 
-sysreturn fs_rename(buffer oldpath, buffer newpath);
+sysreturn fs_rename(sstring oldpath, sstring newpath);
 
 void file_release(file f);
 
-fsfile fsfile_open(buffer file_path);
-fsfile fsfile_open_or_create(buffer file_path, boolean truncate);
+fsfile fsfile_open(sstring file_path);
+fsfile fsfile_open_or_create(sstring file_path, boolean truncate);
 fs_status fsfile_truncate(fsfile f, u64 len);
 
 notify_entry fs_watch(heap h, tuple n, u64 eventmask, event_handler eh, notify_set *s);

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -376,12 +376,12 @@ printer_print_duration_usec(struct ftrace_printer * p, timestamp num, u16 width)
     nsec = nsec % THOUSAND;
 
     /* print a symbol to highlight the timescale */
-    printer_write(p, "%s ",
-        (usec >= 100000) ? "@" :
-        (usec >= 10000)  ? "*" :
-        (usec >= 1000)   ? "#" :
-        (usec >= 100)    ? "!" :
-        (usec >= 10)     ? "+" : " "
+    printer_write(p, "%c ",
+        (usec >= 100000) ? '@' :
+        (usec >= 10000)  ? '*' :
+        (usec >= 1000)   ? '#' :
+        (usec >= 100)    ? '!' :
+        (usec >= 10)     ? '+' : ' '
     );
 
     bprintf(b, "%ld.", usec);
@@ -397,11 +397,9 @@ printer_print_duration_usec(struct ftrace_printer * p, timestamp num, u16 width)
     /* truncate the buffer after "width"-3 digits */
     len = buffer_length(b);
     if (len > width - 3)
-        ((char *)buffer_ref(b, width-3))[0] = '\0';
-    else
-        ((char *)buffer_ref(b, len))[0] = '\0';
+        b->end = b->start + width - 3;
 
-    printer_write(p, "%s us", (char *)buffer_ref(b, 0));
+    printer_write(p, "%b us", b);
 
     /* add spaces if needed */
     while (len < width - 3) {
@@ -1667,7 +1665,7 @@ __ftrace_send_http_chunk_internal(struct ftrace_routine * routine, struct ftrace
 
     /* no real error handling for http get here */
     if (ret < 0) {
-        msg_err("%s: get failed with %d\n", __func__, ret);
+        msg_err("get failed with %d\n", ret);
         return false;
     }
 
@@ -1679,7 +1677,7 @@ __ftrace_send_http_chunk_internal(struct ftrace_routine * routine, struct ftrace
         /* reset printer for next chunk */
         p->flags &= ~TRACE_FLAG_HEADER;
         if (printer_init(p, p->flags) < 0) {
-            msg_err("%s: printer_init failed (alloc)\n", __func__);
+            msg_err("printer_init failed (alloc)\n");
             return false;
         }
 
@@ -1708,7 +1706,7 @@ __ftrace_send_http_chunk_internal(struct ftrace_routine * routine, struct ftrace
     return false;
 
 send_http_chunk_failed:
-    msg_err("%s: send_http_chunk failed with %v\n", __func__, s);
+    msg_err("send_http_chunk failed with %v\n", s);
     return false;
 }
 

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -37,7 +37,7 @@ static struct futex * soft_create_futex(process p, u64 key)
     }
 
     f->h = h;
-    f->bq = allocate_blockq(f->h, "futex");
+    f->bq = allocate_blockq(f->h, ss("futex"));
     if (f->bq == INVALID_ADDRESS) {
         msg_err("failed to allocate futex blockq\n");
         deallocate(f->h, f, sizeof(struct futex));
@@ -110,11 +110,12 @@ closure_function(3, 1, sysreturn, futex_bh,
 {
     thread t = bound(t);
     struct futex *f = bound(f);
+    sstring func = func_ss;
     sysreturn rv;
 
     if (!(flags & BLOCKQ_ACTION_BLOCKED)) {
         futex_unlock(f);
-        thread_log(t, "%s: struct futex: %p, blocking", __func__, f);
+        thread_log(t, "%s: struct futex: %p, blocking", func, f);
         return BLOCKQ_BLOCK_REQUIRED;
     }
 
@@ -127,7 +128,7 @@ closure_function(3, 1, sysreturn, futex_bh,
         rv = 0; /* no timer expire + not us --> actual wakeup */
     }
 
-    thread_log(t, "%s: struct futex: %p, flags 0x%lx, rv %ld", __func__, f, flags, rv);
+    thread_log(t, "%s: struct futex: %p, flags 0x%lx, rv %ld", func, f, flags, rv);
     closure_finish();
     return syscall_return(t, rv);
 }

--- a/src/unix/inotify.c
+++ b/src/unix/inotify.c
@@ -293,7 +293,7 @@ sysreturn inotify_init1(int flags)
     if (in->event_buf == INVALID_ADDRESS) {
         goto nomem;
     }
-    in->bq = allocate_blockq(h, "inotify");
+    in->bq = allocate_blockq(h, ss("inotify"));
     if (in->bq == INVALID_ADDRESS) {
         deallocate_ringbuf(in->event_buf);
         goto nomem;
@@ -321,7 +321,8 @@ sysreturn inotify_init1(int flags)
 
 sysreturn inotify_add_watch(int fd, const char *pathname, u32 mask)
 {
-    if (!fault_in_user_string(pathname))
+    sstring pathname_ss;
+    if (!fault_in_user_string(pathname, &pathname_ss))
         return -EFAULT;
     if (!mask)
         return -EINVAL;
@@ -334,7 +335,7 @@ sysreturn inotify_add_watch(int fd, const char *pathname, u32 mask)
     process_get_cwd(current->p, &fs, &cwd);
     filesystem cwd_fs = fs;
     tuple n;
-    fs_status fss = filesystem_get_node(&fs, cwd, pathname, (mask & IN_DONT_FOLLOW) != 0, false,
+    fs_status fss = filesystem_get_node(&fs, cwd, pathname_ss, (mask & IN_DONT_FOLLOW) != 0, false,
                                         false, false, &n, 0);
     if (fss != FS_STATUS_OK) {
         rv = sysreturn_from_fs_status(fss);

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -25,7 +25,7 @@
 //#define IOUR_DEBUG
 #ifdef IOUR_DEBUG
 #define iour_debug(x, ...) do { \
-        tprintf(sym(iour), 0, "%s: " x "\n", __func__, ##__VA_ARGS__);   \
+        tprintf(sym(iour), 0, ss("%s: " x "\n"), func_ss, ##__VA_ARGS__);   \
 } while(0)
 #else
 #define iour_debug(x, ...)
@@ -601,7 +601,7 @@ static void iour_iov(io_uring iour, fdesc f, boolean write, struct iovec *iov,
 static void iour_rw(io_uring iour, fdesc f, boolean write, void *addr, u32 len,
                     u64 offset, u64 user_data)
 {
-    iour_debug("%s at %p, len %d, offset %ld", write ? "write" : "read", addr,
+    iour_debug("%s at %p, len %d, offset %ld", write ? ss("write") : ss("read"), addr,
             len, offset);
     int err = 0;
     file_io op = write ? f->write : f->read;

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -192,8 +192,8 @@ static status demand_anonymous_page(pending_fault pf, context ctx, vmap vm, u64 
                 kern_yield();
             }
         }
-        apply(completion, timm("result", "out of memory"));
-        return timm("result", "out of memory");
+        apply(completion, timm_oom);
+        return timm_oom;
     }
     count_minor_fault();
     return STATUS_OK;

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -75,7 +75,7 @@ define_closure_function(1, 1, void, pending_fault_complete,
     pending_fault pf = bound(pf);
     pf_debug("%s: page 0x%lx, status %v\n", __func__, pf->addr, s);
     if (!is_ok(s)) {
-        rprintf("%s: page fill failed with %v\n", __func__, s);
+        msg_err("page fill failed with %v\n", s);
     } else if (pf->bss_start > 0) {
         assert(pf->bss_start < PAGESIZE);
         range r = irangel(pf->addr + pf->bss_start, PAGESIZE - pf->bss_start);

--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -5,7 +5,7 @@
 
 //#define NETLINK_DEBUG
 #ifdef NETLINK_DEBUG
-#define nl_debug(x, ...) do {tprintf(sym(netlink), 0, x "\n", ##__VA_ARGS__);} while(0)
+#define nl_debug(x, ...) do {tprintf(sym(netlink), 0, ss(x "\n"), ##__VA_ARGS__);} while(0)
 #else
 #define nl_debug(x, ...)
 #endif

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -4,7 +4,7 @@
 
 //#define EPOLL_DEBUG
 #ifdef EPOLL_DEBUG
-#define epoll_debug(x, ...) do {tprintf(sym(poll), 0, "%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#define epoll_debug(x, ...) do {tprintf(sym(poll), 0, ss("%s: " x), func_ss, ##__VA_ARGS__);} while(0)
 #else
 #define epoll_debug(x, ...)
 #endif

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -972,7 +972,7 @@ static sysreturn allocate_signalfd(const u64 *mask, int flags)
   err_mem_bq:
     deallocate(h, sfd, sizeof(*sfd));
   err_mem:
-    msg_err("%s: failed to allocate\n", __func__);
+    msg_err("failed to allocate\n");
     return set_syscall_error(current, ENOMEM);
 }
 

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -110,12 +110,12 @@ struct sock {
 static inline int socket_init(heap h, int domain, int type, u32 flags, struct sock *s)
 {
     runtime_memset((u8 *) s, 0, sizeof(*s));
-    s->rxbq = allocate_blockq(h, "sock receive");
+    s->rxbq = allocate_blockq(h, ss("sock receive"));
     if (s->rxbq == INVALID_ADDRESS) {
         msg_err("failed to allocate blockq\n");
         goto err_rx;
     }
-    s->txbq = allocate_blockq(h, "sock transmit");
+    s->txbq = allocate_blockq(h, ss("sock transmit"));
     if (s->txbq == INVALID_ADDRESS) {
         msg_err("failed to allocate blockq\n");
         goto err_tx;

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -88,7 +88,7 @@ define_closure_function(2, 1, void, iov_op_each_complete,
     fdesc f = p->f;
     boolean write = p->write;
     thread t = current;
-    thread_log(t, "%s: rv %ld, curr %d, iovcnt %d", __func__, rv, p->curr, iovcnt);
+    thread_log(t, "%s: rv %ld, curr %d, iovcnt %d", func_ss, rv, p->curr, iovcnt);
 
     file_io op = write ? f->write : f->read;
     if (!op)
@@ -148,7 +148,7 @@ closure_function(4, 1, void, iov_read_complete,
 {
     sg_list sg = bound(sg);
     io_completion completion = bound(completion);
-    thread_log(current, "%s: sg %p, completion %F, rv %ld", __func__, sg, completion,
+    thread_log(current, "%s: sg %p, completion %F, rv %ld", func_ss, sg, completion,
                rv);
     if (rv > 0) {
         if (!sg_to_iov(sg, bound(iov), bound(iovcnt)))
@@ -165,7 +165,7 @@ closure_function(2, 1, void, iov_write_complete,
 {
     sg_list sg = bound(sg);
     io_completion completion = bound(completion);
-    thread_log(current, "%s: sg %p, completion %F, rv %ld", __func__, sg, completion,
+    thread_log(current, "%s: sg %p, completion %F, rv %ld", func_ss, sg, completion,
                rv);
     sg_list_release(sg);
     deallocate_sg_list(sg);
@@ -372,7 +372,7 @@ closure_function(9, 1, void, sendfile_bh,
 {
     thread t = current;
     thread_log(t, "%s: readlen %ld, written %ld, bh %d, rv %ld",
-               __func__, bound(readlen), bound(written), bound(bh), rv);
+               func_ss, bound(readlen), bound(written), bound(bh), rv);
 
     if (rv <= 0) {
         if (bound(bh) && rv == -EAGAIN) { /* result of a write */
@@ -460,7 +460,7 @@ out_complete:
 static sysreturn sendfile(int out_fd, int in_fd, long *offset, bytes count)
 {
     thread_log(current, "%s: out %d, in %d, offset %p, *offset %d, count %ld",
-               __func__, out_fd, in_fd, offset, offset ? *offset : 0, count);
+               func_ss, out_fd, in_fd, offset, offset ? *offset : 0, count);
     u64 read_offset;
     if (offset) {
         if (!get_user_value(offset, &read_offset))
@@ -533,7 +533,7 @@ closure_function(6, 1, void, file_read_complete,
                  status, s)
 {
     thread t = current;
-    thread_log(t, "%s: status %v", __func__, s);
+    thread_log(t, "%s: status %v", func_ss, s);
     sysreturn rv;
     sg_list sg = bound(sg);
     context ctx = get_current_context(current_cpu());
@@ -574,7 +574,7 @@ closure_function(2, 6, sysreturn, file_read,
     u64 offset = is_file_offset ? f->offset : offset_arg;
     thread t = current;
     thread_log(t, "%s: f %p, dest %p, offset %ld (%s), length %ld, file length %ld",
-               __func__, f, dest, offset, is_file_offset ? "file" : "specified",
+               func_ss, f, dest, offset, is_file_offset ? ss("file") : ss("specified"),
                length, f->fsf ? fsfile_get_length(f->fsf) : 0);
 
     sysreturn rv;
@@ -602,7 +602,7 @@ closure_function(4, 1, void, file_sg_read_complete,
                  file, f, sg_list, sg, boolean, is_file_offset, io_completion, completion,
                  status, s)
 {
-    thread_log(current, "%s: status %v", __func__, s);
+    thread_log(current, "%s: status %v", func_ss, s);
     sysreturn rv;
     if (is_ok(s)) {
        u64 length = bound(sg)->count;
@@ -627,7 +627,7 @@ closure_function(2, 6, sysreturn, file_sg_read,
     u64 offset = is_file_offset ? f->offset : offset_arg;
     thread t = current;
     thread_log(t, "%s: f %p, sg %p, offset %ld (%s), length %ld, file length %ld",
-               __func__, f, sg, offset, is_file_offset ? "file" : "specified",
+               func_ss, f, sg, offset, is_file_offset ? ss("file") : ss("specified"),
                length, f->fsf ? fsfile_get_length(f->fsf) : 0);
 
     sysreturn rv;
@@ -676,7 +676,7 @@ closure_function(6, 1, void, file_write_complete,
 {
     if (!bound(flush)) {
         thread_log(current, "%s: f %p, sg, %p, completion %F, status %v",
-                   __func__, bound(f), bound(sg), bound(completion), s);
+                   func_ss, bound(f), bound(sg), bound(completion), s);
         sg_list_release(bound(sg));
         deallocate_sg_list(bound(sg));
         file f = bound(f);
@@ -700,7 +700,7 @@ closure_function(2, 6, sysreturn, file_write,
     u64 offset = is_file_offset ? f->offset : offset_arg;
     thread t = current;
     thread_log(t, "%s: f %p, src %p, offset %ld (%s), length %ld, file length %ld",
-               __func__, f, src, offset, is_file_offset ? "file" : "specified",
+               func_ss, f, src, offset, is_file_offset ? ss("file") : ss("specified"),
                length, f->fsf ? fsfile_get_length(f->fsf) : 0);
 
     if (!f->fsf)
@@ -746,7 +746,7 @@ closure_function(5, 1, void, file_sg_write_complete,
     u64 len = bound(len);
     io_completion completion = bound(completion);
     thread_log(current, "%s: f %p, len %ld, completion %F, status %v",
-               __func__, f, len, completion, s);
+               func_ss, f, len, completion, s);
     file_write_complete_internal(f, len, bound(is_file_offset), completion,
                                  s);
     closure_finish();
@@ -763,7 +763,7 @@ closure_function(2, 6, sysreturn, file_sg_write,
     u64 offset = is_file_offset ? f->offset : offset_arg;
     thread t = current;
     thread_log(t, "%s: f %p, sg %p, offset %ld (%s), len %ld, file length %ld",
-               __func__, f, sg, offset, is_file_offset ? "file" : "specified",
+               func_ss, f, sg, offset, is_file_offset ? ss("file") : ss("specified"),
                len, f->fsf ? fsfile_get_length(f->fsf) : 0);
     if (!f->fsf) {
         rv = -EBADF;
@@ -849,16 +849,7 @@ static int dt_from_tuple(tuple n)
         return DT_REG;
 }
 
-static inline fs_status node_from_user_path(filesystem *fs, inode cwd, const char *path,
-                                            boolean nofollow, boolean create, boolean exclusive,
-                                            boolean truncate, tuple *n, fsfile *f)
-{
-    if (!fault_in_user_string(path))
-        return FS_STATUS_FAULT;
-    return filesystem_get_node(fs, cwd, path, nofollow, create, exclusive, truncate, n, f);
-}
-
-sysreturn open_internal(filesystem fs, inode cwd, const char *name, int flags,
+sysreturn open_internal(filesystem fs, inode cwd, sstring name, int flags,
                         int mode)
 {
     heap h = heap_locked(get_kernel_heaps());
@@ -880,7 +871,7 @@ sysreturn open_internal(filesystem fs, inode cwd, const char *name, int flags,
     }
 
     if (do_missing_files) {
-        b = string_from_cstring(name);
+        b = wrap_string_sstring(name);
         assert(b != INVALID_ADDRESS);
         b = buffer_basename(b);
     }
@@ -1031,13 +1022,14 @@ sysreturn open_internal(filesystem fs, inode cwd, const char *name, int flags,
 #ifdef __x86_64__
 sysreturn open(const char *name, int flags, int mode)
 {
-    if (!fault_in_user_string(name))
+    sstring name_ss;
+    if (!fault_in_user_string(name, &name_ss))
         return -EFAULT;
-    thread_log(current, "open: \"%s\", flags %x, mode %x", name, flags, mode);
+    thread_log(current, "open: \"%s\", flags %x, mode %x", name_ss, flags, mode);
     filesystem cwd_fs;
     inode cwd;
     process_get_cwd(current->p, &cwd_fs, &cwd);
-    sysreturn rv = open_internal(cwd_fs, cwd, name, flags, mode);
+    sysreturn rv = open_internal(cwd_fs, cwd, name_ss, flags, mode);
     filesystem_release(cwd_fs);
     return rv;
 }
@@ -1060,7 +1052,7 @@ sysreturn dup(int fd)
 
 sysreturn dup2(int oldfd, int newfd)
 {
-    thread_log(current, "%s: oldfd %d, newfd %d", __func__, oldfd, newfd);
+    thread_log(current, "%s: oldfd %d, newfd %d", func_ss, oldfd, newfd);
     process p = current->p;
     fdesc f = resolve_fd(p, oldfd);
     if (newfd != oldfd) {
@@ -1100,13 +1092,14 @@ sysreturn dup3(int oldfd, int newfd, int flags)
 
 sysreturn mkdir(const char *pathname, int mode)
 {
-    if (!fault_in_user_string(pathname))
+    sstring pathname_ss;
+    if (!fault_in_user_string(pathname, &pathname_ss))
         return -EFAULT;
-    thread_log(current, "mkdir: \"%s\", mode 0x%x", pathname, mode);
+    thread_log(current, "mkdir: \"%s\", mode 0x%x", pathname_ss, mode);
     filesystem cwd_fs;
     inode cwd;
     process_get_cwd(current->p, &cwd_fs, &cwd);
-    sysreturn rv = sysreturn_from_fs_status(filesystem_mkdir(cwd_fs, cwd, pathname));
+    sysreturn rv = sysreturn_from_fs_status(filesystem_mkdir(cwd_fs, cwd, pathname_ss));
     filesystem_release(cwd_fs);
     return rv;
 }
@@ -1125,25 +1118,27 @@ If pathname is absolute, then dirfd is ignore
 */
 sysreturn mkdirat(int dirfd, char *pathname, int mode)
 {
+    sstring pathname_ss;
     filesystem fs;
     inode cwd;
-    cwd = resolve_dir(fs, dirfd, pathname);
-    thread_log(current, "mkdirat: \"%s\", dirfd %d, mode 0x%x", pathname, dirfd, mode);
+    cwd = resolve_dir(fs, dirfd, pathname, pathname_ss);
+    thread_log(current, "mkdirat: \"%s\", dirfd %d, mode 0x%x", pathname_ss, dirfd, mode);
 
-    sysreturn rv = sysreturn_from_fs_status(filesystem_mkdir(fs, cwd, pathname));
+    sysreturn rv = sysreturn_from_fs_status(filesystem_mkdir(fs, cwd, pathname_ss));
     filesystem_release(fs);
     return rv;
 }
 
 sysreturn creat(const char *pathname, int mode)
 {
-    if (!fault_in_user_string(pathname))
+    sstring pathname_ss;
+    if (!fault_in_user_string(pathname, &pathname_ss))
         return -EFAULT;
-    thread_log(current, "creat: \"%s\", mode 0x%x", pathname, mode);
+    thread_log(current, "creat: \"%s\", mode 0x%x", pathname_ss, mode);
     filesystem cwd_fs;
     inode cwd;
     process_get_cwd(current->p, &cwd_fs, &cwd);
-    sysreturn rv = open_internal(cwd_fs, cwd, pathname,
+    sysreturn rv = open_internal(cwd_fs, cwd, pathname_ss,
         O_CREAT|O_WRONLY|O_TRUNC, mode);
     filesystem_release(cwd_fs);
     return rv;
@@ -1201,11 +1196,11 @@ sysreturn getrandom(void *buf, u64 buflen, unsigned int flags)
     return buflen;
 }
 
-static int try_write_dirent(void *dirp, boolean dirent64, char *p,
+static int try_write_dirent(void *dirp, boolean dirent64, string p,
         int *read_sofar, int *written_sofar, u64 *f_offset,
         unsigned int *count, filesystem fs, tuple n)
 {
-    int len = runtime_strlen(p);
+    int len = buffer_length(p);
     *read_sofar += len;
     if (*read_sofar > *f_offset) {
         int reclen = dirent64 ? (offsetof(struct linux_dirent64 *, d_name) + len + 1) :
@@ -1222,14 +1217,15 @@ static int try_write_dirent(void *dirp, boolean dirent64, char *p,
                 struct linux_dirent64 *dp = dirp;
                 dp->d_ino = fs->get_inode(fs, n);
                 dp->d_reclen = reclen;
-                runtime_memcpy(dp->d_name, p, len + 1);
+                runtime_memcpy(dp->d_name, buffer_ref(p, 0), len);
+                dp->d_name[len] = '\0';
                 dp->d_off = reclen + *written_sofar;
                 dp->d_type = dt_from_tuple(n);
             } else {
                 struct linux_dirent *dp = dirp;
                 dp->d_ino = fs->get_inode(fs, n);
                 dp->d_reclen = reclen;
-                runtime_memcpy(dp->d_name, p, len);
+                runtime_memcpy(dp->d_name, buffer_ref(p, 0), len);
                 zero(dp->d_name + len, reclen - (((void *)dp->d_name) - dirp) - len - 1);
                 dp->d_off = reclen + *written_sofar;
                 ((char *)dirp)[reclen - 1] = dt_from_tuple(n);
@@ -1249,8 +1245,7 @@ closure_function(8, 2, boolean, getdents_each,
                  value, k, value, v)
 {
     assert(is_symbol(k));
-    buffer tmpbuf = little_stack_buffer(NAME_MAX + 1);
-    char *p = cstring(symbol_string(k), tmpbuf);
+    string p = symbol_string(k);
     *bound(r) = try_write_dirent(*bound(dirp), bound(dirent64), p,
                                  bound(read_sofar), bound(written_sofar), &bound(f)->offset, bound(count),
                                  bound(fs), v);
@@ -1310,9 +1305,10 @@ sysreturn getdents64(int fd, struct linux_dirent64 *dirp, unsigned int count)
 
 sysreturn chdir(const char *path)
 {
-    if (!fault_in_user_string(path))
+    sstring path_ss;
+    if (!fault_in_user_string(path, &path_ss))
         return -EFAULT;
-    return sysreturn_from_fs_status(filesystem_chdir(current->p, path));
+    return sysreturn_from_fs_status(filesystem_chdir(current->p, path_ss));
 }
 
 sysreturn fchdir(int dirfd)
@@ -1357,14 +1353,17 @@ static sysreturn truncate_internal(filesystem fs, fsfile fsf, file f, long lengt
 
 sysreturn truncate(const char *path, long length)
 {
+    sstring path_ss;
+    if (!fault_in_user_string(path, &path_ss))
+        return -EFAULT;
     tuple t;
     filesystem fs;
     inode cwd;
     process_get_cwd(current->p, &fs, &cwd);
     filesystem cwd_fs = fs;
     fsfile fsf;
-    fs_status fss = node_from_user_path(&fs, cwd, path, false, false, false, false, &t, &fsf);
-    thread_log(current, "%s \"%s\" %d", __func__, path, length);
+    fs_status fss = filesystem_get_node(&fs, cwd, path_ss, false, false, false, false, &t, &fsf);
+    thread_log(current, "%s \"%s\" %d", func_ss, path_ss, length);
     sysreturn rv;
     if (fss != FS_STATUS_OK) {
         rv = sysreturn_from_fs_status(fss);
@@ -1390,7 +1389,7 @@ sysreturn truncate(const char *path, long length)
 
 sysreturn ftruncate(int fd, long length)
 {
-    thread_log(current, "%s %d %d", __func__, fd, length);
+    thread_log(current, "%s %d %d", func_ss, fd, length);
     file f = resolve_fd(current->p, fd);
     sysreturn rv;
     if (!(f->f.flags & (O_RDWR | O_WRONLY)) ||
@@ -1409,7 +1408,7 @@ closure_function(1, 1, void, sync_complete,
 {
     assert(is_syscall_context(get_current_context(current_cpu())));
     thread t = current;
-    thread_log(current, "%s: status %v", __func__, s);
+    thread_log(current, "%s: status %v", func_ss, s);
     fdesc f = bound(f);
     if (f)
         fdesc_put(f);
@@ -1480,7 +1479,7 @@ sysreturn fdatasync(int fd)
     return fsync_internal(fd, true);
 }
 
-static sysreturn access_internal(filesystem fs, inode cwd, const char *pathname, int mode)
+static sysreturn access_internal(filesystem fs, inode cwd, sstring pathname, int mode)
 {
     tuple m = 0;
     fs_status fss = filesystem_get_node(&fs, cwd, pathname, false, false, false, false, &m, 0);
@@ -1499,23 +1498,25 @@ static sysreturn access_internal(filesystem fs, inode cwd, const char *pathname,
 
 sysreturn access(const char *pathname, int mode)
 {
-    if (!fault_in_user_string(pathname))
+    sstring pathname_ss;
+    if (!fault_in_user_string(pathname, &pathname_ss))
         return -EFAULT;
-    thread_log(current, "access: \"%s\", mode %d", pathname, mode);
+    thread_log(current, "access: \"%s\", mode %d", pathname_ss, mode);
     filesystem cwd_fs;
     inode cwd;
     process_get_cwd(current->p, &cwd_fs, &cwd);
-    sysreturn rv = access_internal(cwd_fs, cwd, pathname, mode);
+    sysreturn rv = access_internal(cwd_fs, cwd, pathname_ss, mode);
     filesystem_release(cwd_fs);
     return rv;
 }
 
 sysreturn faccessat(int dirfd, const char *pathname, int mode)
 {
+    sstring pathname_ss;
     filesystem fs;
-    inode cwd = resolve_dir(fs, dirfd, pathname);
-    thread_log(current, "faccessat: dirfd %d, \"%s\", mode %d", dirfd, pathname, mode);
-    sysreturn rv = access_internal(fs, cwd, pathname, mode);
+    inode cwd = resolve_dir(fs, dirfd, pathname, pathname_ss);
+    thread_log(current, "faccessat: dirfd %d, \"%s\", mode %d", dirfd, pathname_ss, mode);
+    sysreturn rv = access_internal(fs, cwd, pathname_ss, mode);
     filesystem_release(fs);
     return rv;
 }
@@ -1537,11 +1538,12 @@ sysreturn openat(int dirfd, const char *name, int flags, int mode)
     if (name == 0)
         return set_syscall_error(current, EINVAL);
 
+    sstring name_ss;
     filesystem fs;
     inode cwd;
-    cwd = resolve_dir(fs, dirfd, name);
+    cwd = resolve_dir(fs, dirfd, name, name_ss);
 
-    sysreturn rv = open_internal(fs, cwd, name, flags, mode);
+    sysreturn rv = open_internal(fs, cwd, name_ss, flags, mode);
     filesystem_release(fs);
     return rv;
 }
@@ -1634,7 +1636,7 @@ static sysreturn fstat(int fd, struct stat *s)
     return rv;
 }
 
-static sysreturn stat_internal(filesystem fs, inode cwd, const char *name, boolean follow,
+static sysreturn stat_internal(filesystem fs, inode cwd, sstring name, boolean follow,
         struct stat *buf)
 {
     tuple n;
@@ -1643,6 +1645,8 @@ static sysreturn stat_internal(filesystem fs, inode cwd, const char *name, boole
     if (!fault_in_user_memory(buf, sizeof(struct stat), true))
         return -EFAULT;
 
+    thread_log(current, "stat: cwd 0x%lx, \"%s\", %sfollow, buf %p", cwd, name,
+               follow ? sstring_empty() : ss("no "), buf);
     fs_status fss = filesystem_get_node(&fs, cwd, name, !follow, false, false, false, &n, &fsf);
     if (fss != FS_STATUS_OK)
         return sysreturn_from_fs_status(fss);
@@ -1660,25 +1664,24 @@ static sysreturn stat_internal(filesystem fs, inode cwd, const char *name, boole
 
 static sysreturn stat_cwd(const char *name, boolean follow, struct stat *buf)
 {
-    if (!fault_in_user_string(name))
+    sstring name_ss;
+    if (!fault_in_user_string(name, &name_ss))
         return -EFAULT;
     filesystem cwd_fs;
     inode cwd;
     process_get_cwd(current->p, &cwd_fs, &cwd);
-    sysreturn rv = stat_internal(cwd_fs, cwd, name, follow, buf);
+    sysreturn rv = stat_internal(cwd_fs, cwd, name_ss, follow, buf);
     filesystem_release(cwd_fs);
     return rv;
 }
 
 static sysreturn stat(const char *name, struct stat *buf)
 {
-    thread_log(current, "stat: \"%s\", buf %p", name, buf);
     return stat_cwd(name, true, buf);
 }
 
 static sysreturn lstat(const char *name, struct stat *buf)
 {
-    thread_log(current, "lstat: \"%s\", buf %p", name, buf);
     return stat_cwd(name, false, buf);
 }
 #endif
@@ -1690,9 +1693,10 @@ static sysreturn newfstatat(int dfd, const char *name, struct stat *s, int flags
         return fstat(dfd, s);
 
     // Else, if we have a fd of a directory, resolve name to it.
+    sstring name_ss;
     filesystem fs;
-    inode n = resolve_dir(fs, dfd, name);
-    sysreturn rv = stat_internal(fs, n, name, !(flags & AT_SYMLINK_NOFOLLOW), s);
+    inode n = resolve_dir(fs, dfd, name, name_ss);
+    sysreturn rv = stat_internal(fs, n, name_ss, !(flags & AT_SYMLINK_NOFOLLOW), s);
     filesystem_release(fs);
     return rv;
 }
@@ -1700,10 +1704,10 @@ static sysreturn newfstatat(int dfd, const char *name, struct stat *s, int flags
 sysreturn lseek(int fd, s64 offset, int whence)
 {
     thread_log(current, "%s: fd %d offset %ld whence %s",
-            __func__, fd, offset, whence == SEEK_SET ? "SEEK_SET" :
-            whence == SEEK_CUR ? "SEEK_CUR" :
-            whence == SEEK_END ? "SEEK_END" :
-            "bugged");
+               func_ss, fd, offset, whence == SEEK_SET ? ss("SEEK_SET") :
+               whence == SEEK_CUR ? ss("SEEK_CUR") :
+               whence == SEEK_END ? ss("SEEK_END") :
+               ss("invalid"));
 
     file f = resolve_fd(current->p, fd);
     s64 new;
@@ -1771,8 +1775,8 @@ sysreturn uname(struct utsname *v)
     runtime_memcpy(v->machine, machine, sizeof(machine));
 
     /* gitversion shouldn't exceed the field, but just in case... */
-    bytes len = MIN(runtime_strlen(gitversion), sizeof(v->version) - 1);
-    runtime_memcpy(v->version, gitversion, len);
+    bytes len = MIN(gitversion.len, sizeof(v->version) - 1);
+    runtime_memcpy(v->version, gitversion.ptr, len);
     v->version[len] = '\0';     /* TODO: append build seq / time */
 
     /* The "5.0-" dummy prefix placates the glibc dynamic loader. */
@@ -1847,7 +1851,7 @@ sysreturn prlimit64(int pid, int resource, const struct rlimit *new_limit, struc
 
 static sysreturn getrusage(int who, struct rusage *usage)
 {
-    thread_log(current, "%s: who %d", __func__, who);
+    thread_log(current, "%s: who %d", func_ss, who);
     context ctx = get_current_context(current_cpu());
     if (!validate_user_memory(usage, sizeof(*usage), true) || context_set_err(ctx))
         return -EFAULT;
@@ -1915,7 +1919,7 @@ static sysreturn brk(void *addr)
     return sysreturn_from_pointer(addr);
 }
 
-static sysreturn readlink_internal(filesystem fs, inode cwd, const char *pathname, char *buf,
+static sysreturn readlink_internal(filesystem fs, inode cwd, sstring pathname, char *buf,
         u64 bufsiz)
 {
     if (!fault_in_user_memory(buf, bufsiz, true)) {
@@ -1942,36 +1946,39 @@ static sysreturn readlink_internal(filesystem fs, inode cwd, const char *pathnam
 
 sysreturn readlink(const char *pathname, char *buf, u64 bufsiz)
 {
-    if (!fault_in_user_string(pathname))
+    sstring pathname_ss;
+    if (!fault_in_user_string(pathname, &pathname_ss))
         return -EFAULT;
-    thread_log(current, "readlink: \"%s\"", pathname);
+    thread_log(current, "readlink: \"%s\"", pathname_ss);
     filesystem cwd_fs;
     inode cwd;
     process_get_cwd(current->p, &cwd_fs, &cwd);
-    sysreturn rv = readlink_internal(cwd_fs, cwd, pathname, buf, bufsiz);
+    sysreturn rv = readlink_internal(cwd_fs, cwd, pathname_ss, buf, bufsiz);
     filesystem_release(cwd_fs);
     return rv;
 }
 
 sysreturn readlinkat(int dirfd, const char *pathname, char *buf, u64 bufsiz)
 {
-    thread_log(current, "readlinkat: \"%s\", dirfd %d", pathname, dirfd);
+    sstring pathname_ss;
     filesystem fs;
-    inode cwd = resolve_dir(fs, dirfd, pathname);
-    sysreturn rv = readlink_internal(fs, cwd, pathname, buf, bufsiz);
+    inode cwd = resolve_dir(fs, dirfd, pathname, pathname_ss);
+    thread_log(current, "readlinkat: \"%s\", dirfd %d", pathname_ss, dirfd);
+    sysreturn rv = readlink_internal(fs, cwd, pathname_ss, buf, bufsiz);
     filesystem_release(fs);
     return rv;
 }
 
 sysreturn unlink(const char *pathname)
 {
-    if (!fault_in_user_string(pathname))
+    sstring pathname_ss;
+    if (!fault_in_user_string(pathname, &pathname_ss))
         return -EFAULT;
-    thread_log(current, "unlink %s", pathname);
+    thread_log(current, "unlink %s", pathname_ss);
     filesystem cwd_fs;
     inode cwd;
     process_get_cwd(current->p, &cwd_fs, &cwd);
-    sysreturn rv = sysreturn_from_fs_status(filesystem_delete(cwd_fs, cwd, pathname, false));
+    sysreturn rv = sysreturn_from_fs_status(filesystem_delete(cwd_fs, cwd, pathname_ss, false));
     filesystem_release(cwd_fs);
     return rv;
 }
@@ -1981,38 +1988,41 @@ sysreturn unlinkat(int dirfd, const char *pathname, int flags)
     if (flags & ~AT_REMOVEDIR) {
         return set_syscall_error(current, EINVAL);
     }
+    sstring path_ss;
     filesystem fs;
-    inode cwd = resolve_dir(fs, dirfd, pathname);
-    thread_log(current, "unlinkat %d %s 0x%x", dirfd, pathname, flags);
+    inode cwd = resolve_dir(fs, dirfd, pathname, path_ss);
+    thread_log(current, "unlinkat %d %s 0x%x", dirfd, path_ss, flags);
     sysreturn rv;
-    rv = sysreturn_from_fs_status(filesystem_delete(fs, cwd, pathname, !!(flags & AT_REMOVEDIR)));
+    rv = sysreturn_from_fs_status(filesystem_delete(fs, cwd, path_ss, !!(flags & AT_REMOVEDIR)));
     filesystem_release(fs);
     return rv;
 }
 
 sysreturn rmdir(const char *pathname)
 {
-    if (!fault_in_user_string(pathname))
+    sstring pathname_ss;
+    if (!fault_in_user_string(pathname, &pathname_ss))
         return -EFAULT;
-    thread_log(current, "rmdir %s", pathname);
+    thread_log(current, "rmdir %s", pathname_ss);
     filesystem cwd_fs;
     inode cwd;
     process_get_cwd(current->p, &cwd_fs, &cwd);
-    sysreturn rv = sysreturn_from_fs_status(filesystem_delete(cwd_fs, cwd, pathname, true));
+    sysreturn rv = sysreturn_from_fs_status(filesystem_delete(cwd_fs, cwd, pathname_ss, true));
     filesystem_release(cwd_fs);
     return rv;
 }
 
 sysreturn rename(const char *oldpath, const char *newpath)
 {
-    if (!fault_in_user_string(oldpath) || !fault_in_user_string(newpath))
+    sstring oldpath_ss, newpath_ss;
+    if (!fault_in_user_string(oldpath, &oldpath_ss) || !fault_in_user_string(newpath, &newpath_ss))
         return -EFAULT;
-    thread_log(current, "rename \"%s\" \"%s\"", oldpath, newpath);
+    thread_log(current, "rename \"%s\" \"%s\"", oldpath_ss, newpath_ss);
     filesystem cwd_fs;
     inode cwd;
     process_get_cwd(current->p, &cwd_fs, &cwd);
-    sysreturn rv = sysreturn_from_fs_status(filesystem_rename(cwd_fs, cwd, oldpath,
-        cwd_fs, cwd, newpath, false));
+    sysreturn rv = sysreturn_from_fs_status(filesystem_rename(cwd_fs, cwd, oldpath_ss,
+                                                              cwd_fs, cwd, newpath_ss, false));
     filesystem_release(cwd_fs);
     return rv;
 }
@@ -2020,12 +2030,13 @@ sysreturn rename(const char *oldpath, const char *newpath)
 sysreturn renameat(int olddirfd, const char *oldpath, int newdirfd,
         const char *newpath)
 {
+    sstring oldpath_ss, newpath_ss;
     filesystem oldfs, newfs;
-    inode oldwd = resolve_dir(oldfs, olddirfd, oldpath);
-    inode newwd = resolve_dir(newfs, newdirfd, newpath);
-    thread_log(current, "renameat %d \"%s\" %d \"%s\"", olddirfd, oldpath, newdirfd, newpath);
-    sysreturn rv = sysreturn_from_fs_status(filesystem_rename(oldfs, oldwd, oldpath,
-        newfs, newwd, newpath, false));
+    inode oldwd = resolve_dir(oldfs, olddirfd, oldpath, oldpath_ss);
+    inode newwd = resolve_dir(newfs, newdirfd, newpath, newpath_ss);
+    thread_log(current, "renameat %d \"%s\" %d \"%s\"", olddirfd, oldpath_ss, newdirfd, newpath_ss);
+    sysreturn rv = sysreturn_from_fs_status(filesystem_rename(oldfs, oldwd, oldpath_ss,
+                                                              newfs, newwd, newpath_ss, false));
     filesystem_release(oldfs);
     filesystem_release(newfs);
     return rv;
@@ -2038,17 +2049,18 @@ sysreturn renameat2(int olddirfd, const char *oldpath, int newdirfd,
             ((flags & RENAME_EXCHANGE) && (flags & RENAME_NOREPLACE))) {
         return set_syscall_error(current, EINVAL);
     }
+    sstring oldpath_ss, newpath_ss;
     filesystem oldfs, newfs;
-    inode oldwd = resolve_dir(oldfs, olddirfd, oldpath);
-    inode newwd = resolve_dir(newfs, newdirfd, newpath);
-    thread_log(current, "renameat2 %d \"%s\" %d \"%s\", flags 0x%x", olddirfd, oldpath,
-               newdirfd, newpath, flags);
+    inode oldwd = resolve_dir(oldfs, olddirfd, oldpath, oldpath_ss);
+    inode newwd = resolve_dir(newfs, newdirfd, newpath, newpath_ss);
+    thread_log(current, "renameat2 %d \"%s\" %d \"%s\", flags 0x%x", olddirfd, oldpath_ss,
+               newdirfd, newpath_ss, flags);
     fs_status fss;
     if (flags & RENAME_EXCHANGE) {
-        fss = filesystem_exchange(oldfs, oldwd, oldpath, newfs, newwd, newpath);
+        fss = filesystem_exchange(oldfs, oldwd, oldpath_ss, newfs, newwd, newpath_ss);
     }
     else {
-        fss = filesystem_rename(oldfs, oldwd, oldpath, newfs, newwd, newpath,
+        fss = filesystem_rename(oldfs, oldwd, oldpath_ss, newfs, newwd, newpath_ss,
             !!(flags & RENAME_NOREPLACE));
     }
     filesystem_release(oldfs);
@@ -2057,12 +2069,11 @@ sysreturn renameat2(int olddirfd, const char *oldpath, int newdirfd,
 }
 
 /* File paths are treated as absolute paths. */
-sysreturn fs_rename(buffer oldpath, buffer newpath)
+sysreturn fs_rename(sstring oldpath, sstring newpath)
 {
     filesystem fs = get_root_fs();
     inode root = fs->get_inode(fs, filesystem_getroot(fs));
-    return sysreturn_from_fs_status(filesystem_rename(fs, root, buffer_to_cstring(oldpath),
-        fs, root, buffer_to_cstring(newpath), false));
+    return sysreturn_from_fs_status(filesystem_rename(fs, root, oldpath, fs, root, newpath, false));
 }
 
 sysreturn close(int fd)
@@ -2480,7 +2491,7 @@ void register_file_syscalls(struct syscall *map)
 
 struct syscall {
     void *handler;
-    const char *name;
+    sstring name;
     u64 flags;
 };
 
@@ -2593,8 +2604,8 @@ void syscall_handler(thread t)
     }
     struct syscall *s = t->p->syscalls + call;
     if (debugsyscalls) {
-        if (s->name)
-            thread_log(t, s->name);
+        if (!sstring_is_null(s->name))
+            thread_log(t, "%s", s->name);
         else
             thread_log(t, "syscall %d", call);
     }
@@ -2613,7 +2624,7 @@ void syscall_handler(thread t)
         if (debugsyscalls)
             thread_log(t, "direct return: %ld, rsp 0x%lx", rv, f[SYSCALL_FRAME_SP]);
     } else if (debugsyscalls) {
-        if (s->name)
+        if (!sstring_is_null(s->name))
             thread_log(t, "nosyscall %s", s->name);
         else
             thread_log(t, "nosyscall %d", call);
@@ -2675,21 +2686,19 @@ static boolean stat_compare(void *za, void *zb)
     return sb->usecs > sa->usecs;
 }
 
-static inline char *print_usecs(buffer b, u64 x)
+static inline sstring print_usecs(buffer b, u64 x)
 {
     buffer_clear(b);
     bprintf(b, "%d.%06d", x / MILLION, x % MILLION);
-    buffer_write_byte(b, 0);
-    return buffer_ref(b, 0);
+    return buffer_to_sstring(b);
 }
 
-static inline char *print_pct(buffer b, u64 x, u64 y)
+static inline sstring print_pct(buffer b, u64 x, u64 y)
 {
     buffer_clear(b);
     x *= 100;
     bprintf(b, "%d.%02d", x / y, (x * 100 / y) % 100);
-    buffer_write_byte(b, 0);
-    return buffer_ref(b, 0);
+    return buffer_to_sstring(b);
 }
 
 #define LINE "------"
@@ -2715,7 +2724,8 @@ closure_function(0, 2, void, print_syscall_stats_cfn,
 
     if (status != 0)
         return;
-    rprintf("\n" HDR_FMT SEPARATOR, "% time", "seconds", "usecs/call", "calls", "errors", "syscall");
+    rprintf("\n" HDR_FMT SEPARATOR, ss("% time"), ss("seconds"), ss("usecs/call"), ss("calls"),
+            ss("errors"), ss("syscall"));
     for (int i = 0; i < SYS_MAX; i++) {
         ss = &stats[i];
         if (ss->calls == 0)
@@ -2729,12 +2739,13 @@ closure_function(0, 2, void, print_syscall_stats_cfn,
         rprintf(DATA_FMT, print_pct(pbuf, ss->usecs, tot_usecs), print_usecs(tbuf, ss->usecs),
             ROUNDED_IDIV(ss->usecs, ss->calls), ss->calls, ss->errors, _linux_syscalls[ss - stats].name);
     }
-    rprintf(SEPARATOR SUM_FMT, "100.00", print_usecs(tbuf, tot_usecs), 0, tot_calls, tot_errs, "total");
+    rprintf(SEPARATOR SUM_FMT, ss("100.00"), print_usecs(tbuf, tot_usecs), 0, tot_calls, tot_errs,
+            ss("total"));
     deallocate_pqueue(pq);
 }
 
-static char *missing_files_exclude[] = {
-    "ld.so.cache",
+static const sstring missing_files_exclude[] = {
+    ss_static_init("ld.so.cache"),
 };
 
 closure_function(0, 2, void, print_missing_files_cfn,
@@ -2744,7 +2755,7 @@ closure_function(0, 2, void, print_missing_files_cfn,
     rprintf("missing_files_begin\n");
     vector_foreach(missing_files, b) {
         for (int i = 0; i < sizeof(missing_files_exclude)/sizeof(missing_files_exclude[0]); i++) {
-            if (buffer_compare_with_cstring(b, missing_files_exclude[i]))
+            if (!buffer_compare_with_sstring(b, missing_files_exclude[i]))
                 goto next;
         }
         rprintf("%v\n", b);
@@ -2782,7 +2793,7 @@ void init_syscalls(process p)
     }
 }
 
-void _register_syscall(struct syscall *m, int n, sysreturn (*f)(), const char *name, u64 flags)
+void _register_syscall(struct syscall *m, int n, sysreturn (*f)(), sstring name, u64 flags)
 {
     assert(m[n].handler == 0);
     m[n].handler = f;
@@ -2798,16 +2809,16 @@ void *swap_syscall_handler(struct syscall *m, int n, sysreturn (*f)())
 }
 
 static struct trace_set {
-    char *name;
+    sstring name;
     u64 flag;
 } trace_sets[] = {
-    { "%file", SYSCALL_F_SET_FILE },
-    { "%desc", SYSCALL_F_SET_DESC },
-    { "%memory", SYSCALL_F_SET_MEM },
-    { "%process", SYSCALL_F_SET_PROC },
-    { "%signal", SYSCALL_F_SET_SIG },
-    { "%net", SYSCALL_F_SET_NET },
-    { "%network", SYSCALL_F_SET_NET },
+    { ss_static_init("%file"), SYSCALL_F_SET_FILE },
+    { ss_static_init("%desc"), SYSCALL_F_SET_DESC },
+    { ss_static_init("%memory"), SYSCALL_F_SET_MEM },
+    { ss_static_init("%process"), SYSCALL_F_SET_PROC },
+    { ss_static_init("%signal"), SYSCALL_F_SET_SIG },
+    { ss_static_init("%net"), SYSCALL_F_SET_NET },
+    { ss_static_init("%network"), SYSCALL_F_SET_NET },
 };
 
 static void notrace_configure(process p, boolean set)
@@ -2828,12 +2839,12 @@ closure_function(2, 2, boolean, notrace_each,
     if (peek_char(v) == '%') {
         for (int j = 0; j < sizeof(trace_sets) / sizeof(trace_sets[0]); j++) {
             struct trace_set *ts = trace_sets + j;
-            if (!buffer_compare_with_cstring(v, ts->name))
+            if (buffer_compare_with_sstring(v, ts->name))
                 continue;
 
             for (int i = 0; i < sizeof(_linux_syscalls) / sizeof(_linux_syscalls[0]); i++) {
                 struct syscall *s = bound(p)->syscalls + i;
-                if (!s->name || !(s->flags & ts->flag))
+                if (sstring_is_null(s->name) || !(s->flags & ts->flag))
                     continue;
 
                 if (bound(set))
@@ -2846,10 +2857,7 @@ closure_function(2, 2, boolean, notrace_each,
     } else {
         for (int i = 0; i < sizeof(_linux_syscalls) / sizeof(_linux_syscalls[0]); i++) {
             struct syscall *s = bound(p)->syscalls + i;
-            if (!s->name)
-                continue;
-
-            if (!buffer_compare_with_cstring(v, s->name))
+            if (sstring_is_null(s->name) || buffer_compare_with_sstring(v, s->name))
                 continue;
 
             if (bound(set))

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -543,7 +543,8 @@ closure_function(6, 1, void, file_read_complete,
          * release it here. */
         sg_buf_release(sg_list_peek_at(sg, -1));
 
-        s = timm("result", "invalid user memory", "fsstatus", "%d", FS_STATUS_FAULT);
+        s = timm("result", "invalid user memory");
+        s = timm_append(s, "fsstatus", "%d", FS_STATUS_FAULT);
     }
     if (is_ok(s)) {
         file f = bound(f);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -499,7 +499,7 @@ thread create_thread(process p, u64 tid)
     destruct_context(&t->context);
     deallocate(h, t, sizeof(struct thread));
   fail:
-    msg_err("%s: failed to allocate\n", __func__);
+    msg_err("failed to allocate\n");
     return INVALID_ADDRESS;
 }
 

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -8,7 +8,7 @@
 
 //#define UNIX_TIMER_DEBUG
 #ifdef UNIX_TIMER_DEBUG
-#define timer_debug(x, ...) do {tprintf(sym(unix_timer), 0, "%s: " x, __func__, ##__VA_ARGS__);} while(0)
+#define timer_debug(x, ...) do {tprintf(sym(unix_timer), 0, ss("%s: " x), func_ss, ##__VA_ARGS__);} while(0)
 #else
 #define timer_debug(x, ...)
 #endif
@@ -360,7 +360,7 @@ sysreturn timerfd_create(int clockid, int flags)
         return -ENOMEM;
 
     init_fdesc(unix_timer_heap, &ut->f, FDESC_TYPE_TIMERFD);
-    ut->info.timerfd.bq = allocate_blockq(unix_timer_heap, "timerfd");
+    ut->info.timerfd.bq = allocate_blockq(unix_timer_heap, ss("timerfd"));
     if (ut->info.timerfd.bq == INVALID_ADDRESS)
         goto err_mem_bq;
     ut->info.timerfd.cancel_on_set = false;
@@ -420,7 +420,7 @@ static void sigev_deliver(unix_timer ut)
         break;
     default:
         /* SIGEV_THREAD is a glibc thing; we should never see it. */
-        halt("%s: invalid sigev_notify %d\n", __func__, sevp->sigev_notify);
+        halt("%s: invalid sigev_notify %d\n", func_ss, sevp->sigev_notify);
     }
 }
 

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -574,7 +574,7 @@ sysreturn timer_create(int clockid, struct sigevent *sevp, u32 *timerid)
             break;
         case SIGEV_THREAD:
             /* should never see this, but bark if we do */
-            msg_err("%s: SIGEV_THREAD should be handled by libc / nptl\n", __func__);
+            msg_err("SIGEV_THREAD should be handled by libc / nptl\n");
             /* no break */
         default:
             rv = -EINVAL;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -131,7 +131,7 @@ void demand_page_done(context ctx, u64 vaddr, status s)
     } else if (is_thread_context(ctx)) {
         pf_debug("demand page failed user mode, reason: %v", s);
         thread t = (thread)ctx;
-        if (buffer_compare_with_cstring_ci(get(s, sym(result)), "out of memory")) {
+        if (s == timm_oom) {
             spin_lock(&oom_lock);
             timestamp here = now(CLOCK_ID_MONOTONIC);
             if (here - oom_last_time > seconds(5)) {

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -208,13 +208,13 @@ const char *string_from_mmap_type(int type)
          "unknown");
 }
 
-#define format_protection_violation(vaddr, ctx, vm, str)        \
-    "page_protection_violation%s\naddr 0x%lx, pc 0x%lx, "       \
-    "error %s%s%s vm->flags (%s%s %s%s%s)\n",                   \
-        str, vaddr, frame_fault_pc(ctx->frame),                 \
-        is_write_fault(ctx->frame) ? "W" : "R",                 \
-        is_usermode_fault(ctx->frame) ? "U" : "S",              \
-        is_instruction_fault(ctx->frame) ? "I" : "D",           \
+#define format_protection_violation(vaddr, ctx, vm)             \
+    "page_protection_violation\naddr 0x%lx, pc 0x%lx, "         \
+    "error %c%c%c vm->flags (%s%s %s%s%s)\n",                   \
+        vaddr, frame_fault_pc(ctx->frame),                      \
+        is_write_fault(ctx->frame) ? 'W' : 'R',                 \
+        is_usermode_fault(ctx->frame) ? 'U' : 'S',              \
+        is_instruction_fault(ctx->frame) ? 'I' : 'D',           \
         (vm->flags & VMAP_FLAG_MMAP) ? "mmap " : "",            \
         string_from_mmap_type(vm->flags & VMAP_MMAP_TYPE_MASK), \
         (vm->flags & VMAP_FLAG_READABLE) ? "readable " : "",    \
@@ -239,7 +239,7 @@ static boolean handle_protection_fault(context ctx, u64 vaddr, vmap vm)
     }
 
     if (is_thread_context(ctx)) {
-        pf_debug(format_protection_violation(vaddr, ctx, vm, ""));
+        pf_debug(format_protection_violation(vaddr, ctx, vm));
         deliver_fault_signal(SIGSEGV, (thread)ctx, vaddr, SEGV_ACCERR);
         return true;
     }

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -83,7 +83,7 @@ closure_function(5, 1, sysreturn, nanosleep_bh,
     thread t = bound(t);
     timestamp elapsed = now(bound(id)) - bound(start);
     thread_log(t, "%s: start %T, interval %T, rem %p, elapsed %T, flags 0x%lx",
-               __func__, bound(start), bound(interval), bound(rem), elapsed, flags);
+               func_ss, bound(start), bound(interval), bound(rem), elapsed, flags);
     sysreturn rv = 0;
     if (flags & BLOCKQ_ACTION_NULLIFY) {
         if (bound(rem)) {
@@ -133,7 +133,7 @@ sysreturn clock_nanosleep(clockid_t _clock_id, int flags, const struct timespec 
 
     /* Report any attempted use of CLOCK_PROCESS_CPUTIME_ID */
     if (_clock_id == CLOCK_PROCESS_CPUTIME_ID) {
-        rprintf("%s: CLOCK_PROCESS_CPUTIME_ID not yet supported\n", __func__);
+        rprintf("%s: CLOCK_PROCESS_CPUTIME_ID not yet supported\n", func_ss);
         return -EINVAL;
     }
 
@@ -213,7 +213,7 @@ sysreturn clock_gettime(clockid_t clk_id, struct timespec *tp)
 
 sysreturn clock_settime(clockid_t clk_id, const struct timespec *tp)
 {
-    thread_log(current, "%s: clk_id %d, tp %p", __func__, clk_id, tp);
+    thread_log(current, "%s: clk_id %d, tp %p", func_ss, clk_id, tp);
     context ctx;
     switch (clk_id) {
     case CLOCK_REALTIME:

--- a/src/unix/vsock.c
+++ b/src/unix/vsock.c
@@ -9,7 +9,7 @@
 
 //#define VSOCK_DEBUG
 #ifdef VSOCK_DEBUG
-#define vsock_debug(x, ...) do {tprintf(sym(vsock), 0, x "\n", ##__VA_ARGS__);} while(0)
+#define vsock_debug(x, ...) do {tprintf(sym(vsock), 0, ss(x "\n"), ##__VA_ARGS__);} while(0)
 #else
 #define vsock_debug(x, ...)
 #endif

--- a/src/unix_process/mmap_heap.c
+++ b/src/unix_process/mmap_heap.c
@@ -6,7 +6,7 @@
 void mmapheap_dealloc(heap h, u64 x, bytes size)
 {
     if (munmap((void *)x, size))
-        halt("munmap failed %s\n", strerror(errno));
+        halt("munmap failed %s\n", errno_sstring());
 }
 
 u64 mmapheap_alloc(heap h, bytes size)
@@ -14,7 +14,7 @@ u64 mmapheap_alloc(heap h, bytes size)
     void * rv = mmap(0, size + h->pagesize, PROT_READ | PROT_WRITE,
 		     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (rv == MAP_FAILED) {
-	msg_err("mmap() failed: errno %s", strerror(errno));
+	msg_err("mmap() failed: errno %s", errno_sstring());
 	return INVALID_PHYSICAL;
     } else {
         return (u64_from_pointer(rv) + h->pagesize - 1) & ~(h->pagesize - 1);

--- a/src/unix_process/socket_user.c
+++ b/src/unix_process/socket_user.c
@@ -530,8 +530,7 @@ void connection(heap h,
     int res = connect(s, (struct sockaddr *)&where, sizeof(struct sockaddr_in));
     if (res) {
         rprintf("zikkay %d %p\n", res, failure);        
-        apply(failure, timm("errno", "%d", errno,
-                            "errstr", "%s", strerror(errno)));
+        apply(failure, timm("errno", "%d", errno));
     } else {
         register_descriptor_write(h, n, s, closure(h, connection_start, h, s, n, c));
     }

--- a/src/unix_process/unix_process_runtime.h
+++ b/src/unix_process/unix_process_runtime.h
@@ -1,5 +1,6 @@
 typedef int descriptor;
 heap init_process_runtime();
+sstring errno_sstring(void);
 heap allocate_mmapheap(heap meta, bytes size);
 heap make_tiny_heap(heap parent);
 tuple parse_arguments(heap h, int argc, char **argv);

--- a/src/virtio/scsi.c
+++ b/src/virtio/scsi.c
@@ -19,7 +19,9 @@ static void scsi_bdump_sense(buffer b, const u8 *sense, int length)
 {
     assert(length >= sizeof(struct scsi_sense_data));
     for (int i = 0; i < sizeof(struct scsi_sense_data); i++) {
-        bprintf(b, "%s%02x", i > 0 ? " " : "", sense[i]);
+        if (i > 0)
+            push_u8(b, ' ');
+        bprintf(b, "%02x", sense[i]);
     }
     struct scsi_sense_data *ssd = (struct scsi_sense_data *) sense;
     bprintf(b, ": KEY %x, ASC/ASCQ %02x/%02x",

--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -105,7 +105,7 @@ void vtdev_set_status(vtdev dev, u8 status)
     }
 }
 
-status virtio_alloc_virtqueue(vtdev dev, const char *name, int idx, struct virtqueue **result)
+status virtio_alloc_virtqueue(vtdev dev, sstring name, int idx, struct virtqueue **result)
 {
     switch (dev->transport) {
     case VTIO_TRANSPORT_MMIO:

--- a/src/virtio/virtio_9p.c
+++ b/src/virtio/virtio_9p.c
@@ -705,7 +705,7 @@ void v9p_read(void *priv, u32 fid, u64 offset, u32 count, void *dest, status_han
     status s;
     struct p9_read *xaction = alloc_map(v9p->backed, sizeof(*xaction), &phys);
     if (xaction == INVALID_ADDRESS) {
-        s = timm("result", "failed to allocate request", "fsstatus", "%d", FS_STATUS_NOMEM);
+        s = timm("result", "failed to allocate request");
         goto error;
     }
     v9p_fill_req_hdr(v9p, xaction, P9_TREAD);
@@ -714,12 +714,12 @@ void v9p_read(void *priv, u32 fid, u64 offset, u32 count, void *dest, status_han
     xaction->req.count = count;
     vqfinish finish = closure(v9p->general, v9p_read_complete, v9p, xaction, phys, complete);
     if (finish == INVALID_ADDRESS) {
-        s = timm("result", "failed to allocate vqfinish", "fsstatus", "%d", FS_STATUS_NOMEM);
+        s = timm("result", "failed to allocate vqfinish");
         goto dealloc_req;
     }
     vqmsg m = allocate_vqmsg(v9p->vq);
     if (m == INVALID_ADDRESS) {
-        s = timm("result", "failed to allocate vqmsg", "fsstatus", "%d", FS_STATUS_NOMEM);
+        s = timm("result", "failed to allocate vqmsg");
         deallocate_closure(finish);
         goto dealloc_req;
     }
@@ -731,6 +731,7 @@ void v9p_read(void *priv, u32 fid, u64 offset, u32 count, void *dest, status_han
   dealloc_req:
     dealloc_unmap(v9p->backed, xaction, phys, sizeof(*xaction));
   error:
+    s = timm_append(s, "fsstatus", "%d", FS_STATUS_NOMEM);
     apply(complete, s);
 }
 
@@ -768,7 +769,7 @@ void v9p_write(void *priv, u32 fid, u64 offset, u32 count, void *src, status_han
     union p9_write_resp *resp;
     struct p9_write_req *req = alloc_map(v9p->backed, sizeof(*req) + sizeof(*resp), &phys);
     if (req == INVALID_ADDRESS) {
-        s = timm("result", "failed to allocate request", "fsstatus", "%d", FS_STATUS_NOMEM);
+        s = timm("result", "failed to allocate request");
         goto error;
     }
     v9p_fill_hdr(v9p, &req->hdr, sizeof(*req) + count, P9_TWRITE);
@@ -777,12 +778,12 @@ void v9p_write(void *priv, u32 fid, u64 offset, u32 count, void *src, status_han
     req->count = count;
     vqfinish finish = closure(v9p->general, v9p_write_complete, v9p, req, phys, complete);
     if (finish == INVALID_ADDRESS) {
-        s = timm("result", "failed to allocate vqfinish", "fsstatus", "%d", FS_STATUS_NOMEM);
+        s = timm("result", "failed to allocate vqfinish");
         goto dealloc_req;
     }
     vqmsg m = allocate_vqmsg(v9p->vq);
     if (m == INVALID_ADDRESS) {
-        s = timm("result", "failed to allocate vqmsg", "fsstatus", "%d", FS_STATUS_NOMEM);
+        s = timm("result", "failed to allocate vqmsg");
         deallocate_closure(finish);
         goto dealloc_req;
     }
@@ -794,5 +795,6 @@ void v9p_write(void *priv, u32 fid, u64 offset, u32 count, void *src, status_han
   dealloc_req:
     dealloc_unmap(v9p->backed, req, phys, sizeof(*req) + sizeof(*resp));
   error:
+    s = timm_append(s, "fsstatus", "%d", FS_STATUS_NOMEM);
     apply(complete, s);
 }

--- a/src/virtio/virtio_9p.h
+++ b/src/virtio/virtio_9p.h
@@ -15,7 +15,7 @@ fs_status v9p_fsync(void *priv, u32 fid, u32 datasync);
 fs_status v9p_mkdir(void *priv, u32 dfid, string name, u32 mode, u64 *qid);
 fs_status v9p_renameat(void *priv, u32 old_dfid, string old_name, u32 new_dfid, string new_name);
 fs_status v9p_unlinkat(void *priv, u32 dfid, string name, u32 flags);
-fs_status v9p_version(void *priv, u32 msize, const char *version, u32 *ret_msize);
+fs_status v9p_version(void *priv, u32 msize, sstring version, u32 *ret_msize);
 fs_status v9p_attach(void *priv, u32 root_fid, u64 *root_qid);
 fs_status v9p_walk(void *priv, u32 fid, u32 newfid, string wname, struct p9_qid *qid);
 fs_status v9p_clunk(void *priv, u32 fid);

--- a/src/virtio/virtio_balloon.c
+++ b/src/virtio/virtio_balloon.c
@@ -266,7 +266,7 @@ closure_function(1, 0, void, virtio_balloon_config_change,
 closure_function(0, 1, u64, virtio_balloon_deflater,
                  u64, deflate_bytes)
 {
-    virtio_balloon_debug("%s: deflate of %ld bytes requested\n", __func__, deflate_bytes);
+    virtio_balloon_debug("deflate of %ld bytes requested\n", deflate_bytes);
     u64 deflate = ((deflate_bytes + MASK(VIRTIO_BALLOON_ALLOC_ORDER))
                    >> VIRTIO_BALLOON_ALLOC_ORDER);
     u64 deflated = virtio_balloon_deflate(deflate);
@@ -394,7 +394,7 @@ static boolean virtio_balloon_attach(heap general, backed_heap backed, id_heap p
         virtio_balloon_init_statsq();
     return true;
   fail:
-    rprintf("%s: failed to attach: %v\n", __func__, s);
+    msg_err("failed to attach: %v\n", s);
     return false;
 }
 

--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -97,11 +97,11 @@ static inline void virtio_attach(heap h, backed_heap page_allocator,
     d->transport = transport;
 }
 
-status virtio_alloc_virtqueue(vtdev dev, const char *name, int idx, struct virtqueue **result);
+status virtio_alloc_virtqueue(vtdev dev, sstring name, int idx, struct virtqueue **result);
 status virtio_register_config_change_handler(vtdev dev, thunk handler);
 
 status virtqueue_alloc(vtdev dev,
-                       const char *name,
+                       sstring name,
                        u16 queue_index,
                        u16 size,
                        bytes notify_offset,

--- a/src/virtio/virtio_mmio.c
+++ b/src/virtio/virtio_mmio.c
@@ -17,7 +17,7 @@
 
 //#define VIRTIO_MMIO_DEBUG
 #ifdef VIRTIO_MMIO_DEBUG
-#define virtio_mmio_debug(x, ...) tprintf(sym(vtmmio), 0, x "\n", ##__VA_ARGS__)
+#define virtio_mmio_debug(x, ...) tprintf(sym(vtmmio), 0, ss(x "\n"), ##__VA_ARGS__)
 #else
 #define virtio_mmio_debug(x, ...)
 #endif
@@ -94,7 +94,7 @@ closure_function(1, 2, void, vtmmio_cmdline_parse,
 
 void virtio_mmio_enum_devs(kernel_heaps kh)
 {
-    cmdline_consume("virtio_mmio", stack_closure(vtmmio_cmdline_parse, kh));
+    cmdline_consume(ss("virtio_mmio"), stack_closure(vtmmio_cmdline_parse, kh));
     acpi_get_vtmmio_devs(stack_closure(vtmmio_new_dev, kh));
 }
 
@@ -188,7 +188,7 @@ define_closure_function(1, 0, void, vtmmio_irq,
     }
 }
 
-status vtmmio_alloc_virtqueue(vtmmio dev, const char *name, int idx,
+status vtmmio_alloc_virtqueue(vtmmio dev, sstring name, int idx,
                               struct virtqueue **result)
 {
     virtio_mmio_debug("allocating virtqueue %d (%s)", idx, name);

--- a/src/virtio/virtio_mmio.h
+++ b/src/virtio/virtio_mmio.h
@@ -72,4 +72,4 @@ typedef closure_type(vtmmio_probe, void, vtmmio);
 void vtmmio_probe_devs(vtmmio_probe probe);
 void vtmmio_set_status(vtmmio dev, u8 status);
 boolean attach_vtmmio(heap h, backed_heap page_allocator, vtmmio d, u64 feature_mask);
-status vtmmio_alloc_virtqueue(vtmmio dev, const char *name, int idx, struct virtqueue **result);
+status vtmmio_alloc_virtqueue(vtmmio dev, sstring name, int idx, struct virtqueue **result);

--- a/src/virtio/virtio_pci.h
+++ b/src/virtio/virtio_pci.h
@@ -94,7 +94,7 @@ struct vtpci {
 
 boolean vtpci_probe(pci_dev d, int virtio_dev_id);
 vtpci attach_vtpci(heap h, backed_heap page_allocator, pci_dev d, u64 feature_mask);
-status vtpci_alloc_virtqueue(vtpci dev, const char *name, int idx, struct virtqueue **result);
+status vtpci_alloc_virtqueue(vtpci dev, sstring name, int idx, struct virtqueue **result);
 status vtpci_register_config_change_handler(vtpci dev, thunk handler);
 void vtpci_set_status(vtpci dev, u8 status);
 boolean vtpci_is_modern(vtpci dev);

--- a/src/virtio/virtio_rng.c
+++ b/src/virtio/virtio_rng.c
@@ -2,7 +2,7 @@
 
 //#define VIRTIO_RNG_DEBUG
 #ifdef VIRTIO_RNG_DEBUG
-#define virtio_rng_debug(x, ...) do {tprintf(sym(vtrng), 0, x, ##__VA_ARGS__);} while(0)
+#define virtio_rng_debug(x, ...) do {tprintf(sym(vtrng), 0, ss(x), ##__VA_ARGS__);} while(0)
 #else
 #define virtio_rng_debug(x, ...)
 #endif
@@ -47,7 +47,7 @@ static inline entropy_buf current_ebuf(void)
 
 static void virtio_rng_fill(entropy_buf ebuf)
 {
-    virtio_rng_debug("%s: ebuf %p\n", __func__, ebuf);
+    virtio_rng_debug("%s: ebuf %p\n", func_ss, ebuf);
     virtqueue vq = virtio_rng.requestq;
     vqmsg m = allocate_vqmsg(vq);
     assert(m != INVALID_ADDRESS);
@@ -60,7 +60,7 @@ define_closure_function(1, 1, void, ebuf_fill_complete,
                         entropy_buf, ebuf,
                         u64, len)
 {
-    virtio_rng_debug("%s: len %ld\n", __func__, len);
+    virtio_rng_debug("%s: len %ld\n", func_ss, len);
     assert(len <= VIRTIO_RNG_BUFSIZE);
     bound(ebuf)->offset = 0;
     bound(ebuf)->len = len;
@@ -72,7 +72,7 @@ define_closure_function(1, 1, void, ebuf_fill_complete,
 
 static void virtio_init_ebufs(void)
 {
-    virtio_rng_debug("%s\n", __func__);
+    virtio_rng_debug("%s\n", func_ss);
     for (int i = 0; i < 2; i++) {
         entropy_buf ebuf = &virtio_rng.ebufs[i];
         ebuf->buf = alloc_map(virtio_rng.backed, VIRTIO_RNG_BUFSIZE, &ebuf->phys);
@@ -100,7 +100,7 @@ static bytes virtio_rng_get_seed(void *seed, bytes len)
             virtio_rng_fill(ebuf);
         }
     }
-    virtio_rng_debug("%s: filled %ld\n", __func__, filled);
+    virtio_rng_debug("%s: filled %ld\n", func_ss, filled);
     return filled;
 }
 
@@ -112,7 +112,7 @@ static boolean virtio_rng_attach(heap general, backed_heap backed, vtdev v)
     virtio_rng.dev = v;
     virtio_rng.initialized = false;
 
-    status s = virtio_alloc_virtqueue(v, "virtio rng requestq", 0, &virtio_rng.requestq);
+    status s = virtio_alloc_virtqueue(v, ss("virtio rng requestq"), 0, &virtio_rng.requestq);
     if (!is_ok(s))
         goto fail;
 
@@ -130,7 +130,7 @@ closure_function(3, 1, boolean, vtpci_rng_probe,
                  heap, general, backed_heap, backed, id_heap, physical,
                  pci_dev, d)
 {
-    virtio_rng_debug("%s\n", __func__);
+    virtio_rng_debug("%s\n", func_ss);
     if (!vtpci_probe(d, VIRTIO_ID_ENTROPY))
         return false;
 
@@ -141,7 +141,7 @@ closure_function(3, 1, boolean, vtpci_rng_probe,
 
 void init_virtio_rng(kernel_heaps kh)
 {
-    virtio_rng_debug("%s\n", __func__);
+    virtio_rng_debug("%s\n", func_ss);
     heap h = heap_locked(kh);
     register_pci_driver(closure(h, vtpci_rng_probe, h, heap_linear_backed(kh), heap_physical(kh)), 0);
 }

--- a/src/virtio/virtio_rng.c
+++ b/src/virtio/virtio_rng.c
@@ -122,7 +122,7 @@ static boolean virtio_rng_attach(heap general, backed_heap backed, vtdev v)
     preferred_get_seed = virtio_rng_get_seed;
     return true;
   fail:
-    rprintf("%s: failed to attach: %v\n", __func__, s);
+    msg_err("failed to attach: %v\n", s);
     return false;
 }
 

--- a/src/virtio/virtio_scsi.c
+++ b/src/virtio/virtio_scsi.c
@@ -175,7 +175,7 @@ closure_function(2, 1, void, virtio_scsi_event_complete,
 {
     virtio_scsi_event e = bound(e);
     virtio_scsi s = bound(s);
-    virtio_scsi_debug("%s: event 0x%x\n", __func__, e->event);
+    virtio_scsi_debug("event 0x%x\n", e->event);
     if (e->event & VIRTIO_SCSI_EVENT_LOST)
         msg_err("scsi event reported lost due to missing buffers\n");
     switch (e->event & ~VIRTIO_SCSI_EVENT_LOST) {

--- a/src/virtio/virtio_socket.c
+++ b/src/virtio/virtio_socket.c
@@ -43,7 +43,7 @@ struct virtio_vsock_hdr {
 
 //#define VIRTIO_SOCK_DEBUG
 #ifdef VIRTIO_SOCK_DEBUG
-#define virtio_sock_debug(x, ...) do {tprintf(sym(virtio_sock), 0, x "\n", ##__VA_ARGS__);} while(0)
+#define virtio_sock_debug(x, ...) do {tprintf(sym(virtio_sock), 0, ss(x "\n"), ##__VA_ARGS__);} while(0)
 #else
 #define virtio_sock_debug(x, ...)
 #endif
@@ -105,13 +105,13 @@ static boolean virtio_sock_dev_attach(heap general, backed_heap backed, vtdev de
         return false;
     vs->guest_cid = vtdev_cfg_read_4(dev, offsetof(struct virtio_vsock_config *, guest_cid));
     virtio_sock_debug("  guest CID %d", vs->guest_cid);
-    status s = virtio_alloc_virtqueue(dev, "virtio socket rx", 0, &vs->rxq);
+    status s = virtio_alloc_virtqueue(dev, ss("virtio socket rx"), 0, &vs->rxq);
     if (!is_ok(s)) {
         msg_err("failed to allocate rx virtqueue: %v\n", s);
         timm_dealloc(s);
         goto err;
     }
-    s = virtio_alloc_virtqueue(dev, "virtio socket tx", 1, &vs->txq);
+    s = virtio_alloc_virtqueue(dev, ss("virtio socket tx"), 1, &vs->txq);
     if (!is_ok(s)) {
         msg_err("failed to allocate tx virtqueue: %v\n", s);
         timm_dealloc(s);
@@ -120,7 +120,7 @@ static boolean virtio_sock_dev_attach(heap general, backed_heap backed, vtdev de
 
     /* The event virtqueue is initialized even if not used, otherwise AWS Firecracker complains
      * about an "attempt to use virtio queue that is not marked ready". */
-    s = virtio_alloc_virtqueue(dev, "virtio socket events", 2, &vs->eventq);
+    s = virtio_alloc_virtqueue(dev, ss("virtio socket events"), 2, &vs->eventq);
     if (!is_ok(s)) {
         msg_err("failed to allocate event virtqueue: %v\n", s);
         timm_dealloc(s);

--- a/src/vmware/vmxnet3_net.c
+++ b/src/vmware/vmxnet3_net.c
@@ -204,7 +204,7 @@ static void vmxnet3_check_version(vmxnet3_pci dev)
 static err_t vmxif_init(struct netif *netif)
 {
     vmxnet3 vn = netif->state;
-    netif->hostname = "uniboot"; // from config
+    netif->hostname = sstring_empty();
 
     netif->name[0] = DEVICE_NAME[0];
     netif->name[1] = DEVICE_NAME[1];
@@ -388,7 +388,7 @@ static void vmxnet3_net_attach(heap general, heap page_allocator, pci_dev d)
     vn->rx_service = closure(dev->general, vmxnet3_rx_service_bh, vn);
 
     vn->rx_intr_handler = closure(dev->general, rx_interrupt, vn);
-    assert(pci_setup_msix(dev->dev, 1, vn->rx_intr_handler, "vmxnet3 rx") != INVALID_PHYSICAL);
+    assert(pci_setup_msix(dev->dev, 1, vn->rx_intr_handler, ss("vmxnet3 rx")) != INVALID_PHYSICAL);
     // interrupts are not used for tx
 
     vmxnet3_tx_queues_alloc(dev);

--- a/src/vmware/vmxnet3_queue.c
+++ b/src/vmware/vmxnet3_queue.c
@@ -27,7 +27,7 @@ vmxnet3_init_txq(vmxnet3_pci dev, int q)
     txr = &txq->vxtxq_cmd_ring;
 
     buffer b = little_stack_buffer(16);
-    bprintf(b, "%s-tx%d", DEVICE_NAME, q);
+    bprintf(b, "%s-tx%d", ss(DEVICE_NAME), q);
     memcpy(txq->vxtxq_name, b->contents, sizeof(txq->vxtxq_name));
 
     txq->vxtxq_sc = dev;
@@ -49,7 +49,7 @@ vmxnet3_init_rxq(vmxnet3_pci dev, int q)
     rxc = &rxq->vxrxq_comp_ring;
 
     buffer b = little_stack_buffer(16);
-    bprintf(b, "%s-rx%d", DEVICE_NAME, q);
+    bprintf(b, "%s-rx%d", ss(DEVICE_NAME), q);
     memcpy(rxq->vxrxq_name, b->contents, sizeof(rxq->vxrxq_name));
 
     rxq->vxrxq_sc = dev;

--- a/src/x86_64/acpi.c
+++ b/src/x86_64/acpi.c
@@ -22,7 +22,7 @@ static u64 find_rsdp_internal(u64 va, u64 len)
         if (runtime_memcmp(&rsdp->sig, "RSD PTR ", sizeof(rsdp->sig)) != 0)
             continue;
         if (!acpi_checksum(rsdp, 20)) {
-            acpi_debug("%s: RSDP failed checksum", __func__);
+            acpi_debug("%s: RSDP failed checksum", func_ss);
             continue;
         }
         return i;
@@ -80,9 +80,9 @@ static u64 find_rsdp(kernel_heaps kh)
 out:
     deallocate_u64(vh, va, BIOS_SEARCH_LENGTH);
     if (rsdp != INVALID_PHYSICAL) {
-        acpi_debug("%s: found RSDP at %p", __func__, rsdp);
+        acpi_debug("%s: found RSDP at %p", func_ss, rsdp);
     } else {
-        acpi_debug("%s: could not find valid RSDP", __func__);
+        acpi_debug("%s: could not find valid RSDP", func_ss);
     }
     return rsdp;
 }
@@ -92,7 +92,7 @@ void acpi_save_rsdp(u64 rsdp)
     saved_rsdp = rsdp;
 }
 
-void acpi_register_irq_handler(int irq, thunk t, const char *name)
+void acpi_register_irq_handler(int irq, thunk t, sstring name)
 {
     ioapic_register_int(irq, t, name);
 }

--- a/src/x86_64/apic.c
+++ b/src/x86_64/apic.c
@@ -156,7 +156,7 @@ boolean init_lapic_timer(clock_timer *ct, thunk *per_cpu_init)
     assert(apic_if);
     *ct = closure(apic_heap, lapic_timer);
     int v = allocate_interrupt();
-    register_interrupt(v, closure(apic_heap, lapic_timer_int), "lapic timer");
+    register_interrupt(v, closure(apic_heap, lapic_timer_int), ss("lapic timer"));
     *per_cpu_init = closure(apic_heap, lapic_timer_percpu_init, v);
     apply(*per_cpu_init);
     calibrate_lapic_timer();
@@ -226,7 +226,7 @@ boolean ioapic_int_is_free(unsigned int gsi)
     return !!(ioapic_read(IOAPIC_REG_REDIR + 2 * gsi) & (1 << IOAPIC_INT_MASK));
 }
 
-void ioapic_register_int(unsigned int gsi, thunk h, const char *name)
+void ioapic_register_int(unsigned int gsi, thunk h, sstring name)
 {
     boolean alloc_vector = ioapic_int_is_free(gsi);
     u64 v;

--- a/src/x86_64/apic.h
+++ b/src/x86_64/apic.h
@@ -68,7 +68,7 @@ int cpuid_from_apicid(u32 aid);
 
 void ioapic_set_int(unsigned int gsi, u64 v);
 boolean ioapic_int_is_free(unsigned int gsi);
-void ioapic_register_int(unsigned int gsi, thunk h, const char *name);
+void ioapic_register_int(unsigned int gsi, thunk h, sstring name);
 
 extern apic_iface apic_if;
 

--- a/src/x86_64/hpet.c
+++ b/src/x86_64/hpet.c
@@ -147,7 +147,7 @@ static void timer_config(int timer, timestamp rate, thunk t, boolean periodic)
             ioapic_set_int(gsi, tim->interrupt);
             tim->config |= gsi << HPET_TIMER_CONFIG_INT_ROUTE_CNF_SHIFT;
         }
-        register_interrupt(tim->interrupt, t, "hpet timer");
+        register_interrupt(tim->interrupt, t, ss("hpet timer"));
     }
 
     if (periodic) {

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -171,7 +171,7 @@ void install_gdt64_and_tss(void *tss_desc, void *tss, void *gdt, void *gdt_point
 /* locking constructs */
 #include <mutex.h>
 
-void cmdline_consume(const char *opt_name, cmdline_handler h);
+void cmdline_consume(sstring opt_name, cmdline_handler h);
 void boot_params_apply(tuple t);
 #endif
 

--- a/src/xen/xen.c
+++ b/src/xen/xen.c
@@ -761,8 +761,8 @@ status xenstore_sync_request(u32 tx_id, enum xsd_sockmsg_type type, buffer reque
     }
 
     if (rmsg->type == XS_ERROR) {
-        s = timm("result", "xen store error",
-                 "errno", "%s", buffer_ref(response, 0));
+        s = timm("result", "xen store error");
+        s = timm_append(s, "errno", "%b", response);
         goto out_dealloc;
     }
   out_dealloc:

--- a/src/xen/xen_internal.h
+++ b/src/xen/xen_internal.h
@@ -44,16 +44,16 @@ int xen_close_evtchn(evtchn_port_t evtchn);
 grant_ref_t xen_grant_page_access(u16 domid, u64 phys, boolean readonly);
 void xen_revoke_page_access(grant_ref_t ref);
 
-typedef closure_type(xenstore_watch_handler, void, const char *);
+typedef closure_type(xenstore_watch_handler, void, sstring);
 
 status xenbus_get_state(buffer path, XenbusState *state);
 status xenbus_set_state(u32 tx_id, buffer path, XenbusState newstate);
 status xenbus_watch_state(buffer path, xenstore_watch_handler handler, boolean watch);
 
-status xenstore_read_u64(u32 tx_id, buffer path, const char *node, u64 *result);
-status xenstore_read_string(u32 tx_id, buffer path, const char *node, buffer result);
+status xenstore_read_u64(u32 tx_id, buffer path, sstring node, u64 *result);
+status xenstore_read_string(u32 tx_id, buffer path, sstring node, buffer result);
 status xenstore_sync_request(u32 tx_id, enum xsd_sockmsg_type type, buffer request, buffer response);
-status xenstore_sync_printf(u32 tx_id, buffer path, const char *node, const char *format, ...);
+status xenstore_sync_printf(u32 tx_id, buffer path, sstring node, sstring format, ...);
 status xenstore_transaction_start(u32 *tx_id);
 status xenstore_transaction_end(u32 tx_id, boolean abort);
 
@@ -62,4 +62,4 @@ status xendev_attach(xen_dev xd, int id, buffer frontend, tuple meta);
 void xen_driver_unbind(tuple meta);
 
 typedef closure_type(xen_device_probe, boolean, int, buffer, tuple);
-void register_xen_driver(const char * name, xen_device_probe probe);
+void register_xen_driver(sstring name, xen_device_probe probe);

--- a/src/xen/xenblk.c
+++ b/src/xen/xenblk.c
@@ -505,7 +505,7 @@ closure_function(2, 3, boolean, xenblk_probe,
     heap h = heap_locked(kh);
     xenblk_dev xbd = allocate(h, sizeof(*xbd));
     if (xbd == INVALID_ADDRESS) {
-        msg_err("%s: cannot allocate device structure\n", __func__);
+        msg_err("cannot allocate device structure\n");
         return false;
     }
     xen_dev xd = &xbd->dev;
@@ -513,13 +513,13 @@ closure_function(2, 3, boolean, xenblk_probe,
     xbd->contiguous = (heap)heap_linear_backed(kh);
     status s = xendev_attach(xd, id, frontend, meta);
     if (!is_ok(s)) {
-        msg_err("%s: cannot attach Xen device: %v\n", __func__, s);
+        msg_err("cannot attach Xen device: %v\n", s);
         timm_dealloc(s);
         goto dealloc_xbd;
     }
     xbd->rreqs = allocate_vector(h, XENBLK_RING_SIZE);
     if (xbd->rreqs == INVALID_ADDRESS) {
-        msg_err("%s: cannot allocate request vector\n", __func__);
+        msg_err("cannot allocate request vector\n");
         goto dealloc_xbd;
     }
     list_init(&xbd->pending);
@@ -531,7 +531,7 @@ closure_function(2, 3, boolean, xenblk_probe,
     xbd->meta = meta;
     s = xenblk_enable(xbd);
     if (!is_ok(s)) {
-        msg_err("%s: cannot enable device: %v\n", __func__, s);
+        msg_err("cannot enable device: %v\n", s);
         timm_dealloc(s);
         goto dealloc_reqs;
     }

--- a/src/xen/xennet.c
+++ b/src/xen/xennet.c
@@ -272,8 +272,7 @@ static void xennet_service_tx_ring(xennet_dev xd)
 
             if (tx->status != NETIF_RSP_OKAY) {
                 /* XXX counters */
-                msg_err("%s: cons %d, tx resp id %d, status %d\n",
-                        __func__, cons, tx->id, tx->status);
+                msg_err("cons %d, tx resp id %d, status %d\n", cons, tx->id, tx->status);
             }
 
             xennet_tx_page txp = xennet_get_tx_page(txb, xennet_tx_page_idx_from_id(tx->id));

--- a/test/runtime/udploop.c
+++ b/test/runtime/udploop.c
@@ -2,6 +2,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
@@ -11,7 +12,7 @@
 
 void fail(char * s)
 {
-    rprintf("%s failed: %s (errno %d)\n", s, strerror(errno), errno);
+    printf("%s failed: %s (errno %d)\n", s, strerror(errno), errno);
     exit(EXIT_FAILURE);
 }
 

--- a/test/runtime/unixsocket.c
+++ b/test/runtime/unixsocket.c
@@ -130,6 +130,9 @@ static void uds_stream_test(void)
 
     s1 = socket(AF_UNIX, SOCK_STREAM, 0);
     test_assert(s1 >= 0);
+
+    addr.sun_family = AF_UNIX + 1;
+    test_assert((bind(s1, (struct sockaddr *) &addr, addr_len) == -1) && (errno == EINVAL));
     addr.sun_family = AF_UNIX;
 
     test_getsockopt(s1, SOCK_STREAM);

--- a/test/unit/id_heap_test.c
+++ b/test/unit/id_heap_test.c
@@ -273,19 +273,19 @@ static boolean alloc_subrange_test(heap h)
 
     /* these should fail */
     if (id_heap_alloc_subrange(id, PAGESIZE, 0, SUBRANGE_TEST_MIN) != INVALID_PHYSICAL) {
-        msg_err("%s: should have failed for lower non-intersecting subrange\n", __func__);
+        msg_err("should have failed for lower non-intersecting subrange\n");
         return false;
     }
 
     if (id_heap_alloc_subrange(id, 1, SUBRANGE_TEST_END - PAGESIZE + 1,
                                SUBRANGE_TEST_END + PAGESIZE) != INVALID_PHYSICAL) {
-        msg_err("%s: should have failed for upper non-intersecting subrange\n", __func__);
+        msg_err("should have failed for upper non-intersecting subrange\n");
         return false;
     }
 
     if (id_heap_alloc_subrange(id, PAGESIZE, SUBRANGE_TEST_MIN + PAGESIZE + 1,
                                SUBRANGE_TEST_MIN + 2 * PAGESIZE + 1) != INVALID_PHYSICAL) {
-        msg_err("%s: should have failed for unaligned subrange\n", __func__);
+        msg_err("should have failed for unaligned subrange\n");
         return false;
     }
 
@@ -299,14 +299,14 @@ static boolean alloc_subrange_test(heap h)
     u64 res;
     for (int i = 0; i < allocs; i++) {
         if ((res = id_heap_alloc_subrange(id, alloc_size, start, end)) != expect) {
-            msg_err("%s: subrange alloc expected 0x%lx, got 0x%lx\n", __func__, expect, res);
+            msg_err("subrange alloc expected 0x%lx, got 0x%lx\n", expect, res);
             return false;
         }
         pages_remaining--;
         expect += PAGESIZE;
     }
     if ((res = id_heap_alloc_subrange(id, alloc_size, start, end)) != INVALID_PHYSICAL) {
-        msg_err("%s: superfluous subrange alloc should have failed, got 0x%lx\n", __func__, res);
+        msg_err("superfluous subrange alloc should have failed, got 0x%lx\n", res);
         return false;
     }
 
@@ -319,20 +319,20 @@ static boolean alloc_subrange_test(heap h)
 
     for (int i = 0; i < allocs; i++) {
         if ((res = id_heap_alloc_subrange(id, alloc_size, start, end)) != expect) {
-            msg_err("%s: multi-page subrange alloc expected 0x%lx, got 0x%lx\n", __func__, expect, res);
+            msg_err("multi-page subrange alloc expected 0x%lx, got 0x%lx\n", expect, res);
             return false;
         }
         pages_remaining -= 3;
         expect += 4 * PAGESIZE;
     }
     if ((res = id_heap_alloc_subrange(id, alloc_size, start, end)) != INVALID_PHYSICAL) {
-        msg_err("%s: multi-page superfluous subrange alloc should have failed, got 0x%lx\n", __func__, res);
+        msg_err("multi-page superfluous subrange alloc should have failed, got 0x%lx\n", res);
         return false;
     }
 
     /* we should have a remainder page for each 3-page alloc plus the skipped page above */
     if (pages_remaining != allocs + 1) {
-        msg_err("%s: test bug, pages_remaining %d, should be %d\n", pages_remaining, allocs + 1);
+        msg_err("test bug, pages_remaining %d, should be %d\n", pages_remaining, allocs + 1);
         return false;
     }
 
@@ -345,15 +345,14 @@ static boolean alloc_subrange_test(heap h)
             expect = SUBRANGE_TEST_MIN; /* should wrap around and pick up skipped page from above */
 
         if ((res = allocate_u64((heap)id, PAGESIZE)) != expect) {
-            msg_err("%s: remainder alloc returned 0x%lx, should be 0x%lx (iter %d)\n",
-                    __func__, res, expect, i);
+            msg_err("remainder alloc returned 0x%lx, should be 0x%lx (iter %d)\n", res, expect, i);
             return false;
         }
     }
 
     /* we should have exhausted the number space */
     if ((res = allocate_u64((heap)id, PAGESIZE)) != INVALID_PHYSICAL) {
-        msg_err("%s: should have exhausted number space, got 0x%lx\n", __func__, res);
+        msg_err("should have exhausted number space, got 0x%lx\n", res);
         return false;
     }
 

--- a/test/unit/memops_test.c
+++ b/test/unit/memops_test.c
@@ -5,7 +5,7 @@
 
 #define test_assert(expr)   do { \
     if (!(expr)) { \
-        msg_err("%s -- failed at %s:%d\n", #expr, __FILE__, __LINE__); \
+        msg_err("%s -- failed at %s:%d\n", ss(#expr), file_ss, __LINE__); \
         exit(EXIT_FAILURE); \
     } \
 } while (0)

--- a/test/unit/network_test.c
+++ b/test/unit/network_test.c
@@ -152,7 +152,9 @@ int main(int argc, char **argv)
     merge m = allocate_merge(h, closure(h, finished, s));
 
     zero(s, sizeof(struct stats)); //?
-    tuple req = timm("url", "/", "fizz", "bun", "Host", "tenny");
+    tuple req = timm("url", "/");
+    req = timm_append(req, "fizz", "bun");
+    req = timm_append(req, "Host", "tenny");
     *newconn = (thunk)closure(h, startconn, h, n, m, target, newconn, s, err, req);
     apply(*newconn);
     notifier_spin(n);

--- a/test/unit/objcache_test.c
+++ b/test/unit/objcache_test.c
@@ -155,7 +155,8 @@ boolean preallocated_objcache_test(heap meta, heap parent, int objsize, boolean 
 
     /* re-allocate a page + 1 worth to trigger parent allocation */
     if (!(alloc_vec(h, opp + 1, objsize, objs) != prealloc_only)) {
-        msg_err("tb: unexpectedly %s to allocate object\n", prealloc_only ? "able" : "failed");
+        msg_err("tb: unexpectedly %s to allocate object\n",
+                prealloc_only ? ss("able") : ss("failed"));
         return false;
     }
 

--- a/test/unit/pqueue_test.c
+++ b/test/unit/pqueue_test.c
@@ -1,5 +1,6 @@
 //#define ENABLE_MSG_DEBUG
 #include <runtime.h>
+#include <stdio.h>
 #include <stdlib.h>
 #define EXIT_FAILURE 1
 #define EXIT_SUCCESS 0
@@ -232,7 +233,7 @@ boolean basic_test(heap h)
     return true;
   fail:
     deallocate_pqueue(q);
-    msg_err("pqueue basic test failed: %s\n", msg);
+    printf("pqueue basic test failed: %s\n", msg);
     return false;
 }
 
@@ -270,7 +271,7 @@ boolean random_test(heap h, int n, int passes)
     }
     return true;
   fail:
-    msg_err("random_test fail; %s\n", msg);
+    printf("random_test fail; %s\n", msg);
     deallocate_pqueue(q);
     return false;
 }
@@ -322,7 +323,7 @@ static boolean remove_test(heap h, int passes)
     deallocate_pqueue(q);
     if (!err_msg)
         return true;
-    msg_err("%s\n", err_msg);
+    printf("remove test failed: %s\n", err_msg);
     return false;
 }
 
@@ -361,7 +362,7 @@ static boolean reorder_test(heap h, int passes)
     deallocate_pqueue(q);
     if (!err_msg)
         return true;
-    msg_err("%s\n", err_msg);
+    printf("reorder test failed: %s\n", err_msg);
     return false;
 }
 

--- a/test/unit/range_test.c
+++ b/test/unit/range_test.c
@@ -134,7 +134,7 @@ boolean basic_test(heap h)
 
   fail:
     deallocate_rangemap(rm, stack_closure(dealloc_test_node, h));
-    msg_err("rangemap basic test failed: %s\n", msg);
+    printf("rangemap basic test failed: %s\n", msg);
     return false;
 }
 

--- a/test/unit/rbtree_test.c
+++ b/test/unit/rbtree_test.c
@@ -3,7 +3,7 @@
 
 //#define RBTEST_DEBUG
 #ifdef RBTEST_DEBUG
-#define rbtest_debug(x, ...) do {rprintf("RBTEST %s: " x, __func__, ##__VA_ARGS__);} while(0)
+#define rbtest_debug(x, ...) do {rprintf("RBTEST %s: " x, func_ss, ##__VA_ARGS__);} while(0)
 #else
 #define rbtest_debug(x, ...)
 #endif
@@ -49,7 +49,7 @@ closure_function(3, 1, boolean, test_max_lte_node,
         rbnode x = *bound(last) ? *bound(last) : INVALID_ADDRESS;
         if (ml != x) {
             rprintf("%s: lookup max lte returned %p, should be last (%p)\n",
-                    __func__, ml, x);
+                    func_ss, ml, x);
             *bound(result) = false;
             return false;
         }
@@ -69,7 +69,7 @@ static boolean test_max_lte(rbtree t)
         rbnode ml = rbtree_lookup_max_lte(t, &k.node);
         if (ml != last) {
             rprintf("%s: lookup max lte for key %d after last node "
-                    "returned %p instead of last (%p)\n", __func__,
+                    "returned %p instead of last (%p)\n", func_ss,
                     k.key, ml, last);
             return false;
         }
@@ -89,16 +89,16 @@ static boolean test_insert(heap h, rbtree t, int key, boolean validate)
     if (validate) {
         status s = rbtree_validate(t);
         if (!is_ok(s)) {
-            rprintf("%s: rbtree_validate failed with %v ", __func__, s);
+            rprintf("%s: rbtree_validate failed with %v ", func_ss, s);
             goto out_fail;
         }
         rbnode r = rbtree_lookup(t, &tn->node);
         if (r != &tn->node) {
-            rprintf("%s: rbtree_lookup failed (returned %p) ", __func__, r);
+            rprintf("%s: rbtree_lookup failed (returned %p) ", func_ss, r);
             goto out_fail;
         }
         if (!test_max_lte(t)) {
-            rprintf("%s: max lte test failed ", __func__);
+            rprintf("%s: max lte test failed ", func_ss);
             goto out_fail;
         }
     }
@@ -222,12 +222,12 @@ closure_function(3, 1, boolean, validate_preorder_vec,
     int *p = bound(vec) + i;
     rbtest_debug("index %d, expect %d, tn->key %d\n", i, *p, tn->key);
     if (*p == -1) {
-        rprintf("%s: result vec exceeded at index %d\n", __func__, i);
+        rprintf("%s: result vec exceeded at index %d\n", func_ss, i);
         *bound(match) = false;
         return false;
     }
     if (*p != tn->key) {
-        rprintf("%s: key %d at index %d, expected %d\n", __func__, tn->key, i, *p);
+        rprintf("%s: key %d at index %d, expected %d\n", func_ss, tn->key, i, *p);
         *bound(match) = false;
         return false;
     }
@@ -239,7 +239,7 @@ static boolean do_transformation_test(rbtree t, heap h, int i, boolean insert)
 {
     int index, k;
     boolean match;
-    char *op = insert ? "insertion" : "removal";
+    sstring op = insert ? ss("insertion") : ss("removal");
     int *keys = insert ? insert_keys[i] : remove_keys[i];
 
     if (keys[0] == -1)
@@ -250,7 +250,7 @@ static boolean do_transformation_test(rbtree t, heap h, int i, boolean insert)
         rbtest_debug("   %d: %d\n", j, k);
         boolean result = insert ? test_insert(h, t, k, true) : test_remove(h, t, k, true);
         if (!result) {
-            rprintf("%s: %s failed for test %d, idx %d, key %d\n", __func__, op, i, j, k);
+            rprintf("%s: %s failed for test %d, idx %d, key %d\n", func_ss, op, i, j, k);
             return false;   /* XXX leak */
         }
     }
@@ -266,12 +266,12 @@ static boolean do_transformation_test(rbtree t, heap h, int i, boolean insert)
     if (match) {
         if (rvec[index] != -1) {
             rprintf("%s: in-order traversal for %s test %d gave incomplete results, end index %d\n",
-                    __func__, op, i, index);
+                    func_ss, op, i, index);
             return false;
         }
     }
     if (!match) {
-        rprintf("%s: validate for %s test %d failed\n", __func__, op, i);
+        rprintf("%s: validate for %s test %d failed\n", func_ss, op, i);
         return false;
     }
     rbtest_debug("passed\n\n");

--- a/test/unit/table_test.c
+++ b/test/unit/table_test.c
@@ -24,7 +24,7 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
     u64 count;
     u64 val;
 
-    table_validate(t, "basic_table_tests: alloc");
+    table_validate(t, ss("basic_table_tests: alloc"));
 
     if (table_elements(t) != 0) {
         msg_err("table_elements() not zero on empty table\n");
@@ -42,12 +42,12 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
         table_set(t, (void *)count, (void *)(count + 1));
     }
 
-    table_validate(t, "basic_table_tests: after fill");
+    table_validate(t, ss("basic_table_tests: after fill"));
 
     /* This should not add anything to the table. */
     table_set(t, (void *)count, 0);
 
-    table_validate(t, "basic_table_tests: after null set");
+    table_validate(t, ss("basic_table_tests: after null set"));
 
     count = 0;
     table_foreach(t, n, v) {
@@ -95,7 +95,7 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
         return false;
     }
 
-    table_validate(t, "basic_table_tests: after remove one");
+    table_validate(t, ss("basic_table_tests: after remove one"));
 
     count = table_elements(t);
     if (count != n_elem - 1) {
@@ -109,7 +109,7 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
         msg_err("invalid element %ld removed, should be 2\n", val);
         return false;
     }
-    table_validate(t, "basic_table_tests: after table_remove()");
+    table_validate(t, ss("basic_table_tests: after table_remove()"));
     count = table_elements(t);
     if (count != n_elem - 2) {
         msg_err("invalid table_elements() %ld after table_remove(), should be %ld\n",
@@ -121,13 +121,13 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
     for (count = 2; count < (n_elem / 2); count++)
         table_set(t, (void *)count, 0);
 
-    table_validate(t, "basic_table_tests: after remove forward");
+    table_validate(t, ss("basic_table_tests: after remove forward"));
 
     /* ... and then backward (descend to bottom of each bucket) */
     for (count = n_elem - 1; count >= (n_elem / 2); count--)
         table_set(t, (void *)count, 0);
 
-    table_validate(t, "basic_table_tests: after remove backward");
+    table_validate(t, ss("basic_table_tests: after remove backward"));
 
     count = table_elements(t);
     if (count != 0) {
@@ -159,13 +159,13 @@ static boolean one_elem_table_tests(heap h, u64 n_elem)
     table t = allocate_table(h, silly_key, anything_equals);
     u64 count;
 
-    table_validate(t, "one_elem_table_tests: after alloc");
+    table_validate(t, ss("one_elem_table_tests: after alloc"));
 
     for (count = 0; count < n_elem; count++) {
         table_set(t, (void *)count, (void *)(count + 1));
     }
 
-    table_validate(t, "one_elem_table_tests: after fill");
+    table_validate(t, ss("one_elem_table_tests: after fill"));
 
     count = 0;
     table_foreach(t, n, v) {
@@ -245,7 +245,7 @@ static boolean preallocated_table_tests(heap h, u64 (*key_function)(void *x), u6
     u64 heap_occupancy = heap_allocated(h);
     u64 count;
 
-    table_validate(t, "preallocated_table_tests: alloc");
+    table_validate(t, ss("preallocated_table_tests: alloc"));
 
     if (table_elements(t) != 0) {
         msg_err("table_elements() not zero on empty table\n");
@@ -255,7 +255,7 @@ static boolean preallocated_table_tests(heap h, u64 (*key_function)(void *x), u6
         table_set(t, (void *)count, (void *)(count + 1));
     }
 
-    table_validate(t, "preallocated_table_tests: after fill");
+    table_validate(t, ss("preallocated_table_tests: after fill"));
 
     if (heap_allocated(h) != heap_occupancy) {
         msg_err("unexpected allocation: heap_allocated(h) %llu, originally %llu\n", heap_allocated(h), heap_occupancy);
@@ -267,10 +267,10 @@ static boolean preallocated_table_tests(heap h, u64 (*key_function)(void *x), u6
         msg_err("found unexpected element 0\n");
         return false;
     }
-    table_validate(t, "preallocated_table_tests: after remove one");
+    table_validate(t, ss("preallocated_table_tests: after remove one"));
 
     table_set(t, 0, (void *)1);
-    table_validate(t, "preallocated_table_tests: after insert one");
+    table_validate(t, ss("preallocated_table_tests: after insert one"));
 
 
     deallocate_table(t);

--- a/test/unit/tuple_test.c
+++ b/test/unit/tuple_test.c
@@ -9,7 +9,7 @@
 
 #define test_assert(expr) do { \
 if (expr) ; else { \
-    msg_err("%s -- failed at %s:%d\n", #expr, __FILE__, __LINE__); \
+    msg_err("%s -- failed at %s:%d\n", ss(#expr), file_ss, __LINE__); \
     goto fail; \
 } \
 } while (0)
@@ -18,12 +18,23 @@ boolean all_tests(heap h)
 {
     boolean failure = true;
 
-    char *tst[COUNT_ELM] = {"00","10","20","30","40","50","60","70","80","90"};
+    sstring tst[COUNT_ELM] = {
+        ss_static_init("00"),
+        ss_static_init("10"),
+        ss_static_init("20"),
+        ss_static_init("30"),
+        ss_static_init("40"),
+        ss_static_init("50"),
+        ss_static_init("60"),
+        ss_static_init("70"),
+        ss_static_init("80"),
+        ss_static_init("90"),
+    };
 
     // check count
     tuple t1 = allocate_tuple();
     for(u8 i = 0; i < COUNT_ELM; i++){
-        buffer b1 = wrap_string_cstring(tst[i]);
+        buffer b1 = wrap_string_sstring(tst[i]);
         set(t1, value_from_u64(i), b1);
     }
     test_assert(tuple_count(t1) == COUNT_ELM);//rprintf("%v\n", t1);
@@ -31,7 +42,7 @@ boolean all_tests(heap h)
     // from vector
     vector v1 = allocate_vector(h, COUNT_ELM);
     for(u8 i = 0; i < COUNT_ELM; i++){
-        vector_push(v1, wrap_string_cstring(tst[i]));
+        vector_push(v1, wrap_string_sstring(tst[i]));
     }
     test_assert(vector_length(v1) == COUNT_ELM);//rprintf("%v\n", t2);
     deallocate_vector(v1);
@@ -117,8 +128,8 @@ boolean all_tests(heap h)
     v1 = allocate_vector(h, 1);
     set(t1, sym(v1), v1);
     tuple t2 = allocate_tuple();
-    set(t2, sym(b0), wrap_string_cstring(tst[0]));
-    set(t2, sym(b1), wrap_string_cstring(tst[1]));
+    set(t2, sym(b0), wrap_string_sstring(tst[0]));
+    set(t2, sym(b1), wrap_string_sstring(tst[1]));
     set(t1, sym(t2), t2);
     tuple t3 = clone_tuple(t1);
     vector v2 = get(t3, sym(v1));

--- a/test/unit/udp_test.c
+++ b/test/unit/udp_test.c
@@ -16,7 +16,7 @@
 
 void fail(char * s)
 {
-    rprintf("%s failed: %s (errno %d)\n", s, strerror(errno), errno);
+    rprintf("%s failed: %s (errno %d)\n", s, errno_sstring(), errno);
     exit(EXIT_FAILURE);
 }
 

--- a/test/unit/vector_test.c
+++ b/test/unit/vector_test.c
@@ -7,6 +7,7 @@
 
 //#define ENABLE_MSG_DEBUG
 #include <runtime.h>
+#include <stdio.h>
 #include <stdlib.h>
 #define EXIT_SUCCESS 0
 #define EXIT_FAILURE 1
@@ -136,7 +137,7 @@ boolean basic_test(heap h)
     return true;
   fail:
     deallocate_vector(v);
-    msg_err("vector basic test failed: %s\n", msg);
+    printf("vector basic test failed: %s\n", msg);
     return false;
 }
 

--- a/tools/contgen.c
+++ b/tools/contgen.c
@@ -88,7 +88,6 @@ void cblock()
     p("static _rettype (**_fill_##_name(u64 ctx, struct _closure_##_name* n, bytes s^))(void *~) {|", ", _lt% l%", ", _rt%");
     p("  if (n != INVALID_ADDRESS) {|");
     p("    n->__apply = _name;|");
-    p("    n->__c.name = #_name;|");
     p("    n->__c.ctx = ctx;|");
     p("    n->__c.size = s;|");
     for (int i = 0; i < nleft ; i++)  p("  n->_ln% = l%;|", i, i);

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -27,7 +27,7 @@ closure_function(2, 1, void, bread,
                  storage_req, req)
 {
     if (req->op != STORAGE_OP_READSG)
-        halt("%s: invalid storage op %d\n", __func__, req->op);
+        halt("%s: invalid storage op %d\n", func_ss, req->op);
     sg_list sg = req->data;
     u64 offset = bound(fs_offset) + (req->blocks.start << SECTOR_OFFSET);
     u64 total = range_span(req->blocks) << SECTOR_OFFSET;
@@ -47,7 +47,7 @@ closure_function(2, 1, void, bread,
         }
         xfer = readv(bound(d), iov, iov_count);
         if (xfer < 0 && errno != EINTR) {
-            apply(req->completion, timm("result", "read error", "error", "%s", strerror(errno)));
+            apply(req->completion, timm("result", "read error %s", errno_sstring()));
             return;
         }
         if (xfer == 0) {
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
     while ((c = getopt(argc, argv, "d:tl")) != EOF) {
         switch (c) {
         case 'd':
-            target_dir = alloca_wrap_buffer(optarg, runtime_strlen(optarg));
+            target_dir = alloca_wrap_buffer(optarg, strlen(optarg));
             break;
         case 't':
             options |= DUMP_OPT_TREE;
@@ -303,7 +303,7 @@ int main(int argc, char **argv)
                       SECTOR_SIZE,
                       infinity,
                       closure(h, bread, fd, get_fs_offset(fd, PARTITION_ROOTFS, false)),
-                      true, 0,  /* read only, no label */
+                      true, sstring_null(), /* read only, no label */
                       closure(h, fsc, h, target_dir, options));
     return EXIT_SUCCESS;
 }

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -756,7 +756,7 @@ int main(int argc, char **argv)
         if (v) {
             char *cdl = buffer_to_cstring((buffer)v);
             if (!parse_size(cdl,  &coredumplimit)) {
-                halt("invalid coredumplimit string \"%s\"\n", cdl);
+                halt("invalid coredumplimit string \"%b\"\n", v);
             }
             if (coredumplimit > img_size)
                 img_size = coredumplimit;


### PR DESCRIPTION
This changeset removes the use of string functions that access string memory without a limit (i.e. that rely on the presence of a string terminator to determine the end of a string). Instead, a new string type (sstring) is being defined; this type is a struct that includes a pointer to string memory and the length of the string; use of this type makes it unnecessary to look for the string terminator in order to determine the length of a string, and thus avoids unbounded access to string memory.
C string literals (which by definition are NULL-terminated strings) are still allowed in the kernel code, but they are converted at compile time into sstring types, e.g. by using the ss() macro.
Since it is still necessary for the kernel to be able to process NULL-terminated strings (for example, strings read by drivers from peripheral memory), the sstring_from_cstring() function is being defined: this function takes a memory pointer and a maximum length value, and returns an sstring built by parsing the memory (up to the maximum length) looking for the string terminator (if no terminator is found, the returned string length is the maximum length).
The "%s" format specifier in printf-style functions now takes an sstring argument instead of a `char *`; the name field has been removed from closure structs, and the function handling the "%F" format specifier has been changed to retrieve a closure name from the kernel symbol table.

Requires https://github.com/nanovms/lwip/pull/11 and https://github.com/nanovms/mbedtls/pull/3