### PR TITLE
Hyper-V: netvsc: fix setting of pbuf length in received packets

### DIFF
--- a/src/hyperv/netvsc/netvsc.c
+++ b/src/hyperv/netvsc/netvsc.c
@@ -346,8 +346,8 @@ netvsc_m_append(hn_softc_t *hn, xpbuf m0, int len, uint8_t *cp)
             space = remainder;
         runtime_memcpy(m->p.pbuf.payload + m->p.pbuf.len, cp, space);
         m->p.pbuf.len += space;
-        m->p.pbuf.tot_len += space;
-        m0->p.pbuf.tot_len += space;
+        for (m = m0; m; m = (xpbuf)m->p.pbuf.next)
+            m->p.pbuf.tot_len += space;
         cp += space;
         remainder -= space;
     }
@@ -361,11 +361,10 @@ netvsc_m_append(hn_softc_t *hn, xpbuf m0, int len, uint8_t *cp)
         struct pbuf* np = &n->p.pbuf;
         np->len = MIN(hn->rxbuflen, remainder);
         np->tot_len = np->len;
-        m0->p.pbuf.tot_len += np->len;
         runtime_memcpy(np->payload, cp, np->len);
         cp += np->len;
         remainder -= np->len;
-        m->p.pbuf.next = np;
+        pbuf_cat(&m0->p.pbuf, np);
         m = n;
     }
     return (remainder == 0);


### PR DESCRIPTION
The existing code is setting the tot_len field of the first struct of a pbuf chain to a value double the correct value, and is failing to update the tot_len value of all pbufs in a chain when appending received data.
This change fixes the above issues, which were causing a page fault in the pbuf_realloc() lwIP function during reception of an IPv6 packet.