### PR TITLE
Memory mapping: add support for Transparent Huge Pages (THP)

### DIFF
--- a/src/aarch64/page_machine.h
+++ b/src/aarch64/page_machine.h
@@ -275,7 +275,7 @@ static inline pageflags pageflags_no_minpage(pageflags flags)
 /* no-exec, read-only */
 static inline pageflags pageflags_default_user(void)
 {
-    return pageflags_user(pageflags_minpage(pageflags_memory()));
+    return pageflags_user(pageflags_memory());
 }
 
 static inline boolean pageflags_is_present(pageflags flags)

--- a/src/aarch64/page_machine.h
+++ b/src/aarch64/page_machine.h
@@ -364,7 +364,7 @@ static inline boolean pte_is_mapping(int level, pte entry)
 
 static inline u64 flags_from_pte(u64 pte)
 {
-    return pte & PAGE_FLAGS_MASK;
+    return pte & (PAGE_FLAGS_MASK & ~PAGE_L3_DESC_PAGE);
 }
 
 static inline pageflags pageflags_from_pte(pte pte)

--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -267,7 +267,6 @@ closure_function(4, 3, boolean, update_pte_flags,
 /* Update access protection flags for any pages mapped within a given area */
 void update_map_flags(u64 vaddr, u64 length, pageflags flags)
 {
-    flags = pageflags_no_minpage(flags);
     page_debug("vaddr 0x%lx, length 0x%lx, flags 0x%lx\n", vaddr, length, flags.w);
 
     /* Catch any attempt to change page flags in a linear_backed mapping */

--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -559,7 +559,7 @@ closure_function(1, 1, boolean, page_dealloc,
 void unmap_and_free_phys(u64 virtual, u64 length)
 {
     unmap_pages_with_handler(virtual, length,
-                             stack_closure(page_dealloc, (heap)get_kernel_heaps()->pages));
+                             stack_closure(page_dealloc, (heap)heap_page_backed(get_kernel_heaps())));
 }
 
 void page_free_phys(u64 phys)

--- a/src/kernel/page.h
+++ b/src/kernel/page.h
@@ -25,31 +25,20 @@ void init_page_tables(heap pageheap);
 void init_flush(heap);
 flush_entry get_page_flush_entry();
 void page_invalidate(flush_entry f, u64 address);
-void page_invalidate_sync(flush_entry f, status_handler completion);
+void page_invalidate_sync(flush_entry f);
 void page_invalidate_flush();
 
 void invalidate(u64 page);
 void flush_tlb(boolean full_flush);
 
 /* mapping and flag update */
-physical map_with_complete(u64 v, physical p, u64 length, pageflags flags, status_handler complete);
-
-static inline void map(u64 v, physical p, u64 length, pageflags flags)
-{
-    map_with_complete(v, p, length, flags, 0);
-}
-
+/* overwrite any existing mappings in the virtual address range */
+void map(u64 v, physical p, u64 length, pageflags flags);
 void map_nolock(u64 v, physical p, u64 length, pageflags flags);
 
-void update_map_flags_with_complete(u64 vaddr, u64 length, pageflags flags, status_handler complete);
+void update_map_flags(u64 vaddr, u64 length, pageflags flags);
 
-static inline void update_map_flags(u64 vaddr, u64 length, pageflags flags)
-{
-    update_map_flags_with_complete(vaddr, length, flags, 0);
-}
-
-/* overwrite any existing mappings in the virtual address range */
-void remap(u64 v, physical p, u64 length, pageflags flags);
+#define remap(v, p, length, flags)  map(v, p, length, flags)
 
 void zero_mapped_pages(u64 vaddr, u64 length);
 void remap_pages(u64 vaddr_new, u64 vaddr_old, u64 length);

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1518,7 +1518,7 @@ static void pagecache_scan_shared_mappings(pagecache pc)
         pagecache_debug("   shared map va %R, node_offset 0x%lx\n", sm->n.r, sm->node_offset);
         pagecache_scan_shared_map(pc, sm, fe);
     }
-    page_invalidate_sync(fe, 0);
+    page_invalidate_sync(fe);
 }
 
 static void pagecache_scan_node(pagecache_node pn)
