### PR TITLE
Core dump: fix writing of core dump file data to disk

### DIFF
--- a/src/unix/coredump.c
+++ b/src/unix/coredump.c
@@ -170,15 +170,6 @@ closure_function(3, 1, boolean, additional_threads_status,
     return add_thread_status(bound(b), t, bound(si));
 }
 
-closure_function(2, 1, void, dump_complete,
-                 fsfile, f, status_handler, completion,
-                 status s)
-{
-    fsfile_release(bound(f));
-    apply(bound(completion), s);
-    closure_finish();
-}
-
 closure_function(8, 1, void, dump_write_complete,
                  fsfile, f, sg_io, write, sg_list, sg, Elf64_Phdr *, phdr, Elf64_Phdr *, phdr_end, buffer, b, status_handler, completion, u64, limit_remain,
                  status s)
@@ -366,7 +357,6 @@ void coredump(thread t, struct siginfo *si, status_handler complete)
     deallocate_vector(v);
 
     /* write dump header and first phdr */
-    status_handler completion = closure(h, dump_complete, f, complete);
     add_to_sgl(sg, buffer_ref(bhdr, 0), buffer_length(bhdr));
     u64 limit_remain = coredump_limit;
     u64 wlen = sg->count;
@@ -374,7 +364,7 @@ void coredump(thread t, struct siginfo *si, status_handler complete)
         wlen = limit_remain;
     limit_remain -= wlen;
     apply(write, sg, irangel(0, wlen),
-        closure(h, dump_write_complete, f, write, sg, phdr_begin, phdr_end, bhdr, completion, limit_remain));
+        closure(h, dump_write_complete, f, write, sg, phdr_begin, phdr_end, bhdr, complete, limit_remain));
     return;
 error:
     apply(complete, s);

--- a/test/extended_tests.py
+++ b/test/extended_tests.py
@@ -61,8 +61,11 @@ def coredump_post(ctx):
                            check=True)
         except:
             return (-1, 'dump failed')
-        if not os.path.isfile(tmp + '/coredumps/core'):
+        coredump_path = tmp + '/coredumps/core'
+        if not os.path.isfile(coredump_path):
             return (-1, 'coredump not generated')
+        elif os.path.getsize(coredump_path) == 0:
+            return (-1, 'empty coredump')
 
 
 def notrace_post(ctx):


### PR DESCRIPTION
This change set fixes creation of the core dump file when the user program terminates abnormally.
In addition, the core dump test in the test suite has been made more robust by adding a file size check, so the test will fail if a zero-sized core dump file is generated.