### PR TITLE
Page faults: add support for custom fault handlers

### DIFF
--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1375,6 +1375,8 @@ closure_function(4, 1, void, pagecache_read_sg_finish,
         sg_list sg = bound(sg);
         context user_ctx = context_from_closure(completion);
         context ctx = get_current_context(current_cpu());
+        if (!user_ctx)
+            user_ctx = ctx;
         if (ctx != user_ctx)
             use_fault_handler(user_ctx->fault_handler);
         /* Fault in memory now to avoid page faults while spinlocks are held. */


### PR DESCRIPTION
This allows custom mmap() implementations for specific file descriptors to handle page faults on mmap()ed memory. This feature
is used by the Nvidia GPU klib.
The first commit allows reading from the page cache with non-contextual completion closures, such as when the reading context suspends itself and the completion resumes the suspended context (this happens in the Nvidia GPU klib when reading the GPU firmware file).