### PR TITLE
TFS extent extension: fix handling of exhausted disk space

### DIFF
--- a/src/fs/tfs.c
+++ b/src/fs/tfs.c
@@ -651,8 +651,10 @@ static int extend(tfsfile f, extent ex, sg_list sg, range blocks, merge m, u64 *
     if (blocks.end > r.end) {
         range new = irangel(ex->start_block + ex->allocated, blocks.end - r.end);
         u64 limit = fs->fs.size >> fs->fs.blocksize_order;
-        if (new.end > limit)
+        if (new.end > limit) {
+            blocks.end -= new.end - limit;
             new.end = limit;
+        }
         if (range_span(new) && filesystem_reserve_storage(fs, new)) {
             int s = update_extent_allocated(f, ex, ex->allocated + range_span(new));
             if (s == 0) {


### PR DESCRIPTION
If there is not enough storage space to extend a TFS file extent to the requested size, the extent size should be adjusted to match the available space. The existing code is updating the extent size as if the storage space limit had not been reached; this can cause the TFS driver to issue disk I/O requests with invalid block ranges, which results in EIO syscall errors.