### PR TITLE
memfd_create(): add support for file sealing

### DIFF
--- a/klib/shmem.c
+++ b/klib/shmem.c
@@ -13,7 +13,25 @@ sysreturn memfd_create(const char *name, unsigned int flags)
 {
     if (flags & ~MEMFD_KNOWN_FLAGS)
         return -EINVAL;
-    return file_open(shmem.fs, shmem.fs->root, O_RDWR | O_TMPFILE, 0);
+    filesystem fs = shmem.fs;
+    fsfile fsf;
+    filesystem_lock(fs);
+    fs_status fss = filesystem_creat_unnamed(fs, &fsf);
+    if (fss == FS_STATUS_OK) {
+        if (!(flags & MFD_ALLOW_SEALING))
+            fss = fs->set_seals(fs, fsf, F_SEAL_SEAL);
+    } else {
+        fsf = 0;
+    }
+    sysreturn rv;
+    if (fss == FS_STATUS_OK)
+        rv = unix_file_new(fs, fs->root, FDESC_TYPE_REGULAR, O_RDWR | O_TMPFILE, fsf);
+    else
+        rv = sysreturn_from_fs_status(fss);
+    filesystem_unlock(fs);
+    if ((rv < 0) && fsf)
+        fsfile_release(fsf);
+    return rv;
 }
 
 int init(status_handler complete)

