### PR TITLE
x86: setup_initmap(): fix mapping of initial pages

### DIFF
--- a/src/x86_64/page_machine.h
+++ b/src/x86_64/page_machine.h
@@ -271,8 +271,9 @@ physical physical_from_virtual(void *x);
 
 void *bootstrap_page_tables(heap initial);
 #if defined(KERNEL) || defined(UEFI)
+struct region;
 void map_setup_2mbpages(u64 v, physical p, int pages, pageflags flags,
-                        u64 *pdpt, u64 *pdt);
+                        struct region *r);
 void init_mmu(void);
 #else
 void init_mmu(heap initial);


### PR DESCRIPTION
Depending on the address of the initial pages allocated in setup_initmap(), the map_setup_2mbpages() function may not find an existing PDPT and or PDT in the page tables, and thus may need to use a new PDPT and/or a new PDT. However, the PDPT and PDT addresses passed to this function correspond to in-use pages, and as such cannot be reused and assigned to new PTEs. Moreover, when creating a new PTE, the map_setup_2mbpages() function is simply OR-ing the page address with the page flags, failing to set the USER flag and thereby preventing any pages referenced by this directory entry from being mapped for user space access; this may cause bogus segmentation fault signals to be delivered to the user process (https://github.com/nanovms/nanos/issues/1999#issuecomment-2072735021).

This change fixes the above issues by amending map_setup_2mbpages() so that it takes a physical memory region from which to allocate any new pages it may need, and calls new_level_pte() when creating a new PTE.