### PR TITLE
pagecache_read_sg_finish(): fix locking order inversion

### DIFF
--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1386,8 +1386,8 @@ closure_function(4, 1, void, pagecache_read_sg_finish,
         u64 page_size = U64_FROM_BIT(page_order);
         k.state_offset = q.start >> page_order;
         u64 offset = q.start & MASK(page_order);
-        pagecache_lock_state(pc);
         pagecache_lock_node(pn);
+        pagecache_lock_state(pc);
         pagecache_page pp = (pagecache_page)rbtree_lookup(&pn->pages, &k.rbnode);
         while (pp != INVALID_ADDRESS) {
             u32 copy_len = MIN(page_size - offset, range_span(q));
@@ -1403,8 +1403,8 @@ closure_function(4, 1, void, pagecache_read_sg_finish,
             pagecache_page_release_locked(pc, pp, false);
             pp = next;
         }
-        pagecache_unlock_node(pn);
         pagecache_unlock_state(pc);
+        pagecache_unlock_node(pn);
         if (ctx != user_ctx)
             clear_fault_handler();
     }


### PR DESCRIPTION
Throughout the page cache code, when both a cache node and the cache state need to be locked at the same time, the node must be locked first. The existing implementation of pagecache_read_sg_finish() is locking the cache state first, thereby creating a locking order inversion that can cause the kernel to deadlock in multi-vCPU instances, for example if multiple reads from the page cache are executed concurrently (the CI test failure at
https://app.circleci.com/pipelines/github/nanovms/nanos/4810/workflows/d6be64e2-18b7-4d4a-bb4c-8426ac35239c/jobs/16820 is caused by this).
Bug introduced in commit 8225e715.