### PR TITLE
Add support for compiling the kernel with clang for all architectures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run: sudo apt-get install nasm qemu-system-x86 ent ruby rustc fuse libfuse-dev
       - run: cd .. && git clone git@github.com:nanovms/ops.git
       - run: make
-      - run: make tfs-fuse
+      - run: make tools && make tfs-fuse
       - run: curl https://ops.city/get.sh -sSfL | sh
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           name: copy build artifacts
           command: |
             shopt -s extglob
-            mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/platform/pc/boot/bootx64.efi temp/ && mkdir temp/klibs && cp output/klib/bin/!(test|*.dbg) temp/klibs
+            mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/platform/pc/boot/bootx64.efi temp/ && mkdir temp/klibs && cp output/platform/pc/bin/!(test|*.dbg|kernel.*) temp/klibs
       - run: echo "export COMMIT_ID="`git rev-parse --short=7 HEAD` >> $BASH_ENV
       - run: cd temp && tar cvzf ../nanos-release-linux-${COMMIT_ID}.tar.gz *
       - run: gsutil cp nanos-release-linux-${COMMIT_ID}.tar.gz gs://nanos/release/${COMMIT_ID}/
@@ -85,7 +85,7 @@ jobs:
           name: copy build artifacts
           command: |
             shopt -s extglob
-            mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/platform/pc/boot/bootx64.efi temp/ && mkdir temp/klibs && cp output/klib/bin/!(test|*.dbg) temp/klibs
+            mkdir temp && cp output/platform/pc/bin/kernel.img temp/ && cp output/platform/pc/boot/boot.img temp/ && cp output/platform/pc/boot/bootx64.efi temp/ && mkdir temp/klibs && cp output/platform/pc/bin/!(test|*.dbg|kernel.*) temp/klibs
       - run: cd temp && tar cvzf nanos-nightly-linux.tar.gz * && gsutil cp nanos-nightly-linux.tar.gz gs://nanos/release/nightly
       - run: gsutil acl ch -u AllUsers:R gs://nanos/release/nightly/nanos-nightly-linux.tar.gz
       - run: rm -r temp
@@ -126,7 +126,7 @@ jobs:
           name: copy build artifacts
           command: |
             shopt -s extglob
-            mkdir temp && cp output/platform/virt/bin/kernel.img temp/ && cp output/platform/virt/boot/bootaa64.efi temp/ && mkdir temp/klibs && cp output/klib/bin/!(test|*.dbg) temp/klibs
+            mkdir temp && cp output/platform/virt/bin/kernel.img temp/ && cp output/platform/virt/boot/bootaa64.efi temp/ && mkdir temp/klibs && cp output/platform/virt/bin/!(test|*.dbg|kernel.*) temp/klibs
 
       - run: echo "export COMMIT_ID="`git rev-parse --short=7 HEAD` >> $BASH_ENV
       - run: cd temp && tar cvzf ../nanos-release-linux-${COMMIT_ID}-virt.tar.gz *
@@ -162,7 +162,7 @@ jobs:
           name: copy build artifacts
           command: |
             shopt -s extglob
-            mkdir temp && cp output/platform/virt/bin/kernel.img temp/ && cp output/platform/virt/boot/bootaa64.efi temp/ && mkdir temp/klibs && cp output/klib/bin/!(test|*.dbg) temp/klibs
+            mkdir temp && cp output/platform/virt/bin/kernel.img temp/ && cp output/platform/virt/boot/bootaa64.efi temp/ && mkdir temp/klibs && cp output/platform/virt/bin/!(test|*.dbg|kernel.*) temp/klibs
 
       - run: cd temp && tar cvzf nanos-nightly-linux-virt.tar.gz * && gsutil cp nanos-nightly-linux-virt.tar.gz gs://nanos/release/nightly
       - run: gsutil acl ch -u AllUsers:R gs://nanos/release/nightly/nanos-nightly-linux-virt.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: Build
+on:
+  push:
+    branches:
+      - 'feature/**'
+      - 'fix/**'
+  pull_request:
+jobs:
+  mac-build:
+    name: Mac Build
+    runs-on: macos-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+    - name: Install tools
+      run: brew install nasm x86_64-elf-binutils aarch64-elf-binutils
+    - name: x86 build
+      run: make -j`sysctl -n hw.ncpu` kernel PLATFORM=pc
+    - name: ARM build
+      run: make -j`sysctl -n hw.ncpu` kernel PLATFORM=virt

--- a/Makefile
+++ b/Makefile
@@ -57,18 +57,17 @@ $(ACPICA_DIR)/.vendored: GITFLAGS= --depth 1  https://github.com/acpica/acpica.g
 $(LWIPDIR)/.vendored: GITFLAGS= --depth 1  https://github.com/nanovms/lwip.git -b STABLE-2_1_x
 $(MBEDTLS_DIR)/.vendored: GITFLAGS= --depth 1 https://github.com/nanovms/mbedtls.git
 
-image: $(THIRD_PARTY) tools
-	$(Q) $(MAKE) -C klib
-	$(Q) $(MAKE) -C $(PLATFORMDIR) image TARGET=$(TARGET)
-
-release: $(THIRD_PARTY) tools
+kernel: $(THIRD_PARTY) contgen
 	$(Q) $(MAKE) -C $(PLATFORMDIR) boot
 	$(Q) $(MAKE) -C klib
 	$(Q) $(MAKE) -C $(PLATFORMDIR) kernel
+
+image: kernel
+	$(Q) $(MAKE) -C $(PLATFORMDIR) image TARGET=$(TARGET)
+
+release: kernel
 	$(Q) $(RM) -r release
 	$(Q) $(MKDIR) release
-	$(CP) $(MKFS) release
-	$(CP) $(DUMP) release
 	if [ -f $(BOOTIMG) ]; then $(CP) $(BOOTIMG) release; fi
 	if [ -f $(UEFI_LOADER) ]; then $(CP) $(UEFI_LOADER) release; fi
 	$(CP) $(KERNEL) release

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 include vars.mk
 
-SUBDIR=		$(PLATFORMDIR) klib test tools
+SUBDIR=		$(PLATFORMDIR) test tools
 
 # runtime tests / ready-to-use targets
 TARGET=		webg
 
 CLEANFILES+=	$(IMAGE)
-CLEANDIRS+=	$(OUTDIR)/image $(OUTDIR)/platform/$(PLATFORM) $(OUTDIR)/platform
+CLEANDIRS+=	$(OUTDIR)/image $(OUTDIR)/platform/$(PLATFORM)
 
 ACPICA_DIR=	$(VENDORDIR)/acpica
 LWIPDIR=	$(VENDORDIR)/lwip
@@ -59,7 +59,6 @@ $(MBEDTLS_DIR)/.vendored: GITFLAGS= --depth 1 https://github.com/nanovms/mbedtls
 
 kernel: $(THIRD_PARTY) contgen
 	$(Q) $(MAKE) -C $(PLATFORMDIR) boot
-	$(Q) $(MAKE) -C klib
 	$(Q) $(MAKE) -C $(PLATFORMDIR) kernel
 
 image: kernel
@@ -72,7 +71,7 @@ release: kernel
 	if [ -f $(UEFI_LOADER) ]; then $(CP) $(UEFI_LOADER) release; fi
 	$(CP) $(KERNEL) release
 	$(Q) $(MKDIR) release/klibs
-	bash -O extglob -c "$(CP) $(OUTDIR)/klib/bin/!(test) release/klibs"
+	bash -O extglob -c "$(CP) $(PLATFORMOBJDIR)/bin/!(test|*.dbg|kernel.*) release/klibs"
 	cd release && $(TAR) -czvf nanos-release-$(REL_OS)-${version}.tar.gz *
 
 target: contgen

--- a/README.md
+++ b/README.md
@@ -73,9 +73,12 @@ brew install nanovms/homebrew-qemu/qemu
 ```
 
 For ARM-based Macs (M1/M2):
+
 ```
-brew update && brew install go wget ent qemu aarch64-elf-gcc aarch64-elf-binutils
-# To build and link runtime tests or aarch64 linux user programs:
+brew update && brew install go wget ent qemu aarch64-elf-binutils
+```
+##### To build and link runtime tests or aarch64 linux user programs:
+```
 brew tap nanovms/homebrew-toolchains
 brew install aarch64-linux-binutils
 ```
@@ -84,12 +87,14 @@ Create a Chroot:
 (this isn't absolutely necessary)
 
 For Intel-based Macs:
+
 ```
 mkdir target-root && cd target-root && wget
 https://storage.googleapis.com/testmisc/target-root.tar.gz && tar xzf target-root.tar.gz
 ```
 
 For ARM-based Macs (M1/M2):
+
 ```
 mkdir target-root && cd target-root && wget
 https://storage.googleapis.com/testmisc/arm64-target-root-new.tar.gz && tar xzf arm64-target-root-new.tar.gz

