### PR TITLE
On-demand program file paging: fix initialization of BSS areas

### DIFF
--- a/src/aarch64/interrupt.c
+++ b/src/aarch64/interrupt.c
@@ -240,7 +240,6 @@ void synchronous_handler(void)
             context_release_refcount(retctx);
             frame_return(retctx->frame);
         }
-        assert(!is_kernel_context(ctx));
         runloop();
     } else {
         console("\nno fault handler for frame ");

--- a/src/aarch64/page_machine.h
+++ b/src/aarch64/page_machine.h
@@ -178,12 +178,12 @@
 
 #ifndef physical_from_virtual
 
-// XXX kernel addr, also should return INVALID_PHYSICAL if PAR_EL1.F is set
+// XXX kernel addr
 #define __physical_from_virtual_locked(v) ({                            \
             register u64 __r;                                           \
             register u64 __x = u64_from_pointer(v);                     \
             asm volatile("at S1E1R, %1; mrs %0, PAR_EL1" : "=r"(__r) : "r"(__x)); \
-            (__r & (MASK(47) & ~MASK(12))) | (__x & MASK(12));})
+            (__r & 0x1) ? INVALID_PHYSICAL : ((__r & (MASK(47) & ~MASK(12))) | (__x & MASK(12)));})
 
 physical physical_from_virtual(void *x);
 

--- a/src/kernel/pagecache.h
+++ b/src/kernel/pagecache.h
@@ -3,6 +3,7 @@ typedef struct pagecache_volume *pagecache_volume;
 typedef struct pagecache_node *pagecache_node;
 
 closure_type(pagecache_node_reserve, status, range r);
+closure_type(pagecache_page_handler, void, void *kvirt);
 
 void pagecache_set_node_length(pagecache_node pn, u64 length);
 
@@ -12,6 +13,9 @@ void pagecache_node_finish_pending_writes(pagecache_node pn, status_handler comp
 
 void pagecache_sync_node(pagecache_node pn, status_handler complete);
 void pagecache_purge_node(pagecache_node pn, status_handler complete);
+
+void pagecache_node_ref(pagecache_node pn);
+void pagecache_node_unref(pagecache_node pn);
 
 void pagecache_nodelocked_pin(pagecache_node pn, range pages);
 void pagecache_node_unpin(pagecache_node pn, range pages);
@@ -45,11 +49,9 @@ boolean pagecache_node_do_page_cow(pagecache_node pn, u64 node_offset, u64 vaddr
 
 void pagecache_node_fetch_pages(pagecache_node pn, range r /* bytes */);
 
-void pagecache_map_page(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags flags,
-                        status_handler complete);
-
-boolean pagecache_map_page_if_filled(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags flags,
-                                     status_handler complete);
+void pagecache_get_page(pagecache_node pn, u64 node_offset, pagecache_page_handler handler);
+void *pagecache_get_page_if_filled(pagecache_node pn, u64 node_offset);
+void pagecache_release_page(pagecache_node pn, u64 node_offset);
 
 void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node_offset);
 #endif

--- a/src/riscv64/interrupt.c
+++ b/src/riscv64/interrupt.c
@@ -350,7 +350,6 @@ void trap_exception(void)
             context_release_refcount(retctx);
             frame_return(retctx->frame);
         }
-        assert(!is_kernel_context(ctx));
         runloop();
     } else {
         console("\nno fault handler for frame\n");

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -451,7 +451,6 @@ thread create_thread(process p, u64 tid)
     t->start_time = 0;
     t->cpu_timers = 0;
 
-    list_init(&t->l_faultwait);
     spin_lock_init(&t->lock);
 
     /* install gdb fault handler if gdb is inited */

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -229,15 +229,7 @@ void common_handler()
                 context_release_refcount(retctx);
                 frame_return(retctx->frame);
             }
-            if (is_syscall_context(ctx))
-                /* This indicates an unhandled fault on a user page from
-                   within a syscall. We need to abandon the syscall at this
-                   point and let the thread run so it may receive the
-                   appropriate signal. The frame is left full so that future
-                   context dumps will report the actual processor state when
-                   the exception occurred. */
-                runloop();
-            assert(!is_kernel_context(ctx));
+            runloop();
         } else {
             console("\nno fault handler\n");
             goto exit_fault;


### PR DESCRIPTION
When on-demand paging of the program file is enabled, BSS areas in pages faulted-in on demand are zeroed in-place, i.e. a newly mapped page retrieved via the page cache is zeroed starting from the BSS offset set up when initializing the relevant vmap. This creates a problem if the page contains other data (e.g. from another loadable section of the program) at or after the BSS offset, in which case this data would be overwritten.
This change fixes the above issue by using a separate page (instead of the page from the page cache) where the initialized program data (located before the BSS offset) is copied from the page cache page, and the rest of the page (starting at the BSS offset) is zeroed out. Closes https://github.com/nanovms/ops/issues/1629.

The last commit fixes an assertion failure that occurs when a page fault during a kernel context cannot be resolved synchronously.