### PR TITLE
Page tables: unmap_page(): fix call to range handler

### DIFF
--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -404,7 +404,7 @@ closure_function(4, 3, boolean, unmap_page,
         }
         page_invalidate(bound(fe), vaddr);
         if (rh) {
-            apply(rh, irangel(page_from_pte(old_entry) + map_offset, map_len - map_offset));
+            apply(rh, irangel(page_from_pte(old_entry) + map_offset, unmap_len));
         }
     }
     return true;


### PR DESCRIPTION
The range passed to the range handler should be the same range that has just been unmapped.
This change fixes an incorrect deallocation of physical memory that happens when a memory range being unmapped contains a 2MB-sized page that covers a portion of the tail of the unmapped range (and that is thus split into 4KB pages); see the "bitmap_dealloc error" messages in https://github.com/nanovms/ops/issues/1654.