### PR TITLE
virtio-net: add multiqueue support

### DIFF
--- a/src/aarch64/acpi.c
+++ b/src/aarch64/acpi.c
@@ -5,7 +5,7 @@
 
 void acpi_register_irq_handler(int irq, thunk t, sstring name)
 {
-    register_interrupt(irq, t, name);
+    irq_register_handler(irq, t, name, irange(0, 0));
 }
 
 /* OS services layer */

--- a/src/aarch64/gic.h
+++ b/src/aarch64/gic.h
@@ -63,6 +63,7 @@
 #define GICD_CTLR_DISABLE           0
 #define GICD_CTLR_ENABLEGRP0        1
 #define GICD_CTLR_ENABLEGRP1        2
+#define GICD_CTLR_ARE_NS            U32_FROM_BIT(5)
 #define GICD_TYPER                  0x0004
 #define GICD_IDbits_BITS            5
 #define GICD_IDbits_SHIFT           19
@@ -103,6 +104,7 @@
 #define GICD_SGIR_NSATT             U64_FROM_BIT(15)
 #define GICD_CPENDSGIR(n)           0x0f10
 #define GICD_SPENDSGIR(n)           0x0f20
+#define GICD_IROUTER(n)             (0x6000 + 8 * (n))
 
 #define GICR_CTLR                   0x0000
 #define GICR_CTLR_EnableLPIs            U64_FROM_BIT(0)
@@ -241,6 +243,7 @@ void gic_enable_int(int irq);
 void gic_clear_pending_int(int irq);
 void gic_set_int_priority(int irq, u32 pri);
 void gic_set_int_config(int irq, u32 cfg);
+void gic_set_int_target(int irq, u32 target_cpu);
 boolean gic_int_is_pending(int irq);
 u64 gic_dispatch_int(void);
 void gic_eoi(int irq);

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -258,6 +258,7 @@ struct cpuinfo_machine {
     context syscall_context;
 
     u64 gic_rdist_base; /* base (virtual) address of GICv3 redistributor */
+    u64 gic_rdist_rdbase;   /* GIC ITS target address of redistributor */
 };
 
 typedef struct cpuinfo *cpuinfo;

