### PR TITLE
Runloop: fix check for unset CPU timer when running a user thread

### DIFF
--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -731,6 +731,9 @@ static inline void schedule_timer_service(void)
 {
     if (compare_and_swap_32(&kernel_timers->service_scheduled, false, true))
         async_apply_bh(kernel_timers->service);
+
+    /* This serves as an indication to the scheduler that the timer in this CPU is not armed. */
+    current_cpu()->last_timer_update = 0;
 }
 
 static inline boolean is_kernel_memory(void *a)

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -164,7 +164,6 @@ timerqueue allocate_timerqueue(heap h, clock_now now, sstring name)
 #ifdef KERNEL
     spin_lock_init(&tq->lock);
     tq->service_scheduled = tq->update = false;
-    tq->empty = true;
     tq->next_expiry = 0;
     tq->service = 0;
 #endif

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -45,7 +45,6 @@ typedef struct timerqueue {
 
     u32 service_scheduled;  /* CAS */
     u32 update;             /* CAS; timer re-programming needed */
-    boolean empty;          /* indicating the queue is empty */
     sstring name;
 } *timerqueue;
 
@@ -139,13 +138,11 @@ static inline void timer_get_remaining(timerqueue tq, timer t, timestamp *remain
 static inline void refresh_timer_update_locked(timerqueue tq, timer next)
 {
     if (next == INVALID_ADDRESS) {
-        tq->empty = true;
         return;
     }
     timestamp n = timerqueue_expiry(tq, next);
     if (n != tq->next_expiry)
         tq->next_expiry = n;
-    tq->empty = false;
     tq->update = true;
 }
 


### PR DESCRIPTION
Before running a user thread, if the local timer of the current CPU is not armed (because either the timer interrupt already fired since doing the last timer update, or the timer has never been armed), the `timeout` variable in the current code in runloop_internal() is negative, thus the `timeout > (s64)max_timeout` condition is always false; this results in the CPU timer not being armed and the user thread potentially running indefinitely. This issue causes the umcg runtime test to hang if run on an instance with more than 4 vCPUs.

This change fixes the above issue by using the `last_timer_update` field of the cpuinfo struct to check the timestamp at which the next timer interrupt will fire (with a 0 value in this field indicating that the timer is not armed). In addition, unnecessary updates of the CPU timer are avoided by removing the call to `set_platform_timer` from `update_timer` (because the timer may have to be re-configured before kernel_sleep() is finally called), and checking whether the current timer setting is different from the next timer timestamp before updating the timer setting. The `empty` field of struct timerqueue is being removed since it is no longer used.