### PR TITLE
Azure: implement sending memory metrics via diagnostic extension

### DIFF
--- a/klib/Makefile
+++ b/klib/Makefile
@@ -23,6 +23,7 @@ SRCS-cloud_init= \
 	$(CURDIR)/cloud_azure.c \
 	$(CURDIR)/cloud_init.c \
 	$(CURDIR)/net_utils.c \
+	$(CURDIR)/xml.c \
 
 SRCS-cloudwatch= \
 	$(CURDIR)/aws.c \

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -4,6 +4,7 @@ LWIPDIR=		$(VENDORDIR)/lwip
 MBEDTLS_DIR=	$(VENDORDIR)/mbedtls
 
 PROGRAMS= \
+	azure \
 	cloud_init \
 	cloudwatch \
 	digitalocean \
@@ -18,6 +19,10 @@ PROGRAMS= \
 	tmpfs \
 	tls \
 	tun \
+
+SRCS-azure= \
+	$(CURDIR)/azure.c \
+	$(CURDIR)/azure_diagnostics.c \
 
 SRCS-cloud_init= \
 	$(CURDIR)/cloud_azure.c \

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -22,6 +22,7 @@ PROGRAMS= \
 SRCS-cloud_init= \
 	$(CURDIR)/cloud_azure.c \
 	$(CURDIR)/cloud_init.c \
+	$(CURDIR)/net_utils.c \
 
 SRCS-cloudwatch= \
 	$(CURDIR)/aws.c \

--- a/klib/azure.c
+++ b/klib/azure.c
@@ -1,0 +1,166 @@
+#include <kernel.h>
+#include <lwip.h>
+#include <net_utils.h>
+
+#include "azure.h"
+
+#ifdef AZURE_DEBUG
+#define azure_debug(fmt, ...)   tprintf(sym(azure), 0, ss(fmt "\n"), ##__VA_ARGS__)
+#else
+#define azure_debug(fmt, ...)
+#endif
+
+#define AZURE_INSTANCE_MD_ADDR  ss("169.254.169.254")
+
+typedef struct az_instance_md_req {
+    az_instance_md_handler complete;
+    tuple req;
+    struct buffer query;
+    struct buffer md_header;
+    closure_struct(value_handler, vh);
+} *az_instance_md_req;
+
+static struct azure {
+    heap h;
+    tuple instance_md;
+} azure;
+
+int init(status_handler complete)
+{
+    tuple root = get_root_tuple();
+    if (!root)
+        return KLIB_INIT_FAILED;
+    tuple az_config = get_tuple(root, sym_this("azure"));
+    if (!az_config)
+        return KLIB_INIT_OK;
+    azure.h = heap_locked(get_kernel_heaps());
+    tuple diag = get_tuple(az_config, sym_this("diagnostics"));
+    if (diag) {
+        int res = azure_diag_init(diag);
+        if (res != KLIB_INIT_OK)
+            return res;
+    }
+    return KLIB_INIT_OK;
+}
+
+closure_function(1, 1, void, azure_instance_md_parsed,
+                 tuple *, result,
+                 void *v)
+{
+    *bound(result) = v;
+}
+
+closure_func_basic(parse_error, void, azure_instance_md_err,
+                   string data)
+{
+    msg_err("failed to parse JSON: %b\n", data);
+}
+
+closure_func_basic(value_handler, void, azure_instance_md_vh,
+                   value v)
+{
+    az_instance_md_req req_data = struct_from_closure(az_instance_md_req, vh);
+    deallocate_value(req_data->req);
+    if (!v) {
+        msg_err("failed to retrieve instance metadata\n");
+        goto done;
+    }
+    value start_line = get(v, sym(start_line));
+    azure_debug("instance metadata server status %v", start_line);
+    buffer status_code = get(start_line, integer_key(1));
+    buffer content;
+    if (status_code && !buffer_strcmp(status_code, "200"))
+        content = get(v, sym_this("content"));
+    else
+        content = 0;
+    if (!content) {
+        msg_err("unexpected metadata server response %v\n", v);
+        goto done;
+    }
+    tuple md = 0;
+    parser p = json_parser(azure.h, stack_closure(azure_instance_md_parsed, &md),
+                           stack_closure_func(parse_error, azure_instance_md_err));
+    p = parser_feed(p, content);
+    p = apply(p, CHARACTER_INVALID);
+    json_parser_free(p);
+    if (md) {
+        if (!compare_and_swap_64((u64 *)&azure.instance_md, 0, u64_from_pointer(md)))
+            destruct_value(md, true);
+    }
+  done:
+    apply(req_data->complete, azure.instance_md);
+    deallocate(azure.h, req_data, sizeof(*req_data));
+}
+
+void azure_instance_md_get(az_instance_md_handler complete)
+{
+    tuple md = azure.instance_md;
+    if (md) {
+        apply(complete, md);
+        return;
+    }
+    struct net_http_req_params req_params;
+    req_params.host = AZURE_INSTANCE_MD_ADDR;
+    req_params.port = 80;
+    req_params.tls = false;
+    req_params.method = HTTP_REQUEST_METHOD_GET;
+    az_instance_md_req req_data = allocate(azure.h, sizeof(*req_data));
+    if (req_data == INVALID_ADDRESS) {
+        msg_err("out of memory\n");
+        goto error;
+    }
+    tuple req = allocate_tuple();
+    if (req == INVALID_ADDRESS) {
+        msg_err("out of memory\n");
+        deallocate(azure.h, req_data, sizeof(*req_data));
+        goto error;
+    }
+    buffer_init_from_string(&req_data->query,
+                            "/metadata/instance?api-version=2021-01-01&format=json");
+    set(req, sym_this("url"), &req_data->query);
+    buffer_init_from_string(&req_data->md_header, "true");
+    set(req, sym_this("Metadata"), &req_data->md_header);
+    req_data->req = req_params.req = req;
+    req_params.body = 0;
+    req_params.resp_handler = init_closure_func(&req_data->vh, value_handler, azure_instance_md_vh);
+    req_data->complete = complete;
+    azure_debug("retrieving instance metadata");
+    status s = net_http_req(&req_params);
+    if (is_ok(s))
+        return;
+    deallocate_value(req);
+    deallocate(azure.h, req_data, sizeof(*req_data));
+  error:
+    apply(complete, 0);
+}
+
+void iso8601_write_interval(timestamp interval, buffer out)
+{
+    push_u8(out, 'P');
+    u64 seconds = sec_from_timestamp(interval);
+    int years = seconds / (365 * 24 * 60 * 60);
+    if (years != 0) {
+        bprintf(out, "%dY", years);
+        seconds -= years * 365 * 24 * 60 * 60;
+    }
+    int days = seconds / (24 * 60 * 60);
+    if (days != 0) {
+        bprintf(out, "%dD", days);
+        seconds -= days * 24 * 60 * 60;
+    }
+    if (seconds == 0)
+        return;
+    push_u8(out, 'T');
+    int hours = seconds / (60 * 60);
+    if (hours != 0) {
+        bprintf(out, "%dH", hours);
+        seconds -= hours * 60 * 60;
+    }
+    int minutes = seconds / 60;
+    if (minutes != 0) {
+        bprintf(out, "%dM", minutes);
+        seconds -= minutes * 60;
+    }
+    if (seconds != 0)
+        bprintf(out, "%dS", seconds);
+}

--- a/klib/azure.h
+++ b/klib/azure.h
@@ -1,0 +1,14 @@
+#ifndef AZURE_H_
+#define AZURE_H_
+
+typedef struct azure_ext {
+    sstring name;
+    sstring version;
+    status s;
+    u64 cfg_seconds;
+    u64 cfg_seqno;
+} *azure_ext;
+
+boolean azure_register_ext(azure_ext ext);
+
+#endif

--- a/klib/azure.h
+++ b/klib/azure.h
@@ -9,6 +9,14 @@ typedef struct azure_ext {
     u64 cfg_seqno;
 } *azure_ext;
 
+closure_type(az_instance_md_handler, void, tuple md);
+
 boolean azure_register_ext(azure_ext ext);
+
+int azure_diag_init(tuple cfg);
+
+void azure_instance_md_get(az_instance_md_handler complete);
+
+void iso8601_write_interval(timestamp interval, buffer out);
 
 #endif

