### PR TITLE
Filesystem: retire fs_status enum in favor of standard error codes

### DIFF
--- a/klib/shmem.c
+++ b/klib/shmem.c
@@ -16,18 +16,18 @@ sysreturn memfd_create(const char *name, unsigned int flags)
     filesystem fs = shmem.fs;
     fsfile fsf;
     filesystem_lock(fs);
-    fs_status fss = filesystem_creat_unnamed(fs, &fsf);
-    if (fss == FS_STATUS_OK) {
+    int fss = filesystem_creat_unnamed(fs, &fsf);
+    if (fss == 0) {
         if (!(flags & MFD_ALLOW_SEALING))
             fss = fs->set_seals(fs, fsf, F_SEAL_SEAL);
     } else {
         fsf = 0;
     }
     sysreturn rv;
-    if (fss == FS_STATUS_OK)
+    if (fss == 0)
         rv = unix_file_new(fs, fs->root, FDESC_TYPE_REGULAR, O_RDWR | O_TMPFILE, fsf);
     else
-        rv = sysreturn_from_fs_status(fss);
+        rv = fss;
     filesystem_unlock(fs);
     if ((rv < 0) && fsf)
         fsfile_release(fsf);

--- a/klib/syslog.c
+++ b/klib/syslog.c
@@ -119,7 +119,7 @@ closure_function(4, 1, void, syslog_file_write_complete,
                 syslog_file_rotate();
             } else {
                 /* Delete old logs instead of rotating. */
-                if (fsfile_truncate(syslog.fsf, 0) == FS_STATUS_OK) {
+                if (fsfile_truncate(syslog.fsf, 0) == 0) {
                     syslog.file_offset = 0;
                 } else {
                     fsfile_release(syslog.fsf);

--- a/platform/pc/boot/stage2.c
+++ b/platform/pc/boot/stage2.c
@@ -76,15 +76,6 @@ void console_write(const char *s, bytes count)
     }
 }
 
-void klog_write(const char *s, bytes count)
-{
-}
-
-heap heap_dma(void)
-{
-    return general;
-}
-
 closure_function(1, 1, void, stage2_bios_read,
                  u64, offset,
                  storage_req req)

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -208,9 +208,6 @@ static inline void wait_for_interrupt(void)
 #define cmdline_consume(o, h)   (void)(h)
 #define boot_params_apply(t)
 
-/* locking constructs */
-#include <mutex.h>
-
 /* device mmio region access */
 #define MK_MMIO_READ(BITS, ISUFFIX, RPREFIX) \
     static inline u##BITS mmio_read_##BITS(u64 addr)                    \

--- a/src/boot/uefi.c
+++ b/src/boot/uefi.c
@@ -50,10 +50,6 @@ void console_write(const char *s, bytes count)
     uefi_system_table->con_out->output_string(uefi_system_table->con_out, buf);
 }
 
-void klog_write(const char *s, bytes count)
-{
-}
-
 void print_frame_trace_from_here(void)
 {
 }
@@ -98,11 +94,6 @@ void halt_with_code(u8 code, sstring format, ...)
     buffer_print(b);
     UBS->exit(uefi_image_handle, EFI_LOAD_ERROR, 0, 0); /* does not return */
     while(1);   /* to honor "noreturn" attribute */
-}
-
-heap heap_dma(void)
-{
-    return &general;
 }
 
 static u64 uefi_alloc(heap h, bytes b)

--- a/src/fs/9p.h
+++ b/src/fs/9p.h
@@ -374,6 +374,5 @@ void p9_strcpy(struct p9_string *dest, sstring str);
 void p9_bufcpy(struct p9_string *dest, buffer b);
 int p9_strcmp(struct p9_string *s1, sstring s2);
 
-fs_status p9_parse_minimal_resp(u8 req_type, union p9_minimal_resp *resp, u32 resp_len);
-fs_status p9_parse_qid_resp(u8 req_type, union p9_qid_resp *resp, u32 resp_len, u64 *qid);
-fs_status p9_ecode_to_fs_status(u32 ecode);
+int p9_parse_minimal_resp(u8 req_type, union p9_minimal_resp *resp, u32 resp_len);
+int p9_parse_qid_resp(u8 req_type, union p9_qid_resp *resp, u32 resp_len, u64 *qid);

--- a/src/fs/tfs.h
+++ b/src/fs/tfs.h
@@ -25,10 +25,10 @@ void destroy_filesystem(filesystem fs);
 fsfile fsfile_from_node(filesystem fs, tuple n);
 tfsfile allocate_fsfile(tfs fs, tuple md);
 
