### PR TITLE
x86: fix overlapping of kernel addresses with vsyscall page

### DIFF
--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -11,7 +11,7 @@
  */
 
 #define KERNEL_BASE             0xffffffff80000000ull
-#define KERNEL_LIMIT            0xfffffffffffff000ull // XXX ? klibs
+#define KERNEL_LIMIT            0xffffffffff600000ull   /* VSYSCALL_BASE */
 #define KMEM_LIMIT              0xffffbfff00000000ull
 #define LINEAR_BACKED_LIMIT     0xffffffff00000000ull
 #define LINEAR_BACKED_BASE      0xffffc00000000000ull


### PR DESCRIPTION
In the x86_64 architecture, the KERNEL_LIMIT constant is currently set to 0xfffffffffffff000; if the KASLR process places the kernel near the end of the allowed address range, kernel addresses may overlap with the vsyscall page, which always starts at a fixed address (0xffffffffff600000); this may cause boot failures such as in https://app.circleci.com/pipelines/github/nanovms/nanos/4631/workflows/1400a162-d5c4-478d-8cc8-bdf84ab2536a/jobs/16261.
This change fixes the above issue by changing the KERNEL_LIMIT constant to coincide with the start of the vsyscall page.