--- a/klib/azure_diagnostics.c
+++ b/klib/azure_diagnostics.c
@@ -1,0 +1,538 @@
+#include <kernel.h>
+#include <lwip.h>
+#include <mktime.h>
+#include <net_utils.h>
+#include <pagecache.h>
+#include <tls.h>
+
+#include "azure.h"
+
+#ifdef AZURE_DIAG_DEBUG
+#define azdiag_debug(fmt, ...)   tprintf(sym(azure_diag), 0, ss(fmt "\n"), ##__VA_ARGS__)
+#else
+#define azdiag_debug(fmt, ...)
+#endif
+
+enum azure_metrics_mem {
+    AZURE_METRICS_MEMORY_AVAILABLE,
+    AZURE_METRICS_MEMORY_USED,
+    AZURE_METRICS_MEMORY_AVAILABLE_PERCENT,
+    AZURE_METRICS_MEMORY_USED_PERCENT,
+    AZURE_METRICS_MEMORY_COUNT
+};
+
+typedef struct azure_metric {
+    sstring category;
+    sstring name;
+    u64 count;
+    u64 last;
+    u64 min;
+    u64 max;
+    u64 total;
+} *azure_metric;
+
+typedef struct az_diag {
+    struct azure_ext extension;
+    heap h;
+    buffer storage_account;
+    buffer storage_account_sas;
+    struct buffer vm_name;
+    struct buffer vm_resource_id;
+    closure_struct(status_handler, setup_complete);
+    struct {
+        timestamp sample_interval;
+        timestamp transfer_interval;
+        struct buffer table_name;
+        struct buffer server;
+        struct timer timer;
+        closure_struct(timer_handler, th);
+        timestamp ts;
+        struct azure_metric data[AZURE_METRICS_MEMORY_COUNT];
+        closure_struct(connection_handler, ch);
+        buffer_handler out;
+        closure_struct(input_buffer_handler, ibh);
+        buffer_handler resp_parser;
+        closure_struct(value_handler, vh);
+        timestamp table_switch;
+        boolean pending;
+    } metrics;
+} *az_diag;
+
+declare_closure_struct(1, 1, void, azdiag_instance_md_handler,
+                       status_handler, complete,
+                       tuple md)
+typedef struct azdiag_setup_s {
+    az_diag diag;
+    closure_struct(azdiag_instance_md_handler, instance_md_handler);
+    closure_struct(status_handler, complete);
+    closure_struct(timer_handler, retry_th);
+    timestamp retry_backoff;
+} *azdiag_setup_s;
+
+static boolean azure_metric_get_interval(tuple metrics, sstring name, const u64 min_value,
+                                         const u64 default_value, timestamp *result)
+{
+    u64 interval;
+    if (get_u64(metrics, sym_sstring(name), &interval)) {
+        if (interval < min_value) {
+            rprintf("Azure diagnostics: invalid metrics %s (minimum allowed value %ld seconds)\n",
+                    name, min_value);
+            return false;
+        }
+    } else {
+        interval = default_value;
+    }
+    *result = seconds(interval);
+    return true;
+}
+
+static void azure_metrics_reset(az_diag diag)
+{
+    for (int i = 0; i < AZURE_METRICS_MEMORY_COUNT; i++) {
+        azure_metric metric = &diag->metrics.data[i];
+        metric->count = 0;
+        metric->min = U64_MAX;
+        metric->max = 0;
+        metric->total = 0;
+    }
+}
+
+define_closure_function(1, 1, void, azdiag_instance_md_handler,
+                        status_handler, complete,
+                        tuple md)
+{
+    azdiag_setup_s setup = struct_from_closure(azdiag_setup_s, instance_md_handler);
+    az_diag diag = setup->diag;
+    status s;
+    if (!md) {
+        s = timm("result", "failed to get instance metadata");
+        goto out;
+    }
+    tuple compute = get_tuple(md, sym_this("compute"));
+    if (!compute) {
+        s = timm("result", "missing compute node");
+        goto out;
+    }
+    string name = get_string(compute, sym_this("name"));
+    if (!name) {
+        s = timm("result", "missing VM name");
+        goto out;
+    }
+    string res_id;
+    tuple vmss = get_tuple(compute, sym_this("virtualMachineScaleSet"));
+    if (!vmss) {
+        azdiag_debug("instance is not in a VM scale set");
+        res_id = get_string(compute, sym_this("resourceId"));
+    } else {
+        azdiag_debug("instance is in a VM scale set");
+        res_id = get_string(vmss, sym_this("id"));
+    }
+    if (!res_id) {
+        s = timm("result", "missing resource id");
+        goto out;
+    }
+    if (!push_buffer(&diag->vm_name, name)) {
+        s = timm_oom;
+        goto out;
+    }
+    foreach_character(i, c, res_id) {
+        if ((c >= 0x20) && (c <= 0x2F))
+            bprintf(&diag->vm_resource_id, ":%04X", c);
+        else
+            push_u8(&diag->vm_resource_id, c);
+    }
+    azdiag_debug("VM name '%b', resource ID %b", &diag->vm_name, &diag->vm_resource_id);
+    s = STATUS_OK;
+  out:
+    if (!is_ok(s)) {
+        buffer_clear(&diag->vm_name);
+        buffer_clear(&diag->vm_resource_id);
+    }
+    apply(bound(complete), s);
+    closure_finish();
+}
+
+static void azdiag_resolve_cb(sstring name, const ip_addr_t *addr, void *cb_arg)
+{
+    connection_handler ch = cb_arg;
+    if (addr) {
+        azdiag_debug("connecting to server (%F)", ch);
+        if (tls_connect((ip_addr_t *)addr, 443, ch) < 0) {
+            msg_err("failed to connect to server %s\n", name);
+            apply(ch, 0);
+        }
+    } else {
+        msg_err("failed to resolve server name %s\n", name);
+        apply(ch, 0);
+    }
+}
+
+static void azure_metrics_connect(az_diag diag)
+{
+    sstring server = buffer_to_sstring(&diag->metrics.server);
+    azdiag_debug("resolving server name %s", server);
+    net_resolve(server, azdiag_resolve_cb, &diag->metrics.ch);
+}
+
+static boolean azure_metrics_table_post(az_diag diag, sstring resource, buffer content_type,
+                                        buffer body, boolean keepalive)
+{
+    tuple req = allocate_tuple();
+    if (req == INVALID_ADDRESS)
+        return false;
+    buffer query_string = little_stack_buffer(256);
+    bprintf(query_string, "/%s?%b&api-version=2024-05-04", resource, diag->storage_account_sas);
+    set(req, sym(url), query_string);
+    set(req, sym(Host), &diag->metrics.server);
+    set(req, sym(Content-Type), content_type);
+    set(req, sym(Accept), alloca_wrap_cstring("*/*"));
+    set(req, sym(Accept-Charset), alloca_wrap_cstring("UTF-8"));
+    set(req, sym(DataServiceVersion), alloca_wrap_cstring("3.0;"));
+    set(req, sym(MaxDataServiceVersion), alloca_wrap_cstring("3.0;NetFx"));
+    set(req, sym(Connection), alloca_wrap_sstring(keepalive ? ss("keep-alive") : ss("close")));
+    status s = http_request(diag->h, diag->metrics.out, HTTP_REQUEST_METHOD_POST, req, body);
+    boolean success = is_ok(s);
+    if (!success) {
+        msg_err("%v\n", s);
+        timm_dealloc(s);
+    }
+    deallocate_value(req);
+    return success;
+}
+
+static boolean azure_metrics_table_create(az_diag diag, buffer table_name)
+{
+    azdiag_debug("creating table %b", table_name);
+    buffer b = allocate_buffer(diag->h, 128);
+    if (b != INVALID_ADDRESS) {
+        bprintf(b, "{\"TableName\":\"%b\"}", table_name);
+        if (!azure_metrics_table_post(diag, ss("Tables"), alloca_wrap_cstring("application/json"),
+                                      b, true)) {
+            deallocate_buffer(b);
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+static void azdiag_setup(azdiag_setup_s setup)
+{
+    az_diag diag = setup->diag;
+    merge m = allocate_merge(diag->h, (status_handler)&setup->complete);
+    status_handler complete = apply_merge(m);
+    if (buffer_length(&diag->vm_name) == 0) {
+        az_instance_md_handler complete = init_closure(&setup->instance_md_handler,
+                                                       azdiag_instance_md_handler, apply_merge(m));
+        azure_instance_md_get(complete);
+    }
+    apply(complete, STATUS_OK);
+}
+
+closure_func_basic(timer_handler, void, azdiag_setup_retry,
+                   u64 expiry, u64 overruns)
+{
+    azdiag_setup_s setup = struct_from_closure(azdiag_setup_s, retry_th);
+    if (overruns != timer_disabled)
+        azdiag_setup(setup);
+}
+
+closure_func_basic(status_handler, void, azdiag_setup_complete,
+                   status s)
+{
+    azdiag_setup_s setup = struct_from_closure(azdiag_setup_s, complete);
+    az_diag diag = setup->diag;
+    heap h = diag->h;
+    if (is_ok(s)) {
+        azdiag_debug("setup complete");
+        if (diag->metrics.sample_interval)
+            register_timer(kernel_timers, &diag->metrics.timer, CLOCK_ID_MONOTONIC, 0, false,
+                           diag->metrics.sample_interval, (timer_handler)&diag->metrics.th);
+    } else {
+        /* Do not print error messages if the instance metadata server is unreachable just after
+         * instance startup (a few seconds might elapse before the network interface acquires a DHCP
+         * address). */
+        if (setup->retry_backoff > seconds(2))
+            msg_err("%v\n", s);
+        else
+            azdiag_debug("setup error %v, retrying", s);
+
+        timm_dealloc(s);
+        setup->retry_backoff <<= 1;
+        timer retry_timer = allocate_timer(h);
+        if (retry_timer != INVALID_ADDRESS) {
+            init_timer(retry_timer);
+            timer_handler setup_retry = init_closure_func(&setup->retry_th, timer_handler,
+                                                          azdiag_setup_retry);
+            register_timer(kernel_timers, retry_timer, CLOCK_ID_MONOTONIC, setup->retry_backoff,
+                           false, 0, setup_retry);
+            return;
+        } else {
+            msg_err("out of memory\n");
+        }
+    }
+    deallocate(h, setup, sizeof(*setup));
+}
+
+static void azure_metrics_mem_add_sample(azure_metric metric, u64 value)
+{
+    metric->last = value;
+    if (value < metric->min)
+        metric->min = value;
+    if (value > metric->max)
+        metric->max = value;
+    metric->total += value;
+    metric->count++;
+}
+
+closure_func_basic(timer_handler, void, azure_metrics_timer_handler,
+                   u64 expiry, u64 overruns)
+{
+    az_diag diag = struct_from_closure(az_diag, metrics.th);
+    azdiag_debug("metrics timer (pending %d)", diag->metrics.pending);
+    if ((overruns == timer_disabled) || diag->metrics.pending)
+        return;
+    heap phys = (heap)heap_physical(get_kernel_heaps());
+    u64 total = heap_total(phys);
+    u64 used = heap_allocated(phys);
+    u64 cached = pagecache_get_occupancy();
+    u64 available = total - used + cached;
+    azure_metrics_mem_add_sample(&diag->metrics.data[AZURE_METRICS_MEMORY_AVAILABLE], available);
+    azure_metrics_mem_add_sample(&diag->metrics.data[AZURE_METRICS_MEMORY_USED], used);
+    azure_metrics_mem_add_sample(&diag->metrics.data[AZURE_METRICS_MEMORY_AVAILABLE_PERCENT],
+                                 100 * available / total);
+    azure_metrics_mem_add_sample(&diag->metrics.data[AZURE_METRICS_MEMORY_USED_PERCENT],
+                                 100 * used / total);
+    u64 count = diag->metrics.data[0].count;
+    if (count == 1) {
+        diag->metrics.ts = kern_now(CLOCK_ID_REALTIME);
+    } else if (count >= diag->metrics.transfer_interval / diag->metrics.sample_interval) {
+        diag->metrics.pending = true;
+        azure_metrics_connect(diag);
+    }
+}
+
+static boolean azure_metrics_table_switch(az_diag diag)
+{
+    buffer table_name = &diag->metrics.table_name;
+    buffer_clear(table_name);
+    buffer_write_cstring(table_name, "WADMetrics");
+    iso8601_write_interval(diag->metrics.transfer_interval, table_name);
+    buffer_write_cstring(table_name, "P10DV2S");
+    u64 secs = sec_from_timestamp(diag->metrics.table_switch);
+    struct tm tm;
+    gmtime_r(&secs, &tm);
+    bprintf(table_name, "%d%02d%02d", 1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday);
+    if (azure_metrics_table_create(diag, table_name)) {
+        diag->metrics.table_switch += seconds(10 * 24 * 60 * 60);
+        return true;
+    }
+    return false;
+}
+
+static boolean azure_metrics_add(az_diag diag, buffer b, sstring boundary,
+                                 enum azure_metrics_mem kind, struct tm *tm, u64 ticks)
+{
+    azure_metric metric = &diag->metrics.data[kind];
+    u64 average = metric->total / metric->count;
+    bprintf(b, "\r\n--%s\r\nContent-Type: application/http\r\n"
+               "Content-Transfer-Encoding: binary\r\n\r\n"
+               "POST https://%b/%b HTTP/1.1\r\n"
+               "Content-Type: application/json\r\n"
+               "Accept: application/json;odata=minimalmetadata\r\n"
+               "Prefer: return-no-content\r\n"
+               "DataServiceVersion: 3.0;\r\n\r\n"
+               "{\"PartitionKey\":\"%b\",\"RowKey\":\":002Fbuiltin:002F%s:002F%s__%019ld\","
+               "\"CounterName\":\"/builtin/%s/%s\",\"Average\":%ld,\"Count\":%ld,\"Last\":%ld,"
+               "\"Minimum\":%ld,\"Maximum\":%ld,\"Total\":%ld,\"DeploymentId\":\"unknown\","
+               "\"Host\":\"%b\",\"TIMESTAMP\":\"%d-%02d-%02dT%02d:%02d:%02dZ\"}",
+            boundary, &diag->metrics.server, &diag->metrics.table_name, &diag->vm_resource_id,
+            metric->category, metric->name, ticks, metric->category, metric->name, average,
+            metric->count, metric->last, metric->min, metric->max, metric->total, &diag->vm_name,
+            1900 + tm->tm_year, 1 + tm->tm_mon, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
+    return true;
+}
+
+static boolean azure_metrics_post(az_diag diag)
+{
+    timestamp ts = diag->metrics.ts;
+    if ((ts >= diag->metrics.table_switch) && !azure_metrics_table_switch(diag)) {
+        msg_err("failed to create table\n");
+        return false;
+    }
+    buffer b = allocate_buffer(diag->h, 1024);
+    if (b == INVALID_ADDRESS) {
+        msg_err("out of memory\n");
+        return false;
+    }
+    u64 secs = sec_from_timestamp(ts);
+    struct tm tm;
+    gmtime_r(&secs, &tm);
+
+    /* ticks start from 00:00:00 UTC, January 1, 0001 and advance every 100 nanoseconds */
+    const u64 unix_epoch_ticks = 621355968000000000ull; /* 00:00:00 UTC, January 1, 1970 */
+    const u64 max_ticks = 3155378975999999999ull;   /* 23:59:59.9999999 UTC, December 31, 9999 */
+    u64 ticks = max_ticks - (unix_epoch_ticks + nsec_from_timestamp(ts) / 100);
+
+    sstring batch_boundary = ss("batch_boundary");
+    buffer content_type = little_stack_buffer(64);
+    bprintf(content_type, "multipart/mixed; boundary=%s", batch_boundary);
+    sstring changeset_boundary = ss("changeset_boundary");
+    bprintf(b, "--%s\r\nContent-Type: multipart/mixed; boundary=%s\r\n", batch_boundary,
+            changeset_boundary);
+    for (int i = 0; i < AZURE_METRICS_MEMORY_COUNT; i++)
+        if (!azure_metrics_add(diag, b, changeset_boundary, i, &tm, ticks))
+            goto err;
+    bprintf(b, "\r\n--%s--\r\n--%s--", changeset_boundary, batch_boundary);
+    if (!azure_metrics_table_post(diag, ss("$batch"), content_type, b, false))
+        goto err;
+    azure_metrics_reset(diag);
+    return true;
+  err:
+    deallocate_buffer(b);
+    return false;
+}
+
+closure_func_basic(connection_handler, input_buffer_handler, azure_metrics_conn_handler,
+                   buffer_handler out)
+{
+    az_diag diag = struct_from_closure(az_diag, metrics.ch);
+    input_buffer_handler ibh = INVALID_ADDRESS;
+    azdiag_debug("connection to metrics server %s", out ? ss("succeeded") : ss("failed"));
+    if (out) {
+        diag->metrics.out = out;
+        if (azure_metrics_post(diag))
+            ibh = (input_buffer_handler)&diag->metrics.ibh;
+    }
+    if (ibh == INVALID_ADDRESS)
+        diag->metrics.pending = false;
+    return ibh;
+}
+
+closure_func_basic(input_buffer_handler, boolean, azure_metrics_in_handler,
+                   buffer data)
+{
+    az_diag diag = struct_from_closure(az_diag, metrics.ibh);
+    if (data) {
+        status s = apply(diag->metrics.resp_parser, data);
+        if (is_ok(s)) {
+            if (!diag->metrics.out)
+                return true;
+        } else {
+            msg_err("failed to parse response: %v\n", s);
+            timm_dealloc(s);
+            apply(diag->metrics.out, 0);
+            return true;
+        }
+    } else {    /* connection closed */
+        diag->metrics.pending = false;
+    }
+    return false;
+}
+
+closure_func_basic(value_handler, void, azure_metrics_value_handler,
+                   value v)
+{
+    az_diag diag = struct_from_closure(az_diag, metrics.vh);
+    value start_line = get(v, sym(start_line));
+    azdiag_debug("metrics server status %v", start_line);
+    u64 status_code = 0;
+    if (get_u64(start_line, integer_key(1), &status_code)) {
+        int expected_codes[] = {
+            202,        /* batch insert accepted */
+            201, 409,   /* table created or table already existing */
+        };
+        int i;
+        for (i = 0; i < _countof(expected_codes); i++) {
+            if (status_code == expected_codes[i])
+                break;
+        }
+        if (i == _countof(expected_codes)) {
+            if (status_code == 403)
+                rprintf("Azure: invalid storage account SAS token\n");
+            else
+                status_code = 0;
+        }
+    }
+    if (!status_code)
+        msg_err("unexpected response %v\n", v);
+    apply(diag->metrics.out, 0);
+    diag->metrics.out = 0;  /* signal to input buffer handler that connection is closed */
+}
+
+int azure_diag_init(tuple cfg)
+{
+    heap h = heap_locked(get_kernel_heaps());
+    az_diag diag = allocate(h, sizeof(*diag));
+    assert(diag != INVALID_ADDRESS);
+    diag->h = h;
+    init_buffer(&diag->vm_name, 0, false, h, 0);
+    init_buffer(&diag->vm_resource_id, 0, false, h, 0);
+    diag->storage_account = get_string(cfg, sym_this("storage_account"));
+    diag->storage_account_sas = get_string(cfg, sym_this("storage_account_sas"));
+    boolean config_empty = true;
+    tuple metrics = get_tuple(cfg, sym_this("metrics"));
+    if (metrics) {
+        if (!diag->storage_account || !diag->storage_account_sas) {
+            rprintf("Azure diagnostics: missing storage account or SAS token, "
+                    "required for metrics\n");
+            return KLIB_INIT_FAILED;
+        }
+        if (!azure_metric_get_interval(metrics, ss("sample_interval"), 15, 15,
+                                       &diag->metrics.sample_interval) ||
+            !azure_metric_get_interval(metrics, ss("transfer_interval"), 60, 60,
+                                       &diag->metrics.transfer_interval))
+            return KLIB_INIT_FAILED;
+        azdiag_debug("metrics sample interval %ld seconds, transfer interval %ld seconds, "
+                     "storage account %b, SAS token length %ld",
+                     sec_from_timestamp(diag->metrics.sample_interval),
+                     sec_from_timestamp(diag->metrics.transfer_interval),
+                     diag->storage_account, buffer_length(diag->storage_account_sas));
+        init_buffer(&diag->metrics.table_name, 0, false, h, 0);
+
+        /* The table where metrics are inserted changes every 10 days; day 0 is January 1, 1601
+         * (Windows epoch). */
+        const u64 epoch_diff = 11644473600ull;  /* seconds between Windows epoch and Unix epoch */
+        u64 secs = epoch_diff + sec_from_timestamp(kern_now(CLOCK_ID_REALTIME));
+        u64 days = secs / (24 * 60 * 60);
+        days = (days / 10) * 10;
+        diag->metrics.table_switch = seconds(days * 24 * 60 * 60 - epoch_diff);
+
+        for (int i = 0; i < AZURE_METRICS_MEMORY_COUNT; i++)
+            diag->metrics.data[i].category = ss("memory");
+        diag->metrics.data[AZURE_METRICS_MEMORY_AVAILABLE].name = ss("availablememory");
+        diag->metrics.data[AZURE_METRICS_MEMORY_USED].name = ss("usedmemory");
+        diag->metrics.data[AZURE_METRICS_MEMORY_AVAILABLE_PERCENT].name =
+            ss("percentavailablememory");
+        diag->metrics.data[AZURE_METRICS_MEMORY_USED_PERCENT].name = ss("percentusedmemory");
+        azure_metrics_reset(diag);
+        init_buffer(&diag->metrics.server, 0, false, h, 0);
+        bprintf(&diag->metrics.server, "%b.table.core.windows.net", diag->storage_account);
+        init_timer(&diag->metrics.timer);
+        init_closure_func(&diag->metrics.th, timer_handler, azure_metrics_timer_handler);
+        init_closure_func(&diag->metrics.ch, connection_handler, azure_metrics_conn_handler);
+        init_closure_func(&diag->metrics.ibh, input_buffer_handler, azure_metrics_in_handler);
+        value_handler vh = init_closure_func(&diag->metrics.vh, value_handler,
+                                             azure_metrics_value_handler);
+        diag->metrics.resp_parser = allocate_http_parser(h, vh);
+        assert(diag->metrics.resp_parser != INVALID_ADDRESS);
+        diag->metrics.pending = false;
+        config_empty = false;
+    }
+    if (!config_empty) {
+        azure_ext extension = &diag->extension;
+        extension->name = ss("Microsoft.Azure.Diagnostics.LinuxDiagnostic");
+        extension->version = ss("3.0.142");
+        if (!azure_register_ext(extension)) {
+            rprintf("Azure diagnostics: failed to register extension\n");
+            return KLIB_INIT_FAILED;
+        }
+        azdiag_setup_s setup = allocate(h, sizeof(*setup));
+        assert(setup != INVALID_ADDRESS);
+        setup->diag = diag;
+        setup->retry_backoff = seconds(1);
+        init_closure_func(&setup->complete, status_handler, azdiag_setup_complete);
+        azdiag_setup(setup);
+    }
+    return KLIB_INIT_OK;
+}

--- a/klib/cloud_azure.c
+++ b/klib/cloud_azure.c
@@ -1,8 +1,12 @@
 #include <kernel.h>
 #include <lwip.h>
+#include <mktime.h>
 #include <net_utils.h>
+#include <xml.h>
 
-#define AZURE_MS_VERSION    "2012-11-30"
+#include "azure.h"
+
+#define AZURE_MS_VERSION    "2015-04-05"
 
 #define AZURE_WIRESERVER_ADDR   ss("168.63.129.16")
 
@@ -16,9 +20,30 @@ typedef struct azure {
     bytes container_id_len;
     char instance_id[64];
     bytes instance_id_len;
-    timestamp report_backoff;
     struct timer report_timer;
-    closure_struct(timer_handler, report_ready);
+    closure_struct(timer_handler, report_th);
+    struct buffer goalstate_incarnation;
+    struct {
+        struct buffer blob_type;
+        struct buffer page_write;
+        struct buffer content_type;
+        struct buffer host;
+        struct buffer create_query;
+        struct buffer data_query;
+        tuple create_req;
+        tuple data_req;
+        buffer blob;
+        struct buffer blob_size;
+        struct buffer blob_range;
+        struct net_http_req_params params;
+        closure_struct(value_handler, vh);
+        timestamp last_update;
+        boolean valid;
+    } status_upload;
+    vector extensions;
+    struct spinlock lock;
+    boolean goalstate_pending;
+    boolean provisioned;
 } *azure;
 
 typedef struct azure_ready_data {
@@ -29,59 +54,364 @@ typedef struct azure_ready_data {
     closure_struct(value_handler, vh);
 } *azure_ready_data;
 
+typedef struct azure_get_ext_data {
+    azure az;
+    buffer query;
+    tuple req;
+    closure_struct(value_handler, vh);
+} *azure_get_ext_data;
+
+static azure az_agent;
+
 static void azure_report_ready(azure az);
 
-closure_func_basic(timer_handler, void, report_ready_func,
+closure_func_basic(timer_handler, void, az_report_th,
                    u64 expiry, u64 overruns)
 {
-    azure az = struct_from_closure(azure, report_ready);
-    if (overruns != timer_disabled)
-        azure_report_ready(az);
+    azure az = struct_from_closure(azure, report_th);
+    if ((overruns == timer_disabled) || az->goalstate_pending)
+        return;
+    status s = net_http_req(&az->goalstate_req_params);
+    if (is_ok(s)) {
+        az->goalstate_pending = true;
+    } else {
+        msg_err("%v\n", s);
+        timm_dealloc(s);
+    }
 }
 
-static void azure_report_retry(azure az)
+static void az_report_status(azure az)
 {
-    register_timer(kernel_timers, &az->report_timer, CLOCK_ID_MONOTONIC, az->report_backoff, false, 0,
-        init_closure_func(&az->report_ready, timer_handler, report_ready_func));
-    if (az->report_backoff < seconds(600))
-        az->report_backoff <<= 1;
+    heap h = az->h;
+    buffer blob = allocate_buffer(h, KB);
+    if (blob == INVALID_ADDRESS) {
+        msg_err("out of memory\n");
+        return;
+    }
+    status s;
+    u64 seconds = sec_from_timestamp(kern_now(CLOCK_ID_REALTIME));
+    struct tm tm;
+    gmtime_r(&seconds, &tm);
+    bprintf(blob, "{"
+        "\"version\": \"1.1\", "
+        "\"timestampUTC\": \"%d-%02d-%02dT%02d:%02d:%02dZ\", "
+        "\"aggregateStatus\": {"
+          "\"guestAgentStatus\": {"
+           "\"version\": \"2.10.0.8\", "
+            "\"status\": \"Ready\", "
+            "\"formattedMessage\": {\"message\": \"Guest Agent is running\", \"lang\": \"en-US\"}"
+          "}, "
+          "\"handlerAggregateStatus\": [",
+          1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+    azure_ext ext;
+    buffer ok_code = alloca_wrap_cstring("0");
+    buffer ok_message = alloca_wrap_cstring("Enable succeeded, extension daemon started");
+    boolean first = true;
+    spin_lock(&az->lock);
+    vector_foreach(az->extensions, ext) {
+        if (!ext->cfg_seconds)
+            continue;
+        status s = ext->s;
+        gmtime_r(&ext->cfg_seconds, &tm);
+        bprintf(blob, "%s{"
+              "\"handlerName\": \"%s\", "
+              "\"handlerVersion\": \"%s\", "
+              "\"status\": \"Ready\", "
+              "\"code\": 0, "
+              "\"formattedMessage\": {\"message\": \"Plugin enabled\", \"lang\": \"en-US\"}, "
+              "\"runtimeSettingsStatus\": {"
+                "\"settingsStatus\": {"
+                  "\"status\": {"
+                    "\"name\": \"%s\", "
+                    "\"operation\": \"Enable\", "
+                    "\"status\": \"%s\", "
+                    "\"code\": \"%b\", "
+                    "\"formattedMessage\": {"
+                      "\"lang\": \"en-US\", "
+                      "\"message\": \"%b\""
+                    "}"
+                  "}, "
+                  "\"version\": 1.0, "
+                  "\"timestampUTC\": \"%d-%02d-%02dT%02d:%02d:%02dZ\""
+                "}, "
+                "\"sequenceNumber\": %d"
+              "}"
+            "}", first ? sstring_empty() : ss("," ), ext->name, ext->version, ext->name,
+                is_ok(s) ? ss("success") : ss("error"), is_ok(s) ? ok_code : get(s, sym(code)),
+                is_ok(s) ? ok_message : get(s, sym(result)), 1900 + tm.tm_year, 1 + tm.tm_mon,
+                tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, ext->cfg_seqno);
+        first = false;
+    }
+    spin_unlock(&az->lock);
+    if (!buffer_write_cstring(blob, "]}}")) {
+        s = timm_oom;
+        goto done;
+    }
+
+    /* Pad the blob until its size is a multiple of 512, as required by the Azure page blob storage
+     * API. */
+    u64 blob_size = buffer_length(blob);
+    u64 padded_size = pad(blob_size, 512);
+    while (blob_size++ < padded_size)
+        push_u8(blob, ' ');
+
+    buffer_clear(&az->status_upload.blob_size);
+    bprintf(&az->status_upload.blob_size, "%ld", padded_size);
+    buffer_clear(&az->status_upload.blob_range);
+    bprintf(&az->status_upload.blob_range, "bytes=0-%ld", padded_size - 1);
+    az->status_upload.blob = blob;
+    tuple req = az->status_upload.create_req;
+    net_http_req_params req_params = &az->status_upload.params;
+    req_params->host = buffer_to_sstring(&az->status_upload.host);
+    req_params->req = req;
+    req_params->body = 0;
+    req_params->resp_handler = (value_handler)&az->status_upload.vh;
+    s = net_http_req(req_params);
+  done:
+    if (!is_ok(s)) {
+        msg_err("%v\n", s);
+        timm_dealloc(s);
+        deallocate_buffer(blob);
+    }
+}
+
+closure_func_basic(value_handler, void, az_get_ext_vh,
+                   value v)
+{
+    azure_get_ext_data req_data = struct_from_closure(azure_get_ext_data, vh);
+    azure az = req_data->az;
+    deallocate_buffer(req_data->query);
+    deallocate_value(req_data->req);
+    deallocate(az->h, req_data, sizeof(*req_data));
+    if (!v) {
+        msg_err("failed to get response\n");
+        return;
+    }
+    buffer content = get(v, sym(content));
+    if (content) {
+        struct xml_elem blob;
+        if (!xml_get_elem(content, ss("StatusUploadBlob"), &blob))
+            goto parse_error;
+        bytes offset = sizeof("https://") - 1;
+        if (blob.data_len <= offset)
+            goto parse_error;
+        blob.data_start += offset;
+        blob.data_len -= offset;
+        void *ptr = runtime_strchr(isstring(buffer_ref(content, blob.data_start), blob.data_len),
+                                   '/');
+        if (!ptr)
+            goto parse_error;
+        offset = ptr - buffer_ref(content, blob.data_start);
+        buffer_clear(&az->status_upload.host);
+        if (!buffer_write(&az->status_upload.host, buffer_ref(content, blob.data_start), offset))
+            goto alloc_error;
+        blob.data_start += offset;
+        blob.data_len -= offset;
+        buffer_clear(&az->status_upload.create_query);
+
+        /* replace occurrences of "&amp;" with "&" */
+        while ((ptr = runtime_strstr(isstring(buffer_ref(content, blob.data_start), blob.data_len),
+                                     ss("&amp;")))) {
+            offset = ptr - buffer_ref(content, blob.data_start);
+            if (!buffer_write(&az->status_upload.create_query, buffer_ref(content, blob.data_start),
+                              offset + 1))
+                goto alloc_error;
+            offset += sizeof("&amp;") - 1;
+            blob.data_start += offset;
+            blob.data_len -= offset;
+        }
+        if ((blob.data_len > 0) &&
+            !buffer_write(&az->status_upload.create_query, buffer_ref(content, blob.data_start),
+                          blob.data_len))
+            goto alloc_error;
+
+        buffer_clear(&az->status_upload.data_query);
+        if (!push_buffer(&az->status_upload.data_query, &az->status_upload.create_query) ||
+            !buffer_write_cstring(&az->status_upload.data_query, "&comp=page"))
+            goto alloc_error;
+        struct xml_elem ext_settings;
+        if (xml_get_elem(content, ss("PluginSettings"), &ext_settings)) {
+            buffer settings = alloca_wrap_buffer(buffer_ref(content, ext_settings.data_start),
+                                                 ext_settings.data_len);
+            struct xml_elem plugin;
+            struct buffer seqno_b;
+            while (xml_get_elem(settings, ss("Plugin"), &plugin)) {
+                bytes ext_name_start, ext_name_len;
+                if (!xml_elem_get_attr(settings, &plugin, ss("name"),
+                                       &ext_name_start, &ext_name_len)) {
+                    buffer_consume(settings, plugin.start + plugin.len);
+                    continue;
+                }
+                char *ext_name = buffer_ref(settings, ext_name_start);
+                buffer_consume(settings, plugin.data_start);
+                struct xml_elem rtsettings;
+                if (!xml_get_elem(settings, ss("RuntimeSettings"), &rtsettings))
+                    goto next;
+                bytes seqno_start, seqno_len;
+                u64 seqno;
+                if (!xml_elem_get_attr(settings, &rtsettings, ss("seqNo"),
+                                       &seqno_start, &seqno_len))
+                    goto next;
+                init_buffer(&seqno_b, seqno_len, true, 0, buffer_ref(settings, seqno_start));
+                buffer_produce(&seqno_b, seqno_len);
+                if (!parse_int(&seqno_b, 10, &seqno))
+                    goto next;
+                azure_ext ext;
+                spin_lock(&az->lock);
+                vector_foreach(az->extensions, ext) {
+                    if ((ext_name_len == ext->name.len) &&
+                        !runtime_memcmp(ext_name, ext->name.ptr, ext_name_len)) {
+                        ext->cfg_seconds = sec_from_timestamp(kern_now(CLOCK_ID_REALTIME));
+                        ext->cfg_seqno = seqno;
+                        timm_dealloc(ext->s);
+                        ext->s = STATUS_OK;
+                    }
+                }
+                spin_unlock(&az->lock);
+              next:
+                buffer_consume(settings, plugin.len - (plugin.data_start - plugin.start));
+            }
+        }
+        az->status_upload.valid = true;
+        az_report_status(az);
+        return;
+    }
+  parse_error:
+    msg_err("failed to parse response\n");
+    return;
+  alloc_error:
+    msg_err("out of memory\n");
+}
+
+static void az_get_ext_config(azure az)
+{
+    heap h = az->h;
+    status s;
+    buffer query = INVALID_ADDRESS;
+    tuple req = INVALID_ADDRESS;
+    azure_get_ext_data req_data = allocate(h, sizeof(*req_data));
+    if (req_data == INVALID_ADDRESS) {
+        s = timm_oom;
+        goto error;
+    }
+    req = allocate_tuple();
+    if (req == INVALID_ADDRESS) {
+        s = timm_oom;
+        goto error;
+    }
+    query = allocate_buffer(az->h, 256);
+    if (query == INVALID_ADDRESS) {
+        s = timm_oom;
+        goto error;
+    }
+    req_data->az = az;
+    struct net_http_req_params req_params;
+    req_params.host = AZURE_WIRESERVER_ADDR;
+    req_params.port = 80;
+    req_params.tls = false;
+    req_params.method = HTTP_REQUEST_METHOD_GET;
+    bprintf(query, "/machine/%s/%s?comp=config&type=extensionsConfig&incarnation=%b",
+            isstring(az->container_id, az->container_id_len),
+            isstring(az->instance_id, az->instance_id_len), &az->goalstate_incarnation);
+    req_data->query = query;
+    set(req, sym_this("url"), query);
+    set(req, sym_this("x-ms-version"), &az->ms_version);
+    req_data->req = req_params.req = req;
+    req_params.body = 0;
+    req_params.resp_handler = init_closure_func(&req_data->vh, value_handler, az_get_ext_vh);
+    s = net_http_req(&req_params);
+    if (is_ok(s))
+        return;
+  error:
+    if (query != INVALID_ADDRESS)
+        deallocate_buffer(query);
+    if (req != INVALID_ADDRESS)
+        deallocate_value(req);
+    if (req_data != INVALID_ADDRESS)
+        deallocate(h, req_data, sizeof(*req_data));
+    if (!is_ok(s)) {
+        msg_err("%v\n", s);
+        timm_dealloc(s);
+    }
+}
+
+closure_func_basic(value_handler, void, az_status_upload_vh,
+                   value v)
+{
+    azure az = struct_from_closure(azure, status_upload.vh);
+    if (!v) {
+        msg_err("failed to get response\n");
+        return;
+    }
+    value start_line = get(v, sym(start_line));
+    buffer status_code = get(start_line, integer_key(1));
+    if (status_code && !buffer_strcmp(status_code, "201")) {
+        tuple req = az->status_upload.data_req;
+        net_http_req_params req_params = &az->status_upload.params;
+        req_params->req = req;
+        req_params->body = az->status_upload.blob;
+        req_params->resp_handler = 0;
+        status s = net_http_req(req_params);
+        if (is_ok(s)) {
+            az->status_upload.last_update = kern_now(CLOCK_ID_REALTIME);
+        } else {
+            msg_err("failed to upload blob page: %v\n", s);
+            timm_dealloc(s);
+            deallocate_buffer(req_params->body);
+        }
+    } else {
+        msg_err("unexpected response %v\n", v);
+    }
 }
 
 closure_func_basic(value_handler, void, az_goalstate_vh,
                    value v)
 {
     azure az = struct_from_closure(azure, goalstate_vh);
+    az->goalstate_pending = false;
     if (!v) {
-        azure_report_retry(az);
+        msg_err("failed to get response\n");
         return;
     }
     buffer content = get(v, sym(content));
     if (content) {
-        int index = buffer_strstr(content, ss("<ContainerId>"));
-        if (index < 0)
+        struct xml_elem elem;
+        if (!xml_get_elem(content, ss("Incarnation"), &elem))
             goto exit;
-        buffer_consume(content, index);
-        buffer_consume(content, buffer_strchr(content, '>') + 1);
-        index = buffer_strchr(content, '<');
-        if (index < 0)
-            goto exit;
-        if (index > sizeof(az->container_id))
-            goto exit;
-        buffer_read(content, az->container_id, index);
-        az->container_id_len = index;
-        index = buffer_strstr(content, ss("<InstanceId>"));
-        if (index < 0)
-            goto exit;
-        buffer_consume(content, index);
-        buffer_consume(content, buffer_strchr(content, '>') + 1);
-        index = buffer_strchr(content, '<');
-        if (index < 0)
-            goto exit;
-        if (index > sizeof(az->instance_id))
-            goto exit;
-        buffer_read(content, az->instance_id, index);
-        az->instance_id_len = index;
-        azure_report_ready(az);
+        boolean new_incarnation =
+            (buffer_memcmp(&az->goalstate_incarnation, buffer_ref(content, elem.data_start),
+                           elem.data_len) != 0);
+        if (new_incarnation) {
+            buffer_clear(&az->goalstate_incarnation);
+            if (!buffer_write(&az->goalstate_incarnation, buffer_ref(content, elem.data_start),
+                              elem.data_len))
+                goto exit;
+            if (az->container_id_len == 0) {
+                if (!xml_get_elem(content, ss("ContainerId"), &elem) ||
+                    (elem.data_len > sizeof(az->container_id)))
+                        goto exit;
+                runtime_memcpy(az->container_id, buffer_ref(content, elem.data_start),
+                               elem.data_len);
+                az->container_id_len = elem.data_len;
+            }
+            if (az->instance_id_len == 0) {
+                if (!xml_get_elem(content, ss("InstanceId"), &elem) ||
+                    (elem.data_len > sizeof(az->instance_id)))
+                    goto exit;
+                runtime_memcpy(az->instance_id, buffer_ref(content, elem.data_start),
+                               elem.data_len);
+                az->instance_id_len = elem.data_len;
+            }
+        }
+        if (!az->provisioned)
+            azure_report_ready(az);
+        if (new_incarnation) {
+            az->status_upload.valid = false;
+            az_get_ext_config(az);
+        } else if (az->status_upload.valid &&
+                (kern_now(CLOCK_ID_REALTIME) - az->status_upload.last_update > seconds(60))) {
+            az_report_status(az);
+        }
         return;
     }
   exit:
@@ -95,17 +425,13 @@ closure_func_basic(value_handler, void, az_ready_vh,
     azure az = req_data->az;
     deallocate_value(req_data->req);
     deallocate(az->h, req_data, sizeof(*req_data));
-    if (!v)
-        azure_report_retry(az);
+    if (v)
+        az->provisioned = true;
 }
 
 static void azure_report_ready(azure az)
 {
     status s;
-    if (!az->instance_id_len) {
-        s = net_http_req(&az->goalstate_req_params);
-        goto exit;
-    }
     heap h = az->h;
     buffer req_body = INVALID_ADDRESS;
     tuple req = INVALID_ADDRESS;
@@ -139,7 +465,7 @@ static void azure_report_ready(azure az)
     bprintf(req_body, "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
                       "<Health xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
                       " xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\">\n"
-                      "  <GoalStateIncarnation>1</GoalStateIncarnation>\n"
+                      "  <GoalStateIncarnation>%b</GoalStateIncarnation>\n"
                       "  <Container>\n"
                       "    <ContainerId>%s</ContainerId>\n"
                       "    <RoleInstanceList>\n"
@@ -152,6 +478,7 @@ static void azure_report_ready(azure az)
                       "    </RoleInstanceList>\n"
                       "  </Container>\n"
                       "</Health>\n",
+            &az->goalstate_incarnation,
             isstring(az->container_id, az->container_id_len),
             isstring(az->instance_id, az->instance_id_len));
     req_params.body = req_body;
@@ -166,11 +493,48 @@ static void azure_report_ready(azure az)
         deallocate_value(req);
     if (req_data != INVALID_ADDRESS)
         deallocate(h, req_data, sizeof(*req_data));
-  exit:
     if (!is_ok(s)) {
         timm_dealloc(s);
-        azure_report_retry(az);
     }
+}
+
+static void az_status_upload_init(azure az)
+{
+    heap h = az->h;
+    init_buffer(&az->status_upload.host, 0, false, h, 0);
+    init_buffer(&az->status_upload.create_query, 0, false, h, 0);
+    init_buffer(&az->status_upload.data_query, 0, false, h, 0);
+    init_buffer(&az->status_upload.blob_size, 0, false, h, 0);
+    init_buffer(&az->status_upload.blob_range, 0, false, h, 0);
+
+    /* Put Blob request */
+    tuple req = allocate_tuple();
+    assert(req != INVALID_ADDRESS);
+    set(req, sym_this("url"), &az->status_upload.create_query);
+    set(req, sym_this("x-ms-version"), &az->ms_version);
+    buffer_init_from_string(&az->status_upload.blob_type, "PageBlob");
+    set(req, sym_this("x-ms-blob-type"), &az->status_upload.blob_type);
+    set(req, sym_this("x-ms-blob-content-length"), &az->status_upload.blob_size);
+    az->status_upload.create_req = req;
+
+    /* Put Page request */
+    req = allocate_tuple();
+    assert(req != INVALID_ADDRESS);
+    set(req, sym_this("url"), &az->status_upload.data_query);
+    set(req, sym_this("x-ms-version"), &az->ms_version);
+    buffer_init_from_string(&az->status_upload.content_type, "application/json");
+    set(req, sym_this("Content-Type"), &az->status_upload.content_type);
+    buffer_init_from_string(&az->status_upload.page_write, "update");
+    set(req, sym_this("x-ms-page-write"), &az->status_upload.page_write);
+    set(req, sym_this("x-ms-range"), &az->status_upload.blob_range);
+    az->status_upload.data_req = req;
+
+    net_http_req_params params = &az->status_upload.params;
+    params->port = 443;
+    params->tls = true;
+    params->method = HTTP_REQUEST_METHOD_PUT;
+    init_closure_func(&az->status_upload.vh, value_handler, az_status_upload_vh);
+    az->status_upload.valid = false;
 }
 
 boolean azure_cloud_init(heap h)
@@ -181,6 +545,7 @@ boolean azure_cloud_init(heap h)
     az->h = h;
     buffer_init_from_string(&az->ms_version, AZURE_MS_VERSION);
     buffer_init_from_string(&az->goalstate_query, "/machine?comp=goalstate");
+    init_buffer(&az->goalstate_incarnation, 0, false, h, 0);
     net_http_req_params params = &az->goalstate_req_params;
     params->host = AZURE_WIRESERVER_ADDR;
     params->port = 80;
@@ -193,9 +558,27 @@ boolean azure_cloud_init(heap h)
     params->req = req;
     params->body = 0;
     params->resp_handler = init_closure_func(&az->goalstate_vh, value_handler, az_goalstate_vh);
+    az->extensions = allocate_vector(h, 1);
+    assert(az->extensions != INVALID_ADDRESS);
+    spin_lock_init(&az->lock);
     az->container_id_len = az->instance_id_len = 0;
-    az->report_backoff = seconds(1);
+    az->goalstate_pending = az->provisioned = false;
+    az_status_upload_init(az);
     init_timer(&az->report_timer);
-    azure_report_ready(az);
+    register_timer(kernel_timers, &az->report_timer, CLOCK_ID_MONOTONIC, seconds(2), false,
+                   seconds(16), init_closure_func(&az->report_th, timer_handler, az_report_th));
+    az_agent = az;
+    return true;
+}
+
+boolean azure_register_ext(azure_ext ext)
+{
+    if (!az_agent)
+        return false;
+    ext->cfg_seconds = 0;   /* so that it's not included in status reports */
+    ext->s = STATUS_OK;
+    spin_lock(&az_agent->lock);
+    vector_push(az_agent->extensions, ext);
+    spin_unlock(&az_agent->lock);
     return true;
 }

--- a/klib/cloud_init.c
+++ b/klib/cloud_init.c
@@ -659,18 +659,16 @@ static int cloud_download_env_parse(tuple config, vector tasks)
 int init(status_handler complete)
 {
     cloud_heap = heap_locked(get_kernel_heaps());
-    if (first_boot()) {
-        enum cloud c = cloud_detect();
-        switch (c) {
-        case CLOUD_ERROR:
+    enum cloud c = cloud_detect();
+    switch (c) {
+    case CLOUD_ERROR:
+        return KLIB_INIT_FAILED;
+    case CLOUD_AZURE:
+        if (!azure_cloud_init(cloud_heap))
             return KLIB_INIT_FAILED;
-        case CLOUD_AZURE:
-            if (!azure_cloud_init(cloud_heap))
-                return KLIB_INIT_FAILED;
-            break;
-        default:
-            break;
-        }
+        break;
+    default:
+        break;
     }
     tuple config = get(get_root_tuple(), sym(cloud_init));
     if (!config)

--- a/klib/cloudwatch.c
+++ b/klib/cloudwatch.c
@@ -805,7 +805,7 @@ closure_func_basic(connection_handler, input_buffer_handler, cw_log_conn_handler
         ibh = (input_buffer_handler)&cw.log_in_handler;
     } else {
         cw_log_send_async();
-        ibh = 0;
+        ibh = INVALID_ADDRESS;
     }
     spin_unlock(&cw.lock);
     return ibh;

--- a/klib/gcp.c
+++ b/klib/gcp.c
@@ -647,10 +647,10 @@ closure_func_basic(connection_handler, input_buffer_handler, gcp_log_conn_handle
         if (gcp_log_post())
             ibh = (input_buffer_handler)&gcp.log_in_handler;
         else
-            ibh = 0;
+            ibh = INVALID_ADDRESS;
     } else {
         gcp_log_send_async();
-        ibh = 0;
+        ibh = INVALID_ADDRESS;
     }
     spin_unlock(&gcp.lock);
     return ibh;
@@ -804,17 +804,13 @@ static boolean gcp_metrics_post(void)
 closure_func_basic(connection_handler, input_buffer_handler, gcp_metrics_conn_handler,
                    buffer_handler out)
 {
-    input_buffer_handler ibh;
+    input_buffer_handler ibh = INVALID_ADDRESS;
     if (out) {
         gcp.metrics_out = out;
         if (gcp_metrics_post())
             ibh = (input_buffer_handler)&gcp.metrics_in_handler;
-        else
-            ibh = 0;
-    } else {
-        ibh = 0;
     }
-    if (!ibh)
+    if (ibh == INVALID_ADDRESS)
         gcp.metrics_pending = false;
     return ibh;
 }

--- a/klib/mbedtls.c
+++ b/klib/mbedtls.c
@@ -146,7 +146,7 @@ closure_func_basic(input_buffer_handler, boolean, tls_in_handler,
             conn->app_in = apply(conn->app_ch, init_closure_func(&conn->app_out, buffer_handler,
                                                                  tls_out_handler));
             conn->app_ch = 0;   /* so that it is not invoked when the connection is closed */
-            if (!conn->app_in)  /* application-level error */
+            if (conn->app_in == INVALID_ADDRESS)    /* application-level error */
                 goto conn_close;
         } else if ((ret != MBEDTLS_ERR_SSL_WANT_READ) && (ret != MBEDTLS_ERR_SSL_WANT_WRITE)) {
             goto conn_close;

--- a/klib/net_utils.c
+++ b/klib/net_utils.c
@@ -118,6 +118,22 @@ closure_func_basic(value_handler, void, net_http_vh,
     }
 }
 
+void net_resolve(sstring host, void (*cb)(sstring host, const ip_addr_t *addr, void *cb_arg),
+                 void *cb_arg)
+{
+    ip_addr_t addr;
+    err_t err = dns_gethostbyname(host, &addr, cb, cb_arg);
+    switch (err) {
+    case ERR_OK:
+        cb(host, &addr, cb_arg);
+        break;
+    case ERR_INPROGRESS:
+        break;
+    default:
+        cb(host, 0, cb_arg);
+    }
+}
+
 status net_http_req(net_http_req_params params)
 {
     heap h = heap_locked(get_kernel_heaps());

--- a/klib/net_utils.c
+++ b/klib/net_utils.c
@@ -1,0 +1,156 @@
+#include <kernel.h>
+#include <lwip.h>
+#include <tls.h>
+
+#include "net_utils.h"
+
+typedef struct net_http_req_data {
+    heap h;
+    struct net_http_req_params params;
+    closure_struct(connection_handler, ch);
+    buffer_handler out;
+    closure_struct(input_buffer_handler, ibh);
+    buffer_handler parser;
+    closure_struct(value_handler, vh);
+} *net_http_req_data;
+
+static void net_http_dealloc(net_http_req_data data)
+{
+    apply(data->parser, 0);
+    buffer req_body = data->params.body;
+    if (req_body)
+        deallocate_buffer(req_body);
+    value_handler resp_handler = data->params.resp_handler;
+    if (resp_handler)
+        apply(resp_handler, 0);
+    deallocate(data->h, data, sizeof(*data));
+}
+
+static status net_http_req_internal(const ip_addr_t *addr, net_http_req_data data)
+{
+    net_http_req_params params = &data->params;
+    u16 port = params->port;
+    connection_handler ch = (connection_handler)&data->ch;
+    status s;
+    if (!params->tls) {
+        s = direct_connect(data->h, (ip_addr_t *)addr, port, ch);
+    } else {
+        if (tls_connect((ip_addr_t *)addr, port, ch) == 0)
+            s =  STATUS_OK;
+        else
+            s = timm("result", "failed to establish TLS connection with HTTP server");
+    }
+    return s;
+}
+
+static void net_http_dns_cb(sstring hostname, const ip_addr_t *addr, void *callback_arg)
+{
+    net_http_req_data req_data = callback_arg;
+    boolean success;
+    if (addr) {
+        status s = net_http_req_internal(addr, req_data);
+        success = is_ok(s);
+        if (!success)
+            timm_dealloc(s);
+    } else {
+        success = true;
+    }
+    if (!success)
+        net_http_dealloc(req_data);
+}
+
+closure_func_basic(connection_handler, input_buffer_handler, net_http_ch,
+                   buffer_handler out)
+{
+    net_http_req_data req_data = struct_from_closure(net_http_req_data, ch);
+    input_buffer_handler in = INVALID_ADDRESS;
+    if (out) {    /* connection succeeded */
+        req_data->out = out;
+        net_http_req_params params = &req_data->params;
+        tuple req = params->req;
+        set(req, sym(Host), alloca_wrap_sstring(params->host));
+        set(req, sym(Connection), alloca_wrap_cstring("close"));
+        status s = http_request(req_data->h, out, params->method, req, params->body);
+        if (is_ok(s)) {
+            /* The body of the request, if present, will be deallocated by the output buffer
+             * handler. */
+            params->body = 0;
+
+            in = (input_buffer_handler)&req_data->ibh;
+        } else {
+            timm_dealloc(s);
+        }
+    }
+    if (in == INVALID_ADDRESS)
+        net_http_dealloc(req_data);
+    return in;
+}
+
+closure_func_basic(input_buffer_handler, boolean, net_http_ibh,
+                   buffer data)
+{
+    net_http_req_data req_data = struct_from_closure(net_http_req_data, ibh);
+    if (data) {
+        status s = apply(req_data->parser, data);
+        boolean close_conn = !is_ok(s) || !req_data->params.resp_handler;
+        timm_dealloc(s);
+        if (close_conn) {
+            apply(req_data->out, 0);
+            return true;
+        }
+    } else {
+        net_http_dealloc(req_data);
+    }
+    return false;
+}
+
+closure_func_basic(value_handler, void, net_http_vh,
+                   value resp)
+{
+    net_http_req_data req_data = struct_from_closure(net_http_req_data, vh);
+    value_handler resp_handler = req_data->params.resp_handler;
+    if (resp_handler) {
+        apply(resp_handler, resp);
+
+        /* Signal to the input buffer handler that the response handler has been invoked and the
+         * connection can be closed. */
+        req_data->params.resp_handler = 0;
+    }
+}
+
+status net_http_req(net_http_req_params params)
+{
+    heap h = heap_locked(get_kernel_heaps());
+    net_http_req_data req_data = allocate(h, sizeof(*req_data));
+    if (req_data == INVALID_ADDRESS)
+        return timm_oom;
+    req_data->parser = allocate_http_parser(h, init_closure_func(&req_data->vh, value_handler,
+                                                                 net_http_vh));
+    if (req_data->parser == INVALID_ADDRESS) {
+        deallocate(h, req_data, sizeof(*req_data));
+        return timm_oom;
+    }
+    req_data->h = h;
+    runtime_memcpy(&req_data->params, params, sizeof(*params));
+    init_closure_func(&req_data->ch, connection_handler, net_http_ch);
+    init_closure_func(&req_data->ibh, input_buffer_handler, net_http_ibh);
+    ip_addr_t addr;
+    sstring host = params->host;
+    err_t err = dns_gethostbyname(host, &addr, net_http_dns_cb, req_data);
+    status s;
+    switch (err) {
+    case ERR_OK:
+        s = net_http_req_internal(&addr, req_data);
+        break;
+    case ERR_INPROGRESS:
+        return STATUS_OK;
+    default:
+        s = timm("result", "failed to resolve hostname '%s' (%d)", host, err);
+    }
+    if (!is_ok(s)) {
+        req_data->params.body = 0;  /* so that it's not deallocated in net_http_dealloc() */
+        req_data->params.resp_handler = 0;  /* so that it's not invoked in net_http_dealloc() */
+        net_http_dealloc(req_data);
+    }
+    return s;
+}

--- a/klib/net_utils.h
+++ b/klib/net_utils.h
@@ -13,6 +13,9 @@ typedef struct net_http_req_params {
     boolean tls;
 } *net_http_req_params;
 
+void net_resolve(sstring host, void (*cb)(sstring host, const ip_addr_t *addr, void *cb_arg),
+                 void *cb_arg);
+
 status net_http_req(net_http_req_params params);
 
 #endif

--- a/klib/net_utils.h
+++ b/klib/net_utils.h
@@ -1,0 +1,18 @@
+#ifndef NET_UTILS_H_
+#define NET_UTILS_H_
+
+#include <http.h>
+
+typedef struct net_http_req_params {
+    sstring host;
+    tuple req;
+    buffer body;
+    value_handler resp_handler;
+    http_method method;
+    u16 port;
+    boolean tls;
+} *net_http_req_params;
+
+status net_http_req(net_http_req_params params);
+
+#endif

--- a/klib/xml.c
+++ b/klib/xml.c
@@ -1,0 +1,76 @@
+#include <runtime.h>
+
+#include "xml.h"
+
+boolean xml_get_elem(buffer b, sstring name, xml_elem elem)
+{
+    bytes initial_buf_start = b->start;
+    boolean success = false;
+    int index;
+    while (1) {
+        index = buffer_strchr(b, '<');
+        if (index < 0)
+            goto done;
+        buffer_consume(b, index + 1);
+        if (buffer_memcmp(b, name.ptr, name.len))
+            continue;
+        buffer_consume(b, name.len);
+        if (buffer_length(b) == 0)
+            goto done;
+        char c = byte(b, 0);
+        if ((c != '>') && (c != ' '))
+            continue;
+        elem->start = b->start - initial_buf_start;
+        index = buffer_strchr(b, '>');
+        if (index < 0)
+            goto done;
+        buffer_consume(b, index + 1);
+        elem->data_start = b->start - initial_buf_start;
+        break;
+    }
+    while (1) {
+        index = buffer_strstr(b, ss("</"));
+        if (index < 0)
+            goto done;
+        buffer_consume(b, index + sizeof("</") - 1);
+        if (!buffer_memcmp(b, name.ptr, name.len) && (buffer_length(b) > name.len) &&
+            (byte(b, name.len) == '>')) {
+            elem->data_len = b->start - (sizeof("</") - 1) - initial_buf_start - elem->data_start;
+            elem->len = b->start + name.len + 1 - initial_buf_start - elem->start;
+            success = true;
+            break;
+        }
+    }
+  done:
+    b->start = initial_buf_start;
+    return success;
+}
+
+boolean xml_elem_get_attr(buffer b, xml_elem elem, sstring name, bytes *start, bytes *len)
+{
+    bytes initial_buf_start = b->start;
+    boolean success = false;
+    buffer_consume(b, elem->start); /* elem->start points to the end of the element name */
+    while (true) {
+        if (pop_u8(b) != ' ')
+            goto done;
+        int name_len = buffer_strchr(b, '=');
+        if ((name_len < 0) || (b->start + name_len >= initial_buf_start + elem->data_start))
+            goto done;
+        if ((name_len != name.len) || buffer_memcmp(b, name.ptr, name.len))
+            continue;
+        buffer_consume(b, name.len + 1);
+        break;
+    }
+    if (pop_u8(b) != '"')
+        goto done;
+    int value_len = buffer_strchr(b, '"');
+    if ((value_len < 0) || (b->start + value_len >= initial_buf_start + elem->data_start))
+        goto done;
+    *start = b->start - initial_buf_start;
+    *len = value_len;
+    success = true;
+  done:
+    b->start = initial_buf_start;
+    return success;
+}

--- a/klib/xml.h
+++ b/klib/xml.h
@@ -1,0 +1,12 @@
+#ifndef XML_H_
+#define XML_H_
+
+typedef struct xml_elem {
+    bytes start, len;
+    bytes data_start, data_len;
+} *xml_elem;
+
+boolean xml_get_elem(buffer b, sstring name, xml_elem elem);
+boolean xml_elem_get_attr(buffer b, xml_elem elem, sstring name, bytes *start, bytes *len);
+
+#endif

--- a/src/fs/tlog.c
+++ b/src/fs/tlog.c
@@ -249,7 +249,7 @@ static void dump_staging(log_ext ext)
     for (int i = 0; i < 4; i++) {
         b->start = i * 256;
         b->end = b->start + 256;
-        rprintf("%X\n", b);
+        rprintf("%B\n", b);
     }
     b->start = 0;
     b->end = z;

--- a/src/gdb/gdbstub.c
+++ b/src/gdb/gdbstub.c
@@ -64,7 +64,7 @@ closure_function(1, 1, context, gdb_handle_exception,
     string output = little_stack_buffer(32);
     reset_buffer(output);
     bprintf (output, "T");
-    print_number(output, (u64)sigval, 16, 2);
+    print_number(output, (u64)sigval, 16, 2, false);
     bprintf(output, "thread:p1.%x;", g->t->tid);
     putpacket_deferred (g, output);
     runloop();
@@ -291,7 +291,7 @@ static boolean handle_request(gdb g, buffer b, buffer output)
     switch (command) {
     case '?':
         bprintf(output, "S");
-        print_number(output, (u64)sigval, 16, 2);
+        print_number(output, (u64)sigval, 16, 2, false);
         break;
     case 'd':
         break;

--- a/src/gdb/gdbutil.c
+++ b/src/gdb/gdbutil.c
@@ -17,7 +17,7 @@ boolean mem2hex (string b, void *mem, int count)
         return false;
     for (i = 0; i < count; i++) {
         ch = *(unsigned char *)(mem++);
-        print_number(b, (u64)ch, 16, 2);
+        print_number(b, (u64)ch, 16, 2, false);
     }
     return (true);
 }
@@ -68,7 +68,7 @@ static void put_sendstring(gdb g, string b)
     }
 
     bprintf (g->send_buffer, "#");
-    print_number(g->send_buffer, (u64)checksum, 16, 2);
+    print_number(g->send_buffer, (u64)checksum, 16, 2, false);
 }
 
 void putpacket_deferred(gdb g, string b)

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -59,11 +59,9 @@ status http_request(heap h, buffer_handler bh, http_method method, tuple headers
     buffer b = allocate_buffer(h, 100);
     buffer url = get(headers, sym(url));
     bprintf(b, "%s %b HTTP/1.1\r\n", http_request_methods[method], url);
-    if (body) {
-        buffer content_len = little_stack_buffer(16);
-        bprintf(content_len, "%ld", buffer_length(body));
-        set(headers, sym(Content-Length), content_len);
-    }
+    buffer content_len = little_stack_buffer(16);
+    bprintf(content_len, "%ld", body ? buffer_length(body) : 0);
+    set(headers, sym(Content-Length), content_len);
     http_header(b, headers);
     status s = apply(bh, b);
     if (!is_ok(s)) {

--- a/src/kernel/init.c
+++ b/src/kernel/init.c
@@ -293,9 +293,6 @@ closure_function(4, 2, void, fsstarted,
     if (klibs && !opening_bootfs)
         init_klib(init_heaps, fs, root, apply_merge(m));
 
-    symbol booted = sym(booted);
-    if (!get(root, booted))
-        filesystem_write_eav((tfs)fs, fs_root, booted, null_value, false);
     config_console(root);
     status_handler complete = bound(complete);
     apply(complete, STATUS_OK);
@@ -518,11 +515,6 @@ void register_root_notify(symbol s, set_value_notify n)
 tuple get_environment(void)
 {
     return get(get_root_tuple(), sym(environment));
-}
-
-boolean first_boot(void)
-{
-    return !get(get_root_tuple(), sym(booted));
 }
 
 static void rootfs_init(u8 *mbr, u64 offset, storage_req_handler req_handler, u64 length,

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -876,8 +876,6 @@ tuple get_root_tuple(void);
 tuple get_environment(void);
 void register_root_notify(symbol s, set_value_notify n);
 
-boolean first_boot(void);
-
 extern void interrupt_exit(void);
 extern const sstring * const state_strings;
 

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -324,7 +324,7 @@ void print_loaded_klibs(void)
             print_u64(kl->load_range.start);
             rputs("/0x");
             buffer r = little_stack_buffer(16);
-            print_number(r, range_span(kl->load_range), 16, 0);
+            print_number(r, range_span(kl->load_range), 16, 0, false);
             buffer_print(r);
             rputs(" ");
         }

--- a/src/runtime/buffer.c
+++ b/src/runtime/buffer.c
@@ -15,6 +15,30 @@ buffer allocate_buffer(heap h, bytes s)
     return b;
 }
 
+bytes buffer_set_capacity(buffer b, bytes len)
+{
+    bytes old_len = b->length;
+    if (buffer_is_wrapped(b))   /* wrapped buffers can't be resized */
+        return old_len;
+    bytes content_len = b->end - b->start;
+    if (len < content_len)
+        len = content_len;
+    if (len != old_len) {
+        void *new = allocate(b->h, len);
+        if (new == INVALID_ADDRESS)
+            return old_len;
+        if (old_len) {
+            runtime_memcpy(new, b->contents + b->start, content_len);
+            deallocate(b->h, b->contents, old_len);
+        }
+        b->length = len;
+        b->end = content_len;
+        b->start = 0;
+        b->contents = new;
+    }
+    return len;
+}
+
 boolean buffer_append(buffer b,
                      const void *body,
                      bytes length)

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -118,25 +118,7 @@ static inline boolean buffer_is_wrapped(buffer b)
     return b->wrapped;
 }
 
-static inline bytes buffer_set_capacity(buffer b, bytes len)
-{
-    if (buffer_is_wrapped(b))   /* wrapped buffers can't be resized */
-        return b->length;
-    if (len < b->end - b->start)
-        len = b->end - b->start;
-    if (len != b->length) {
-        void *new = allocate(b->h, len);
-        if (new == INVALID_ADDRESS)
-            return b->length;
-        runtime_memcpy(new, b->contents + b->start, b->end - b->start);
-        deallocate(b->h, b->contents, b->length);
-        b->length = len;
-        b->end = b->end - b->start;
-        b->start = 0;
-        b->contents = new;
-    }
-    return len;
-}
+bytes buffer_set_capacity(buffer b, bytes len);
 
 static inline boolean buffer_extend(buffer b, bytes len)
 {

--- a/src/runtime/buffer.h
+++ b/src/runtime/buffer.h
@@ -26,6 +26,12 @@ static inline void init_buffer(buffer b, bytes s, boolean wrapped, heap h, void 
     b->contents = contents;
 }
 
+#define buffer_init_from_string(b, s)   do {    \
+    sstring _s = ss(s);                         \
+    init_buffer(b, _s.len, true, 0, _s.ptr);    \
+    (b)->end = _s.len;                          \
+} while (0)
+
 static inline void *buffer_ref(buffer b, bytes offset)
 {
     buffer_assert(b->start + offset <= b->length);

--- a/src/runtime/extra_prints.c
+++ b/src/runtime/extra_prints.c
@@ -331,7 +331,7 @@ void init_extra_prints(void)
     register_format('v', format_value, 0);
     register_format('V', format_value_with_attributes, 0);
 #endif
-    register_format('X', format_hex_buffer, 0);
+    register_format('B', format_hex_buffer, 0);
     register_format('T', format_timestamp, 0);
     register_format('R', format_range, 0);
     register_format('C', format_csum_buffer, 0);

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -174,8 +174,8 @@ void sha256(buffer dest, buffer source);
 
 typedef struct buffer *buffer;
 
-void print_number(buffer s, u64 x, int base, int pad);
-void print_signed_number(buffer s, s64 x, int base, int pad);
+void print_number(buffer s, u64 x, int base, int pad, boolean upper);
+void print_signed_number(buffer s, s64 x, int base, int pad, boolean upper);
 
 typedef struct flush_entry *flush_entry;
 

--- a/src/runtime/symbol.c
+++ b/src/runtime/symbol.c
@@ -32,7 +32,7 @@ struct symbol {
 symbol intern_u64(u64 u)
 {
     buffer b = little_stack_buffer(20);
-    print_number(b, u, 10, 0);
+    print_number(b, u, 10, 0, false);
     return intern(b);
 }
 

--- a/src/runtime/tuple.c
+++ b/src/runtime/tuple.c
@@ -40,14 +40,14 @@ static inline void validate_tag_type(sstring fn, value v, u16 tag)
 value indirect_integer_from_u64(u64 n)
 {
     buffer result = allocate_buffer(iheap, 10);
-    print_number(result, n, 10, 0);
+    print_number(result, n, 10, 0, false);
     return (value)result;
 }
 
 value indirect_integer_from_s64(s64 n)
 {
     buffer result = allocate_buffer(iheap, 10);
-    print_signed_number(result, n, 10, 0);
+    print_signed_number(result, n, 10, 0, false);
     return (value)result;
 }
 

--- a/src/runtime/tuple.c
+++ b/src/runtime/tuple.c
@@ -451,7 +451,7 @@ value decode_value(heap h, table dictionary, buffer source, u64 *total,
                 return null_value;
             }
             if (!old_encoding)
-                rprintf("%s: warning: untyped buffer, len %ld, offset %d: %X\n", func_ss,
+                rprintf("%s: warning: untyped buffer, len %ld, offset %d: %B\n", func_ss,
                         len, source->start, alloca_wrap_buffer(buffer_ref(source, 0), len));
 
             /* address a long-standing bug in bootloaders; untyped buffers must be tagged */

--- a/src/runtime/tuple.h
+++ b/src/runtime/tuple.h
@@ -133,7 +133,7 @@ static inline value value_rewrite_u64(value v, u64 n)
         return tagged_immediate_unsigned(n);
     assert(is_string(v) || is_integer(v));
     buffer_clear((buffer)v);
-    print_number((buffer)v, n, 10, 0);
+    print_number((buffer)v, n, 10, 0, false);
     return v;
 }
 
@@ -143,7 +143,7 @@ static inline value value_rewrite_s64(value v, s64 n)
         return tagged_immediate_signed(n);
     assert(is_string(v) || is_integer(v));
     buffer_clear((buffer)v);
-    print_signed_number((buffer)v, n, 10, 0);
+    print_signed_number((buffer)v, n, 10, 0, false);
     return v;
 }
 

--- a/src/xen/xennet.c
+++ b/src/xen/xennet.c
@@ -592,7 +592,7 @@ static void xennet_service_rx_ring(xennet_dev xd)
             xennet_debug("   RX flags %x, status %d, offset %d\n",
                          rx->flags, rx->status, rx->offset);
 #ifdef XENNET_DEBUG_DATA
-            xennet_debug("   buf:\n%X", alloca_wrap_buffer(rxb->p.pbuf.payload,
+            xennet_debug("   buf:\n%B", alloca_wrap_buffer(rxb->p.pbuf.payload,
                                                            rx->status + rx->offset));
 #endif
             rxb->p.pbuf.len = rx->status;


### PR DESCRIPTION
This change set enhances the cloud_init klib by implementing an Azure VM agent (this fixes the "virtual machine agent status is not ready" warning that is currently displayed for Nanos instances in the Azure portal), and adds a new "azure" klib that implements an Azure extension similar to the Linux Diagnostic extension.

The current implementation supports sending 4 types of memory metrics (i.e. available and used memory, as both number of bytes and percentage of total memory). The azure klib is configured in the manifest options via an "azure" tuple; the diagnostic functionalities in this klib are enabled and configured by inserting a "diagnostic" tuple with the following attributes:
- `storage_account`: indicates the Azure storage account to be used to store metrics data generated by the klib; the storage account must be located in the same region as the region where the Azure instance is deployed
- `storage_account_sas`: Shared Access Signature token for accessing the storage account: this token must have proper permissions to create Azure storage tables and add table entities in the above storage account; SAS tokens for a given storage account can be generated for example via the Azure portal in the "Security + networking" section
- `metrics`: tuple that enables sending memory metrics; it can contain 2 optional attributes:
  - `sample_interval`: interval expressed in seconds at which metrics data is collected (default: 15)
  - `transfer_interval`: interval expressed in seconds at which metrics data is aggregated and sent to the storage account (default: 60)

Example snippet of Ops configuration file:
```
"ManifestPassthrough": {
  "azure": {
    "diagnostics": {
      "storage_account": "mystorageaccount",
      "storage_account_sas": "sv=2022-11-02&ss=bfqt&srt=sco&sp=rwdlacupiytfx&se=2024-05-22T14:50:28Z&st=2024-05-12T06:50:28Z&spr=https&sig=xxyyzz",
      "metrics": {"sample_interval": "15","transfer_interval": "60"}
    }
  }
}
```

Aggregated memory metrics data consist of the number of samples, the minimum, maximum, last, and average value, and the sum of all values; these data are inserted in an Azure storage table (one entity per aggregated data). The name of the table is in the format "WADMetricsxxxxP10DV2Syyyymmdd", where xxxx is the transfer interval expressed with ISO8601 format, and yyyymmdd is a representation of the 10-day date interval to which the metrics refer (thus, a new table is created every 10 days). For example, a table named "WADMetricsPT1MP10DV2S20240503" contains metrics data aggregated every minute ("PT1M" is the ISO8601 representation of a 1-minute period) generated for a 10-day period starting on May 3, 2024.

By default, the Azure portal does not display these metrics in its charts; in order for metrics to be available in the portal, the Linux Diagnostics Extension must be enabled and configured in a running instance (this can be done in the "Diagnostic settings"
section in the portal) to match the settings in the Nanos manifest options. More specifically, the storage account and the metric aggregation interval specified in the Azure diagnostic settings must match those specified in the manifest options.
Note: the Azure VM agent implemented in the cloud_init klib responds to requests to enable and configure the diagnostic
extension, but does not actually apply the extension settings specified in the requests; instead, it always applies the settings from the manifest.

Closes https://github.com/nanovms/nanos/issues/2014