### PR TITLE
iov_to_sg(): fix SG buffer creation for iov entries larger than 4GB

### DIFF
--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -77,8 +77,7 @@ void file_readahead(file f, u64 offset, u64 len)
 static sysreturn file_io_init_internal(file f, u64 offset, struct iovec *iov, int count, sg_list sg)
 {
     if (!(f->f.flags & O_DIRECT)) {
-        iov_to_sg(sg, iov, count);
-        return 0;
+        return iov_to_sg(sg, iov, count) ? 0 : -ENOMEM;
     }
     u64 block_mask = fs_blocksize(f->fs) - 1;
     if (offset & block_mask)


### PR DESCRIPTION
The size and offset fields of struct sg_buf are 32-bit fields, thus a single SG buffer can only be used for data sizes smaller than 4 GB.
This change amends the iov_to_sg() function so that it creates multiple SG buffers if an iovec entry length is 4GB or larger.
Fixes https://github.com/nanovms/ops/issues/1654