### PR TITLE
x86 bootloader: keep 8259 PIC enabled when reading from disk

### DIFF
--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -113,11 +113,6 @@ CLEANDIRS+=     $(OBJDIR)/platform/pc $(OBJDIR)/platform $(OBJDIR) $(OBJDIRS-uef
 boot: $(OBJDIR)/boot.img $(OBJDIR)/bootx64.efi
 
 $(OBJDIR)/boot.img: $(OBJDIR)/stage1 $(OBJDIR)/stage2.pad
-ifeq ($(MEMDEBUG),)
-ifeq ($(UBSAN),)
-	$(Q) test `$(SIZE_CMD) $(OBJDIR)/stage2.pad` -le 65536 || ($(ECHO) stage2 exceeds 64KB && exit 1)
-endif
-endif
 	$(call cmd,cat)
 
 $(OBJDIR)/stage1: stage1.s $(OBJDIR)/stage2.pad

--- a/platform/pc/boot/stage1.s
+++ b/platform/pc/boot/stage1.s
@@ -21,12 +21,13 @@ init:
 	;; setting a20 allows us to address all of 'extended' memory
 	call seta20
 
+	call readsectors
+
         ;;;  disable 8259
         mov al, 0xff
         out 0xa1, al
         out 0x21, al
 
-        call readsectors
 	call e820
 
 	cli


### PR DESCRIPTION
Following a recent update of the hypervisor and/or the BIOS firmware on AWS Xen-based instances (e.g. t2 instances), the BIOS never returns from the INT 13H routine that the stage1 bootloader uses to read stage2 code from disk. This prevents the kernel from booting on those instance types.
This change fixes the above issue by disabling the 8259 PIC only after reading stage2 code from disk. This allows the BIOS firmware to work properly when executing the INT 13H routine, and also allows this routine to be executed more than once. Therefore, the limitation of 64 kB on stage2 code size is being lifted, since a larger stage2 binary (which requires more than one INT 13H call in order to be read from disk) is now properly handled on AWS instances.