### PR TITLE
Fixing linker warnings

### DIFF
--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -40,7 +40,7 @@ CFLAGS+= \
 	-I$(SRCDIR)/runtime \
 	-I$(SRCDIR)/kernel \
 	-I$(SRCDIR)/x86_64
-LDFLAGS+=	--gc-sections -T linker_script
+LDFLAGS+=	-z noexecstack --gc-sections -T linker_script
 AFLAGS+=	-I$(SRCDIR)/x86_64 -felf
 
 NASMFLAGS	= -l $@.lst -I $(SRCDIR)/x86_64/ -dSTAGE2SIZE=$(shell $(SIZE_CMD) $(OBJDIR)/stage2.pad)
@@ -97,7 +97,7 @@ CFLAGS-uefi= \
 	-I$(SRCDIR) -I$(SRCDIR)/boot -I$(SRCDIR)/kernel -I$(SRCDIR)/runtime \
 	-I$(SRCDIR)/fs -I$(SRCDIR)/x86_64 -I$(OBJDIR) \
 	-DBOOT -DUEFI -DEFIAPI="__attribute__((ms_abi))"
-LDLAGS-uefi= -nostdlib -shared -Bsymbolic -T $(SRCDIR)/x86_64/uefi.lds
+LDLAGS-uefi= -z noexecstack -nostdlib -shared -Bsymbolic -T $(SRCDIR)/x86_64/uefi.lds
 
 DEPFILES+= $(DEPS-uefi)
 

--- a/platform/pc/boot/linker_script
+++ b/platform/pc/boot/linker_script
@@ -3,12 +3,19 @@ OUTPUT_ARCH(i386)
 
 ENTRY(_start)
 
+PHDRS
+{
+  text PT_LOAD FLAGS(5);          /* R E */
+  rodata PT_LOAD FLAGS(4);        /* R */
+  data PT_LOAD FLAGS(6);          /* RW */
+}
+
 SECTIONS
 {
   . = 0x8000;
-  .start : { *(.start)}
-  .text : { *(.text)}
-  .rodata : { *(.rodata)}
-  .data : { *(.data) }
-  .bss  ALIGN(32): { *(.bss) }
+  .start : { *(.start)} :text
+  .text : { *(.text) *(.text.*) } :text
+  .rodata : { *(.rodata) *(.rodata.*) } :rodata
+  .data : { *(.data) *(.data.*) } :data
+  .bss ALIGN(32): { *(.bss) *(.bss.*) } :data
 }

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -239,7 +239,7 @@ UEFI_CFLAGS=    -Wall -Werror -fpic -fshort-wchar -O3 -std=gnu11 \
 	-ffreestanding -DBOOT -DUEFI $(call cc-option, -mno-outline-atomics, "") \
 	-I$(SRCDIR) -I$(SRCDIR)/aarch64 -I$(SRCDIR)/boot -I$(SRCDIR)/kernel \
 	-I$(SRCDIR)/runtime -I$(SRCDIR)/fs -I$(PLATFORMDIR) -I$(OBJDIR)
-UEFI_LDFLAGS=   -nostdlib -shared -Bsymbolic -T $(SRCDIR)/aarch64/uefi.lds
+UEFI_LDFLAGS=   -z noexecstack -nostdlib -shared -Bsymbolic -T $(SRCDIR)/aarch64/uefi.lds
 
 DEPFILES+=      $(VDSO_DEPS) $(UEFI_DEPS)
 CLEANFILES+=    $(foreach f,gitversion.c frame.inc kernel.dis bin/kernel.elf boot/uefi.so src/unix/ftrace.* $(ARCHDIR)/ftrace.*,$(OBJDIR)/$f) $(VDSO_OBJDIR)/vdso.so $(VDSO_OBJDIR)/vdso-image.c $(VDSO_OBJDIR)/vdso-offset.h $(VDSO_OBJS) $(VDSO_DEPS) $(UEFI_OBJS) $(UEFI_DEPS) $(UEFI_LOADER) $(BOOTIMG) $(KERNEL)

--- a/rules.mk
+++ b/rules.mk
@@ -104,7 +104,7 @@ KERNCFLAGS+=	-march=rv64gc -mabi=lp64d
 endif
 
 KERNCFLAGS+=	-fno-omit-frame-pointer