--- a/README.md
+++ b/README.md
@@ -127,7 +127,19 @@ If you wish to use FUSE you'll also want to install
 sudo apt-get install libfuse-dev fuse
 ```
 
-#### To build:
+#### To build the kernel (in addition to the bootloaders and klibs):
+```
+make kernel
+```
+
+#### To run an example program from the test/runtime folder:
+With hardware acceleration:
+
+```
+make run
+```
+Without hardware acceleration:
+
 ```
 make run-noaccel
 ```

--- a/kernel.mk
+++ b/kernel.mk
@@ -1,0 +1,174 @@
+CFLAGS+=$(KERNCFLAGS) -DKERNEL -O3
+CFLAGS+=-Wno-address # lwIP build sadness
+CFLAGS+=$(INCLUDES)
+
+ifneq (,$(findstring ftrace,$(TRACE)))
+CFLAGS+= -DCONFIG_FTRACE -pg
+SRCS-kernel.elf+= \
+	$(SRCDIR)/unix/ftrace.c \
+	$(ARCHDIR)/ftrace.s
+endif
+
+ifneq (,$(findstring tracelog,$(TRACE)))
+CFLAGS+= -DCONFIG_TRACELOG
+SRCS-kernel.elf+= \
+	$(SRCDIR)/kernel/tracelog.c
+ifneq ($(TRACELOG_FILE),)
+TRACELOG_MKFS_OPTS="-t (tracelog:(file:$(TRACELOG_FILE)))"
+endif
+endif
+
+ifneq (,$(findstring lockstats,$(TRACE)))
+CFLAGS+= -DLOCK_STATS
+SRCS-kernel.elf+= \
+	$(SRCDIR)/kernel/lockstats.c
+endif
+
+ifeq ($(MANAGEMENT),telnet)
+CFLAGS+= -DMANAGEMENT_TELNET
+SRCS-kernel.elf+= \
+	$(SRCDIR)/kernel/management_telnet.c
+endif
+
+ifneq ($(NOSMP),)
+CFLAGS+=	-DSPIN_LOCK_DEBUG_NOSMP
+else
+CFLAGS+=	-DSMP_ENABLE
+endif
+
+VDSOGEN=	$(TOOLDIR)/vdsogen
+VDSO_SRCDIR=    $(SRCDIR)/kernel
+VDSO_OBJDIR=    $(OBJDIR)/vdso
+VDSO_SRCS=      $(VDSO_SRCDIR)/vdso.c $(VDSO_SRCDIR)/vdso-now.c
+VDSO_OBJS=      $(patsubst $(VDSO_SRCDIR)/%.c,$(VDSO_OBJDIR)/%.o,$(VDSO_SRCS))
+VDSO_CFLAGS=    $(TARGET_CFLAGS) -DKERNEL -DBUILD_VDSO -I$(INCLUDES) -I$(OBJDIR) -I$(OUTDIR) -I$(SRCDIR) -fPIC -c
+VDSO_LDFLAGS=   -nostdlib -fPIC -shared --build-id=none --hash-style=both --eh-frame-hdr -T$(ARCHDIR)/vdso.lds
+VDSO_DEPS=      $(patsubst %.o,%.d,$(VDSO_OBJS))
+
+LDFLAGS+=	$(KERNLDFLAGS) --undefined=_start -T linker_script
+
+STRIPFLAGS=	-g
+
+msg_vdsogen=    VDSOGEN	$@
+cmd_vdsogen=    $(VDSOGEN) $(VDSO_OBJDIR)/vdso.so $@
+
+msg_vdso_cc=    CC	$@
+cmd_vdso_cc=    $(CC) $(DEPFLAGS) $(VDSO_CFLAGS) -c $< -o $@
+
+msg_vdso_ld=    LD	$@
+cmd_vdso_ld=    $(LD) $(VDSO_LDFLAGS) $(VDSO_OBJS) -o $@
+
+msg_objcopy=	OBJCOPY	$@
+cmd_objcopy=	$(OBJCOPY) $(OBJCOPYFLAGS) $(OBJCOPYFLAGS_$(@F)) $< $@
+
+msg_objdump=	OBJDUMP	$@
+cmd_objdump=	$(OBJDUMP) $(OBJDUMPFLAGS) $(OBJDUMPFLAGS_$(@F)) $< $< >$@
+
+msg_sed=	SED	$@
+cmd_sed=	$(SED) -e 's/\#/%/' <$^ >$@
+
+msg_version=	VERSION	$@
+cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "\#include <runtime.h>\nconst sstring gitversion = ss_static_init(\"$(shell $(GIT) rev-parse HEAD)\");" >$@
+
+include ../../klib/klib.mk
+
+include ../../rules.mk
+
+.PHONY: mkfs vdsogen boot kernel kernel.dis target image
+
+mkfs vdsogen:
+	$(Q) $(MAKE) -C $(ROOTDIR)/tools $@
+
+target:
+ifeq ($(TARGET),)
+	@echo TARGET variable not specified
+	@false
+endif
+	$(Q) $(MAKE) -C $(ROOTDIR)/test/runtime $(TARGET)
+
+ifneq ($(NANOS_TARGET_ROOT),)
+TARGET_ROOT_OPT=	-r $(NANOS_TARGET_ROOT)
+endif
+
+$(OBJDIR)/gitversion.c: $(ROOTDIR)/.git/index $(ROOTDIR)/.git/HEAD
+	$(call cmd,version)
+
+$(VDSOGEN):
+	@$(MAKE) -C $(ROOTDIR)/tools vdsogen
+
+$(VDSO_OBJDIR)/%.o: $(VDSO_SRCDIR)/%.c
+	@$(MKDIR) $(dir $@)
+	$(call cmd,vdso_cc)
+
+$(VDSO_OBJDIR)/vdso.so: $(VDSO_OBJS)
+	$(call cmd,vdso_ld)
+
+$(VDSO_OBJDIR)/vdso-image.c: $(VDSOGEN) $(VDSO_OBJDIR)/vdso.so
+	$(call cmd,vdsogen)
+
+$(PROG-kernel.elf): linker_script klib-syms $(VDSO_OBJDIR)/vdso-image.c
+
+$(KERNEL): $(PROG-kernel.elf)
+	$(call cmd,strip)
+
+$(OBJDIR)/kernel.dis: $(KERNEL)
+	$(call cmd,objdump)
+
+msg_klib_cc=    $(msg_cc)
+cmd_klib_cc=    $(CC) $(DEPFLAGS) $(KLIB_CFLAGS) -c $< -o $@
+
+msg_klib_ld=    $(msg_ld)
+cmd_klib_ld=    $(LD) $(KLIB_LDFLAGS) $^ -o $@
+
+msg_add_syms=	KLIB_SYMS	$@
+cmd_add_syms=	$(foreach prog, $(KLIB_BINARIES), $(call add_syms,$(prog)))
+
+define build_klib
+
+PROG-$1=	$(OBJDIR)/bin/$1
+OBJS-$1=	$$(foreach s,$$(filter %.c %.s %.S,$$(SRCS-$1)),$$(call objfile,.o,$$s))
+OBJDIRS-$1=	$$(sort $$(dir $$(OBJS-$1)))
+DEPS-$1=	$$(patsubst %.o,%.d,$$(OBJS-$1))
+
+$1: $$(PROG-$1)
+
+ifneq ($$(OBJS-$1),)
+$$(PROG-$1).dbg: $$(OBJS-$1)
+	@$(MKDIR) $$(dir $$@)
+	$$(call cmd,klib_ld)
+$$(PROG-$1): $$(PROG-$1).dbg
+	$$(call cmd,strip)
+endif
+
+DEPFILES+=		$$(DEPS-$1)
+CLEANFILES+=	$$(PROG-$1) $$(PROG-$1).dbg $$(OBJS-$1) $$(DEPS-$1) $$(GENHEADERS-$1)
+CLEANDIRS+=		$$(OBJDIRS-$1)
+
+endef
+
+# append list of undefined symbols to linker script
+define add_syms
+
+	$(Q) $(OBJDUMP) -R $1 | $(SED) -n -E 's/.*(GLOB_DAT|JUMP_SLOT|RISCV_64)[[:space:]]*/EXTERN(/p' | $(SED) -n 's/$$/)/p' >> $(KLIB_SYMS)
+
+endef
+
+$(foreach klib, $(KLIBS), $(eval $(call build_klib,$(klib))))
+
+klib-syms: $(KLIB_SYMS)
+
+$(KLIB_SYMS): $(KLIB_BINARIES)
+	$(Q) $(RM) $(KLIB_SYMS)
+	$(call cmd,add_syms)
+# remove duplicated lines in linker script
+	$(Q) $(SED) -i.bak -n 'G; s/\n/&&/; /^\([^\n]*\n\).*\n\1/d; s/\n//; h; P' $(KLIB_SYMS)
+# delete linker script backup file
+	$(Q) $(RM) $(KLIB_SYMS).bak
+
+$(OBJDIR)/klib/%.o: $(KLIB_DIR)/%.c $(GENHEADERS)
+	@$(MKDIR) $(dir $@)
+	$(call cmd,klib_cc)
+
+$(OBJDIR)/vendor/mbedtls/%.o: $(MBEDTLS_DIR)/%.c $(GENHEADERS)
+	@$(MKDIR) $(dir $@)
+	$(call cmd,klib_cc)

--- a/klib/Makefile
+++ b/klib/Makefile
@@ -222,10 +222,6 @@ $(KLIB_SYMS): $(PROGRAM_BINARIES)
 # delete linker script backup file
 	$(Q) $(RM) $(KLIB_SYMS).bak
 
-ifeq ($(findstring clang,$(COMPILER_VERSION)),clang)
-ELF_TARGET=     -target $(ARCH)-elf
-CFLAGS+=        $(ELF_TARGET)
-endif
 LD=             $(CROSS_COMPILE)ld
 
 INCLUDES= \

--- a/klib/pledge.c
+++ b/klib/pledge.c
@@ -135,7 +135,7 @@ static sysreturn pledge(const char *promises, const char *execpromises)
     sstring promises_ss;
     if (!fault_in_user_string(promises, &promises_ss))
         return -EFAULT;
-    heap h = heap_locked(&get_unix_heaps()->kh);
+    heap h = heap_locked(get_kernel_heaps());
     u64 new_abilities = 0;
     vector prom = split(h, alloca_wrap_sstring(promises_ss), ' ');
     string pr;

--- a/klib/strace.c
+++ b/klib/strace.c
@@ -150,7 +150,6 @@ static struct {
         strace_syscall_init(io_uring_enter, STRACE_SC_F_SET_DESC),
         strace_syscall_init(io_uring_register, STRACE_SC_F_SET_DESC),
         strace_syscall_init(getcpu, 0),
-        strace_syscall_init(futex, 0),
         strace_syscall_init(set_robust_list, 0),
         strace_syscall_init(get_robust_list, 0),
         strace_syscall_init(clone, STRACE_SC_F_SET_PROC),

--- a/klib/test/klib.c
+++ b/klib/test/klib.c
@@ -1,5 +1,4 @@
-#include <klib.h>
-#include <runtime.h>
+#include <kernel.h>
 
 #define Z_LEN 1024
 

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -310,15 +310,7 @@ endif
 	@ $(MKDIR) $(dir $(IMAGE))
 	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) -t "(debug_exit:t)" $(TRACELOG_MKFS_OPTS) $(EXTRA_MKFS_OPTS) $(IMAGE)
 
-release: mkfs boot kernel
-	$(Q) $(RM) -r release
-	$(Q) $(MKDIR) release
-	$(CP) $(MKFS) release
-	$(CP) $(BOOTIMG) release
-	$(CP) $(KERNEL) release
-	cd release && $(TAR) -czvf nanos-release-$(REL_OS)-${version}.tar.gz *
-
-.PHONY: mkfs vdsogen boot kernel kernel.dis target image release
+.PHONY: mkfs vdsogen boot kernel kernel.dis target image
 
 $(VDSOGEN):
 	@$(MAKE) -C $(ROOTDIR)/tools vdsogen

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -187,88 +187,22 @@ INCLUDES=\
 
 AFLAGS+=-I$(ARCHDIR)/
 
-CFLAGS+=$(KERNCFLAGS) -DKERNEL -O3
-CFLAGS+=-Wno-address # lwIP build sadness
 CFLAGS+=-DCONFIG_LTRACE
 CFLAGS+=-DDMA_BUFFERING	# required by memory encryption
-CFLAGS+=$(INCLUDES)
 
-# Enable tracing by specifying TRACE=ftrace on command line
-ifneq (,$(findstring ftrace,$(TRACE)))
-CFLAGS+= -DCONFIG_FTRACE -pg
-SRCS-kernel.elf+= \
-	$(SRCDIR)/unix/ftrace.c \
-	$(ARCHDIR)/ftrace.s
-endif
-
-ifneq (,$(findstring tracelog,$(TRACE)))
-CFLAGS+= -DCONFIG_TRACELOG
-SRCS-kernel.elf+= \
-	$(SRCDIR)/kernel/tracelog.c
-ifneq ($(TRACELOG_FILE),)
-TRACELOG_MKFS_OPTS="-t (tracelog:(file:$(TRACELOG_FILE)))"
-endif
-endif
-
-ifneq (,$(findstring lockstats,$(TRACE)))
-CFLAGS+= -DLOCK_STATS
-SRCS-kernel.elf+= \
-	$(SRCDIR)/kernel/lockstats.c
-endif
-
-ifeq ($(MANAGEMENT),telnet)
-CFLAGS+= -DMANAGEMENT_TELNET
-SRCS-kernel.elf+= \
-	$(SRCDIR)/kernel/management_telnet.c
-endif
-
-ifneq ($(NOSMP),)
-CFLAGS+=	-DSPIN_LOCK_DEBUG_NOSMP
-else
-CFLAGS+=	-DSMP_ENABLE
-endif
-#CFLAGS+=	-DLWIPDIR_DEBUG -DEPOLL_DEBUG -DNETSYSCALL_DEBUG -DKERNEL_DEBUG
 AFLAGS+=	-felf64 -I$(OBJDIR)/
-LDFLAGS+=	$(KERNLDFLAGS) --undefined=_start -T linker_script
 
-VDSOGEN=	$(TOOLDIR)/vdsogen
-VDSO_SRCDIR=    $(SRCDIR)/kernel
-VDSO_OBJDIR=    $(OBJDIR)/vdso
-VDSO_SRCS=      $(VDSO_SRCDIR)/vdso.c $(VDSO_SRCDIR)/vdso-now.c
-VDSO_OBJS=      $(patsubst $(VDSO_SRCDIR)/%.c,$(VDSO_OBJDIR)/%.o,$(VDSO_SRCS))
-VDSO_CFLAGS=    $(TARGET_CFLAGS) -DKERNEL -DBUILD_VDSO -I$(INCLUDES) -I$(OBJDIR) -I$(OUTDIR) -I$(SRCDIR) -fPIC -c
-VDSO_LDFLAGS=   -nostdlib -fPIC -shared --build-id=none --hash-style=both --eh-frame-hdr -T$(ARCHDIR)/vdso.lds
-VDSO_DEPS=      $(patsubst %.o,%.d,$(VDSO_OBJS))
 OBJDUMPFLAGS=	-d -S -M intel-mnemonic
-STRIPFLAGS=	-g
 
 DEPFILES+=      $(VDSO_DEPS)
 CLEANFILES+=    $(foreach f,gitversion.c frame.inc kernel.dis kernel.elf src/unix/ftrace.* $(ARCHDIR)/ftrace.*,$(OBJDIR)/$f) $(VDSO_OBJDIR)/vdso.so $(VDSO_OBJDIR)/vdso-image.c $(VDSO_OBJS) $(VDSO_DEPS) $(KERNEL)
-CLEANDIRS+=     $(foreach d,output/platform output src src/aws src/hyperv vdso/src/$(ARCH) vdso/src vdso vendor vendor/lwip vendor/lwip/src vendor/lwip/src/netif vendor/lwip/src/netif/ppp vendor/acpica vendor/acpica/source vendor/acpica/source/components platform,$(OBJDIR)/$d)
-
-msg_vdsogen=    VDSOGEN	$@
-cmd_vdsogen=    $(VDSOGEN) $(VDSO_OBJDIR)/vdso.so $@
-
-msg_vdso_cc=    CC	$@
-cmd_vdso_cc=    $(CC) $(DEPFLAGS) $(VDSO_CFLAGS) -c $< -o $@
-
-msg_vdso_ld=    LD	$@
-cmd_vdso_ld=    $(LD) $(VDSO_LDFLAGS) $(VDSO_OBJS) -o $@ 
-
-msg_objdump=	OBJDUMP	$@
-cmd_objdump=	$(OBJDUMP) $(OBJDUMPFLAGS) $(OBJDUMPFLAGS_$(@F)) $< $< >$@
-
-msg_sed=	SED	$@
-cmd_sed=	$(SED) -e 's/\#/%/' <$^ >$@
-
-msg_version=	VERSION	$@
-cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "\#include <runtime.h>\nconst sstring gitversion = ss_static_init(\"$(shell $(GIT) rev-parse HEAD)\");" >$@
-
-include ../../rules.mk
+CLEANDIRS+=     $(foreach d,output/platform output src/aws src/hyperv vdso/src/$(ARCH) vdso/src vdso vendor vendor/lwip vendor/lwip/src vendor/lwip/src/netif vendor/lwip/src/netif/ppp vendor/acpica vendor/acpica/source vendor/acpica/source/components platform,$(OBJDIR)/$d)
 
 MKFS=		$(TOOLDIR)/mkfs
 BOOTIMG=	$(OBJDIR)/boot/boot.img
 KERNEL=		$(OBJDIR)/bin/kernel.img
+
+include ../../kernel.mk
 
 ifneq ($(ARCH),x86_64)
 $(error The pc platform only supports the x86_64 architecture.)
@@ -276,26 +210,12 @@ endif
 
 all: kernel.dis boot
 
-mkfs vdsogen:
-	$(Q) $(MAKE) -C $(ROOTDIR)/tools $@
-
 boot:
 	$(Q) $(MAKE) -C boot
 
 kernel: $(KERNEL)
 
 kernel.dis: $(KERNEL) $(OBJDIR)/kernel.dis
-
-target:
-ifeq ($(TARGET),)
-	@echo TARGET variable not specified
-	@false
-endif
-	$(Q) $(MAKE) -C $(ROOTDIR)/test/runtime $(TARGET)
-
-ifneq ($(NANOS_TARGET_ROOT),)
-TARGET_ROOT_OPT=	-r $(NANOS_TARGET_ROOT)
-endif
 
 ifneq ($(ENABLE_UEFI),)
 MKFS_UEFI=	-u $(OBJDIR)/boot/bootx64.efi
@@ -308,33 +228,9 @@ ifeq ($(IMAGE),)
 endif
 	@ echo "MKFS	$@"
 	@ $(MKDIR) $(dir $(IMAGE))
-	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) -t "(debug_exit:t)" $(TRACELOG_MKFS_OPTS) $(EXTRA_MKFS_OPTS) $(IMAGE)
-
-.PHONY: mkfs vdsogen boot kernel kernel.dis target image
-
-$(VDSOGEN):
-	@$(MAKE) -C $(ROOTDIR)/tools vdsogen
-
-$(OBJDIR)/kernel.dis: $(PROG-kernel.elf)
-	$(call cmd,objdump)
-
-$(VDSO_OBJDIR)/%.o: $(VDSO_SRCDIR)/%.c
-	@$(MKDIR) $(dir $@)
-	$(call cmd,vdso_cc)
-
-$(VDSO_OBJDIR)/vdso.so: $(VDSO_OBJS)
-	$(call cmd,vdso_ld)
-
-$(VDSO_OBJDIR)/vdso-image.c: $(VDSOGEN) $(VDSO_OBJDIR)/vdso.so
-	$(call cmd,vdsogen)
-
-$(PROG-kernel.elf): linker_script $(OUTDIR)/klib/klib-syms.lds $(VDSO_OBJDIR)/vdso-image.c
-
-$(KERNEL): $(PROG-kernel.elf)
-	$(call cmd,strip)
-
-$(OBJDIR)/gitversion.c: $(ROOTDIR)/.git/index $(ROOTDIR)/.git/HEAD
-	$(call cmd,version)
+	$(Q) cd $(ROOTDIR); \
+		$(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}/ARCH_DIR/{gsub("ARCH_DIR","$(PLATFORMOBJDIR)")}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | \
+		$(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) -t "(debug_exit:t)" $(TRACELOG_MKFS_OPTS) $(EXTRA_MKFS_OPTS) $(IMAGE)
 
 $(OBJDIR)/src/$(ARCH)/crt0.o: $(OBJDIR)/frame.inc
 

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -236,7 +236,7 @@ VDSO_SRCDIR=    $(SRCDIR)/kernel
 VDSO_OBJDIR=    $(OBJDIR)/vdso
 VDSO_SRCS=      $(VDSO_SRCDIR)/vdso.c $(VDSO_SRCDIR)/vdso-now.c
 VDSO_OBJS=      $(patsubst $(VDSO_SRCDIR)/%.c,$(VDSO_OBJDIR)/%.o,$(VDSO_SRCS))
-VDSO_CFLAGS=    -DKERNEL -DBUILD_VDSO -I$(INCLUDES) -I$(OBJDIR) -I$(OUTDIR) -I$(SRCDIR) -fPIC -c
+VDSO_CFLAGS=    $(TARGET_CFLAGS) -DKERNEL -DBUILD_VDSO -I$(INCLUDES) -I$(OBJDIR) -I$(OUTDIR) -I$(SRCDIR) -fPIC -c
 VDSO_LDFLAGS=   -nostdlib -fPIC -shared --build-id=none --hash-style=both --eh-frame-hdr -T$(ARCHDIR)/vdso.lds
 VDSO_DEPS=      $(patsubst %.o,%.d,$(VDSO_OBJS))
 OBJDUMPFLAGS=	-d -S -M intel-mnemonic
@@ -350,9 +350,6 @@ $(OBJDIR)/frame.inc: $(ARCHDIR)/frame.h
 	$(call cmd,sed)
 
 ifeq ($(UNAME_s),Darwin)
-ELF_TARGET=     -target x86_64-elf
-CFLAGS+=        $(ELF_TARGET)
-VDSO_CFLAGS+=   $(ELF_TARGET)
 VDSO_LDFLAGS+=  -undefined dynamic_lookup
 LD=             x86_64-elf-ld
 OBJDUMP=        x86_64-elf-objdump

--- a/platform/pc/Makefile
+++ b/platform/pc/Makefile
@@ -343,20 +343,16 @@ $(OBJDIR)/frame.inc: $(ARCHDIR)/frame.h
 
 ifeq ($(UNAME_s),Darwin)
 VDSO_LDFLAGS+=  -undefined dynamic_lookup
-LD=             x86_64-elf-ld
-OBJDUMP=        x86_64-elf-objdump
-STRIP=          x86_64-elf-strip
 REL_OS=		darwin
 # disable rdtscp as a workaround on mac since it can't pass the instruction through
 # see https://bugs.launchpad.net/qemu/+bug/1894836
 QEMU_ACCEL=	-accel $(ACCEL) -cpu host,-rdtscp
 ACCEL?=		hvf
 else
-# XXX already defined?
-LD=             $(CROSS_COMPILE)ld
 REL_OS=		linux
 QEMU_ACCEL=	-enable-kvm -cpu host
 endif
+LD=             $(CROSS_COMPILE)ld
 
 ##############################################################################
 # run

--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -91,7 +91,7 @@ DEPS-uefi= $(patsubst %.o,%.d,$(OBJS-uefi))
 AFLAGS-uefi= -felf64
 CFLAGS-uefi= \
 	-Wall -Werror -fpic -fshort-wchar -mno-red-zone -mno-avx -O3 -std=gnu11 \
-	-ffreestanding \
+	$(TARGET_CFLAGS) -ffreestanding \
 	-I$(SRCDIR) -I$(SRCDIR)/boot -I$(SRCDIR)/kernel -I$(SRCDIR)/runtime \
 	-I$(SRCDIR)/fs -I$(SRCDIR)/x86_64 -I$(OBJDIR) \
 	-DBOOT -DUEFI -DEFIAPI="__attribute__((ms_abi))"
@@ -136,7 +136,6 @@ $(PROG-stage2.elf): linker_script
 
 ifeq ($(UNAME_s),Darwin)
 CFLAGS+=	-target i386-elf
-CFLAGS-uefi+=	-target x86_64-elf
 LD=		x86_64-elf-ld
 STRIP=		x86_64-elf-strip
 OBJCOPY=	/usr/local/opt/binutils/bin/objcopy

--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -106,7 +106,7 @@ all: boot
 include ../../../rules.mk
 
 CLEANFILES+=	$(foreach f,boot.img stage1 stage1.lst stage2.pad stage2.bin stage2.strip uefi.so bootx64.efi,$(OBJDIR)/$f) $(OBJS-uefi) $(DEPS-uefi)
-CLEANDIRS+=     $(OBJDIR)/platform/pc $(OBJDIR)/platform $(OBJDIRS-uefi)
+CLEANDIRS+=     $(OBJDIR)/platform/pc $(OBJDIR)/platform $(OBJDIR) $(OBJDIRS-uefi)
 
 .PHONY: boot
 

--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -136,15 +136,12 @@ $(PROG-stage2.elf): linker_script
 
 ifeq ($(UNAME_s),Darwin)
 CFLAGS+=	-target i386-elf
-LD=		x86_64-elf-ld
-STRIP=		x86_64-elf-strip
-OBJCOPY=	/usr/local/opt/binutils/bin/objcopy
 SIZE_CMD=	stat -f %z
 else
-LD=		$(CROSS_COMPILE)ld
 CFLAGS+=	-m32
 SIZE_CMD=	stat -c %s
 endif
+LD=		$(CROSS_COMPILE)ld
 CFLAGS-uefi+=	$(if $(filter gcc, $(CC)), -maccumulate-outgoing-args)
 
 msg_uefi_as=    AS	$@

--- a/platform/riscv-virt/Makefile
+++ b/platform/riscv-virt/Makefile
@@ -150,85 +150,18 @@ INCLUDES=\
 	-I$(OUTDIR)
 
 AFLAGS+=-I$(ARCHDIR) -march=rv64gc -mabi=lp64d
-
-CFLAGS+=$(KERNCFLAGS) -DKERNEL -O3
-CFLAGS+=-Wno-address # lwIP build sadness
-CFLAGS+=$(INCLUDES)
-
-# Enable tracing by specifying TRACE=ftrace on command line
-ifeq ($(TRACE),ftrace)
-CFLAGS+= -DCONFIG_FTRACE -pg
-SRCS-kernel.elf+= \
-	$(SRCDIR)/unix/ftrace.c \
-	$(ARCHDIR)/ftrace.s
-endif
-
-ifeq ($(TRACE),tracelog)
-CFLAGS+= -DCONFIG_TRACELOG
-SRCS-kernel.elf+= \
-	$(SRCDIR)/kernel/tracelog.c
-ifneq ($(TRACELOG_FILE),)
-TRACELOG_MKFS_OPTS="-t (tracelog:(file:$(TRACELOG_FILE)))"
-endif
-endif
-
-ifeq ($(MANAGEMENT),telnet)
-CFLAGS+= -DMANAGEMENT_TELNET
-SRCS-kernel.elf+= \
-	$(SRCDIR)/kernel/management_telnet.c
-endif
-
-ifneq ($(NOSMP),)
-CFLAGS+=	-DSPIN_LOCK_DEBUG_NOSMP
-else
-CFLAGS+=	-DSMP_ENABLE
-endif
-#CFLAGS+=	-DLWIPDIR_DEBUG -DEPOLL_DEBUG -DNETSYSCALL_DEBUG -DKERNEL_DEBUG
 AFLAGS+=	-I$(OBJDIR)/
-LDFLAGS+=	$(KERNLDFLAGS) --undefined=_start -T linker_script
 
-VDSOGEN=	$(TOOLDIR)/vdsogen
-VDSO_SRCDIR=    $(SRCDIR)/kernel
-VDSO_OBJDIR=    $(OBJDIR)/vdso
-VDSO_SRCS=      $(VDSO_SRCDIR)/vdso.c $(VDSO_SRCDIR)/vdso-now.c
-VDSO_OBJS=      $(patsubst $(VDSO_SRCDIR)/%.c,$(VDSO_OBJDIR)/%.o,$(VDSO_SRCS))
-VDSO_CFLAGS=    $(TARGET_CFLAGS) -DKERNEL -DBUILD_VDSO -I$(INCLUDES) -I$(OBJDIR) -I$(SRCDIR) -fPIC -c
-VDSO_LDFLAGS=   -nostdlib -fPIC -shared --build-id=none --hash-style=both --eh-frame-hdr -T$(ARCHDIR)/vdso.lds
-VDSO_DEPS=      $(patsubst %.o,%.d,$(VDSO_OBJS))
 OBJDUMPFLAGS=	-d -S
-STRIPFLAGS=	-g
 
 DEPFILES+=      $(VDSO_DEPS)
 CLEANFILES+=    $(foreach f,gitversion.c frame.inc kernel.dis bin/kernel.elf src/unix/ftrace.* $(ARCHDIR)/ftrace.*,$(OBJDIR)/$f) $(VDSO_OBJDIR)/vdso.so $(VDSO_OBJDIR)/vdso-image.c $(VDSO_OBJDIR)/vdso-offset.h $(VDSO_OBJS) $(VDSO_DEPS) $(BOOTIMG) $(KERNEL)
-CLEANDIRS+=     $(foreach d,output/platform output src vdso/src/$(ARCH) vdso/src vdso vendor vendor/lwip vendor/lwip/src vendor/lwip/src/netif vendor/lwip/src/netif/ppp platform,$(OBJDIR)/$d)
+CLEANDIRS+=     $(foreach d,output/platform output vdso/src/$(ARCH) vdso/src vdso vendor vendor/lwip vendor/lwip/src vendor/lwip/src/netif vendor/lwip/src/netif/ppp platform,$(OBJDIR)/$d)
 
 OBJCOPYFLAGS	= -S -O binary
 
-msg_vdsogen=    VDSOGEN	$@
-cmd_vdsogen=    $(VDSOGEN) $(VDSO_OBJDIR)/vdso.so $@
-
-msg_vdso_cc=    CC	$@
-cmd_vdso_cc=    $(CC) $(DEPFLAGS) $(VDSO_CFLAGS) -c $< -o $@
-
-msg_vdso_ld=    LD	$@
-cmd_vdso_ld=    $(LD) $(VDSO_LDFLAGS) $(VDSO_OBJS) -o $@ 
-
-msg_objdump=	OBJDUMP	$@
-cmd_objdump=	$(OBJDUMP) $(OBJDUMPFLAGS) $(OBJDUMPFLAGS_$(@F)) $< $< >$@
-
-msg_objcopy=	OBJCOPY	$@
-cmd_objcopy=	$(OBJCOPY) $(OBJCOPYFLAGS) $(OBJCOPYFLAGS_$(@F)) $< $@
-
-msg_sed=	SED	$@
-cmd_sed=	$(SED) -e 's/\#/%/' <$^ >$@
-
-msg_version=	VERSION	$@
-cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "\#include <runtime.h>\nconst sstring gitversion = ss_static_init(\"$(shell $(GIT) rev-parse HEAD)\");" >$@
-
 msg_xxd_r=	XXD_R	$@
 cmd_xxd_r=	$(XXD) -r $< $@
-
-include ../../rules.mk
 
 # check riscv64 gcc version for 9.3.0, lowest known working version (from Ubuntu 20)
 GCCRAWVER= $(shell $(CC) -dumpfullversion -dumpversion)
@@ -242,29 +175,17 @@ MKFS=		$(TOOLDIR)/mkfs
 BOOTIMG=	$(OBJDIR)/boot-stub.img
 KERNEL=		$(OBJDIR)/bin/kernel.img
 
+include ../../kernel.mk
+
 ifneq ($(ARCH),riscv64)
 $(error The riscv platform only supports the riscv64 architecture.)
 endif
 
 all: $(KERNEL)
 
-mkfs vdsogen:
-	$(Q) $(MAKE) -C $(ROOTDIR)/tools $@
-
 kernel: $(KERNEL) kernel.dis
 
 kernel.dis: $(KERNEL) $(OBJDIR)/kernel.dis
-
-target:
-ifeq ($(TARGET),)
-	@echo TARGET variable not specified
-	@false
-endif
-	$(Q) $(MAKE) -C $(ROOTDIR)/test/runtime $(TARGET)
-
-ifneq ($(NANOS_TARGET_ROOT),)
-TARGET_ROOT_OPT=	-r $(NANOS_TARGET_ROOT)
-endif
 
 image: mkfs kernel target $(BOOTIMG)
 ifeq ($(IMAGE),)
@@ -273,38 +194,14 @@ ifeq ($(IMAGE),)
 endif
 	@ echo "MKFS	$@"
 	@ $(MKDIR) $(dir $(IMAGE))
-	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) -k $(KERNEL) $(TRACELOG_MKFS_OPTS) $(IMAGE)
-
-.PHONY: mkfs vdsogen boot kernel target image
-
-$(VDSOGEN):
-	@$(MAKE) -C $(ROOTDIR)/tools vdsogen
-
-$(OBJDIR)/kernel.dis: $(KERNEL)
-	$(call cmd,objdump)
-
-$(VDSO_OBJDIR)/%.o: $(VDSO_SRCDIR)/%.c
-	@$(MKDIR) $(dir $@)
-	$(call cmd,vdso_cc)
-
-$(VDSO_OBJDIR)/vdso.so: $(VDSO_OBJS)
-	$(call cmd,vdso_ld)
-
-$(VDSO_OBJDIR)/vdso-image.c: $(VDSOGEN) $(VDSO_OBJDIR)/vdso.so
-	$(call cmd,vdsogen)
+	$(Q) cd $(ROOTDIR); \
+		$(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}/ARCH_DIR/{gsub("ARCH_DIR","$(PLATFORMOBJDIR)")}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | \
+		$(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) -k $(KERNEL) $(TRACELOG_MKFS_OPTS) $(IMAGE)
 
 $(VDSO_OBJDIR)/vdso-offset.h: $(VDSO_OBJDIR)/vdso.so
 	$(Q) $(OBJDUMP) -t $(VDSO_OBJDIR)/vdso.so | grep __vdso_rt_sigreturn | sed "s/^\([[:xdigit:]]*\) .*/#define VDSO_OFFSET_RT_SIGRETURN 0x\1/" > $@
 
 $(OBJDIR)/src/$(ARCH)/unix_machine.o: $(VDSO_OBJDIR)/vdso-offset.h
-
-$(PROG-kernel.elf): linker_script $(OUTDIR)/klib/klib-syms.lds $(VDSO_OBJDIR)/vdso-image.c
-
-$(KERNEL): $(PROG-kernel.elf)
-	$(call cmd,strip)
-
-$(OBJDIR)/gitversion.c: $(ROOTDIR)/.git/index $(ROOTDIR)/.git/HEAD
-	$(call cmd,version)
 
 $(BOOTIMG): mbr.hex
 	$(call cmd,xxd_r)

--- a/platform/riscv-virt/Makefile
+++ b/platform/riscv-virt/Makefile
@@ -275,14 +275,7 @@ endif
 	@ $(MKDIR) $(dir $(IMAGE))
 	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) -k $(KERNEL) $(TRACELOG_MKFS_OPTS) $(IMAGE)
 
-release: mkfs kernel
-	$(Q) $(RM) -r release
-	$(Q) $(MKDIR) release
-	$(CP) $(MKFS) release
-	$(CP) $(KERNEL) release
-	cd release && $(TAR) -czvf nanos-release-$(REL_OS)-${version}.tar.gz *
-
-.PHONY: mkfs vdsogen kernel target image release
+.PHONY: mkfs vdsogen boot kernel target image
 
 $(VDSOGEN):
 	@$(MAKE) -C $(ROOTDIR)/tools vdsogen

--- a/platform/riscv-virt/Makefile
+++ b/platform/riscv-virt/Makefile
@@ -192,7 +192,7 @@ VDSO_SRCDIR=    $(SRCDIR)/kernel
 VDSO_OBJDIR=    $(OBJDIR)/vdso
 VDSO_SRCS=      $(VDSO_SRCDIR)/vdso.c $(VDSO_SRCDIR)/vdso-now.c
 VDSO_OBJS=      $(patsubst $(VDSO_SRCDIR)/%.c,$(VDSO_OBJDIR)/%.o,$(VDSO_SRCS))
-VDSO_CFLAGS=    -DKERNEL -DBUILD_VDSO -I$(INCLUDES) -I$(OBJDIR) -I$(SRCDIR) -fPIC -c
+VDSO_CFLAGS=    $(TARGET_CFLAGS) -DKERNEL -DBUILD_VDSO -I$(INCLUDES) -I$(OBJDIR) -I$(SRCDIR) -fPIC -c
 VDSO_LDFLAGS=   -nostdlib -fPIC -shared --build-id=none --hash-style=both --eh-frame-hdr -T$(ARCHDIR)/vdso.lds
 VDSO_DEPS=      $(patsubst %.o,%.d,$(VDSO_OBJS))
 OBJDUMPFLAGS=	-d -S

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -339,14 +339,7 @@ endif
 	@ $(MKDIR) $(dir $(IMAGE))
 	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) $(TRACELOG_MKFS_OPTS) -t "(debug_exit:t)" $(IMAGE)
 
-release: mkfs kernel
-	$(Q) $(RM) -r release
-	$(Q) $(MKDIR) release
-	$(CP) $(MKFS) release
-	$(CP) $(KERNEL) release
-	cd release && $(TAR) -czvf nanos-release-$(REL_OS)-${version}.tar.gz *
-
-.PHONY: mkfs vdsogen kernel kernel.dis target image release
+.PHONY: mkfs vdsogen kernel kernel.dis target image
 
 $(VDSOGEN):
 	@$(MAKE) -C $(ROOTDIR)/tools vdsogen

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -176,48 +176,11 @@ INCLUDES=\
 
 AFLAGS+=-I$(ARCHDIR)
 
-CFLAGS+=$(KERNCFLAGS) -DKERNEL -DSMP_ENABLE -O3
-CFLAGS+=-Wno-address # lwIP build sadness
 CFLAGS+=-DCONFIG_LTRACE
-CFLAGS+=$(INCLUDES)
 
-# Enable tracing by specifying TRACE=ftrace on command line
-ifeq ($(TRACE),ftrace)
-CFLAGS+= -DCONFIG_FTRACE -pg
-SRCS-kernel.elf+= \
-	$(SRCDIR)/unix/ftrace.c \
-	$(ARCHDIR)/ftrace.s
-endif
-
-ifeq ($(TRACE),tracelog)
-CFLAGS+= -DCONFIG_TRACELOG
-SRCS-kernel.elf+= \
-	$(SRCDIR)/kernel/tracelog.c
-ifneq ($(TRACELOG_FILE),)
-TRACELOG_MKFS_OPTS="-t (tracelog:(file:$(TRACELOG_FILE)))"
-endif
-endif
-
-ifeq ($(MANAGEMENT),telnet)
-CFLAGS+= -DMANAGEMENT_TELNET
-SRCS-kernel.elf+= \
-	$(SRCDIR)/kernel/management_telnet.c
-endif
-
-#CFLAGS+=	-DLWIPDIR_DEBUG -DEPOLL_DEBUG -DNETSYSCALL_DEBUG -DKERNEL_DEBUG
 AFLAGS+=	-I$(OBJDIR)/
-LDFLAGS+=	$(KERNLDFLAGS) --undefined=_start -T linker_script
 
-VDSOGEN=	$(TOOLDIR)/vdsogen
-VDSO_SRCDIR=    $(SRCDIR)/kernel
-VDSO_OBJDIR=    $(OBJDIR)/vdso
-VDSO_SRCS=      $(VDSO_SRCDIR)/vdso.c $(VDSO_SRCDIR)/vdso-now.c
-VDSO_OBJS=      $(patsubst $(VDSO_SRCDIR)/%.c,$(VDSO_OBJDIR)/%.o,$(VDSO_SRCS))
-VDSO_CFLAGS=    $(TARGET_CFLAGS) -DKERNEL -DBUILD_VDSO -I$(INCLUDES) -I$(OBJDIR) -I$(SRCDIR) -fPIC -c
-VDSO_LDFLAGS=   -nostdlib -fPIC -shared --build-id=none --hash-style=both --eh-frame-hdr -T$(ARCHDIR)/vdso.lds
-VDSO_DEPS=      $(patsubst %.o,%.d,$(VDSO_OBJS))
 OBJDUMPFLAGS=	-d -S
-STRIPFLAGS=	-g
 
 BOOT_OBJDIR=    $(OBJDIR)/boot
 
@@ -256,30 +219,9 @@ UEFI_LDFLAGS=   -z noexecstack -nostdlib -shared -Bsymbolic -T $(SRCDIR)/aarch64
 
 DEPFILES+=      $(VDSO_DEPS) $(UEFI_DEPS)
 CLEANFILES+=    $(foreach f,gitversion.c frame.inc kernel.dis bin/kernel.elf boot/uefi.so src/unix/ftrace.* $(ARCHDIR)/ftrace.*,$(OBJDIR)/$f) $(VDSO_OBJDIR)/vdso.so $(VDSO_OBJDIR)/vdso-image.c $(VDSO_OBJDIR)/vdso-offset.h $(VDSO_OBJS) $(VDSO_DEPS) $(UEFI_OBJS) $(UEFI_DEPS) $(UEFI_LOADER) $(BOOTIMG) $(KERNEL)
-CLEANDIRS+=     $(foreach d,output/platform output src src/aws vdso/src/$(ARCH) vdso/src vdso vendor vendor/lwip vendor/lwip/src vendor/lwip/src/netif vendor/lwip/src/netif/ppp vendor/acpica vendor/acpica/source vendor/acpica/source/components platform,$(OBJDIR)/$d) $(BOOT_OBJDIR) $(UEFI_OBJDIRS)
+CLEANDIRS+=     $(foreach d,output/platform output src/aws src/hyperv vdso/src/$(ARCH) vdso/src vdso vendor vendor/lwip vendor/lwip/src vendor/lwip/src/netif vendor/lwip/src/netif/ppp vendor/acpica vendor/acpica/source vendor/acpica/source/components platform,$(OBJDIR)/$d) $(BOOT_OBJDIR) $(UEFI_OBJDIRS)
 
 OBJCOPYFLAGS	= -S -O binary
-
-msg_vdsogen=    VDSOGEN	$@
-cmd_vdsogen=    $(VDSOGEN) $(VDSO_OBJDIR)/vdso.so $@
-
-msg_vdso_cc=    CC	$@
-cmd_vdso_cc=    $(CC) $(DEPFLAGS) $(VDSO_CFLAGS) -c $< -o $@
-
-msg_vdso_ld=    LD	$@
-cmd_vdso_ld=    $(LD) $(VDSO_LDFLAGS) $(VDSO_OBJS) -o $@ 
-
-msg_objdump=	OBJDUMP	$@
-cmd_objdump=	$(OBJDUMP) $(OBJDUMPFLAGS) $(OBJDUMPFLAGS_$(@F)) $< $< >$@
-
-msg_objcopy=	OBJCOPY	$@
-cmd_objcopy=	$(OBJCOPY) $(OBJCOPYFLAGS) $(OBJCOPYFLAGS_$(@F)) $< $@
-
-msg_sed=	SED	$@
-cmd_sed=	$(SED) -e 's/\#/%/' <$^ >$@
-
-msg_version=	VERSION	$@
-cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "\#include <runtime.h>\nconst sstring gitversion = ss_static_init(\"$(shell $(GIT) rev-parse HEAD)\");" >$@
 
 msg_xxd_r=	XXD_R	$@
 cmd_xxd_r=	$(XXD) -r $< $@
@@ -293,12 +235,12 @@ cmd_uefi_ld=    $(LD) $(UEFI_LDFLAGS) $(UEFI_OBJS) -o $@
 msg_uefi_objcopy=    $(msg_objcopy)
 cmd_uefi_objcopy=    $(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .dynsym  -j .rel -j .rela -j .rel.* -j .rela.* -j .reloc -O binary --subsystem=10 $< $@
 
-include ../../rules.mk
-
 MKFS=		$(TOOLDIR)/mkfs
 BOOTIMG=	$(OBJDIR)/boot-stub.img
 UEFI_LOADER=$(OBJDIR)/boot/bootaa64.efi
 KERNEL=		$(OBJDIR)/bin/kernel.img
+
+include ../../kernel.mk
 
 ifneq ($(ARCH),aarch64)
 $(error The virt platform only supports the aarch64 architecture.)
@@ -306,25 +248,11 @@ endif
 
 all: $(KERNEL) kernel.dis
 
-mkfs vdsogen:
-	$(Q) $(MAKE) -C $(ROOTDIR)/tools $@
-
 boot: $(UEFI_LOADER)
 
 kernel: $(KERNEL)
 
 kernel.dis: $(KERNEL) $(OBJDIR)/kernel.dis
-
-target:
-ifeq ($(TARGET),)
-	@echo TARGET variable not specified
-	@false
-endif
-	$(Q) $(MAKE) -C $(ROOTDIR)/test/runtime $(TARGET)
-
-ifneq ($(NANOS_TARGET_ROOT),)
-TARGET_ROOT_OPT=	-r $(NANOS_TARGET_ROOT)
-endif
 
 ifneq ($(ENABLE_UEFI),)
 MKFS_UEFI=	-u $(UEFI_LOADER)
@@ -337,38 +265,14 @@ ifeq ($(IMAGE),)
 endif
 	@ echo "MKFS	$@"
 	@ $(MKDIR) $(dir $(IMAGE))
-	$(Q) cd $(ROOTDIR); $(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | $(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) $(TRACELOG_MKFS_OPTS) -t "(debug_exit:t)" $(IMAGE)
-
-.PHONY: mkfs vdsogen kernel kernel.dis target image
-
-$(VDSOGEN):
-	@$(MAKE) -C $(ROOTDIR)/tools vdsogen
-
-$(OBJDIR)/kernel.dis: $(KERNEL)
-	$(call cmd,objdump)
-
-$(VDSO_OBJDIR)/%.o: $(VDSO_SRCDIR)/%.c
-	@$(MKDIR) $(dir $@)
-	$(call cmd,vdso_cc)
-
-$(VDSO_OBJDIR)/vdso.so: $(VDSO_OBJS)
-	$(call cmd,vdso_ld)
-
-$(VDSO_OBJDIR)/vdso-image.c: $(VDSOGEN) $(VDSO_OBJDIR)/vdso.so
-	$(call cmd,vdsogen)
+	$(Q) cd $(ROOTDIR); \
+		$(AWK) 'BEGIN{getline l < "$(PLATFORMDIR)/test-libs"}/TEST-LIBS/{gsub("TEST-LIBS",l)}/ARCH_DIR/{gsub("ARCH_DIR","$(PLATFORMOBJDIR)")}1' $(ROOTDIR)/test/runtime/$(TARGET).manifest | \
+		$(MKFS) $(TARGET_ROOT_OPT) -b $(BOOTIMG) $(MKFS_UEFI) -k $(KERNEL) $(TRACELOG_MKFS_OPTS) -t "(debug_exit:t)" $(IMAGE)
 
 $(VDSO_OBJDIR)/vdso-offset.h: $(VDSO_OBJDIR)/vdso.so
 	$(Q) $(OBJDUMP) -t $(VDSO_OBJDIR)/vdso.so | grep __vdso_rt_sigreturn | sed "s/^\([[:xdigit:]]*\) .*/#define VDSO_OFFSET_RT_SIGRETURN 0x\1/" > $@
 
 $(OBJDIR)/src/$(ARCH)/unix_machine.o: $(VDSO_OBJDIR)/vdso-offset.h
-
-$(PROG-kernel.elf): linker_script $(OUTDIR)/klib/klib-syms.lds $(VDSO_OBJDIR)/vdso-image.c
-
-$(KERNEL): $(PROG-kernel.elf)
-	$(call cmd,strip)
-
-$(OBJDIR)/gitversion.c: $(ROOTDIR)/.git/index $(ROOTDIR)/.git/HEAD
-	$(call cmd,version)
 
 $(BOOTIMG): mbr.hex
 	$(call cmd,xxd_r)

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -213,7 +213,7 @@ VDSO_SRCDIR=    $(SRCDIR)/kernel
 VDSO_OBJDIR=    $(OBJDIR)/vdso
 VDSO_SRCS=      $(VDSO_SRCDIR)/vdso.c $(VDSO_SRCDIR)/vdso-now.c
 VDSO_OBJS=      $(patsubst $(VDSO_SRCDIR)/%.c,$(VDSO_OBJDIR)/%.o,$(VDSO_SRCS))
-VDSO_CFLAGS=    -DKERNEL -DBUILD_VDSO -I$(INCLUDES) -I$(OBJDIR) -I$(SRCDIR) -fPIC -c
+VDSO_CFLAGS=    $(TARGET_CFLAGS) -DKERNEL -DBUILD_VDSO -I$(INCLUDES) -I$(OBJDIR) -I$(SRCDIR) -fPIC -c
 VDSO_LDFLAGS=   -nostdlib -fPIC -shared --build-id=none --hash-style=both --eh-frame-hdr -T$(ARCHDIR)/vdso.lds
 VDSO_DEPS=      $(patsubst %.o,%.d,$(VDSO_OBJS))
 OBJDUMPFLAGS=	-d -S
@@ -248,7 +248,7 @@ UEFI_OBJS=      $(patsubst $(SRCDIR)/%.c,$(UEFI_OBJDIR)/%.o,$(UEFI_SRCS)) \
 	$(UEFI_OBJDIR)/aarch64/uefi-crt0.o
 UEFI_OBJDIRS=	$(sort $(dir $(UEFI_OBJS))) $(UEFI_OBJDIR)
 UEFI_DEPS=      $(patsubst %.o,%.d,$(UEFI_OBJS))
-UEFI_CFLAGS=    -Wall -Werror -fpic -fshort-wchar -O3 -std=gnu11 \
+UEFI_CFLAGS=    $(TARGET_CFLAGS) -Wall -Werror -fpic -fshort-wchar -O3 -std=gnu11 \
 	-ffreestanding -DBOOT -DUEFI $(call cc-option, -mno-outline-atomics, "") \
 	-I$(SRCDIR) -I$(SRCDIR)/aarch64 -I$(SRCDIR)/boot -I$(SRCDIR)/kernel \
 	-I$(SRCDIR)/runtime -I$(SRCDIR)/fs -I$(PLATFORMDIR) -I$(OBJDIR)

--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -375,7 +375,7 @@ $(BOOTIMG): mbr.hex
 
 $(UEFI_OBJDIR)/aarch64/uefi-crt0.o:	$(SRCDIR)/aarch64/uefi-crt0.s
 	@$(MKDIR) $(dir $@)
-	$(call cmd,uefi_cc)
+	$(call cmd,as)
 
 $(UEFI_OBJDIR)/%.o: $(SRCDIR)/%.c $(GENHEADERS)
 	@$(MKDIR) $(dir $@)

--- a/rules.mk
+++ b/rules.mk
@@ -103,7 +103,11 @@ ifeq ($(ARCH),riscv64)
 KERNCFLAGS+=	-march=rv64gc -mabi=lp64d
 endif
 
-KERNCFLAGS+=	-fno-omit-frame-pointer
+ifeq ($(findstring clang,$(COMPILER_VERSION)),clang)
+TARGET_CFLAGS=	-target $(ARCH)-elf
+endif
+
+KERNCFLAGS+=	$(TARGET_CFLAGS) -fno-omit-frame-pointer
 KERNLDFLAGS=	--gc-sections -z notext -z noexecstack -z max-page-size=4096 -L $(OUTDIR)/klib -pie --no-dynamic-linker
 
 ifneq ($(UBSAN),)

--- a/rules.mk
+++ b/rules.mk
@@ -30,11 +30,7 @@ ASDEPFLAGS=
 endif
 
 ifeq ($(UNAME_s),Darwin)
-ifeq ($(ARCH),aarch64)
-CC=		$(CROSS_COMPILE)gcc
-else
 CC=		cc
-endif
 else
 CC=		$(CROSS_COMPILE)gcc
 endif

--- a/rules.mk
+++ b/rules.mk
@@ -104,7 +104,7 @@ TARGET_CFLAGS=	-target $(ARCH)-elf
 endif
 
 KERNCFLAGS+=	$(TARGET_CFLAGS) -fno-omit-frame-pointer
-KERNLDFLAGS=	--gc-sections -z notext -z noexecstack -z max-page-size=4096 -L $(OUTDIR)/klib -pie --no-dynamic-linker
+KERNLDFLAGS=	--gc-sections -z notext -z noexecstack -z max-page-size=4096 -L $(OBJDIR) -pie --no-dynamic-linker
 
 ifneq ($(UBSAN),)
 KERNCFLAGS+= -fsanitize=undefined -fno-sanitize=alignment,null -fsanitize-undefined-trap-on-error
@@ -260,7 +260,7 @@ pre-clean:
 do-clean: pre-clean
 	$(foreach d,$(SUBDIR),$(call execute_command,$(Q) $(MAKE) -C $d clean))
 	$(Q) $(RM) $(CLEANFILES)
-	$(Q) $(RM) -d $(call reverse,$(sort $(CLEANDIRS))) $(OBJDIR)
+	$(Q) $(RM) -d $(call reverse,$(sort $(CLEANDIRS)))
 
 post-clean: do-clean
 

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -181,14 +181,14 @@ static inline void disable_interrupts(void)
 
 static inline u64 irq_enable_save(void)
 {
-    register u32 daif;
+    register u64 daif;
     asm volatile("mrs %0, daif; msr daifclr, #2" : "=r"(daif));
     return daif;
 }
 
 static inline u64 irq_disable_save(void)
 {
-    register u32 daif;
+    register u64 daif;
     asm volatile("mrs %0, daif; msr daifset, #2" : "=r"(daif));
     return daif;
 }
@@ -235,9 +235,9 @@ MK_MMIO_WRITE(64, "", "x");
 
 /* special register access */
 #define read_psr(reg) ({ register u64 r; asm volatile("mrs %0, " #reg : "=r"(r)); r;})
-#define write_psr(reg, v) do { asm volatile("msr " #reg ", %0" : : "r"(v)); } while (0)
+#define write_psr(reg, v) do { asm volatile("msr " #reg ", %0" : : "r"((u64)(v))); } while (0)
 #define read_psr_s(rstr) ({ register u64 r; asm volatile("mrs %0, " rstr : "=r"(r)); r;})
-#define write_psr_s(rstr, v) do { asm volatile("msr " rstr ", %0" : : "r"(v)); } while (0)
+#define write_psr_s(rstr, v) do { asm volatile("msr " rstr ", %0" : : "r"((u64)(v))); } while (0)
 
 struct cpuinfo_machine {
     /*** Fields accessed by low-level entry points. ***/

--- a/src/kernel/pci.c
+++ b/src/kernel/pci.c
@@ -277,7 +277,9 @@ void pci_probe_device(pci_dev dev)
             spin_unlock(&pci_lock);
             return;
         }
-        *new_dev = *dev;
+        new_dev->bus = dev->bus;
+        new_dev->slot = dev->slot;
+        new_dev->function = dev->function;
         new_dev->driver = 0;
         pci_parse_iomem(new_dev, true);
         vector_push(devices, new_dev);

--- a/src/kernel/vdso.c
+++ b/src/kernel/vdso.c
@@ -134,11 +134,12 @@ time(time_t * t)
 }
 
 #ifdef __aarch64__
-sysreturn __vdso_rt_sigreturn(void)
+sysreturn __attribute__((noreturn)) __vdso_rt_sigreturn(void)
 {
     /* these two instructions cannot change - libgcc and others look
        for these when unwinding signal handlers */
     asm volatile ("mov x8, #139; svc #0"); // SYS_rt_sigreturn
+    while (1);
 }
 #endif
 #ifdef __riscv

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1313,7 +1313,7 @@ static int allocate_sock(process p, int af, int type, u32 flags, boolean alloc_f
         goto err_sock;
     }
 
-    heap h = heap_locked((kernel_heaps)p->uh);
+    heap h = heap_locked(get_kernel_heaps());
     if (socket_init(h, af, type, flags, &s->sock) < 0)
         goto err_sock_init;
     s->sock.f.read = init_closure_func(&s->read, file_io, socket_read);
@@ -2721,7 +2721,7 @@ boolean netsyscall_init(unix_heaps uh, tuple cfg)
         so_rcvbuf = MIN(MAX(rcvbuf, 256), MASK(sizeof(so_rcvbuf) * 8 - 1));
     else
         so_rcvbuf = DEFAULT_SO_RCVBUF;
-    kernel_heaps kh = (kernel_heaps)uh;
+    kernel_heaps kh = get_kernel_heaps();
     heap h = heap_locked(kh);
     caching_heap socket_cache = allocate_objcache(h, (heap)heap_page_backed(kh),
                                                   sizeof(struct netsock), PAGESIZE, true);

--- a/src/riscv64/crt0.S
+++ b/src/riscv64/crt0.S
@@ -1,7 +1,7 @@
 #define __ASSEMBLY__
 #include <frame.h>
 #include <kernel_machine.h>
-#define U64_FROM_BIT(x) (1ull<<(x))
+#define U64_FROM_BIT(x) (1ULL<<(x))
 
 .macro global_func name
         .global \name
@@ -110,8 +110,9 @@ trap_handler:
         csrr t1, scause
         sd t1, FRAME_CAUSE*8(t0)
         srli t1, t1, 63
-        bnez t1, trap_interrupt
+        bnez t1, 1f
         j trap_exception
+1:      j trap_interrupt
 
 .globl frame_return
 frame_return:

--- a/src/riscv64/kernel_machine.h
+++ b/src/riscv64/kernel_machine.h
@@ -6,7 +6,7 @@
 #define KERNEL_BASE      0xffffffff80000000ull
 #define DEVICE_BASE      0xffffffff00000000ull
 
-#define KERNEL_PHYS 0x80200000ull /* must match linker script - XXX extern? */
+#define KERNEL_PHYS 0x80200000ULL /* must match linker script - XXX extern? */
 
 #include <kernel_platform.h>
 

--- a/src/riscv64/machine.h
+++ b/src/riscv64/machine.h
@@ -249,12 +249,12 @@ mk_fake_atomic_swap(16)
 
 static inline __attribute__((always_inline)) u8 compare_and_swap_64(u64 *p, u64 old, u64 new)
 {
-    return __atomic_compare_exchange_8(p, &old, new, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    return __atomic_compare_exchange_n(p, &old, new, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 }
 
 static inline __attribute__((always_inline)) u8 compare_and_swap_32(u32 *p, u32 old, u32 new)
 {
-    return __atomic_compare_exchange_4(p, &old, new, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    return __atomic_compare_exchange_n(p, &old, new, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
 }
 
 #if 0

--- a/src/unix/eventfd.c
+++ b/src/unix/eventfd.c
@@ -175,8 +175,7 @@ closure_func_basic(fdesc_close, sysreturn, efd_close,
 
 int do_eventfd2(unsigned int count, int flags)
 {
-    unix_heaps uh = get_unix_heaps();
-    heap h = heap_locked((kernel_heaps)uh);
+    heap h = heap_locked(get_kernel_heaps());
     struct efd *efd;
 
     if (flags & ~(EFD_CLOEXEC | EFD_NONBLOCK | EFD_SEMAPHORE)) {

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -356,7 +356,7 @@ static void exec_elf_finish(buffer ex, fsfile f, process kp,
     unix_heaps uh = kp->uh;
     tuple root = kp->process_root;
     filesystem fs = kp->root_fs;
-    kernel_heaps kh = (kernel_heaps)uh;
+    kernel_heaps kh = get_kernel_heaps();
     process proc = create_process(uh, root, fs);
     thread t = create_thread(proc, proc->pid);
     fsfile interp;
@@ -541,7 +541,7 @@ closure_function(4, 2, void, exec_elf_read,
 void exec_elf(process kp, string program_path, status_handler complete)
 {
     exec_debug("%s: path \"%b\", complete %p (%F)\n", func_ss, program_path, complete, complete);
-    kernel_heaps kh = (kernel_heaps)(kp->uh);
+    kernel_heaps kh = get_kernel_heaps();
     heap general = heap_locked(kh);
     tuple root = kp->process_root;
     fsfile f = fsfile_open(buffer_to_sstring(program_path));

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -318,7 +318,7 @@ sysreturn futex(int *uaddr, int futex_op, int val,
 void
 init_futices(process p)
 {
-    heap h = heap_locked(&p->uh->kh);
+    heap h = heap_locked(get_kernel_heaps());
     p->futices = allocate_table(h, futex_key_function, futex_key_equal);
     if (p->futices == INVALID_ADDRESS)
         halt("failed to allocate futex table\n");

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -1552,7 +1552,7 @@ boolean fault_in_user_memory(const void *buf, bytes length, boolean writable)
 
 void mmap_process_init(process p, tuple root)
 {
-    kernel_heaps kh = &p->uh->kh;
+    kernel_heaps kh = get_kernel_heaps();
     heap h = heap_locked(kh);
     boolean aslr = !get(root, sym(noaslr));
     mmap_info.h = h;

--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -1104,7 +1104,7 @@ sysreturn netlink_open(int type, int family)
     default:
         return -EPROTONOSUPPORT;
     }
-    heap h = heap_locked(&get_unix_heaps()->kh);
+    heap h = heap_locked(get_kernel_heaps());
     nlsock s = allocate(h, sizeof(*s));
     if (s == INVALID_ADDRESS)
         return -ENOMEM;
@@ -1143,7 +1143,7 @@ sysreturn netlink_open(int type, int family)
 
 void netlink_init(void)
 {
-    heap h = heap_locked(&get_unix_heaps()->kh);
+    heap h = heap_locked(get_kernel_heaps());
     netlink.pids = create_id_heap(h, h, 1, U32_MAX, 1, false);
     assert(netlink.pids != INVALID_ADDRESS);
     netlink.sockets = allocate_vector(h, 8);

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -42,8 +42,9 @@ struct pipe {
 
 boolean pipe_init(unix_heaps uh)
 {
-    heap h = heap_locked((kernel_heaps)uh);
-    heap backed = (heap)heap_page_backed((kernel_heaps)uh);
+    kernel_heaps kh = get_kernel_heaps();
+    heap h = heap_locked(kh);
+    heap backed = (heap)heap_page_backed(kh);
 
     uh->pipe_cache = allocate_objcache(h, backed, sizeof(struct pipe), PAGESIZE, true);
     return (uh->pipe_cache == INVALID_ADDRESS ? false : true);
@@ -273,8 +274,6 @@ closure_func_basic(fdesc_events, u32, pipe_write_events,
 
 int do_pipe2(int fds[2], int flags)
 {
-    unix_heaps uh = get_unix_heaps();
-
     pipe pipe = unix_cache_alloc(get_unix_heaps(), pipe);
     if (pipe == INVALID_ADDRESS) {
         msg_err("failed to allocate struct pipe\n");
@@ -289,7 +288,7 @@ int do_pipe2(int fds[2], int flags)
         return -EOPNOTSUPP;
     }
 
-    pipe->h = heap_locked((kernel_heaps)uh);
+    pipe->h = heap_locked(get_kernel_heaps());
     pipe->data = INVALID_ADDRESS;
     pipe->proc = current->p;
 

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -1065,5 +1065,5 @@ void register_poll_syscalls(struct syscall *map)
 
 boolean poll_init(unix_heaps uh)
 {
-    return ((epoll_heap = heap_locked((kernel_heaps)uh)) != INVALID_ADDRESS);
+    return ((epoll_heap = heap_locked(get_kernel_heaps())) != INVALID_ADDRESS);
 }

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -985,8 +985,7 @@ err_queue:
 }
 
 sysreturn unixsock_open(int type, int protocol) {
-    unix_heaps uh = get_unix_heaps();
-    heap h = heap_locked((kernel_heaps)uh);
+    heap h = heap_locked(get_kernel_heaps());
     unixsock s;
 
     if (!unixsock_type_is_supported(type))
@@ -999,8 +998,7 @@ sysreturn unixsock_open(int type, int protocol) {
 }
 
 sysreturn socketpair(int domain, int type, int protocol, int sv[2]) {
-    unix_heaps uh = get_unix_heaps();
-    heap h = heap_locked((kernel_heaps)uh);
+    heap h = heap_locked(get_kernel_heaps());
     unixsock s1, s2;
 
     if (domain != AF_UNIX) {

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -354,7 +354,7 @@ void register_special_files(process p)
     filesystem fs = p->root_fs;
     sstring self_exe_path = ss("/proc/self/exe");
     tuple self_exe;
-    heap h = heap_locked((kernel_heaps)p->uh);
+    heap h = heap_locked(get_kernel_heaps());
 
     int fss = filesystem_get_node(&fs, p->cwd, self_exe_path, false, false, false, false,
         &self_exe, 0);

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -368,7 +368,7 @@ timerqueue thread_get_cpu_timer_queue(thread t)
 {
     thread_lock(t);
     if (!t->cpu_timers) {
-        timerqueue tq = allocate_timerqueue(heap_locked((kernel_heaps)&t->uh),
+        timerqueue tq = allocate_timerqueue(heap_locked(get_kernel_heaps()),
                                             init_closure_func(&t->now, clock_now, thread_now),
                                             sstring_from_cstring(t->name, sizeof(t->name)));
         if (tq != INVALID_ADDRESS)
@@ -394,7 +394,7 @@ closure_func_basic(thunk, void, free_thread)
 
 thread create_thread(process p, u64 tid)
 {
-    heap h = heap_locked((kernel_heaps)p->uh);
+    heap h = heap_locked(get_kernel_heaps());
 
     thread t = allocate(h, sizeof(struct thread));
     if (t == INVALID_ADDRESS)
@@ -541,7 +541,7 @@ void threads_to_vector(process p, vector v)
 
 void init_threads(process p)
 {
-    heap h = heap_locked((kernel_heaps)p->uh);
+    heap h = heap_locked(get_kernel_heaps());
     p->threads = allocate_rbtree(h, closure_func(h, rb_key_compare, thread_tid_compare),
                                  closure_func(h, rbnode_handler, tid_print_key));
     spin_lock_init(&p->threads_lock);

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -826,7 +826,7 @@ void register_timer_syscalls(struct syscall *map)
 
 boolean unix_timers_init(unix_heaps uh)
 {
-    unix_timer_heap = heap_locked((kernel_heaps)uh);
+    unix_timer_heap = heap_locked(get_kernel_heaps());
     spin_lock_init(&timer_cancel_lock);
     list_init(&timer_cancel_list);
     return true;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -436,7 +436,7 @@ closure_func_basic(fdesc_events, u32, std_input_events,
 
 static boolean create_stdfiles(unix_heaps uh, process p)
 {
-    heap h = heap_locked((kernel_heaps)uh);
+    heap h = heap_locked(get_kernel_heaps());
     file in = unix_cache_alloc(uh, file);
     file out = unix_cache_alloc(uh, file);
     file err = unix_cache_alloc(uh, file);
@@ -523,7 +523,7 @@ closure_func_basic(clock_now, timestamp, process_now)
 
 process create_process(unix_heaps uh, tuple root, filesystem fs)
 {
-    kernel_heaps kh = (kernel_heaps)uh;
+    kernel_heaps kh = get_kernel_heaps();
     heap locked = heap_locked(kh);
     process p = allocate(locked, sizeof(struct process));
     assert(p != INVALID_ADDRESS);
@@ -633,7 +633,6 @@ process init_unix(kernel_heaps kh, tuple root, filesystem fs)
 	return INVALID_ADDRESS;
 
     u_heap = uh;
-    uh->kh = *kh;
     uh->processes = locking_heap_wrapper(h, (heap)create_id_heap(h, h, 1, 65535, 1, false));
     uh->file_cache = allocate_objcache(h, (heap)heap_page_backed(kh), sizeof(struct file),
                                        PAGESIZE, true);
@@ -765,7 +764,7 @@ static void dump_heap_stats(buffer b, sstring name, heap h)
 void dump_mem_stats(buffer b)
 {
     unix_heaps uh = get_unix_heaps();
-    kernel_heaps kh = &uh->kh;
+    kernel_heaps kh = get_kernel_heaps();
     bprintf(b, "Kernel heaps:\n");
     dump_heap_stats(b, ss("general"), heap_general(kh));
     dump_heap_stats(b, ss("physical"), (heap)heap_physical(kh));

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -130,8 +130,6 @@ typedef struct user_cap_data {
 
 /* unix-specific memory objects and ids */
 typedef struct unix_heaps {
-    struct kernel_heaps kh;	/* must be first */
-
     /* object caches */
     caching_heap file_cache;
     caching_heap pipe_cache;

--- a/src/unix/vdso.c
+++ b/src/unix/vdso.c
@@ -58,6 +58,6 @@ void init_vdso(process p)
 
 #ifdef __x86_64__
     /* init legacy vsyscall mappings */
-    init_vsyscall((heap)heap_physical(&p->uh->kh));
+    init_vsyscall((heap)heap_physical(get_kernel_heaps()));
 #endif
 }

--- a/src/unix/vsock.c
+++ b/src/unix/vsock.c
@@ -773,7 +773,7 @@ err_incoming:
 
 void vsock_init(void)
 {
-    vsock_priv.h = heap_locked(&get_unix_heaps()->kh);
+    vsock_priv.h = heap_locked(get_kernel_heaps());
     vsock_priv.bound = allocate_table(vsock_priv.h, identity_key, pointer_equal);
     assert(vsock_priv.bound != INVALID_ADDRESS);
     vsock_priv.connections = allocate_table(vsock_priv.h, vsock_conn_key, vsock_conn_equals);

--- a/test/runtime/fcntl.manifest
+++ b/test/runtime/fcntl.manifest
@@ -2,8 +2,8 @@
     boot:(
         children:(
             klib:(children:(
-                tmpfs:(contents:(host:output/klib/bin/tmpfs))
-                shmem:(contents:(host:output/klib/bin/shmem))
+                tmpfs:(contents:(host:ARCH_DIR/bin/tmpfs))
+                shmem:(contents:(host:ARCH_DIR/bin/shmem))
             ))
         )
     )

--- a/test/runtime/hws.manifest
+++ b/test/runtime/hws.manifest
@@ -2,7 +2,7 @@
     boot:(
         children:(
             klib:(children:(
-                strace:(contents:(host:output/klib/bin/strace))
+                strace:(contents:(host:ARCH_DIR/bin/strace))
             ))
         )
     )

--- a/test/runtime/ktest.manifest
+++ b/test/runtime/ktest.manifest
@@ -3,9 +3,9 @@
           children:(
                     klib:(children:(
                         test:(children:(
-                            klib:(contents:(host:output/klib/bin/test/klib))
-                            lock:(contents:(host:output/klib/bin/test/lock))
-                            page_table:(contents:(host:output/klib/bin/test/page_table))
+                            klib:(contents:(host:ARCH_DIR/bin/test/klib))
+                            lock:(contents:(host:ARCH_DIR/bin/test/lock))
+                            page_table:(contents:(host:ARCH_DIR/bin/test/page_table))
                             ))
                         ))
                     )

--- a/test/runtime/sandbox.manifest
+++ b/test/runtime/sandbox.manifest
@@ -2,7 +2,7 @@
     boot:(
           children:(
                     klib:(children:(
-                            sandbox:(contents:(host:output/klib/bin/sandbox))
+                            sandbox:(contents:(host:ARCH_DIR/bin/sandbox))
                         ))
                     )
           )

--- a/test/runtime/shmem.manifest
+++ b/test/runtime/shmem.manifest
@@ -2,8 +2,8 @@
     boot:(
         children:(
             klib:(children:(
-                tmpfs:(contents:(host:output/klib/bin/tmpfs))
-                shmem:(contents:(host:output/klib/bin/shmem))
+                tmpfs:(contents:(host:ARCH_DIR/bin/tmpfs))
+                shmem:(contents:(host:ARCH_DIR/bin/shmem))
             ))
         )
     )

--- a/test/runtime/syslog.manifest
+++ b/test/runtime/syslog.manifest
@@ -2,8 +2,8 @@
     boot:(
         children:(
             klib:(children:(
-                strace:(contents:(host:output/klib/bin/strace))
-                syslog:(contents:(host:output/klib/bin/syslog))
+                strace:(contents:(host:ARCH_DIR/bin/strace))
+                syslog:(contents:(host:ARCH_DIR/bin/syslog))
             ))
         )
     )

--- a/test/runtime/tun.manifest
+++ b/test/runtime/tun.manifest
@@ -1,7 +1,7 @@
 (
     boot:(
         children:(
-            klib:(children:(tun:(contents:(host:output/klib/bin/tun))))
+            klib:(children:(tun:(contents:(host:ARCH_DIR/bin/tun))))
         )
     )
     children:(

--- a/test/runtime/umcg.manifest
+++ b/test/runtime/umcg.manifest
@@ -1,7 +1,7 @@
 (
     boot:(
         children:(
-            klib:(children:(umcg:(contents:(host:output/klib/bin/umcg))))
+            klib:(children:(umcg:(contents:(host:ARCH_DIR/bin/umcg))))
         )
     )
     children:(

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -1,6 +1,6 @@
 include ../../vars.mk
 
-override ARCH=$(shell uname -m)
+override ARCH=$(HOST_ARCH)
 override CROSS_COMPILE=
 ifeq ($(shell uname -s),Darwin)
 override CC=cc

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,6 +1,6 @@
 include ../vars.mk
 
-override ARCH=$(shell uname -m)
+override ARCH=$(HOST_ARCH)
 override CROSS_COMPILE=
 ifeq ($(shell uname -s),Darwin)
 override CC=cc

--- a/vars.mk
+++ b/vars.mk
@@ -1,7 +1,7 @@
 # paths
 makefile_dir=	$(patsubst %/,%,$(dir $(abspath $(firstword $(filter $1, $(MAKEFILE_LIST))))))
 CURDIR=		$(call makefile_dir, Makefile)
-ROOTDIR=	$(call makefile_dir, %rules.mk)
+ROOTDIR=	$(call makefile_dir, %vars.mk)
 SRCDIR=		$(ROOTDIR)/src
 OUTDIR=		$(ROOTDIR)/output
 OBJDIR=		$(subst $(ROOTDIR),$(OUTDIR),$(CURDIR))

--- a/vars.mk
+++ b/vars.mk
@@ -11,12 +11,14 @@ PATCHDIR=	$(ROOTDIR)/patches
 UNAME_s=	$(shell uname -s)
 UNAME_m=	$(shell uname -m)
 
+HOST_ARCH=	$(UNAME_m)
+ifeq ($(HOST_ARCH),arm64)
+override HOST_ARCH:=	aarch64
+endif
+
 # If no platform is specified, try to guess it from the host architecture.
 ifeq ($(PLATFORM),)
-ARCH?=	$(UNAME_m)
-ifeq ($(ARCH),arm64)
-override ARCH:=		aarch64
-endif
+ARCH?=	$(HOST_ARCH)
 ifeq ($(ARCH),aarch64)
 PLATFORM?=	virt
 endif
@@ -37,7 +39,7 @@ endif
 ifeq ($(PLATFORM),riscv-virt)
 ARCH?=		riscv64
 endif
-ifneq ($(ARCH),$(UNAME_m))
+ifneq ($(ARCH),$(HOST_ARCH))
 CROSS_COMPILE?=	$(ARCH)-linux-gnu-
 endif
 endif


### PR DESCRIPTION
This change set allows compiling the kernel with the clang compiler for all architectures.
A new target (`make kernel`) has been defined in the Makefile: this target builds the kernel, the bootloaders (if applicable for a given platform), and the klibs, and allows the core pieces of a unikernel image to be built without the compiler toolchain that is needed to build user-mode programs for the target architecture.
The `make release` target has been updated to not include the mkfs and dump tools in the release tarball (they are no longer needed since Ops implements internally equivalent functionalities).
Example command line to build with clang the kernel for the same architecture as the host machine: `make kernel CC=clang`