### PR TITLE
fix doc and build issue (for linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,12 @@ Note: This is only recommended for those that wish to make code changes to Nanos
 
 Nanos doesn't need too many dependencies on Linux.
 
-To build you need to install nasm && qemu:
+To build you need to install nasm, qemu and go (If you don't want to install go, choose a different target, see below):
 
 ```
-sudo apt-get install qemu-system-x86 nasm
+sudo apt-get install qemu-system-x86 nasm golang-go
 ```
+
 
 For tests you'll also need the following installed:
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ brew install x86_64-elf-binutils
 brew tap nanovms/homebrew-qemu
 brew install nanovms/homebrew-qemu/qemu
 ```
+(note: ```go``` is only needed for certain [examples](#examples), but not for building the kernel)
 
 For ARM-based Macs (M1/M2):
 
@@ -109,12 +110,12 @@ Note: This is only recommended for those that wish to make code changes to Nanos
 
 Nanos doesn't need too many dependencies on Linux.
 
-To build you need to install nasm, qemu and go (If you don't want to install go, choose a different target, see below):
+To build you need to install nasm, qemu and go:
 
 ```
 sudo apt-get install qemu-system-x86 nasm golang-go
 ```
-
+(note: ```go``` is only needed for certain [examples](#examples), but not for building the kernel)
 
 For tests you'll also need the following installed:
 
@@ -143,7 +144,11 @@ sudo apt-get install libfuse-dev fuse
 make kernel
 ```
 
-#### To run an example program from the test/runtime folder:
+#### Examples
+
+
+To run an example program from the test/runtime folder:
+
 With hardware acceleration:
 
 ```
@@ -154,6 +159,15 @@ Without hardware acceleration:
 ```
 make run-noaccel
 ```
+
+Set ```TARGET``` to run a specific example:
+```
+make TARGET=<example> run
+```
+
+Check out [test/runtime](test/runtime/README.md) for a list of examples. Certain examples require ```go``` to be built. 
+
+More examples can be found in [docs/examples#examples](https://docs.ops.city/ops/examples#examples).
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ For tests you'll also need the following installed:
 sudo apt-get install ent ruby
 ```
 
+Ops:
+```
+curl https://ops.city/get.sh -sSfL | sh
+```
+
 Rust:
 ```
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh

--- a/kernel.mk
+++ b/kernel.mk
@@ -68,7 +68,7 @@ msg_sed=	SED	$@
 cmd_sed=	$(SED) -e 's/\#/%/' <$^ >$@
 
 msg_version=	VERSION	$@
-cmd_version=	$(MKDIR) $(dir $@); $(ECHO) "\#include <runtime.h>\nconst sstring gitversion = ss_static_init(\"$(shell $(GIT) rev-parse HEAD)\");" >$@
+cmd_version=	$(MKDIR) $(dir $@); ( $(ECHO) "\#include <runtime.h>"; $(ECHO) "const sstring gitversion = ss_static_init(\"$(shell $(GIT) rev-parse HEAD)\");" ) >$@
 
 include ../../klib/klib.mk
 

--- a/src/kernel/storage.c
+++ b/src/kernel/storage.c
@@ -271,7 +271,7 @@ closure_function(1, 2, boolean, volume_add_mount_each,
 
 boolean volume_add(u8 *uuid, char *label, void *priv, fs_init_handler init_handler, int attach_id)
 {
-    storage_debug("new volume (%ld bytes)", size);
+    storage_debug("new volume");
     volume v = allocate(storage.h, sizeof(*v));
     if (v == INVALID_ADDRESS)
         return false;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -207,7 +207,8 @@ sstring string_from_mmap_type(int type)
             ss("unknown"));
 }
 
-#define format_protection_violation(vaddr, ctx, vm)             \
+#define pf_debug_protection_violation(vaddr, ctx, vm)           \
+    pf_debug(                                                   \
     "page_protection_violation\naddr 0x%lx, pc 0x%lx, "         \
     "error %c%c%c vm->flags (%s%s %s%s%s)\n",                   \
         vaddr, frame_fault_pc(ctx->frame),                      \
@@ -218,7 +219,8 @@ sstring string_from_mmap_type(int type)
         string_from_mmap_type(vm->flags & VMAP_MMAP_TYPE_MASK), \
         (vm->flags & VMAP_FLAG_READABLE) ? ss("readable ") : sstring_empty(),   \
         (vm->flags & VMAP_FLAG_WRITABLE) ? ss("writable ") : sstring_empty(),   \
-        (vm->flags & VMAP_FLAG_EXEC) ? ss("executable ") : sstring_empty()
+        (vm->flags & VMAP_FLAG_EXEC) ? ss("executable ") : sstring_empty()      \
+    )
 
 static boolean handle_protection_fault(context ctx, u64 vaddr, vmap vm)
 {
@@ -238,7 +240,7 @@ static boolean handle_protection_fault(context ctx, u64 vaddr, vmap vm)
     }
 
     if (is_thread_context(ctx)) {
-        pf_debug(format_protection_violation(vaddr, ctx, vm));
+        pf_debug_protection_violation(vaddr, ctx, vm);
         deliver_fault_signal(SIGSEGV, (thread)ctx, vaddr, SEGV_ACCERR);
         return true;
     }

--- a/test/runtime/README.md
+++ b/test/runtime/README.md
@@ -1,0 +1,66 @@
+# Examples
+
+Set ```TARGET``` to run a specific example:
+```
+make TARGET=<example> run
+```
+
+Certain examples require ```go``` to be built. 
+
+More examples can be found in [docs/examples#examples](https://docs.opsity/ops/examples#examples).
+
+Example | Language | Description
+-|-|-
+aio | c | 
+aslr | c | 
+creat | c | 
+dup | c | 
+epoll | c | 
+eventfd | c | 
+fadvise | c | 
+fallocate | c | 
+fcntl | c | 
+fst | go | 
+fs_full | c | 
+ftrace | c | 
+futex | c | 
+futexrobust | c | 
+getdents | c | 
+getrandom | c | 
+hw | c | hello world (dynamic linking)
+hws | c | hello world (static linking)
+hwg | go | hello world
+inotify | c | 
+io_uring | c | 
+ktest | c | 
+mkdir | c | 
+mmap | c | 
+netlink | c | 
+netsock | c | 
+nullpage | c | 
+paging | c | 
+pipe | c | 
+readv | c | 
+rename | c | 
+sandbox | c | 
+sendfile | c | 
+shmem | c | 
+signal | c | 
+sigoverflow | c | 
+socketpair | c | 
+symlink | c | 
+syslog | c | 
+thread_test | c | 
+time | c | 
+tlbshootdown | c | 
+tun | c | 
+udploop | c | 
+umcg | c | 
+unixsocket | c | 
+unlink | c | 
+vsyscall | c | 
+web | c | webserver on localhost:8080 (dynamic linking)
+webs | c | webserver on localhost:8080 (static linking)
+webg | go | webserver on localhost:8080
+write | c | 
+writev | c |

--- a/test/unit/udp_test.c
+++ b/test/unit/udp_test.c
@@ -30,7 +30,7 @@ int main(int argc, char ** argv)
     u32 daddr;
     u16 dport;
     if (!parse_v4_address_and_port(target, &daddr, &dport))
-        test_perror("parse");
+        test_error("failed to parse address and port");
 
     u16 lport = DEFAULT_LOCAL_PORT;
     u64 result;

--- a/test/unit/udp_test.c
+++ b/test/unit/udp_test.c
@@ -29,7 +29,8 @@ int main(int argc, char ** argv)
     buffer target = vector_pop(unassoc);
     u32 daddr;
     u16 dport;
-    parse_v4_address_and_port(target, &daddr, &dport);
+    if (!parse_v4_address_and_port(target, &daddr, &dport))
+        test_perror("parse");
 
     u16 lport = DEFAULT_LOCAL_PORT;
     u64 result;


### PR DESCRIPTION
**Build is not working due to following issues:**

- ```go``` is not documented as dependency in the description for Linux
```bash
GO	/home/user/repos/nanos/output/test/runtime/bin/webg
/bin/sh: line 1: go: command not found
```
- there is an issue with a new line that is not printed due to ```echo``` not processing ```\n```
```bash
VERSION	/home/user/repos/nanos/output/platform/pc/gitversion.c
CC	/home/user/repos/nanos/output/platform/pc/output/platform/pc/gitversion.o
/home/user/repos/nanos/output/platform/pc/gitversion.c:1:21: error: extra tokens at end of #include directive [-Werror]
    1 | #include <runtime.h>\nconst sstring gitversion = ss_static_init("243c5a2010916b8fd69f86b290d637ad0efc1dbd");
      |    
```

**Test-Build is not working due to following issues:**

- ```ops``` is not documented as dependency in the description for Linux
```bash
=== RUN   TestE2E/packages/node_alloc
    e2e.go:181: Waiting for command to complete...
    e2e.go:207: Output: /bin/bash: line 1: ops: command not found
    e2e.go:208: ops exit code 127
```

- ```udp_test.c``` doesn't check for parse errors 
```bash
CC	/home/user/repos/nanos/output/test/unit/test/unit/udp_test.o
In file included from /usr/include/endian.h:35,
                 from /usr/include/sys/types.h:176,
                 from /usr/include/bits/socket.h:29,
                 from /usr/include/sys/socket.h:33,
                 from /usr/include/netinet/in.h:23,
                 from /usr/include/arpa/inet.h:22,
                 from /home/user/repos/nanos/test/unit/udp_test.c:8:
In function ‘__bswap_16’,
    inlined from ‘main’ at /home/user/repos/nanos/test/unit/udp_test.c:57:21:
/usr/include/bits/byteswap.h:37:10: error: ‘dport’ may be used uninitialized [-Werror=maybe-uninitialized]
   37 |   return __builtin_bswap16 (__bsx);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/user/repos/nanos/test/unit/udp_test.c: In function ‘main’:
/home/user/repos/nanos/test/unit/udp_test.c:31:9: note: ‘dport’ was declared here
   31 |     u16 dport;
      |         ^~~~~
```

**Debug-Build is not working due to following issues:**

- ```storage.c``` prints a parameter, that doesn't exist

 ```bash
CC	/home/user/repos/nanos/output/platform/pc/src/kernel/storage.o
/home/user/repos/nanos/src/kernel/storage.c: In function ‘volume_add’:
/home/user/repos/nanos/src/kernel/storage.c:274:45: error: ‘size’ undeclared (first use in this function)
  274 |     storage_debug("new volume (%ld bytes)", size);
      |                                             
```


- ```unix.c``` has an improper macro expansion 
 
 ```bash
CC	/home/pepper/dev/repos/nanos/output/platform/pc/src/unix/unix.o
/home/pepper/dev/repos/nanos/src/unix/unix.c: In function ‘handle_protection_fault’:
/home/pepper/dev/repos/nanos/src/unix/unix.c:241:61: error: macro "ss" passed 11 arguments, but takes just 1
  241 |         pf_debug(format_protection_violation(vaddr, ctx, vm));
      |                                                             ^
In file included from /home/pepper/dev/repos/nanos/src/runtime/runtime.h:54,
                 from /home/pepper/dev/repos/nanos/src/kernel/kernel.h:2,
                 from /home/pepper/dev/repos/nanos/src/unix/unix_internal.h:3,
                 from /home/pepper/dev/repos/nanos/src/unix/unix.c:1:
```