### PR TITLE
timm_dealloc(): fix handling of tuples that reference `timm_oom`

### DIFF
--- a/src/runtime/tuple.c
+++ b/src/runtime/tuple.c
@@ -263,10 +263,23 @@ tuple timm_clone(tuple t)
     return (t != INVALID_ADDRESS) ? t : timm_oom;
 }
 
+closure_function(1, 2, boolean, timm_dealloc_each,
+                 tuple, t,
+                 value s, value v)
+{
+    if (tagof(v) == tag_string)
+        deallocate_string((string)v);
+    else
+        timm_dealloc((tuple)v);
+    return true;
+}
+
 void timm_dealloc(tuple t)
 {
-    if ((t != STATUS_OK) && (t != timm_oom))
-        destruct_value(t, true);
+    if ((t != STATUS_OK) && (t != timm_oom)) {
+        iterate(t, stack_closure(timm_dealloc_each, t));
+        deallocate_table(&t->t);
+    }
 }
 
 // header: immediate(1)


### PR DESCRIPTION
A given status tuple may contain another status tuple as value for one of its attributes (e.g. when a status tuple is generated via a call to `timm_up()`), and the inner tuple can be an arbitrary tuple, including `timm_oom` (i.e. the global tuple that is allocated during kernel initialization and is used to indicate out-of-memory conditions). The `timm_oom` tuple must never be deallocated, but the existing code deallocates it if it is the value for an attribute of an outer status tuple.
This change fixes the above issue.