--- a/src/aws/ena/ena.h
+++ b/src/aws/ena/ena.h
@@ -329,12 +329,10 @@ struct ena_hw_stats {
 
 /* Board specific private data structure */
 struct ena_adapter {
+    struct netif_dev ndev;
     heap general, contiguous;
     pci_dev pdev;
     struct ena_com_dev *ena_dev;
-
-    /* OS defined structs */
-    struct netif ifp;
 
     /* OS resources */
     struct pci_bar memory;

--- a/src/aws/ena/ena_datapath.c
+++ b/src/aws/ena/ena_datapath.c
@@ -55,7 +55,7 @@ void ena_cleanup(void *arg, int pending)
 {
     struct ena_que *que = arg;
     struct ena_adapter *adapter = que->adapter;
-    struct netif *netif = &adapter->ifp;
+    struct netif *netif = &adapter->ndev.n;
     struct ena_ring *tx_ring;
     struct ena_ring *rx_ring;
     struct ena_com_io_cq *io_cq;
@@ -99,7 +99,7 @@ void ena_cleanup(void *arg, int pending)
 void ena_deferred_mq_start(void *arg, int pending)
 {
     struct ena_ring *tx_ring = (struct ena_ring*) arg;
-    struct netif *netif = &tx_ring->adapter->ifp;
+    struct netif *netif = &tx_ring->adapter->ndev.n;
 
     while (!queue_empty(tx_ring->br) && tx_ring->running && netif_is_flag_set(netif, NETIF_FLAG_UP)) {
         ENA_RING_MTX_LOCK(tx_ring);
@@ -371,7 +371,7 @@ static int ena_rx_cleanup(struct ena_ring *rx_ring)
     int budget = RX_BUDGET;
 
     adapter = rx_ring->que->adapter;
-    ifp = &adapter->ifp;
+    ifp = &adapter->ndev.n;
     qid = rx_ring->que->id;
     ena_qid = ENA_IO_RXQ_IDX(qid);
     io_cq = &adapter->ena_dev->io_cq_queues[ena_qid];
@@ -575,7 +575,7 @@ static void ena_start_xmit(struct ena_ring *tx_ring)
 {
     struct pbuf *mbuf;
     struct ena_adapter *adapter = tx_ring->adapter;
-    struct netif *netif = &adapter->ifp;
+    struct netif *netif = &adapter->ndev.n;
     struct ena_com_io_sq *io_sq;
     int ena_qid;
     int ret = 0;

--- a/src/drivers/ata-pci.c
+++ b/src/drivers/ata-pci.c
@@ -334,7 +334,7 @@ closure_function(3, 1, boolean, ata_pci_probe,
     ata_clear_irq(dev->ata);
     u64 irq = allocate_interrupt();
     assert(irq != INVALID_PHYSICAL);
-    ioapic_set_int(ATA_IRQ(ATA_PRIMARY), irq);
+    ioapic_set_int(ATA_IRQ(ATA_PRIMARY), irq, irq_get_target_cpu(irange(0, 0)));
     register_interrupt(irq, (thunk)&dev->irq_handler, ss("ata pci"));
     apply(bound(a),
           storage_init_req_handler(&dev->req_handler, (block_io)&dev->read, (block_io)&dev->write),

--- a/src/hyperv/netvsc/hv_net_vsc.c
+++ b/src/hyperv/netvsc/hv_net_vsc.c
@@ -525,7 +525,7 @@ hv_nv_connect_to_vsp(struct hv_device *device)
     uint32_t ndis_version;
     int ret = 0;
     hn_softc_t *sc = device->device;
-    struct netif *ifp = sc->netif;
+    struct netif *ifp = &sc->ndev.n;
 
     net_dev = hv_nv_get_outbound_net_device(device);
 

--- a/src/hyperv/netvsc/hv_net_vsc.h
+++ b/src/hyperv/netvsc/hv_net_vsc.h
@@ -40,6 +40,7 @@
 
 
 #include <hyperv.h>
+#include <lwip.h>
 #include <vmbus.h>
 
 typedef uint8_t hv_bool_uint8_t;
@@ -959,14 +960,13 @@ typedef struct netvsc_packet_ {
  * Device-specific softc structure
  */
 typedef struct hn_softc {
+	struct netif_dev ndev;
 	heap general;
 	heap contiguous;                /* physically */
 
 	struct hv_device       *hn_dev_obj;
 	netvsc_dev      *net_dev;
 
-	/* lwIP */
-	struct netif *netif;
 	u16 rxbuflen;
 	caching_heap rxbuffers;
 	closure_struct(mem_cleaner, mem_cleaner);

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -189,7 +189,6 @@ cpuinfo init_cpuinfo(heap backed, int cpu)
     ci->cpu_queue = allocate_queue(backed, CPU_QUEUE_SIZE);
     assert(ci->cpu_queue != INVALID_ADDRESS);
     ci->last_timer_update = 0;
-    ci->frcount = 0;
     ci->mcs_prev = 0;
     ci->mcs_next = 0;
     ci->mcs_waiting = false;

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -189,6 +189,7 @@ cpuinfo init_cpuinfo(heap backed, int cpu)
     ci->cpu_queue = allocate_queue(backed, CPU_QUEUE_SIZE);
     assert(ci->cpu_queue != INVALID_ADDRESS);
     ci->last_timer_update = 0;
+    ci->targeted_irqs = 0;
     ci->mcs_prev = 0;
     ci->mcs_next = 0;
     ci->mcs_waiting = false;
@@ -271,6 +272,49 @@ u64 hw_get_seed(void)
     if (seed != 0)
         return seed;
     return rdtsc();
+}
+
+u32 irq_get_target_cpu(range cpu_affinity)
+{
+    static u32 last_target;
+    if (range_empty(cpu_affinity))
+        cpu_affinity = irange(0, total_processors);
+    u32 first, last;
+    if (point_in_range(cpu_affinity, last_target)) {
+        first = last_target + 1;
+        last = last_target;
+    } else {
+        first = cpu_affinity.start;
+        last = cpu_affinity.end - 1;
+    }
+    int irq_count = 0, min_irq = S32_MAX;
+    u32 cpu = U32_MAX;
+    do {
+        for (u32 cpu_id = first; ; cpu_id++) {
+            if (cpu_id == cpu_affinity.end)
+                cpu_id = cpu_affinity.start;
+            cpuinfo ci = cpuinfo_from_id(cpu_id);
+            int targeted_irqs = ci->targeted_irqs;
+            if (targeted_irqs == irq_count) {
+                ci->targeted_irqs++;
+                cpu = cpu_id;
+                break;
+            }
+            if (targeted_irqs < min_irq)
+                min_irq = targeted_irqs;
+            if (cpu_id == last)
+                break;
+        }
+        irq_count = min_irq;
+        min_irq = S32_MAX;
+    } while (cpu == U32_MAX);
+    return (last_target = cpu);
+}
+
+void irq_put_target_cpu(u32 cpu_id)
+{
+    cpuinfo ci = cpuinfo_from_id(cpu_id);
+    ci->targeted_irqs--;
 }
 
 #ifndef CONFIG_TRACELOG

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -83,6 +83,7 @@ struct cpuinfo {
     queue cpu_queue;
     struct sched_queue thread_queue;
     timestamp last_timer_update;
+    int targeted_irqs;
     u64 inval_gen; /* Generation number for invalidates */
 
     cpuinfo mcs_prev;
@@ -822,23 +823,27 @@ void init_clock(void);
 
 void process_bhqueue();
 
-void msi_format(u32 *address, u32 *data, int vector);
-int msi_get_vector(u32 data);
+void msi_format(u32 *address, u32 *data, int vector, u32 target_cpu);
+void msi_get_config(u32 address, u32 data, int *vector, u32 *target_cpu);
 
 u64 allocate_ipi_interrupt(void);
 void deallocate_ipi_interrupt(u64 irq);
 void register_interrupt(int vector, thunk t, sstring name);
 void unregister_interrupt(int vector);
+void irq_register_handler(int irq, thunk h, sstring name, range cpu_affinity);
 
 u64 allocate_shirq(void);
 void register_shirq(int vector, thunk t, sstring name);
 
-boolean dev_irq_enable(u32 dev_id, int vector);
+boolean dev_irq_enable(u32 dev_id, int vector, u32 target_cpu);
 void dev_irq_disable(u32 dev_id, int vector);
 
 #define TARGET_EXCLUSIVE_BROADCAST  (-1ull)
 
 void send_ipi(u64 cpu, u8 vector);
+
+u32 irq_get_target_cpu(range cpu_affinity);
+void irq_put_target_cpu(u32 cpu_id);
 
 void init_scheduler(heap);
 void init_scheduler_cpus(heap h);

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -83,7 +83,6 @@ struct cpuinfo {
     queue cpu_queue;
     struct sched_queue thread_queue;
     timestamp last_timer_update;
-    u64 frcount;
     u64 inval_gen; /* Generation number for invalidates */
 
     cpuinfo mcs_prev;

--- a/src/kernel/pci.h
+++ b/src/kernel/pci.h
@@ -160,7 +160,8 @@ void pci_bar_init(pci_dev dev, struct pci_bar *b, int bar, bytes offset, bytes l
 void pci_bar_deinit(struct pci_bar *b);
 void pci_platform_init(void);
 void pci_platform_init_bar(pci_dev dev, int bar);
-u64 pci_platform_allocate_msi(pci_dev dev, thunk h, sstring name, u32 *address, u32 *data);
+u64 pci_platform_allocate_msi(pci_dev dev, thunk h, sstring name, u32 target_cpu,
+                              u32 *address, u32 *data);
 void pci_platform_deallocate_msi(pci_dev dev, u64 v);
 boolean pci_platform_has_msi(void);
 
@@ -193,10 +194,14 @@ void pci_set_bus_master(pci_dev dev);
 int pci_get_msix_count(pci_dev dev);
 int pci_enable_msix(pci_dev dev);
 void pci_enable_io_and_memory(pci_dev dev);
-u64 pci_setup_msix(pci_dev dev, int msi_slot, thunk h, sstring name);
+u64 pci_setup_msix_aff(pci_dev dev, int msi_slot, thunk h, sstring name, range cpu_affinity);
+#define pci_setup_msix(dev, slot, handler, name)    \
+    pci_setup_msix_aff(dev, slot, handler, name, irange(0, 0))
 void pci_teardown_msix(pci_dev dev, int msi_slot);
 void pci_disable_msix(pci_dev dev);
-void pci_setup_non_msi_irq(pci_dev dev, thunk h, sstring name);
+void pci_setup_irq_aff(pci_dev dev, thunk h, sstring name, range cpu_affinity);
+#define pci_setup_non_msi_irq(dev, handler, name)   \
+    pci_setup_irq_aff(dev, handler, name, irange(0, 0))
 
 static inline u64 pci_msix_table_addr(pci_dev dev)
 {

--- a/src/net/lwip.h
+++ b/src/net/lwip.h
@@ -18,6 +18,18 @@
 
 status direct_connect(heap h, ip_addr_t *addr, u16 port, connection_handler ch);
 
+closure_type(netif_dev_setup, boolean, tuple config);
+
+typedef struct netif_dev {
+    struct netif n;
+    closure_struct(netif_dev_setup, setup);
+} *netif_dev;
+
+static inline void netif_dev_init(netif_dev dev)
+{
+    dev->setup.__apply = 0;
+}
+
 u16 ifflags_from_netif(struct netif *netif);
 boolean ifflags_to_netif(struct netif *netif, u16 flags); /* do not call with lwIP lock held */
 bytes netif_name_cpy(char *dest, struct netif *netif);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -371,6 +371,15 @@ void init_network_iface(tuple root, merge m) {
                 t = root;
         }
 
+        n->hostname = sstring_empty();
+        if (n->flags & NETIF_FLAG_ETHARP) {
+            n->output = etharp_output;
+            n->output_ip6 = ethip6_output;
+        }
+        netif_dev dev = n->state;
+        netif_dev_setup setup = (netif_dev_setup)&dev->setup;
+        if (*setup && !apply(setup, t))
+            msg_err("failed to set up %s\n", ifname);
         u64 mtu;
         if (t) {
             if (get_u64(t, sym(mtu), &mtu)) {
@@ -389,7 +398,6 @@ void init_network_iface(tuple root, merge m) {
             }
         }
 
-        n->output_ip6 = ethip6_output;
         netif_create_ip6_linklocal_address(n, 1);
         netif_set_flags(n, NETIF_FLAG_MLD6);
         if (!default_iface)

--- a/src/riscv64/interrupt.c
+++ b/src/riscv64/interrupt.c
@@ -154,7 +154,6 @@ void register_interrupt(int vector, thunk t, sstring name)
 
     if (vector <= PLIC_MAX_INT && !initialized) {
         plic_set_int_priority(vector, 1);
-        plic_clear_pending_int(vector);
         plic_enable_int(vector);
     }
 }
@@ -318,13 +317,13 @@ void trap_exception(void)
 #ifdef INT_DEBUG
         if (v < sizeof(interrupt_names)/sizeof(interrupt_names[0])) {
             rputs(" (");
-            rputs_sstring(interrupt_names[v]);
+            rput_sstring(interrupt_names[v]);
             rputs(")");
         }
         rputs("\n   context: ");
         print_u64_with_sym(u64_from_pointer(ctx));
         rputs(" (");
-        rputs(state_strings[ci->state]);
+        rput_sstring(state_strings[ci->state]);
         rputs(")");
         rputs("\n    status: ");
         print_u64_with_sym(u64_from_pointer(f[FRAME_STATUS]));

--- a/src/riscv64/kernel_machine.c
+++ b/src/riscv64/kernel_machine.c
@@ -103,6 +103,7 @@ void ap_start(u64 hartid)
     cpuinfo ci = init_cpuinfo(heap_locked(get_kernel_heaps()), cpuid);
     assert(ci != INVALID_ADDRESS);
     ci->m.hartid = hartid;
+    plic_set_threshold(hartid, 0);
     context_frame f = ci->m.kernel_context->frame;
     switch_stack_1(frame_get_stack_top(f), ap_start_newstack, cpuid);
 }
@@ -126,7 +127,6 @@ void start_secondary_cores(kernel_heaps kh)
             halt("failed to start cpu %d (hartid %d): error 0x%lx, value 0x%lx\n",
                  cpuid, hartid, r.error, r.value);
         }
-        plic_set_threshold(hartid, 0);
     }
 }
 

--- a/src/riscv64/kernel_machine.c
+++ b/src/riscv64/kernel_machine.c
@@ -139,7 +139,7 @@ closure_function(1, 2, boolean, cpu_dtb_handler,
         return true;
     dt_value dtval = dtb_read_value(DEVICETREE, n, device_type);
     if (dtval.type != DT_VALUE_STRING ||
-        runtime_strcmp(isstring(dtval.u.string, dtval.dlen), ss("cpu")))
+        runtime_strcmp(sstring_from_cstring(dtval.u.string, dtval.dlen), ss("cpu")))
         return true;
 
     dt_prop reg = dtb_get_prop(DEVICETREE, n, ss("reg"));

--- a/src/riscv64/plic.c
+++ b/src/riscv64/plic.c
@@ -23,12 +23,10 @@ void plic_disable_int(int irq)
     }
 }
 
-void plic_enable_int(int irq)
+void plic_enable_int(int irq, u32 target_cpu)
 {
-    for (int cpuid = 0; cpuid < present_processors; cpuid++) {
-        cpuinfo ci = cpuinfo_from_id(cpuid);
-        set_plic_bit(PLIC_ENABLE(context_from_hartid(ci->m.hartid)), irq);
-    }
+    cpuinfo ci = cpuinfo_from_id(target_cpu);
+    set_plic_bit(PLIC_ENABLE(context_from_hartid(ci->m.hartid)), irq);
 }
 
 void plic_set_int_priority(int irq, u32 pri)
@@ -60,11 +58,10 @@ void init_plic()
 {
 }
 
-void msi_format(u32 *address, u32 *data, int vector)
+void msi_format(u32 *address, u32 *data, int vector, u32 target_cpu)
 {
 }
 
-int msi_get_vector(u32 data)
+void msi_get_config(u32 address, u32 data, int *vector, u32 *target_cpu)
 {
-    return 0;
 }

--- a/src/riscv64/plic.c
+++ b/src/riscv64/plic.c
@@ -31,25 +31,6 @@ void plic_enable_int(int irq)
     }
 }
 
-void plic_clear_pending_int(int irq)
-{
-    for (int cpuid = 0; cpuid < present_processors; cpuid++) {
-        cpuinfo ci = cpuinfo_from_id(cpuid);
-        u64 context = context_from_hartid(ci->m.hartid);
-        boolean en = read_plic_bit(PLIC_ENABLE(context), irq);
-        if (!en)
-            set_plic_bit(PLIC_ENABLE(context), irq);
-        u32 v;
-        while ((v = read_plic(PLIC_CLAIM(context)))) {
-            write_plic(PLIC_CLAIM(context), v);
-            if (v == irq)
-                break;
-        }
-        if (!en)
-            clear_plic_bit(PLIC_ENABLE(context), irq);
-    }
-}
-
 void plic_set_int_priority(int irq, u32 pri)
 {
     write_plic_irq(PLIC_PRIORITY, irq, pri);

--- a/src/riscv64/plic.h
+++ b/src/riscv64/plic.h
@@ -18,7 +18,6 @@
 
 void plic_disable_int(int irq);
 void plic_enable_int(int irq);
-void plic_clear_pending_int(int irq);
 void plic_set_int_priority(int irq, u32 pri);
 void plic_set_threshold(u64 hartid, u32 thresh);
 void plic_set_int_config(int irq, u32 cfg);

--- a/src/riscv64/plic.h
+++ b/src/riscv64/plic.h
@@ -17,7 +17,7 @@
 #define PLIC_CLAIM(CTX)     (PLIC_CLAIM_BASE + PLIC_CLAIM_CTX_LEN * (CTX))
 
 void plic_disable_int(int irq);
-void plic_enable_int(int irq);
+void plic_enable_int(int irq, u32 target_cpu);
 void plic_set_int_priority(int irq, u32 pri);
 void plic_set_threshold(u64 hartid, u32 thresh);
 void plic_set_int_config(int irq, u32 cfg);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -284,7 +284,6 @@ closure_func_basic(thunk, void, thread_return)
     assert(f[FRAME_FULL]);
     thread_trace(t, TRACE_THREAD_RUN, "run thread, cpu %d, frame %p, pc 0x%lx, sp 0x%lx, rv 0x%lx",
                  current_cpu()->id, f, f[SYSCALL_FRAME_PC], f[SYSCALL_FRAME_SP], f[SYSCALL_FRAME_RETVAL1]);
-    ci->frcount++;
     clear_fault_handler();
     context_switch(&t->context);
     thread_release(t);

--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -105,13 +105,14 @@ void vtdev_set_status(vtdev dev, u8 status)
     }
 }
 
-status virtio_alloc_virtqueue(vtdev dev, sstring name, int idx, struct virtqueue **result)
+status virtio_alloc_vq_aff(vtdev dev, sstring name, int idx, range cpu_affinity,
+                           struct virtqueue **result)
 {
     switch (dev->transport) {
     case VTIO_TRANSPORT_MMIO:
-        return vtmmio_alloc_virtqueue((vtmmio)dev, name, idx, result);
+        return vtmmio_alloc_virtqueue((vtmmio)dev, name, idx, cpu_affinity, result);
     case VTIO_TRANSPORT_PCI:
-        return vtpci_alloc_virtqueue((vtpci)dev, name, idx, result);
+        return vtpci_alloc_virtqueue((vtpci)dev, name, idx, cpu_affinity, result);
     default:
         return timm("status", "unknown transport %d", dev->transport);
     }

--- a/src/virtio/virtio_internal.h
+++ b/src/virtio/virtio_internal.h
@@ -97,7 +97,10 @@ static inline void virtio_attach(heap h, backed_heap page_allocator,
     d->transport = transport;
 }
 
-status virtio_alloc_virtqueue(vtdev dev, sstring name, int idx, struct virtqueue **result);
+status virtio_alloc_vq_aff(vtdev dev, sstring name, int idx, range cpu_affinity,
+                           struct virtqueue **result);
+#define virtio_alloc_virtqueue(dev, name, idx, result)  \
+    virtio_alloc_vq_aff(dev, name, idx, irange(0, 0), result)
 status virtio_register_config_change_handler(vtdev dev, thunk handler);
 
 status virtqueue_alloc(vtdev dev,

--- a/src/virtio/virtio_mmio.c
+++ b/src/virtio/virtio_mmio.c
@@ -186,7 +186,7 @@ closure_func_basic(thunk, void, vtmmio_irq)
     }
 }
 
-status vtmmio_alloc_virtqueue(vtmmio dev, sstring name, int idx,
+status vtmmio_alloc_virtqueue(vtmmio dev, sstring name, int idx, range cpu_affinity,
                               struct virtqueue **result)
 {
     virtio_mmio_debug("allocating virtqueue %d (%s)", idx, name);
@@ -210,7 +210,7 @@ status vtmmio_alloc_virtqueue(vtmmio dev, sstring name, int idx,
                            name);
         // XXX arm
 #ifdef __x86_64__
-        ioapic_set_int(dev->irq, dev->irq_vector);
+        ioapic_set_int(dev->irq, dev->irq_vector, irq_get_target_cpu(cpu_affinity));
 #endif
     }
     vector_push(dev->vq_handlers, handler);

--- a/src/virtio/virtio_mmio.h
+++ b/src/virtio/virtio_mmio.h
@@ -65,4 +65,5 @@ closure_type(vtmmio_probe, void, vtmmio dev);
 void vtmmio_probe_devs(vtmmio_probe probe);
 void vtmmio_set_status(vtmmio dev, u8 status);
 boolean attach_vtmmio(heap h, backed_heap page_allocator, vtmmio d, u64 feature_mask);
-status vtmmio_alloc_virtqueue(vtmmio dev, sstring name, int idx, struct virtqueue **result);
+status vtmmio_alloc_virtqueue(vtmmio dev, sstring name, int idx, range cpu_affinity,
+                              struct virtqueue **result);

--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -58,7 +58,14 @@
 #define VIRTIO_NET_DRV_FEATURES \
     (VIRTIO_NET_F_GUEST_CSUM | VIRTIO_NET_F_MAC | VIRTIO_NET_F_GUEST_TSO4 |         \
      VIRTIO_NET_F_GUEST_TSO6 | VIRTIO_NET_F_GUEST_ECN | VIRTIO_NET_F_GUEST_UFO |    \
-     VIRTIO_NET_F_MRG_RXBUF | VIRTIO_F_ANY_LAYOUT | VIRTIO_F_RING_EVENT_IDX)
+     VIRTIO_NET_F_MRG_RXBUF | VIRTIO_F_ANY_LAYOUT | VIRTIO_F_RING_EVENT_IDX |       \
+     VIRTIO_NET_F_CTRL_VQ | VIRTIO_NET_F_MQ)
+
+typedef struct vnet_rx {
+    virtqueue q;
+    u32 seqno;
+    struct virtio_net_hdr_mrg_rxbuf *hdr;
+} *vnet_rx;
 
 typedef struct vnet {
     struct netif_dev ndev;
@@ -69,19 +76,26 @@ typedef struct vnet {
     closure_struct(mem_cleaner, mem_cleaner);
     bytes net_header_len;
     int rxbuflen;
-    u32 rx_seqno;
-    struct virtio_net_hdr_mrg_rxbuf *rx_hdr;
-    struct virtqueue *txq;
-    struct virtqueue *rxq;
+    virtqueue *txq_map;
+    vnet_rx rx;
     struct virtqueue *ctl;
     u64 empty_phys;
     void *empty; // just a mac..fix, from pre-heap days
 } *vnet;
 
+typedef struct vnet_cmd {
+    heap h;
+    struct virtio_net_ctrl_hdr hdr;
+    u8 ack;
+    closure_struct(vqfinish, finish);
+    status_handler complete;
+} *vnet_cmd;
+
 typedef struct xpbuf
 {
     struct pbuf_custom p;
     vnet vn;
+    vnet_rx rx;
     closure_struct(vqfinish, input);
     u32 seqno;
 } __attribute__((aligned(8))) *xpbuf;
@@ -100,16 +114,17 @@ static err_t low_level_output(struct netif *netif, struct pbuf *p)
 {
     vnet vn = netif->state;
 
-    vqmsg m = allocate_vqmsg(vn->txq);
+    virtqueue txq = vn->txq_map[current_cpu()->id];
+    vqmsg m = allocate_vqmsg(txq);
     assert(m != INVALID_ADDRESS);
-    vqmsg_push(vn->txq, m, vn->empty_phys, vn->net_header_len, false);
+    vqmsg_push(txq, m, vn->empty_phys, vn->net_header_len, false);
 
     pbuf_ref(p);
 
     for (struct pbuf * q = p; q != NULL; q = q->next)
-        vqmsg_push(vn->txq, m, physical_from_virtual(q->payload), q->len, false);
+        vqmsg_push(txq, m, physical_from_virtual(q->payload), q->len, false);
 
-    vqmsg_commit(vn->txq, m, closure((heap)vn->txhandlers, tx_complete, p));
+    vqmsg_commit(txq, m, closure((heap)vn->txhandlers, tx_complete, p));
     
     MIB2_STATS_NETIF_ADD(netif, ifoutoctets, p->tot_len);
     if (((u8_t *)p->payload)[0] & 1) {
@@ -128,7 +143,7 @@ static err_t low_level_output(struct netif *netif, struct pbuf *p)
 
 static vqmsg vnet_rxq_push(vnet vn, xpbuf x, int *desc_count)
 {
-    virtqueue rxq = vn->rxq;
+    virtqueue rxq = x->rx->q;
     vqmsg m = allocate_vqmsg(rxq);
     if (m == INVALID_ADDRESS)
         return m;
@@ -151,7 +166,7 @@ static void receive_buffer_release(struct pbuf *p)
 {
     xpbuf x  = (void *)p;
     vnet vn = x->vn;
-    virtqueue rxq = vn->rxq;
+    virtqueue rxq = x->rx->q;
     if (virtqueue_free_entries(rxq) > 0) {
         int desc_count;
         vqmsg m = vnet_rxq_push(vn, x, &desc_count);
@@ -163,7 +178,7 @@ static void receive_buffer_release(struct pbuf *p)
     deallocate((heap)vn->rxbuffers, x, vn->rxbuflen + sizeof(struct xpbuf));
 }
 
-static int post_receive(vnet vn);
+static int post_receive(vnet vn, vnet_rx rx);
 
 closure_func_basic(vqfinish, void, vnet_input,
                    u64 len)
@@ -172,6 +187,7 @@ closure_func_basic(vqfinish, void, vnet_input,
 
     xpbuf x = struct_from_field(closure_self(), xpbuf, input);
     vnet vn= x->vn;
+    vnet_rx rx = x->rx;
     boolean err = false;
     struct virtio_net_hdr *hdr;
     boolean pkt_complete;
@@ -179,7 +195,7 @@ closure_func_basic(vqfinish, void, vnet_input,
         /* Ensure received messages are processed in the same order as they are received.
          * This is necessary in order to correctly process packets spread in multiple rx buffers. */
         u32 attempts = 0;
-        while ((volatile u32)vn->rx_seqno != x->seqno) {
+        while ((volatile u32)rx->seqno != x->seqno) {
             if (++attempts == 0) {
                 err = true;
                 goto out;
@@ -187,7 +203,7 @@ closure_func_basic(vqfinish, void, vnet_input,
             kern_pause();
         }
 
-        struct virtio_net_hdr_mrg_rxbuf *saved_hdr = vn->rx_hdr;
+        struct virtio_net_hdr_mrg_rxbuf *saved_hdr = rx->hdr;
         boolean first_msg = (saved_hdr == 0);
         if (first_msg) {
             saved_hdr = (struct virtio_net_hdr_mrg_rxbuf *)x->p.pbuf.payload;
@@ -195,7 +211,7 @@ closure_func_basic(vqfinish, void, vnet_input,
                 pkt_complete = true;
             } else {
                 saved_hdr->num_buffers--;
-                vn->rx_hdr = saved_hdr;
+                rx->hdr = saved_hdr;
                 pkt_complete = false;
             }
         } else {
@@ -208,11 +224,11 @@ closure_func_basic(vqfinish, void, vnet_input,
                 hdr = &saved_hdr->hdr;
                 x = head_pbuf;
                 len = head_pbuf->p.pbuf.tot_len;
-                vn->rx_hdr = 0;
+                rx->hdr = 0;
                 pkt_complete = true;
             }
         }
-        vn->rx_seqno++;
+        rx->seqno++;
         if (!first_msg)
             goto msg_processed;
     } else {
@@ -225,7 +241,7 @@ closure_func_basic(vqfinish, void, vnet_input,
     x->p.pbuf.payload += vn->net_header_len;
   msg_processed:
     if (!pkt_complete) {
-        post_receive(vn);
+        post_receive(vn, rx);
         return;
     }
     if (hdr->flags & VIRTIO_NET_HDR_F_NEEDS_CSUM) {
@@ -264,13 +280,13 @@ closure_func_basic(vqfinish, void, vnet_input,
         receive_buffer_release(&x->p.pbuf);
     // we need to get a signal from the device side that there was
     // an underrun here to open up the window
-    post_receive(vn);
+    post_receive(vn, rx);
 }
 
 
-static int post_receive(vnet vn)
+static int post_receive(vnet vn, vnet_rx rx)
 {
-    virtqueue rxq = vn->rxq;
+    virtqueue rxq = rx->q;
     u16 free_entries = virtqueue_free_entries(rxq);
     int new_entries = 0;
     int rxbuflen = vn->rxbuflen;
@@ -279,6 +295,7 @@ static int post_receive(vnet vn)
         if (x == INVALID_ADDRESS)
             break;
         x->vn = vn;
+        x->rx = rx;
         x->p.custom_free_function = receive_buffer_release;
         int desc_count;
         vqmsg m = vnet_rxq_push(vn, x, &desc_count);
@@ -299,6 +316,63 @@ closure_func_basic(mem_cleaner, u64, vnet_mem_cleaner,
     vnet vn = struct_from_field(closure_self(), vnet, mem_cleaner);
     return cache_drain(vn->rxbuffers, clean_bytes,
                        NET_RX_BUFFERS_RETAIN * (sizeof(struct xpbuf) + vn->rxbuflen));
+}
+
+closure_func_basic(vqfinish, void, vnet_cmd_finish,
+                   u64 len)
+{
+    virtio_net_debug("%s len %ld\n", func_ss, len);
+    vnet_cmd command = struct_from_closure(vnet_cmd, finish);
+    status s;
+    if (len != 1)
+        s = timm("result", "invalid length %ld", len);
+    else if (command->ack != VIRTIO_NET_OK)
+        s = timm("result", "command status %d", command->ack);
+    else
+        s = STATUS_OK;
+    status_handler complete = command->complete;
+    deallocate(command->h, command, sizeof(*command));
+    apply(complete, s);
+}
+
+static boolean vnet_ctrl_cmd(vnet vn, u8 class, u8 cmd, void *data, u32 data_len,
+                             status_handler complete)
+{
+    virtio_net_debug("%s: class %d, cmd %d\n", func_ss, class, cmd);
+    heap h = (heap)vn->dev->contiguous;
+    vnet_cmd command = allocate(h, sizeof(*command));
+    if (command == INVALID_ADDRESS)
+        return false;
+    virtqueue vq = vn->ctl;
+    vqmsg m = allocate_vqmsg(vq);
+    if (m == INVALID_ADDRESS) {
+        deallocate(h, command, sizeof(*command));
+        return false;
+    }
+    command->h = h;
+    command->hdr.class = class;
+    command->hdr.cmd = cmd;
+    command->ack = VIRTIO_NET_ERR;
+    command->complete = complete;
+    vqmsg_push(vq, m, physical_from_virtual(&command->hdr), sizeof(command->hdr), false);
+    if (data_len > 0)
+        vqmsg_push(vq, m, physical_from_virtual(data), data_len, false);
+    vqmsg_push(vq, m, physical_from_virtual(&command->ack), sizeof(command->ack), true);
+    vqmsg_commit(vq, m, init_closure_func(&command->finish, vqfinish, vnet_cmd_finish));
+    return true;
+}
+
+closure_function(2, 1, void, vnet_cmd_mq_complete,
+                 vnet, vn, struct virtio_net_ctrl_mq, ctrl_mq,
+                 status s)
+{
+    if (s == STATUS_OK) {
+        netif_set_link_up(&bound(vn)->ndev.n);
+    } else {
+        msg_err("status %v\n", s);
+        timm_dealloc(s);
+    }
+    closure_finish();
 }
 
 static err_t virtioif_init(struct netif *netif)
@@ -326,7 +400,7 @@ static err_t virtioif_init(struct netif *netif)
 
     /* device capabilities */
     /* don't set NETIF_FLAG_ETHARP if this device is not an ethernet one */
-    netif->flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_LINK_UP | NETIF_FLAG_UP;
+    netif->flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_UP;
     return ERR_OK;
 }
 
@@ -334,6 +408,129 @@ static inline u64 find_page_size(bytes each, int n)
 {
     /* extra element to cover objcache meta */
     return MIN(1ul << find_order(each * (n + 1)), PAGESIZE_2M);
+}
+
+closure_func_basic(netif_dev_setup, boolean, virtio_net_setup,
+                   tuple config)
+{
+    vnet vn = struct_from_closure(vnet, ndev.setup);
+    vtdev dev = vn->dev;
+    heap h = dev->general;
+    heap contiguous = (heap)dev->contiguous;
+    u64 max_vq_pairs, vq_pairs;
+    if (dev->features & VIRTIO_NET_F_MQ) {
+        max_vq_pairs = vtdev_cfg_read_2(dev, VIRTIO_NET_R_MAX_VQ);
+        if (max_vq_pairs == 0) {
+            msg_err("device reports 0 virtqueue pairs\n");
+            return false;
+        }
+        if (config && get_u64(config, sym_this("io-queues"), &vq_pairs) && (vq_pairs > 0))
+            vq_pairs = MIN(vq_pairs, max_vq_pairs);
+        else
+            vq_pairs = max_vq_pairs;
+        vq_pairs = MIN(vq_pairs, total_processors);
+    } else {
+        max_vq_pairs = vq_pairs = 1;
+    }
+    virtio_net_debug("max vq pairs %d, using %d\n", max_vq_pairs, vq_pairs);
+    u64 cpus_per_vq = total_processors / vq_pairs;
+    u64 excess_cpus = total_processors - cpus_per_vq * vq_pairs;
+    vnet_rx rx = allocate(h, vq_pairs * sizeof(*rx));
+    if (rx == INVALID_ADDRESS)
+        goto err;
+    vn->rx = rx;
+    vn->txq_map = allocate(h, total_processors * sizeof(vn->txq_map[0]));
+    if (vn->txq_map == INVALID_ADDRESS)
+        goto err1;
+    int rxq_entries = 0, txq_entries = 0;
+    range cpu_affinity;
+    u64 first_cpu = 0, num_cpus = 0;
+    for (u64 i = 0; i < vq_pairs; i++) {
+        first_cpu += num_cpus;
+        num_cpus = (i < excess_cpus) ? (cpus_per_vq + 1) : cpus_per_vq;
+        cpu_affinity = irangel(first_cpu, num_cpus);
+        virtqueue vq;
+        int vq_index = 2 * i;
+        status s = virtio_alloc_vq_aff(dev, ss("virtio net rx"), vq_index, cpu_affinity, &vq);
+        if (!is_ok(s)) {
+            msg_err("failed to allocate vq: %v\n", s);
+            timm_dealloc(s);
+            goto err2;
+        }
+        rx[i].q = vq;
+        rx[i].seqno = 0;
+        rx[i].hdr = 0;
+        rxq_entries += virtqueue_entries(vq);
+        vq_index++;
+        s = virtio_alloc_vq_aff(dev, ss("virtio net tx"), vq_index, cpu_affinity, &vq);
+        if (!is_ok(s)) {
+            msg_err("failed to allocate vq: %v\n", s);
+            timm_dealloc(s);
+            goto err2;
+        }
+        virtqueue_set_polling(vq, true);
+        for (u64 j = first_cpu; j < first_cpu + num_cpus; j++)
+            vn->txq_map[j] = vq;
+        txq_entries += virtqueue_entries(vq);
+    }
+    if (vq_pairs > 1) {
+        status s = virtio_alloc_virtqueue(dev, ss("virtio net ctrl"), 2 * max_vq_pairs, &vn->ctl);
+        if (!is_ok(s)) {
+            msg_err("failed to allocate vq: %v\n", s);
+            timm_dealloc(s);
+            goto err2;
+        }
+    }
+    virtio_net_debug("%s: rx q entries %d, tx q entries %d\n", func_ss,
+                     rxq_entries, txq_entries);
+    bytes rx_allocsize = vn->rxbuflen + sizeof(struct xpbuf);
+    bytes rxbuffers_pagesize = find_page_size(rx_allocsize, rxq_entries);
+    bytes tx_handler_size = sizeof(closure_struct_type(tx_complete));
+    bytes tx_handler_pagesize = find_page_size(tx_handler_size, txq_entries);
+    virtio_net_debug("%s: net_header_len %d, rx_allocsize %d, rxbuffers_pagesize %d "
+                     "tx_handler_size %d tx_handler_pagesize %d\n", func_ss, vn->net_header_len,
+                     rx_allocsize, rxbuffers_pagesize, tx_handler_size, tx_handler_pagesize);
+    vn->rxbuffers = allocate_objcache(h, contiguous, rx_allocsize, rxbuffers_pagesize, true);
+    if (vn->rxbuffers == INVALID_ADDRESS)
+        goto err2;
+    vn->txhandlers = allocate_objcache(h, contiguous, tx_handler_size, tx_handler_pagesize, true);
+    if (vn->txhandlers == INVALID_ADDRESS)
+        goto err3;
+    for (u16 i = 0; i < vq_pairs; i++)
+        if (post_receive(vn, vn->rx + i) == 0) {
+            msg_err("failed to fill rx queues (%d)\n", rxq_entries);
+            goto err4;
+        }
+    if (vq_pairs > 1) {
+        struct virtio_net_ctrl_mq ctrl_mq = {
+            .virtqueue_pairs = vq_pairs,
+        };
+        status_handler complete = closure(contiguous, vnet_cmd_mq_complete, vn, ctrl_mq);
+        if (complete == INVALID_ADDRESS)
+            goto err4;
+        if (!vnet_ctrl_cmd(vn, VIRTIO_NET_CTRL_MQ, VIRTIO_NET_CTRL_MQ_VQ_PAIRS_SET,
+                             &closure_member(vnet_cmd_mq_complete, complete, ctrl_mq),
+                             sizeof(ctrl_mq), complete)) {
+            deallocate_closure(complete);
+            goto err4;
+        }
+    } else {
+        netif_set_link_up(&vn->ndev.n);
+    }
+    vtdev_set_status(dev, VIRTIO_CONFIG_STATUS_DRIVER_OK);
+    mm_register_mem_cleaner(init_closure_func(&vn->mem_cleaner, mem_cleaner, vnet_mem_cleaner));
+    return true;
+  err4:
+      destroy_heap((heap)vn->txhandlers);
+  err3:
+    destroy_heap((heap)vn->rxbuffers);
+  err2:
+    deallocate(h, vn->txq_map, total_processors * sizeof(vn->txq_map[0]));
+  err1:
+    deallocate(h, rx, vq_pairs * sizeof(*rx));
+  err:
+    msg_err("vq pairs %d (max %d)\n", vq_pairs, max_vq_pairs);
+    return false;
 }
 
 static void virtio_net_attach(vtdev dev)
@@ -346,7 +543,7 @@ static void virtio_net_attach(vtdev dev)
     backed_heap contiguous = dev->contiguous;
     vnet vn = allocate(h, sizeof(struct vnet));
     assert(vn != INVALID_ADDRESS);
-    netif_dev_init(&vn->ndev);
+    init_closure_func(&vn->ndev.setup, netif_dev_setup, virtio_net_setup);
     vn->net_header_len = (dev->features & VIRTIO_F_VERSION_1) ||
         (dev->features & VIRTIO_NET_F_MRG_RXBUF) != 0 ?
         sizeof(struct virtio_net_hdr_mrg_rxbuf) : sizeof(struct virtio_net_hdr);
@@ -361,39 +558,16 @@ static void virtio_net_attach(vtdev dev)
     else
         vn->rxbuflen = U16_MAX & ~0x7;  /* lwIP maximum packet length is U16_MAX */
 
-    mm_register_mem_cleaner(init_closure_func(&vn->mem_cleaner, mem_cleaner, vnet_mem_cleaner));
-    /* rx = 0, tx = 1, ctl = 2 by 
-       page 53 of http://docs.oasis-open.org/virtio/virtio/v1.0/cs01/virtio-v1.0-cs01.pdf */
     vn->dev = dev;
-    virtio_alloc_virtqueue(dev, ss("virtio net tx"), 1, &vn->txq);
-    virtqueue_set_polling(vn->txq, true);
-    virtio_alloc_virtqueue(dev, ss("virtio net rx"), 0, &vn->rxq);
-    virtio_net_debug("%s: rx q entries %d, tx q entries %d\n", func_ss,
-                     virtqueue_entries(vn->rxq), virtqueue_entries(vn->txq));
-    bytes rx_allocsize = vn->rxbuflen + sizeof(struct xpbuf);
-    bytes rxbuffers_pagesize = find_page_size(rx_allocsize, virtqueue_entries(vn->rxq));
-    bytes tx_handler_size = sizeof(closure_struct_type(tx_complete));
-    bytes tx_handler_pagesize = find_page_size(tx_handler_size, virtqueue_entries(vn->txq));
-    virtio_net_debug("%s: net_header_len %d, rx_allocsize %d, rxbuffers_pagesize %d "
-                     "tx_handler_size %d tx_handler_pagesize %d\n", func_ss, vn->net_header_len,
-                     rx_allocsize, rxbuffers_pagesize, tx_handler_size, tx_handler_pagesize);
-    vn->rxbuffers = allocate_objcache(h, (heap)contiguous, rx_allocsize, rxbuffers_pagesize, true);
-    assert(vn->rxbuffers != INVALID_ADDRESS);
-    vn->rx_seqno = 0;
-    vn->rx_hdr = 0;
-    vn->txhandlers = allocate_objcache(h, (heap)contiguous, tx_handler_size, tx_handler_pagesize, true);
-    assert(vn->txhandlers != INVALID_ADDRESS);
     vn->empty = alloc_map(contiguous, contiguous->h.pagesize, &vn->empty_phys);
     assert(vn->empty != INVALID_ADDRESS);
     for (int i = 0; i < vn->net_header_len; i++)
         ((u8 *)vn->empty)[i] = 0;
-    vtdev_set_status(dev, VIRTIO_CONFIG_STATUS_DRIVER_OK);
     netif_add(&vn->ndev.n,
               0, 0, 0, 
               vn,
               virtioif_init,
               ethernet_input);
-    assert(post_receive(vn) > 0);
 }
 
 closure_function(2, 1, boolean, vtpci_net_probe,

--- a/src/virtio/virtio_net.h
+++ b/src/virtio/virtio_net.h
@@ -72,6 +72,8 @@ struct virtio_net_config {
 	u16	max_virtqueue_pairs;
 } __attribute__((packed));
 
+#define VIRTIO_NET_R_MAX_VQ     (offsetof(struct virtio_net_config *, max_virtqueue_pairs))
+
 /*
  * This is the first element of the scatter-gather list.  If you don't
  * specify GSO or CSUM features, you can simply ignore the header.

--- a/src/virtio/virtio_pci.h
+++ b/src/virtio/virtio_pci.h
@@ -90,7 +90,8 @@ struct vtpci {
 
 boolean vtpci_probe(pci_dev d, int virtio_dev_id);
 vtpci attach_vtpci(heap h, backed_heap page_allocator, pci_dev d, u64 feature_mask);
-status vtpci_alloc_virtqueue(vtpci dev, sstring name, int idx, struct virtqueue **result);
+status vtpci_alloc_virtqueue(vtpci dev, sstring name, int idx, range cpu_affinity,
+                             struct virtqueue **result);
 status vtpci_register_config_change_handler(vtpci dev, thunk handler);
 void vtpci_set_status(vtpci dev, u8 status);
 boolean vtpci_is_modern(vtpci dev);

--- a/src/virtio/virtio_scsi.c
+++ b/src/virtio/virtio_scsi.c
@@ -700,11 +700,13 @@ static void virtio_scsi_attach(heap general, storage_attach a, backed_heap page_
     s->max_lun = pci_bar_read_4(&s->v->device_config, VIRTIO_SCSI_R_MAX_LUN);
     virtio_scsi_debug("max lun %d\n", s->max_lun);
 
-    status st = vtpci_alloc_virtqueue(s->v, ss("virtio scsi command"), 0, &s->command);
+    range cpu_affinity = irange(0, 0);
+    status st = vtpci_alloc_virtqueue(s->v, ss("virtio scsi command"), 0, cpu_affinity,
+                                      &s->command);
     assert(st == STATUS_OK);
-    st = vtpci_alloc_virtqueue(s->v, ss("virtio scsi event"), 1, &s->eventq);
+    st = vtpci_alloc_virtqueue(s->v, ss("virtio scsi event"), 1, cpu_affinity, &s->eventq);
     assert(st == STATUS_OK);
-    st = vtpci_alloc_virtqueue(s->v, ss("virtio scsi request"), 2, &s->requestq);
+    st = vtpci_alloc_virtqueue(s->v, ss("virtio scsi request"), 2, cpu_affinity, &s->requestq);
     assert(st == STATUS_OK);
 
     // On reset, the device MUST set sense_size to 96 and cdb_size to 32

--- a/src/x86_64/acpi.c
+++ b/src/x86_64/acpi.c
@@ -94,7 +94,7 @@ void acpi_save_rsdp(u64 rsdp)
 
 void acpi_register_irq_handler(int irq, thunk t, sstring name)
 {
-    ioapic_register_int(irq, t, name);
+    ioapic_register_int(irq, t, name, irange(0, 0));
 }
 
 /* OS services layer */

--- a/src/x86_64/apic.h
+++ b/src/x86_64/apic.h
@@ -66,9 +66,9 @@ void apic_per_cpu_init(void);
 void apic_enable(void);
 int cpuid_from_apicid(u32 aid);
 
-void ioapic_set_int(unsigned int gsi, u64 v);
+void ioapic_set_int(unsigned int gsi, u64 v, u32 target_cpu);
 boolean ioapic_int_is_free(unsigned int gsi);
-void ioapic_register_int(unsigned int gsi, thunk h, sstring name);
+void ioapic_register_int(unsigned int gsi, thunk h, sstring name, range cpu_affinity);
 
 extern apic_iface apic_if;
 

--- a/src/x86_64/hpet.c
+++ b/src/x86_64/hpet.c
@@ -124,9 +124,10 @@ static void timer_config(int timer, timestamp rate, thunk t, boolean periodic)
     if (!tim->interrupt) {
         tim->config = TCONF(32MODE_CNF) | TCONF(INT_ENB_CNF);
         tim->interrupt = allocate_interrupt();
+        u32 target_cpu = irq_get_target_cpu(irange(0, 0));
         if (hpet->timers[timer].config & TCONF(FSB_INT_DEL_CAP)) {
             u32 a, d;
-            msi_format(&a, &d, tim->interrupt);
+            msi_format(&a, &d, tim->interrupt, target_cpu);
             hpet->timers[timer].fsb_int = ((u64)a << 32) | d;
             tim->config |= TCONF(FSB_EN_CNF);
         } else {
@@ -144,7 +145,7 @@ static void timer_config(int timer, timestamp rate, thunk t, boolean periodic)
                 }
             }
             assert(gsi >= 0);
-            ioapic_set_int(gsi, tim->interrupt);
+            ioapic_set_int(gsi, tim->interrupt, target_cpu);
             tim->config |= gsi << HPET_TIMER_CONFIG_INT_ROUTE_CNF_SHIFT;
         }
         register_interrupt(tim->interrupt, t, ss("hpet timer"));


### PR DESCRIPTION
This changeset enhances the virtio-net driver to support multiple tx/rx queues. This allows achieving better network performance in multi-CPU instances running workloads that serve multiple network connections simultaneously.
By default, the virtio-net driver uses as many queues as supported by the attached device; it is possible to override this behavior by specifying the "io-queues" configuration option in the manifest tuple corresponding to a given network interface. For example,
the following snippet of an Ops configuration file instructs the driver to use 2 queues for the first network interface:
```
"ManifestPassthrough": {
  "en1": {
    "io-queues": "2"
  }
}
```
The number of queues used by the driver is always limited to the number of CPUs in the running instance (this behavior cannot be overridden by the "io-queues" option).
In order to optimize parallelism, each tx/rx queue is configured with an interrupt affinity such that different queues are served
by different CPUs.