### PR TITLE
Aarch64 physical ID heap: fix setting of memory end address

### DIFF
--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -191,7 +191,7 @@ id_heap init_physical_id_heap(heap h)
         unmap(map_base, map_size);
     } else {
         u64 base = KERNEL_PHYS + kernel_size;
-        u64 end = base + get_memory_size(pointer_from_u64(DEVICETREE_BLOB_BASE));
+        u64 end = PHYSMEM_BASE + get_memory_size(pointer_from_u64(DEVICETREE_BLOB_BASE));
         u64 bootstrap_size = init_bootstrap_heap(end - base);
         map(BOOTSTRAP_BASE, base, bootstrap_size, pageflags_writable(pageflags_memory()));
         base += bootstrap_size;


### PR DESCRIPTION
In instances where the physical memory start address is fixed to a hard-coded value (such as when instantiating a Qemu "virt" machine type), the memory end address should be calculated from the hard-coded start value instead of from the start of usable memory.

This change fixes a "frame 0x00ff800042200800 already full" fatal error caused by a "data abort in el1 write" exception that is triggered when the kernel allocates memory at an address range past the end of physical memory (e.g. when the user process tries to use more memory than available).