### PR TITLE
tmpfs_create(): add missing initialization of return value

### DIFF
--- a/klib/tmpfs.c
+++ b/klib/tmpfs.c
@@ -147,6 +147,7 @@ static fs_status tmpfs_create(filesystem fs, tuple parent, string name, tuple md
             fsfile_reserve(&fsf->f);
     } else {
         fsf = INVALID_ADDRESS;
+        fss = FS_STATUS_OK;
     }
     if (md)
         table_set(tmpfs->files, md, fsf);


### PR DESCRIPTION
The `fss` variable, which contains the return value of the tmpfs_create() function, is not being initialized when creating non-regular files. This issue is detected by the clang compiler with "error: variable 'fss' is used uninitialized whenever 'if' condition is false".