### PR TITLE
ARM: add parsing of device tree blob

### DIFF
--- a/platform/virt/pci.c
+++ b/platform/virt/pci.c
@@ -106,6 +106,11 @@ void pci_setup_irq_aff(pci_dev dev, thunk h, sstring name, range cpu_affinity)
     irq_register_handler(v, h, name, cpu_affinity);
 }
 
+void pci_platform_set_ecam(u64 ecam_base)
+{
+    pcie_ecam_base = ecam_base;
+}
+
 closure_func_basic(mcfg_handler, boolean, pci_mcfg_handler,
                    u64 addr, u16 segment, u8 bus_start, u8 bus_end)
 {
@@ -118,9 +123,8 @@ closure_func_basic(mcfg_handler, boolean, pci_mcfg_handler,
 
 void pci_platform_init(void)
 {
-    acpi_walk_mcfg(stack_closure_func(mcfg_handler, pci_mcfg_handler));
     if (!pcie_ecam_base)
-        pcie_ecam_base = mmio_base_addr(PCIE_ECAM);
+        acpi_walk_mcfg(stack_closure_func(mcfg_handler, pci_mcfg_handler));
 }
 
 /* Rudimentary resource allocation based on fixed offests for virt

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -539,6 +539,7 @@ void deallocate_msi_interrupt(u64 v);
 u64 allocate_mmio_interrupt(void);
 void deallocate_mmio_interrupt(u64 v);
 
+vector cpus_init_ids(heap h);
 u64 mpid_from_cpuid(int id);
 
 void aarch64_cpu_init(void);
@@ -546,5 +547,7 @@ void arm_hvc(u64 x0, u64 x1, u64 x2, u64 x3);
 void angel_shutdown(u64 x0);
 void psci_shutdown(void);
 void psci_reset(void);
+
+void pci_platform_set_ecam(u64 ecam_base);
 
 #endif /* __ASSEMBLY__ */

--- a/src/devicetree/devicetree.h
+++ b/src/devicetree/devicetree.h
@@ -42,6 +42,11 @@ typedef struct dt_value {
 
 closure_type(dt_node_handler, boolean, dt_node n, sstring name);
 
+typedef struct fdt {
+    void *ptr, *end;
+    char *strings_start, *strings_end;
+} *fdt;
+
 sstring dtb_string(void *dtb, u64 off);
 
 u32 dtb_read_u32(dt_prop p);
@@ -61,4 +66,12 @@ dt_value dtb_read_value(void *dtb, dt_node n, dt_prop p);
 
 void devicetree_dump(void *dtb);
 
+boolean dtb_parse_init(void *dtb, fdt fdt);
+dt_node fdt_get_node(fdt fdt);
+dt_node fdt_next_node(fdt fdt);
+sstring fdt_node_name(fdt fdt, dt_node node);
+void fdt_get_cells(fdt fdt, u32 *acells, u32 *scells);
+boolean fdt_get_reg(fdt fdt, u32 acells, u32 scells, dt_reg_iterator *iter);
 
+#define fdt_foreach_node(fdt, node) \
+    for (dt_node node = fdt_get_node(fdt); node; node = fdt_next_node(fdt))

--- a/src/kernel/pci.c
+++ b/src/kernel/pci.c
@@ -247,7 +247,7 @@ static void pci_parse_iomem(pci_dev dev, boolean allocate)
     for (int bar = 0; bar <= max_bar; bar++) {
         u32 base = pci_cfgread(dev, PCIR_BAR(bar), 4);
         if (((base & PCI_BAR_B_TYPE_MASK) == PCI_BAR_MEMORY) &&
-            ((base & ~PCI_BAR_B_MEMORY_MASK) != 0)) {
+            (base != 0)) {
             u64 size = pci_bar_size(dev, PCI_BAR_MEMORY, base & PCI_BAR_B_MEMORY_MASK, bar);
             u64 addr = base & ~PCI_BAR_B_MEMORY_MASK;
             if (base & PCI_BAR_F_64BIT) {


### PR DESCRIPTION
This change set adds parsing of the device tree blob during kernel initialization when running on ARM machines, in order to retrieve the number of vCPUs and the base address of the PCI configuration space.
This allows the kernel to:
- properly detect the number of vCPUs when ACPI tables are not present (e.g. when running an on-prem instance with Ops)
- run without the 'highmem=off' Qemu command line option

The first commit fixes a "set_gap error" message that is printed on the console when running an ARM instance using a QEMU "virt" machine with the "highmem" setting enabled and with UEFI firmware.