### PR TITLE
mmap(2): add support for MAP_GROWSDOWN flag

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,8 @@ __Page Protections__:
 
 * Text no write
 
+* Guard gap between process stack and adjacent mapping
+
 __Random Number Generation__:
 
 * virtio-rng driver

--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -302,7 +302,7 @@ closure_function(4, 3, boolean, remap_entry,
         offset = 0;
     }
     u64 new_curr = bound(new) + offset;
-    u64 phys = page_from_pte(oldentry);
+    u64 phys = page_from_pte(oldentry) + map_offset;
     u64 flags = flags_from_pte(oldentry);
     u64 map_len = pte_map_size(level, oldentry);
     u64 remap_len = MIN(map_len - map_offset, bound(len) - offset);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -44,6 +44,7 @@
 
 #define PROCESS_STACK_SIZE          (2 * MB)
 #define PROCESS_STACK_PREALLOC_SIZE PAGESIZE
+#define PROCESS_STACK_GUARD_GAP     (256 * PAGESIZE)    /* same as default value on Linux */
 
 /* restrict the area in which ELF segments can be placed */
 #define PROCESS_ELF_LOAD_END        (3ull * GB) /* 3gb hard upper limit */


### PR DESCRIPTION
A mapping with this flag can be expanded downwards dynamically (up to the PROCESS_STACK_SIZE limit) by "touching" addresses lower than the base of the mapping.
This feature requires that a guard gap is kept between a MAP_GROWSDOWN mapping and any adjacent mappings. The second commit implements enforcing of the guard gap next to the process stack, which is a security feature because it greatly
decreases the likelihood of a stack overflow not being detected and prevents the exploitation of many application vulnerabilities
that involve overflowing the stack.
The first commit fixes a bug in the paging code that was causing sporadic failures when running the mmap runtime test.