-fs_status filesystem_write_tuple(tfs fs, tuple t);
-fs_status filesystem_write_eav(tfs fs, tuple t, symbol a, value v, boolean cleanup);
+int filesystem_write_tuple(tfs fs, tuple t);
+int filesystem_write_eav(tfs fs, tuple t, symbol a, value v, boolean cleanup);
 
-fs_status filesystem_mkentry(filesystem fs, tuple cwd, sstring fp, tuple entry,
+int filesystem_mkentry(filesystem fs, tuple cwd, sstring fp, tuple entry,
     boolean persistent, boolean recursive);
-fs_status filesystem_mkdirpath(filesystem fs, tuple cwd, sstring fp,
+int filesystem_mkdirpath(filesystem fs, tuple cwd, sstring fp,
         boolean persistent);

--- a/src/fs/tfs_internal.h
+++ b/src/fs/tfs_internal.h
@@ -1,9 +1,9 @@
 #ifdef KERNEL
 #include <kernel.h>
+#include <pagecache.h>
 #else
 #include <runtime.h>
 #endif
-#include <pagecache.h>
 #include <storage.h>
 #include <tfs.h>
 
@@ -14,7 +14,9 @@ typedef struct log *log;
 typedef struct tfs {
     struct filesystem fs;   /* must be first */
     rangemap storage;
+#ifdef KERNEL
     struct spinlock storage_lock;
+#endif
     int alignment_order;        /* in blocks */
     int page_order;
     u8 uuid[UUID_LEN];

--- a/src/hyperv/include/hyperv_internal.h
+++ b/src/hyperv/include/hyperv_internal.h
@@ -1,6 +1,8 @@
 #ifndef _HYPERV_INTERNAL_H_
 #define _HYPERV_INTERNAL_H_
 
+#include <errno.h>
+
 #include "ctassert.h"
 
 #define _KERNEL
@@ -50,14 +52,6 @@ typedef struct iovec {
     void *iov_base;
     u64 iov_len;
 } *iovec;
-
-#define EIO             5               /* Input/output error */
-#define ENXIO           6               /* Device not configured */
-#define EAGAIN          11              /* Resource deadlock avoided */
-#define ENODEV          19              /* Operation not supported by device */
-#define EINVAL          22              /* Invalid argument */
-#define EOPNOTSUPP      95              /* Operation not supported */
-#define ENOBUFS         105             /* No buffer space available */
 
 struct hypercall_ctx {
     void *hc_addr;

--- a/src/kernel/errno.h
+++ b/src/kernel/errno.h
@@ -1,0 +1,70 @@
+#ifndef _ERRNO_H_
+#define _ERRNO_H_
+
+#define EPERM           1       /* Operation not permitted */
+#define ENOENT          2       /* No such file or directory */
+#define ESRCH           3       /* No such process */
+#define EINTR           4       /* Interrupted system call */
+#define EIO             5       /* Input/output error */
+#define ENXIO           6       /* Device not configured */
+#define E2BIG           7       /* Argument list too long */
+#define ENOEXEC         8       /* Exec format error */
+#define EBADF           9       /* Bad file descriptor */
+#define ECHILD          10      /* No child processes */
+#define EAGAIN          11      /* Resource deadlock avoided */
+#define ENOMEM          12      /* Cannot allocate memory */
+#define EACCES          13      /* Permission denied */
+#define EFAULT          14      /* Bad address */
+#define EBUSY           16      /* Device busy */
+#define EEXIST          17      /* File exists */
+#define EXDEV           18      /* Cross-device link */
+#define ENODEV          19      /* Operation not supported by device */
+#define ENOTDIR         20      /* Not a directory */
+#define EISDIR          21      /* Is a directory */
+#define EINVAL          22      /* Invalid argument */
+#define ENFILE          23      /* Too many open files in system */
+#define EMFILE          24      /* Too many open files */
+#define ENOTTY          25      /* Inappropriate ioctl for device */
+#define EFBIG           27      /* File too large */
+#define ENOSPC          28      /* No space left on device */
+#define ESPIPE          29      /* Illegal seek */
+#define EROFS           30      /* Read-only filesystem */
+#define EMLINK          31      /* Too many links */
+#define EPIPE           32      /* Broken pipe */
+#define ERANGE          34      /* Math result not representable */
+#define ENAMETOOLONG    36      /* File name too long */
+#define ENOSYS          38      /* Invalid system call number */
+#define ENOTEMPTY       39      /* Directory not empty */
+#define ELOOP           40      /* Too many symbolic links */
+#define ENOPROTOOPT     42      /* Protocol not available */
+#define ENODATA         61      /* No data available */
+#define ETIME           62      /* Timer expired */
+#define EOVERFLOW       75      /* Value too large for defined data type */
+#define EBADFD          77      /* File descriptor in bad state */
+#define ENOTSOCK        88      /* Socket operation on non-socket */
+#define EDESTADDRREQ    89      /* Destination address required */
+#define EMSGSIZE        90      /* Message too long */
+#define EPROTOTYPE      91      /* Wrong protocol type for socket */
+#define EPROTONOSUPPORT 93      /* Protocol not supported */
+#define ESOCKTNOSUPPORT 94      /* Socket type not supported */
+#define EOPNOTSUPP      95      /* Operation not supported */
+#define EPFNOSUPPORT    96      /* Protocol family not supported */
+#define EAFNOSUPPORT    97      /* Address family not supported by protocol */
+#define EADDRINUSE      98      /* Address already in use */
+#define EADDRNOTAVAIL   99      /* Cannot assign requested address */
+#define ENETDOWN        100     /* Network is down */
+#define ENETUNREACH     101     /* Network is unreachable */
+#define ENETRESET       102     /* Network dropped connection because of reset */
+#define ECONNABORTED    103     /* Software caused connection abort */
+#define ECONNRESET      104     /* Connection reset by peer */
+#define ENOBUFS         105     /* No buffer space available */
+#define EISCONN         106     /* Transport endpoint is already connected */
+#define ENOTCONN        107     /* Transport endpoint is not connected */
+#define ETIMEDOUT       110     /* Connection timed out */
+#define ECONNREFUSED    111     /* Connection refused */
+#define EHOSTUNREACH    113     /* No route to host */
+#define EALREADY        114     /* Operation already in progress */
+#define EINPROGRESS     115     /* Operation now in progress */
+#define ECANCELED       125     /* Operation canceled */
+
+#endif

--- a/src/kernel/kernel.c
+++ b/src/kernel/kernel.c
@@ -1,3 +1,4 @@
+#include <errno.h>
 #include <kernel.h>
 #include <symtab.h>
 
@@ -315,6 +316,30 @@ void irq_put_target_cpu(u32 cpu_id)
 {
     cpuinfo ci = cpuinfo_from_id(cpu_id);
     ci->targeted_irqs--;
+}
+
+sstring string_from_errno(int errno)
+{
+    switch (errno) {
+    case ENOSPC:
+        return ss("no space");
+    case EIO:
+        return ss("I/O error");
+    case ENOENT:
+        return ss("no entry");
+    case EEXIST:
+        return ss("file exists");
+    case ENOTDIR:
+        return ss("not a directory");
+    case ENOMEM:
+        return ss("out of memory");
+    case ELOOP:
+        return ss("maximum link hops reached");
+    case EROFS:
+        return ss("filesystem read-only");
+    default:
+        return ss("unknown error");
+    }
 }
 
 #ifndef CONFIG_TRACELOG

--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -2,7 +2,9 @@
 
 #include <kernel.h>
 
+#ifdef KERNEL
 struct spinlock pt_lock;
+#endif
 
 //#define PAGE_INIT_DEBUG
 //#define PAGE_DEBUG

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -9,6 +9,7 @@
 
 #include <kernel.h>
 #include <dma.h>
+#include <errno.h>
 #include <pagecache.h>
 #include <pagecache_internal.h>
 #include <tfs.h>
@@ -573,7 +574,7 @@ closure_function(6, 1, void, pagecache_write_sg_finish,
         use_fault_handler(saved_ctx->fault_handler);
         if (!sg_fault_in(sg, q.end - (bound(pi) << page_order) - offset)) {
             s = timm("result", "invalid user memory");
-            s = timm_append(s, "fsstatus", "%d", FS_STATUS_FAULT);
+            s = timm_append(s, "fsstatus", "%d", -EFAULT);
             clear_fault_handler();
         }
     }
@@ -1379,7 +1380,7 @@ closure_function(4, 1, void, pagecache_read_sg_finish,
         /* Fault in memory now to avoid page faults while spinlocks are held. */
         if (!sg_fault_in(sg, range_span(q))) {
             s = timm("result", "invalid user memory");
-            s = timm_append(s, "fsstatus", "%d", FS_STATUS_FAULT);
+            s = timm_append(s, "fsstatus", "%d", -EFAULT);
         }
         struct pagecache_page k;
         int page_order = pc->page_order;
@@ -1431,7 +1432,7 @@ closure_function(1, 3, void, pagecache_read_sg,
                                       read_sg_finish);
     } else {
         status s = timm("result", "out of memory");
-        apply(completion, timm_append(s, "fsstatus", "%d", FS_STATUS_NOMEM));
+        apply(completion, timm_append(s, "fsstatus", "%d", -ENOMEM));
     }
 }
 

--- a/src/kernel/pagecache.h
+++ b/src/kernel/pagecache.h
@@ -38,7 +38,6 @@ sg_io pagecache_node_get_reader(pagecache_node pn);
 
 sg_io pagecache_node_get_writer(pagecache_node pn);
 
-#ifdef KERNEL
 void pagecache_node_add_shared_map(pagecache_node pn , range v /* bytes */, u64 node_offset);
 
 void pagecache_node_close_shared_pages(pagecache_node pn, range q /* bytes */, flush_entry fe);
@@ -55,9 +54,6 @@ void *pagecache_get_page_if_filled(pagecache_node pn, u64 node_offset);
 void pagecache_release_page(pagecache_node pn, u64 node_offset);
 
 void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node_offset);
-#endif
-
-
 
 pagecache_volume pagecache_allocate_volume(u64 length, int block_order);
 void pagecache_dealloc_volume(pagecache_volume pv);

--- a/src/kernel/storage.c
+++ b/src/kernel/storage.c
@@ -109,9 +109,9 @@ closure_function(2, 2, void, volume_link,
     volume v = bound(v);
     if (is_ok(s)) {
         inode mount_dir = bound(mount_dir);
-        fs_status fss = filesystem_mount(storage.root_fs, mount_dir, fs);
-        if (fss != FS_STATUS_OK) {
-            msg_err("cannot mount filesystem: %s\n", string_from_fs_status(fss));
+        int fss = filesystem_mount(storage.root_fs, mount_dir, fs);
+        if (fss != 0) {
+            msg_err("cannot mount filesystem: %s\n", string_from_errno(-fss));
         } else {
             v->fs = fs;
             v->mount_dir = mount_dir;
@@ -142,9 +142,9 @@ static void volume_mount(volume v, buffer mount_point)
     filesystem fs = storage.root_fs;
     tuple root = filesystem_getroot(storage.root_fs);
     tuple mount_dir_t;
-    fs_status fss = filesystem_get_node(&fs, fs->get_inode(fs, root), cmount_point,
+    int fss = filesystem_get_node(&fs, fs->get_inode(fs, root), cmount_point,
         false, false, false, false, &mount_dir_t, 0);
-    if (fss != FS_STATUS_OK) {
+    if (fss != 0) {
         msg_err("mount point %s not found\n", cmount_point);
         return;
     }

--- a/src/net/net_system_structs.h
+++ b/src/net/net_system_structs.h
@@ -1,22 +1,3 @@
-#define	ENOTSOCK	88	/* Socket operation on non-socket */
-#define	EPROTONOSUPPORT 93	/* Protocol not supported */
-#define	ESOCKTNOSUPPORT 94	/* Socket type not supported */
-#define	EPFNOSUPPORT	96	/* Protocol family not supported */
-#define	EAFNOSUPPORT	97	/* Address family not supported by protocol */
-#define	EADDRINUSE	98	/* Address already in use */
-#define	EADDRNOTAVAIL	99	/* Cannot assign requested address */
-#define	ENETDOWN	100	/* Network is down */
-#define	ENETUNREACH	101	/* Network is unreachable */
-#define	ENETRESET	102	/* Network dropped connection because of reset */
-#define	ECONNRESET	104
-#define	ENOBUFS		105	/* No buffer space available */
-#define	EISCONN		106	/* Transport endpoint is already connected */
-#define	ENOTCONN	107	/* Transport endpoint is not connected */
-#define	ETIMEDOUT	110	/* Connection timed out */
-#define	ECONNREFUSED	111	/* Connection refused */
-#define	EHOSTUNREACH	113	/* No route to host */
-
-
 enum protocol_type {
     SOCK_STREAM  = 1,    /* stream (connection) socket	*/
     SOCK_DGRAM   = 2,    /* datagram (conn.less) socket	*/

--- a/src/riscv64/kernel_machine.h
+++ b/src/riscv64/kernel_machine.h
@@ -138,9 +138,6 @@ static inline void wait_for_interrupt(void)
 #define cmdline_consume(o, h)   (void)(h)
 #define boot_params_apply(t)
 
-/* locking constructs */
-#include <mutex.h>
-
 /* device mmio region access */
 #define MK_MMIO_READ(BITS, ISUFFIX) \
     static inline u##BITS mmio_read_##BITS(u64 addr)                    \

--- a/src/runtime/buffer.c
+++ b/src/runtime/buffer.c
@@ -1,5 +1,8 @@
 #include <runtime.h>
+
+#ifdef KERNEL
 #include <log.h>
+#endif
 
 buffer allocate_buffer(heap h, bytes s)
 {
@@ -88,5 +91,7 @@ int buffer_strstr(buffer b, sstring str) {
 void buffer_print(buffer b)
 {
     console_write(buffer_ref(b, 0), buffer_length(b));
+#ifdef KERNEL
     klog_write(buffer_ref(b, 0), buffer_length(b));
+#endif
 }

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -86,8 +86,6 @@ void print_frame_trace_from_here();
 #define string_literal(s)           (char []){s}
 #define assert_string_literal(s)    (void)string_literal(s)
 
-#include <lock.h>
-
 void runtime_memcpy(void *a, const void *b, bytes len);
 
 void runtime_memset(u8 *a, u8 b, bytes len);

--- a/src/runtime/runtime_init.c
+++ b/src/runtime/runtime_init.c
@@ -1,5 +1,8 @@
 #include <runtime.h>
+
+#ifdef KERNEL
 #include <log.h>
+#endif
 
 void initialize_buffer();
 
@@ -154,7 +157,9 @@ void init_runtime(heap general, heap safe)
 void rput_sstring(sstring s)
 {
     console_write(s.ptr, s.len);
+#ifdef KERNEL
     klog_write(s.ptr, s.len);
+#endif
 }
 
 #define STACK_CHK_GUARD 0x595e9fbd94fda766

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -1,3 +1,7 @@
+#ifdef KERNEL
+#include <lock.h>
+#endif
+
 typedef struct timer *timer;
 
 /* On timer expiration, the registered timer handler will be invoked with the

--- a/src/runtime/tuple.h
+++ b/src/runtime/tuple.h
@@ -187,6 +187,14 @@ static inline boolean get_u64(value e, symbol a, u64 *result)
     return u64_from_value(v, result);
 }
 
+static inline boolean get_s64(value e, symbol a, s64 *result)
+{
+    value v = get(e, a);
+    if (!v)
+        return false;
+    return s64_from_value(v, result);
+}
+
 /* really just for parser output */
 static inline boolean is_null_string(value v)
 {

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -441,9 +441,9 @@ static void exec_elf_finish(buffer ex, fsfile f, process kp,
     register_root_notify(sym(trace), closure(heap_locked(kh), trace_notify, proc));
     string cwd = get_string(root, sym(cwd));
     if (cwd) {
-        fs_status fss = filesystem_chdir(proc, buffer_to_sstring(cwd));
-        if (fss != FS_STATUS_OK) {
-            s = timm("result", "unable to change cwd to \"%b\"; %s", cwd, string_from_fs_status(fss));
+        int fss = filesystem_chdir(proc, buffer_to_sstring(cwd));
+        if (fss != 0) {
+            s = timm("result", "unable to change cwd to \"%b\"; %s", cwd, string_from_errno(-fss));
             goto out;
         }
     }

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -22,7 +22,6 @@
     cwd; \
 })
 
-sysreturn sysreturn_from_fs_status(fs_status s);
 sysreturn sysreturn_from_fs_status_value(status s);
 
 /* Perform read-ahead following a userspace read request.
@@ -32,7 +31,7 @@ void file_readahead(file f, u64 offset, u64 len);
 
 sysreturn file_io_init_sg(file f, u64 offset, struct iovec *iov, int count, sg_list *sgp);
 
-fs_status filesystem_chdir(process p, sstring path);
+int filesystem_chdir(process p, sstring path);
 
 void filesystem_update_relatime(filesystem fs, tuple md);
 
@@ -57,7 +56,7 @@ void file_release(file f);
 
 fsfile fsfile_open(sstring file_path);
 fsfile fsfile_open_or_create(sstring file_path, boolean truncate);
-fs_status fsfile_truncate(fsfile f, u64 len);
+int fsfile_truncate(fsfile f, u64 len);
 
 sysreturn fsfile_add_seals(fsfile f, u64 seals);
 sysreturn fsfile_get_seals(fsfile f, u64 *seals);

--- a/src/unix/inotify.c
+++ b/src/unix/inotify.c
@@ -332,12 +332,10 @@ sysreturn inotify_add_watch(int fd, const char *pathname, u32 mask)
     process_get_cwd(current->p, &fs, &cwd);
     filesystem cwd_fs = fs;
     tuple n;
-    fs_status fss = filesystem_get_node(&fs, cwd, pathname_ss, (mask & IN_DONT_FOLLOW) != 0, false,
+    rv = filesystem_get_node(&fs, cwd, pathname_ss, (mask & IN_DONT_FOLLOW) != 0, false,
                                         false, false, &n, 0);
-    if (fss != FS_STATUS_OK) {
-        rv = sysreturn_from_fs_status(fss);
+    if (rv != 0)
         goto out;
-    }
     if ((mask & IN_ONLYDIR) && !is_dir(n)) {
         rv = -ENOTDIR;
         filesystem_put_node(fs, n);

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -1276,7 +1276,7 @@ static sysreturn mmap(void *addr, u64 length, int prot, int flags, int fd, u64 o
                 filesystem fs = fsf->fs;
                 if (fs->get_seals) {
                     u64 seals;
-                    if ((fs->get_seals(fs, fsf, &seals) == FS_STATUS_OK) &&
+                    if ((fs->get_seals(fs, fsf, &seals) == 0) &&
                         (seals & (F_SEAL_WRITE | F_SEAL_FUTURE_WRITE))) {
                         if (vmflags & VMAP_FLAG_WRITABLE) {
                             ret = -EPERM;

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -342,8 +342,8 @@ boolean create_special_file(sstring path, spec_file_open open, u64 size, u64 rde
     filesystem fs = get_root_fs();
     if (rdev)
         filesystem_set_rdev(fs, entry, rdev);
-    fs_status s = filesystem_mkentry(fs, 0, path, entry, false, true);
-    if (s == FS_STATUS_OK)
+    int s = filesystem_mkentry(fs, 0, path, entry, false, true);
+    if (s == 0)
         return true;
     deallocate_value(entry);
     return false;
@@ -356,13 +356,13 @@ void register_special_files(process p)
     tuple self_exe;
     heap h = heap_locked((kernel_heaps)p->uh);
 
-    fs_status fss = filesystem_get_node(&fs, p->cwd, self_exe_path, false, false, false, false,
+    int fss = filesystem_get_node(&fs, p->cwd, self_exe_path, false, false, false, false,
         &self_exe, 0);
-    if (fss == FS_STATUS_OK) {
+    if (fss == 0) {
         filesystem_put_node(fs, self_exe);
     } else {
         fss = filesystem_mkdirpath(p->root_fs, 0, ss("/proc/self"), true);
-        if ((fss == FS_STATUS_OK) || (fss == FS_STATUS_EXIST)) {
+        if ((fss == 0) || (fss == -EEXIST)) {
             value program = get(p->process_root, sym(program));
             assert(program);
             buffer b = allocate_buffer(h, buffer_length(program) + 1);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -1,6 +1,8 @@
 /* architecture-independent syscall types and definitions -
    arch-specific bits live in corresponding unix_machine.h */
 
+#include <errno.h>
+
 /* limits */
 #define S_IFMT   00170000
 #define S_IFSOCK 0140000
@@ -46,60 +48,6 @@ typedef struct iovec {
     void *iov_base;
     u64 iov_len;
 } *iovec;
-
-#define EPERM           1               /* Operation not permitted */
-#define ENOENT          2               /* No such file or directory */
-#define ESRCH           3               /* No such process */
-#define EINTR           4               /* Interrupted system call */
-#define EIO             5               /* Input/output error */
-#define ENXIO           6               /* Device not configured */
-#define E2BIG           7               /* Argument list too long */
-#define ENOEXEC         8               /* Exec format error */
-#define EBADF           9               /* Bad file descriptor */
-#define ECHILD          10              /* No child processes */
-#define EAGAIN          11              /* Resource deadlock avoided */
-#define ENOMEM          12              /* Cannot allocate memory */
-#define EACCES          13              /* Permission denied */
-#define EFAULT          14              /* Bad address */
-#define EBUSY           16              /* Device busy */
-#define EEXIST          17              /* File exists */
-#define EXDEV           18              /* Cross-device link */
-#define ENODEV          19              /* Operation not supported by device */
-#define ENOTDIR         20              /* Not a directory */
-#define EISDIR          21              /* Is a directory */
-#define EINVAL          22              /* Invalid argument */
-#define ENFILE          23              /* Too many open files in system */
-#define EMFILE          24              /* Too many open files */
-#define ENOTTY          25              /* Inappropriate ioctl for device */
-#define EFBIG           27              /* File too large */
-#define ENOSPC          28              /* No space left on device */
-#define ESPIPE          29              /* Illegal seek */
-#define EROFS           30              /* Read-only filesystem */
-#define EMLINK          31              /* Too many links */
-#define EPIPE           32              /* Broken pipe */
-#define ERANGE          34              /* Math result not representable */
-#define ENAMETOOLONG    36              /* File name too long */
-
-#define ENOSYS          38              /* Invalid system call number */
-#define ENOTEMPTY       39              /* Directory not empty */
-#define ELOOP           40              /* Too many symbolic links */
-#define ENOPROTOOPT     42              /* Protocol not available */
-
-#define ENODATA         61		/* No data available */
-#define ETIME           62		/* Timer expired */
-#define EOVERFLOW       75		/* Value too large for defined data type */
-#define EBADFD          77		/* File descriptor in bad state */
-#define EDESTADDRREQ    89		/* Destination address required */
-#define EMSGSIZE        90		/* Message too long */
-#define EPROTOTYPE      91		/* Wrong protocol type for socket */
-#define EOPNOTSUPP      95		/* Operation not supported */
-#define ECONNABORTED    103             /* Software caused connection abort */
-#define EISCONN         106
-#define ENOTCONN        107
-#define ETIMEDOUT       110             /* Connection timed out */
-#define EALREADY        114
-#define EINPROGRESS     115
-#define ECANCELED       125             /* Used for timer cancel on RTC shift */
 
 #define ERESTARTSYS     512
 #define ERESTARTNOHAND  514

--- a/src/unix_process/unix_process_runtime.c
+++ b/src/unix_process/unix_process_runtime.c
@@ -102,11 +102,6 @@ heap malloc_allocator()
     return h;
 }
 
-heap heap_dma(void)
-{
-    return malloc_heap;
-}
-
 void halt_with_code(u8 code, sstring format, ...)
 {
     buffer z = little_stack_buffer(500);
@@ -210,10 +205,6 @@ sstring errno_sstring(void)
 void console_write(const char *s, bytes count)
 {
     igr(write(1, s, count));
-}
-
-void klog_write(const char *s, bytes count)
-{
 }
 
 u64 physical_from_virtual(void *__x)

--- a/src/virtio/virtio_9p.h
+++ b/src/virtio/virtio_9p.h
@@ -1,24 +1,24 @@
 void *v9p_get_iobuf(void *priv, u64 size);
 void v9p_put_iobuf(void *priv, void *buf, u64 size);
 
-fs_status v9p_statfs(void *priv, u32 fid, struct p9_statfs_resp *resp);
-fs_status v9p_lopen(void *priv, u32 fid, u32 flags, u64 *qid, u32 *iounit);
-fs_status v9p_lcreate(void *priv, u32 fid, string name, u32 flags, u32 mode, u64 *qid, u32 *iounit);
-fs_status v9p_symlink(void *priv, u32 dfid, string name, string target, u64 *qid);
-fs_status v9p_mknod(void *priv, u32 dfid, string name, u32 mode, u32 major, u32 minor, u64 *qid);
-fs_status v9p_readlink(void *priv, u32 fid, buffer target);
-fs_status v9p_getattr(void *priv, u32 fid, u64 req_mask, struct p9_getattr_resp *resp);
-fs_status v9p_setattr(void *priv, u32 fid, u32 valid, u32 mode, u32 uid, u32 gid, u64 size,
+int v9p_statfs(void *priv, u32 fid, struct p9_statfs_resp *resp);
+int v9p_lopen(void *priv, u32 fid, u32 flags, u64 *qid, u32 *iounit);
+int v9p_lcreate(void *priv, u32 fid, string name, u32 flags, u32 mode, u64 *qid, u32 *iounit);
+int v9p_symlink(void *priv, u32 dfid, string name, string target, u64 *qid);
+int v9p_mknod(void *priv, u32 dfid, string name, u32 mode, u32 major, u32 minor, u64 *qid);
+int v9p_readlink(void *priv, u32 fid, buffer target);
+int v9p_getattr(void *priv, u32 fid, u64 req_mask, struct p9_getattr_resp *resp);
+int v9p_setattr(void *priv, u32 fid, u32 valid, u32 mode, u32 uid, u32 gid, u64 size,
                       timestamp atime, timestamp mtime);
-fs_status v9p_readdir(void *priv, u32 fid, u64 offset, void *buf, u32 count, u32 *ret_count);
-fs_status v9p_fsync(void *priv, u32 fid, u32 datasync);
-fs_status v9p_mkdir(void *priv, u32 dfid, string name, u32 mode, u64 *qid);
-fs_status v9p_renameat(void *priv, u32 old_dfid, string old_name, u32 new_dfid, string new_name);
-fs_status v9p_unlinkat(void *priv, u32 dfid, string name, u32 flags);
-fs_status v9p_version(void *priv, u32 msize, sstring version, u32 *ret_msize);
-fs_status v9p_attach(void *priv, u32 root_fid, u64 *root_qid);
-fs_status v9p_walk(void *priv, u32 fid, u32 newfid, string wname, struct p9_qid *qid);
-fs_status v9p_clunk(void *priv, u32 fid);
+int v9p_readdir(void *priv, u32 fid, u64 offset, void *buf, u32 count, u32 *ret_count);
+int v9p_fsync(void *priv, u32 fid, u32 datasync);
+int v9p_mkdir(void *priv, u32 dfid, string name, u32 mode, u64 *qid);
+int v9p_renameat(void *priv, u32 old_dfid, string old_name, u32 new_dfid, string new_name);
+int v9p_unlinkat(void *priv, u32 dfid, string name, u32 flags);
+int v9p_version(void *priv, u32 msize, sstring version, u32 *ret_msize);
+int v9p_attach(void *priv, u32 root_fid, u64 *root_qid);
+int v9p_walk(void *priv, u32 fid, u32 newfid, string wname, struct p9_qid *qid);
+int v9p_clunk(void *priv, u32 fid);
 
 void v9p_read(void *priv, u32 fid, u64 offset, u32 count, void *dest, status_handler complete);
 void v9p_write(void *priv, u32 fid, u64 offset, u32 count, void *src, status_handler complete);

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -166,9 +166,6 @@ void set_ist(struct cpuinfo_machine *cpu, int i, u64 sp);
 void install_gdt64_and_tss(void *tss_desc, void *tss, void *gdt, void *gdt_pointer);
 
 #ifdef KERNEL
-/* locking constructs */
-#include <mutex.h>
-
 void cmdline_consume(sstring opt_name, cmdline_handler h);
 void boot_params_apply(tuple t);
 #endif

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -335,7 +335,6 @@ CFLAGS+=	-O3 -DENABLE_MSG_DEBUG
 CFLAGS+=	-I$(ARCHDIR) \
 		-I$(SRCDIR) \
 		-I$(SRCDIR)/http \
-		-I$(SRCDIR)/kernel \
 		-I$(SRCDIR)/runtime \
 		-I$(SRCDIR)/unix \
 		-I$(SRCDIR)/unix_process

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -131,7 +131,6 @@ CFLAGS+=	-O3 \
 		-I$(ARCHDIR) \
 		-I$(SRCDIR) \
 		-I$(SRCDIR)/http \
-		-I$(SRCDIR)/kernel \
 		-I$(SRCDIR)/runtime \
 		-I$(SRCDIR)/unix_process \
 		-I$(SRCDIR)/unix \

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -39,7 +39,6 @@ SRCS-vdsogen=	$(CURDIR)/vdsogen.c
 CFLAGS+=-O3 \
 	-I$(ARCHDIR) \
 	-I$(SRCDIR) \
-	-I$(SRCDIR)/kernel \
 	-I$(SRCDIR)/runtime \
 	-I$(SRCDIR)/fs \
 	-I$(SRCDIR)/unix_process

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -7,12 +7,12 @@
 #include <sys/uio.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <kernel/log.h>
 #include <storage.h>
 #include <tfs.h>
 #include <errno.h>
 #include <string.h>
 #include <limits.h>
-#include <log.h>
 
 #define DUMP_OPT_TREE  (1U << 0)
 

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -14,7 +14,7 @@
 #include <errno.h>
 #include <limits.h>
 
-#include <region.h>
+#include <kernel/region.h>
 
 #define string_ends_with(str, substr) ({                \
     int slen = strlen(str);                             \


### PR DESCRIPTION
Having filesystem-specific error codes requires conversion between filesystem codes and POSIX standard codes every time a filesystem- related error is reported to userspace. For the 9P filesystem, in some cases a double conversion (from a standard code to a filesystem code and then back to a standard code) may need to be done.
This change removes the fs_status enum that declares the filesystem error codes, and uses standard POSIX codes to report filesystem errors; this allows eliminating the above conversions. Standard error codes are defined in the new kernel/errno.h header file; in order to prevent this file from being included from userspace code, the kernel directory is being removed from the include paths in the relevant Makefiles; this required some adjustments to other header files so that they can be included by both kernel and non- kernel code.
For the 9P filesystem, the p9_create() callback function is being modified so that EOPNOTSUPP is returned instead or EINVAL if the user program tries to open a file with the O_TMPFILE flag (#2051).