-KERNLDFLAGS=	--gc-sections -z max-page-size=4096 -L $(OUTDIR)/klib -pie --no-dynamic-linker
+KERNLDFLAGS=	--gc-sections -z notext -z noexecstack -z max-page-size=4096 -L $(OUTDIR)/klib -pie --no-dynamic-linker
 
 ifneq ($(UBSAN),)
 KERNCFLAGS+= -fsanitize=undefined -fno-sanitize=alignment,null -fsanitize-undefined-trap-on-error

--- a/src/aarch64/klib.lds
+++ b/src/aarch64/klib.lds
@@ -2,14 +2,23 @@ OUTPUT_FORMAT("elf64-littleaarch64")
 
 ENTRY(init)
 
+PHDRS
+{
+        text PT_LOAD FLAGS(5);          /* R E */
+        rodata PT_LOAD FLAGS(4);        /* R */
+        data PT_LOAD FLAGS(6);          /* RW */
+}
+
 SECTIONS
 {
         . = SIZEOF_HEADERS;
-        .text : { *(.text)}
-        .rodata : { *(.rodata)}
+        .text : { *(.text) *(.text.*) } :text
+        . = ALIGN(4096);
+        .rodata : { *(.rodata) *(.rodata.*) } :rodata
 
-        .data ALIGN(4096) : { *(.data) *(.data.*) }
-        .bss ALIGN(32): { *(.bss) *(.bss.*) }
+        . = ALIGN(4096);
+        .data : { *(.data) *(.data.*) } :data
+        .bss : { *(.bss) *(.bss.*) } :data
 
         /DISCARD/ : { *(.interp) }
 }

--- a/src/riscv64/klib.lds
+++ b/src/riscv64/klib.lds
@@ -2,14 +2,23 @@ OUTPUT_FORMAT("elf64-littleriscv")
 
 ENTRY(init)
 
+PHDRS
+{
+        text PT_LOAD FLAGS(5);          /* R E */
+        rodata PT_LOAD FLAGS(4);        /* R */
+        data PT_LOAD FLAGS(6);          /* RW */
+}
+
 SECTIONS
 {
         . = SIZEOF_HEADERS;
-        .text : { *(.text)}
-        .rodata : { *(.rodata)}
+        .text : { *(.text) *(.text.*) } :text
+        . = ALIGN(4096);
+        .rodata : { *(.rodata) *(.rodata.*) } :rodata
 
-        .data ALIGN(4096) : { *(.data) *(.data.*) }
-        .bss ALIGN(32): { *(.bss) *(.bss.*) }
+        . = ALIGN(4096);
+        .data : { *(.data) *(.data.*) } :data
+        .bss : { *(.bss) *(.bss.*) } :data
 
         /DISCARD/ : { *(.interp) }
 }

--- a/src/x86_64/klib.lds
+++ b/src/x86_64/klib.lds
@@ -2,14 +2,23 @@ OUTPUT_FORMAT("elf64-x86-64")
 
 ENTRY(init)
 
+PHDRS
+{
+        text PT_LOAD FLAGS(5);          /* R E */
+        rodata PT_LOAD FLAGS(4);        /* R */
+        data PT_LOAD FLAGS(6);          /* RW */
+}
+
 SECTIONS
 {
         . = SIZEOF_HEADERS;
-        .text : { *(.text)}
-        .rodata : { *(.rodata)}
+        .text : { *(.text) *(.text.*) } :text
+        . = ALIGN(4096);
+        .rodata : { *(.rodata) *(.rodata.*) } :rodata
 
-        .data ALIGN(4096) : { *(.data) *(.data.*) }
-        .bss ALIGN(32): { *(.bss) *(.bss.*) }
+        . = ALIGN(4096);
+        .data : { *(.data) *(.data.*) } :data
+        .bss : { *(.bss) *(.bss.*) } :data
 
         /DISCARD/ : { *(.interp) }
 }


### PR DESCRIPTION
This changeset fixes linker warnings that appeared starting with release 2.39 of the GNU binutils.
In addition, it amends the x86 bootloader linker script so that the size of the bootloader binary file is decreased by around 2%.

Closes #1870 and #2010