@@ -1530,7 +1530,7 @@ static void pagecache_scan_node(pagecache_node pn)
         pagecache_debug("   shared map va %R, node_offset 0x%lx\n", n->r, sm->node_offset);
         pagecache_scan_shared_map(pn->pv->pc, sm, fe);
     }
-    page_invalidate_sync(fe, 0);
+    page_invalidate_sync(fe);
 }
 
 closure_func_basic(timer_handler, void, pagecache_scan_timer,
@@ -1630,7 +1630,7 @@ void pagecache_node_scan_and_commit_shared_pages(pagecache_node pn, range q /* b
     rangemap_range_lookup(pn->shared_maps, q,
                           stack_closure(scan_shared_pages_intersection, pn->pv->pc, fe));
     pagecache_commit_dirty_node(pn, 0);
-    page_invalidate_sync(fe, 0);
+    page_invalidate_sync(fe);
 }
 
 boolean pagecache_node_do_page_cow(pagecache_node pn, u64 node_offset, u64 vaddr, pageflags flags)
@@ -1771,7 +1771,7 @@ void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node
     traverse_ptes(v.start, range_span(v), stack_closure(pagecache_unmap_page_nodelocked, pn,
                                                         v.start, node_offset, fe));
     pagecache_unlock_node(pn);
-    page_invalidate_sync(fe, 0);
+    page_invalidate_sync(fe);
 }
 #endif
 

--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -24,8 +24,8 @@ closure_function(3, 1, void, program_start,
 
     /* Set mapping flags to read-only for data that has been initialized during boot and should not
      * be modified afterwards. */
-    extern void *ro_after_init_start, *ro_after_init_end;
-    extern void *bss_ro_after_init_start, *bss_ro_after_init_end;
+    extern u8 ro_after_init_start, ro_after_init_end;
+    extern u8 bss_ro_after_init_start, bss_ro_after_init_end;
     update_map_flags(u64_from_pointer(&ro_after_init_start),
                      &ro_after_init_end - &ro_after_init_start,
                      pageflags_memory());

--- a/src/riscv64/page_machine.h
+++ b/src/riscv64/page_machine.h
@@ -96,7 +96,7 @@ static inline pageflags pageflags_no_minpage(pageflags flags)
 /* no-exec, read-only */
 static inline pageflags pageflags_default_user(void)
 {
-    return pageflags_user(pageflags_minpage(pageflags_memory()));
+    return pageflags_user(pageflags_memory());
 }
 
 static inline boolean pageflags_is_writable(pageflags flags)

--- a/src/runtime/heap/id.c
+++ b/src/runtime/heap/id.c
@@ -198,9 +198,14 @@ closure_function(2, 1, boolean, dealloc_from_range,
         msg_err("heap %p: bitmap dealloc for range %R failed; leaking\n", i, q);
         return false;
     }
+    u64 pages_rounded = U64_FROM_BIT(order);
 
-    if (bit < get_next_bit(r, order))
+    /* Only set next_bit to properly aligned values, otherwise the heap may fail to respect the
+     * property that allocated values are aligned to the nearest power-of-2 value equal to or
+     * greater than the allocation size. */
+    if ((pages == pages_rounded) && !(ri.start & (pages - 1)) && (bit < get_next_bit(r, order)))
         set_next_bit(r, order, bit);
+
     u64 deallocated = pages << page_order(i);
     assert(i->allocated >= deallocated);
     i->allocated -= deallocated;

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -233,7 +233,7 @@ closure_function(4, 5, boolean, static_map,
         struct vmap k = ivmap(vmflags, bound(allowed_flags), 0, 0, 0);
         if (allocate_vmap(bound(p), r, k) == INVALID_ADDRESS)
             goto alloc_fail;
-        map(map_start, paddr, data_size, pageflags_user(pageflags_minpage(flags)));
+        map(map_start, paddr, data_size, pageflags_user(flags));
         map_start += data_size;
     }
     if (bss_size > 0) {
@@ -241,7 +241,7 @@ closure_function(4, 5, boolean, static_map,
         u64 paddr = allocate_u64((heap)heap_physical(bound(kh)), maplen);
         if (paddr == INVALID_PHYSICAL)
             goto alloc_fail;
-        map(map_start, paddr, maplen, pageflags_user(pageflags_minpage(flags)));
+        map(map_start, paddr, maplen, pageflags_user(flags));
         u64 vmflags = VMAP_FLAG_READABLE | VMAP_FLAG_WRITABLE | VMAP_FLAG_BSS;
         range r = irangel(map_start, maplen);
         exec_debug("   add bss vmap: %R vmflags 0x%lx\n", r, vmflags);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -239,6 +239,10 @@ struct flock {
 #define MS_INVALIDATE 2
 #define MS_SYNC       4
 
+/* madvise */
+#define MADV_HUGEPAGE       14
+#define MADV_NOHUGEPAGE     15
+
 typedef int clockid_t;
 
 #define CLOCK_REALTIME              0

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -18,6 +18,7 @@
 #define VMAP_FLAG_PROG     0x1000
 #define VMAP_FLAG_BSS      0x2000
 #define VMAP_FLAG_TAIL_BSS 0x4000
+#define VMAP_FLAG_THP      0x8000   /* Transparent Huge Pages */
 
 #define VMAP_MMAP_TYPE_MASK       0x0f00
 #define VMAP_MMAP_TYPE_ANONYMOUS  0x0100
@@ -834,7 +835,6 @@ boolean unix_timers_init(unix_heaps uh);
 #define vmap_unlock(p) spin_unlock_irq(&(p)->vmap_lock, _savedflags)
 
 extern sysreturn syscall_ignore();
-u64 new_zeroed_pages(u64 v, u64 length, pageflags flags, status_handler complete);
 status do_demand_page(process p, context ctx, u64 vaddr, vmap vm, boolean *done);
 void demand_page_done(context ctx, u64 vaddr, status s);
 vmap vmap_from_vaddr(process p, u64 vaddr);

--- a/src/x86_64/page.c
+++ b/src/x86_64/page.c
@@ -26,10 +26,8 @@ void page_invalidate(flush_entry f, u64 address)
     flush_tlb(true);
 }
 
-void page_invalidate_sync(flush_entry f, status_handler completion)
+void page_invalidate_sync(flush_entry f)
 {
-    if (completion)
-        apply(completion, STATUS_OK);
 }
 
 void page_invalidate_flush(void)

--- a/src/x86_64/page_machine.h
+++ b/src/x86_64/page_machine.h
@@ -93,7 +93,7 @@ static inline pageflags pageflags_no_minpage(pageflags flags)
 /* no-exec, read-only */
 static inline pageflags pageflags_default_user(void)
 {
-    return pageflags_user(pageflags_minpage(pageflags_memory()));
+    return pageflags_user(pageflags_memory());
 }
 
 static inline boolean pageflags_is_present(pageflags flags)

--- a/src/x86_64/page_machine.h
+++ b/src/x86_64/page_machine.h
@@ -146,7 +146,7 @@ static inline boolean pte_is_block_mapping(pte entry)
 
 static inline u64 flags_from_pte(u64 pte)
 {
-    return pte & (PAGE_FLAGS_MASK | page_encr_mask);
+    return pte & ((PAGE_FLAGS_MASK & ~PAGE_PS) | page_encr_mask);
 }
 
 static inline pageflags pageflags_from_pte(pte pte)


### PR DESCRIPTION
Memory areas mapped in the user process virtual address space are paged on-demand when the process causes a page fault by de-referencing a virtual address. In the existing implementation, a single 4-KB memory page is allocated and mapped after a page fault; with THP, memory pages belonging to anonymous mappings can be allocated and mapped using larger sizes (up to 2 MB); this decreases the number of page faults triggered when the process accesses a large memory area, resulting in improved performance. In addition, by allowing user pages to be mapped at a block level (i.e. in 2MB chunks) instead of being limited to page-level mappings (i.e. 4KB chunks), TLB usage is optimized and TLB hit rates are increased.

The THP feature is enabled by default in memory areas mapped via the mmap() syscall, and can be enabled and disabled dynamically for an arbitrary (non-file-backed) memory area via the newly implemented madvise() syscall, by using the MADV_HUGEPAGE and MADV_NOHUGEPAGE advice values.