--- a/src/fs/fs.c
+++ b/src/fs/fs.c
@@ -790,6 +790,8 @@ status filesystem_init(filesystem fs, heap h, u64 size, u64 blocksize, boolean r
     fs->pv = pagecache_allocate_volume(size, fs->blocksize_order);
     if (fs->pv == INVALID_ADDRESS)
         return timm("result", "failed to allocate pagacache volume");
+    fs->get_seals = 0;
+    fs->set_seals = 0;
 #ifndef FS_READ_ONLY
     init_refcount(&fs->refcount, 1, init_closure_func(&fs->sync, thunk, fs_sync));
     fs->sync_complete = 0;

--- a/src/fs/fs.h
+++ b/src/fs/fs.h
@@ -97,6 +97,8 @@ struct filesystem {
     u64 (*get_freeblocks)(filesystem fs);
     status_handler (*get_sync_handler)(filesystem fs, fsfile fsf, boolean datasync,
                                        status_handler completion);
+    fs_status (*get_seals)(filesystem fs, fsfile fsf, u64 *seals);
+    fs_status (*set_seals)(filesystem fs, fsfile fsf, u64 seals);
     void (*destroy_fs)(filesystem fs);
     tuple root;
 #ifdef KERNEL

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -57,5 +57,8 @@ fsfile fsfile_open(sstring file_path);
 fsfile fsfile_open_or_create(sstring file_path, boolean truncate);
 fs_status fsfile_truncate(fsfile f, u64 len);
 
+sysreturn fsfile_add_seals(fsfile f, u64 seals);
+sysreturn fsfile_get_seals(fsfile f, u64 *seals);
+
 notify_entry fs_watch(heap h, tuple n, u64 eventmask, event_handler eh, notify_set *s);
 void fs_notify_event(tuple n, u64 event);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -136,6 +136,8 @@ typedef struct iovec {
 #define F_DUPFD_CLOEXEC (F_LINUX_SPECIFIC_BASE + 6)
 #define F_SETPIPE_SZ    (F_LINUX_SPECIFIC_BASE + 7)
 #define F_GETPIPE_SZ    (F_LINUX_SPECIFIC_BASE + 8)
+#define F_ADD_SEALS     (F_LINUX_SPECIFIC_BASE + 9)
+#define F_GET_SEALS     (F_LINUX_SPECIFIC_BASE + 10)
 
 /* Values for 'mode' argument of access/faccessat syscalls */
 #define F_OK    0x0
@@ -154,6 +156,12 @@ struct flock {
 #define F_RDLCK         0
 #define F_WRLCK         1
 #define F_UNLCK         2
+
+#define F_SEAL_SEAL         0x0001
+#define F_SEAL_SHRINK       0x0002
+#define F_SEAL_GROW         0x0004
+#define F_SEAL_WRITE        0x0008
+#define F_SEAL_FUTURE_WRITE 0x0010
 
 #define IOC_NR(req)     ((req) & 0x000000ff)
 #define IOC_TYPE(req)   (((req) & 0x0000ff00) >> 8)

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -413,6 +413,9 @@ struct file {
     closure_struct(fdesc_close, close);
 };
 
+/* Allocates a file descriptor and returns its value (or an error code) */
+int unix_file_new(filesystem fs, tuple md, int type, int flags, fsfile fsf);
+
 sysreturn ioctl_generic(fdesc f, unsigned long request, vlist ap);
 
 void epoll_finish(epoll e);

--- a/test/runtime/fcntl.c
+++ b/test/runtime/fcntl.c
@@ -1,7 +1,13 @@
+#define _GNU_SOURCE
 #include <unistd.h>
 #include <string.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <sys/mman.h>
+
+#if !defined(F_SEAL_FUTURE_WRITE)   /* for older glibc versions */
+#define F_SEAL_FUTURE_WRITE 0x0010
+#endif
 
 #include "../test_utils.h"
 
@@ -64,6 +70,90 @@ void test_dupfd(int fd)
     test_assert(close(new_fd2) == 0);
 }
 
+static void test_seals(int non_tmpfs_fd)
+{
+    int tmpfs_fd;
+    int seals;
+    char buf[8];
+    void *addr0, *addr1;
+
+    /* seal operations on non-regular files or files whose filesystem doesn't support sealing */
+    test_assert((fcntl(0, F_GET_SEALS) == -1) && (errno == EINVAL));
+    test_assert((fcntl(0, F_ADD_SEALS) == -1) && (errno == EINVAL));
+    test_assert((fcntl(non_tmpfs_fd, F_GET_SEALS) == -1) && (errno == EINVAL));
+    test_assert((fcntl(non_tmpfs_fd, F_ADD_SEALS) == -1) && (errno == EINVAL));
+
+    /* memfd descriptor that doesn't allow sealing */
+    tmpfs_fd = memfd_create("", 0);
+    test_assert(tmpfs_fd >= 0);
+    test_assert(fcntl(tmpfs_fd, F_GET_SEALS) == F_SEAL_SEAL);
+    test_assert((fcntl(tmpfs_fd, F_ADD_SEALS, 0) == -1) && (errno == EPERM));
+    close(tmpfs_fd);
+
+    tmpfs_fd = memfd_create("", MFD_ALLOW_SEALING);
+    test_assert(tmpfs_fd >= 0);
+    test_assert((fcntl(tmpfs_fd, F_ADD_SEALS, -1u) == -1) && (errno == EINVAL));
+    test_assert(fcntl(tmpfs_fd, F_GET_SEALS) == 0);
+    test_assert(ftruncate(tmpfs_fd, 4) == 0);
+
+    test_assert(fcntl(tmpfs_fd, F_ADD_SEALS, F_SEAL_SHRINK) == 0);
+    test_assert(fcntl(tmpfs_fd, F_GET_SEALS) == F_SEAL_SHRINK);
+    test_assert((ftruncate(tmpfs_fd, 3) == -1) && (errno == EPERM));
+    test_assert(ftruncate(tmpfs_fd, 5) == 0);
+
+    test_assert(fcntl(tmpfs_fd, F_ADD_SEALS, F_SEAL_GROW) == 0);
+    test_assert(fcntl(tmpfs_fd, F_GET_SEALS) == (F_SEAL_SHRINK | F_SEAL_GROW));
+    test_assert(lseek(tmpfs_fd, -1, SEEK_END) == 4);
+    test_assert((write(tmpfs_fd, buf, 2) == -1) && (errno == EPERM));
+    test_assert(write(tmpfs_fd, buf, 1) == 1);
+    test_assert(write(tmpfs_fd, buf, 0) == 0);
+    test_assert((write(tmpfs_fd, buf, 1) == -1) && (errno == EPERM));
+    test_assert((ftruncate(tmpfs_fd, 6) == -1) && (errno == EPERM));
+    test_assert(ftruncate(tmpfs_fd, 5) == 0);
+
+    addr0 = mmap(NULL, 4096, PROT_WRITE, MAP_SHARED, tmpfs_fd, 0);
+    test_assert(addr0 != MAP_FAILED);
+    test_assert(fcntl(tmpfs_fd, F_ADD_SEALS, F_SEAL_FUTURE_WRITE) == 0);
+    seals = fcntl(tmpfs_fd, F_GET_SEALS);
+    test_assert(seals == (F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_FUTURE_WRITE));
+    test_assert(lseek(tmpfs_fd, 0, SEEK_SET) == 0);
+    test_assert(write(tmpfs_fd, buf, 0) == 0);
+    test_assert((write(tmpfs_fd, buf, 1) == -1) && (errno == EPERM));
+
+    /* shared file mapping after F_SEAL_FUTURE_WRITE */
+    addr1 = mmap(NULL, 4096, PROT_READ, MAP_SHARED, tmpfs_fd, 0);
+    test_assert(addr1 != MAP_FAILED);
+    test_assert((mprotect(addr1, 4096, PROT_READ | PROT_WRITE) == -1) && (errno == EACCES));
+    munmap(addr1, 4096);
+    test_assert(mmap(NULL, 4096, PROT_WRITE, MAP_SHARED, tmpfs_fd, 0) == MAP_FAILED);
+    test_assert(errno == EPERM);
+
+    /* F_SEAL_WRITE cannot be added with an existing writable mapping (regardless of its currrent
+     * access protection flags). */
+    test_assert((fcntl(tmpfs_fd, F_ADD_SEALS, F_SEAL_WRITE) == -1) && (errno == EBUSY));
+    test_assert(mprotect(addr0, 4096, PROT_READ) == 0);
+    test_assert((fcntl(tmpfs_fd, F_ADD_SEALS, F_SEAL_WRITE) == -1) && (errno == EBUSY));
+
+    munmap(addr0, 4096);
+    test_assert(fcntl(tmpfs_fd, F_ADD_SEALS, F_SEAL_WRITE) == 0);
+    seals = fcntl(tmpfs_fd, F_GET_SEALS);
+    test_assert(seals == (F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE | F_SEAL_FUTURE_WRITE));
+
+    test_assert(fcntl(tmpfs_fd, F_ADD_SEALS, F_SEAL_SEAL) == 0);
+    seals = fcntl(tmpfs_fd, F_GET_SEALS);
+    test_assert(seals ==
+                (F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE | F_SEAL_FUTURE_WRITE | F_SEAL_SEAL));
+
+    test_assert(write(tmpfs_fd, buf, 0) == 0);  /* dummy write */
+
+    /* private file mapping of sealed file */
+    addr0 = mmap(NULL, 4096, PROT_WRITE, MAP_PRIVATE, tmpfs_fd, 0);
+    test_assert(addr0 != MAP_FAILED);
+    munmap(addr0, 4096);
+
+    close(tmpfs_fd);
+}
+
 int main(int argc, char **argv)
 {
     struct flock lock;
@@ -83,6 +173,7 @@ int main(int argc, char **argv)
     test_lk(fd, F_SETLKW, &lock, 0);
 
     test_dupfd(fd);
+    test_seals(fd);
 
     printf("test passed\n");
     return EXIT_SUCCESS;

--- a/test/runtime/fcntl.manifest
+++ b/test/runtime/fcntl.manifest
@@ -1,10 +1,19 @@
 (
+    boot:(
+        children:(
+            klib:(children:(
+                tmpfs:(contents:(host:output/klib/bin/tmpfs))
+                shmem:(contents:(host:output/klib/bin/shmem))
+            ))
+        )
+    )
     children:(
               #user program
 	      fcntl:(contents:(host:output/test/runtime/bin/fcntl))
 	      )
     # filesystem path to elf for kernel to run
     program:/fcntl
+    klibs:bootfs
 #    trace:t
 #    debugsyscalls:t
 #    futex_trace:t


### PR DESCRIPTION
This change set enhances the tmpfs implementation so that it supports file sealing, and modifies memfd_create() so that it acts upon the MFD_ALLOW_SEALING flag when configuring the initial set of seals for the underlying tmpfs file.
The fcntl() syscall now accepts 2 additional commands, needed for file sealing operations: F_ADD_SEALS and F_GET_SEALS.
The fcntl runtime test has been amended to exercise this new feature.