### PR TITLE
New features to support TigerBeetle

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1796,6 +1796,17 @@ sysreturn sendto(int sockfd, void *buf, u64 len, int flags,
     return sock->sendto(sock, buf, len, flags, dest_addr, addrlen, ctx, false, completion);
 }
 
+sysreturn socket_send(fdesc f, void *buf, u64 len, context ctx, boolean in_bh,
+                      io_completion completion)
+{
+    if (f->type != FDESC_TYPE_SOCKET)
+        return io_complete(completion, -ENOTSOCK);
+    if (!validate_user_memory(buf, len, false))
+        return io_complete(completion, -EFAULT);
+    struct sock *sock = struct_from_field(f, struct sock *, f);
+    return sock->sendto(sock, buf, len, 0, 0, 0, ctx, in_bh, completion);
+}
+
 static sysreturn netsock_sendmsg(struct sock *s, const struct msghdr *msg, int flags,
                                  boolean in_bh, io_completion completion)
 {
@@ -1933,6 +1944,17 @@ sysreturn recvfrom(int sockfd, void * buf, u64 len, int flags,
     context ctx = get_current_context(current_cpu());
     io_completion completion = (io_completion)&sock->f.io_complete;
     return sock->recvfrom(sock, buf, len, flags, src_addr, addrlen, ctx, false, completion);
+}
+
+sysreturn socket_recv(fdesc f, void *buf, u64 len, context ctx, boolean in_bh,
+                      io_completion completion)
+{
+    if (f->type != FDESC_TYPE_SOCKET)
+        return io_complete(completion, -ENOTSOCK);
+    if (!validate_user_memory(buf, len, true))
+        return io_complete(completion, -EFAULT);
+    struct sock *sock = struct_from_field(f, struct sock *, f);
+    return sock->recvfrom(sock, buf, len, 0, 0, 0, ctx, in_bh, completion);
 }
 
 static sysreturn netsock_recvmsg(struct sock *sock, struct msghdr *msg,

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -217,8 +217,7 @@ sysreturn blockq_check_timeout(blockq bq, blockq_action a, boolean in_bh,
     blockq_lock(bq);
     thread_lock(t);
     t->bq_action = a;
-    if (!in_bh)
-        t->blocked_on = bq;
+    t->blocked_on = bq;
     if (timeout > 0) {
         t->bq_timer_pending = true;
         t->bq_clkid = clkid;

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -24,7 +24,7 @@
 
 sysreturn sysreturn_from_fs_status_value(status s);
 
-u16 file_mode_from_type(int type);
+u16 stat_mode(process p, int type, tuple meta);
 
 /* Perform read-ahead following a userspace read request.
  * offset and len arguments refer to the byte range being read from userspace,

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -37,6 +37,8 @@ int filesystem_chdir(process p, sstring path);
 
 void filesystem_update_relatime(filesystem fs, tuple md);
 
+sysreturn openat(int dirfd, const char *name, int flags, int mode);
+
 sysreturn symlink(const char *target, const char *linkpath);
 sysreturn symlinkat(const char *target, int dirfd, const char *linkpath);
 

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -567,7 +567,7 @@ static void iour_complete_timeout(io_uring iour, u64 user_data)
     }
 }
 
-closure_function(4, 1, void, iour_rw_complete,
+closure_function(4, 1, void, iour_fdesc_complete,
                  io_uring, iour, fdesc, f, u64, user_data, context, proc_ctx,
                  sysreturn rv)
 {
@@ -583,7 +583,7 @@ static void iour_iov(io_uring iour, fdesc f, boolean write, struct iovec *iov,
     io_completion completion;
     process_context pc = get_process_context();
     if (pc != INVALID_ADDRESS) {
-        completion = closure(iour->h, iour_rw_complete, iour, f, user_data, &pc->uc.kc.context);
+        completion = closure(iour->h, iour_fdesc_complete, iour, f, user_data, &pc->uc.kc.context);
         if (completion == INVALID_ADDRESS)
             context_release_refcount(&pc->uc.kc.context);
     } else {
@@ -615,7 +615,8 @@ static void iour_rw(io_uring iour, fdesc f, boolean write, void *addr, u32 len,
     } else {
         pc = get_process_context();
         if (pc != INVALID_ADDRESS) {
-            completion = closure(iour->h, iour_rw_complete, iour, f, user_data, &pc->uc.kc.context);
+            completion = closure(iour->h, iour_fdesc_complete, iour, f, user_data,
+                                 &pc->uc.kc.context);
             if (completion == INVALID_ADDRESS)
                 context_release_refcount(&pc->uc.kc.context);
         } else {

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -414,7 +414,7 @@ vmap vmap_from_vaddr(process p, u64 vaddr)
     if ((vm != INVALID_ADDRESS) && (vm->node.r.start > vaddr)) {
         /* vm does not cover this address; if it is a stack mapping, check whether it can be
          * expanded downwards. */
-        if (!(vm->flags & VMAP_FLAG_STACK) || (vm->node.r.end > vaddr + PROCESS_STACK_SIZE))
+        if (!(vm->flags & VMAP_FLAG_STACK) || (vm->node.r.end > vaddr + p->rlimit_stack))
             return INVALID_ADDRESS;
         vmap prev = (vmap)rangemap_prev_node(rm, &vm->node);
         vaddr &= ~PAGEMASK;

--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -765,7 +765,7 @@ closure_function(8, 1, sysreturn, nl_read_bh,
         rv = -ERESTARTSYS;
         goto out;
     }
-    context ctx = get_current_context(current_cpu());
+    context ctx = context_from_closure(closure_self());
     nl_lock(s);
     struct nlmsghdr *hdr = dequeue(s->data);
     if (hdr == INVALID_ADDRESS) {

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -177,7 +177,7 @@ closure_function(7, 1, sysreturn, unixsock_read_bh,
         rv = -ERESTARTSYS;
         goto out;
     }
-    context ctx = get_current_context(current_cpu());
+    context ctx = context_from_closure(closure_self());
     shb = queue_peek(s->data);
     if (shb == INVALID_ADDRESS) {
         if (disconnected) {
@@ -407,7 +407,7 @@ closure_function(6, 1, sysreturn, unixsock_write_bh,
     rv = unixsock_write_to(src, bound(iov), length, dest, s);
     if ((rv == -EAGAIN) && !(s->sock.f.flags & SOCK_NONBLOCK)) {
         unixsock_unlock(dest);
-        return blockq_block_required((unix_context)get_current_context(current_cpu()), flags);
+        return blockq_block_required((unix_context)context_from_closure(closure_self()), flags);
     }
     full = (dest->sock.rx_len >= so_rcvbuf) || queue_full(dest->data);
 out:

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -88,16 +88,19 @@ struct sock {
     sysreturn (*connect)(struct sock *sock, struct sockaddr *addr,
             socklen_t addrlen);
     sysreturn (*accept4)(struct sock *sock, struct sockaddr *addr,
-            socklen_t *addrlen, int flags);
+                         socklen_t *addrlen, int flags, context ctx, boolean in_bh,
+                         io_completion completion);
     sysreturn (*getsockname)(struct sock *sock, struct sockaddr *addr, socklen_t *addrlen);
     sysreturn (*getsockopt)(struct sock *sock, int level,
                             int optname, void *optval, socklen_t *optlen);
     sysreturn (*setsockopt)(struct sock *sock, int level,
                             int optname, void *optval, socklen_t optlen);
     sysreturn (*sendto)(struct sock *sock, void *buf, u64 len, int flags,
-             struct sockaddr *dest_addr, socklen_t addrlen);
+                        struct sockaddr *dest_addr, socklen_t addrlen, context ctx, boolean in_bh,
+                        io_completion completion);
     sysreturn (*recvfrom)(struct sock *sock, void *buf, u64 len, int flags,
-             struct sockaddr *dest_addr, socklen_t *addrlen);
+                          struct sockaddr *dest_addr, socklen_t *addrlen, context ctx,
+                          boolean in_bh, io_completion completion);
     sysreturn (*sendmsg)(struct sock *sock, const struct msghdr *msg,
                          int flags, boolean in_bh, io_completion completion);
     sysreturn (*recvmsg)(struct sock *sock, struct msghdr *msg, int flags, boolean in_bh,
@@ -148,6 +151,8 @@ static inline void socket_flush_q(struct sock *s)
 }
 
 sysreturn socket_ioctl(struct sock *s, unsigned long request, vlist ap);
+sysreturn socket_accept4(fdesc f, struct sockaddr *addr, socklen_t *addrlen, int flags, context ctx,
+                         boolean in_bh, io_completion completion);
 
 static inline boolean validate_msghdr(const struct msghdr *mh, boolean write)
 {

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -153,6 +153,10 @@ static inline void socket_flush_q(struct sock *s)
 sysreturn socket_ioctl(struct sock *s, unsigned long request, vlist ap);
 sysreturn socket_accept4(fdesc f, struct sockaddr *addr, socklen_t *addrlen, int flags, context ctx,
                          boolean in_bh, io_completion completion);
+sysreturn socket_send(fdesc f, void *buf, u64 len, context ctx, boolean in_bh,
+                      io_completion completion);
+sysreturn socket_recv(fdesc f, void *buf, u64 len, context ctx, boolean in_bh,
+                      io_completion completion);
 
 static inline boolean validate_msghdr(const struct msghdr *mh, boolean write)
 {

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1447,7 +1447,7 @@ sysreturn openat(int dirfd, const char *name, int flags, int mode)
 static void fill_stat(int type, filesystem fs, fsfile f, tuple n, struct stat *s)
 {
     zero(s, sizeof(struct stat));
-    s->st_mode = file_mode_from_type(type);
+    s->st_mode = stat_mode(current->p, type, n);
     switch (type) {
     case FDESC_TYPE_REGULAR:
         if (f) {

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -566,6 +566,7 @@ process create_process(unix_heaps uh, tuple root, filesystem fs)
     assert(p->cpu_timers != INVALID_ADDRESS);
     p->aio_ids = create_id_heap(locked, locked, 0, S32_MAX, 1, false);
     p->aio = allocate_vector(locked, 8);
+    p->rlimit_stack = PROCESS_STACK_SIZE;
     p->trace = 0;
     p->trap = 0;
     if ((u64)p->pid - 1 < MAX_PROCESSES)

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -522,6 +522,7 @@ typedef struct process {
     timerqueue        cpu_timers;
     id_heap           aio_ids;
     vector            aio;
+    u64               rlimit_stack;
     u8                trace;
     boolean           trap;         /* do not run threads when set */
     struct spinlock   lock; /* generic lock for struct members without a specific lock */

--- a/test/runtime/symlink.c
+++ b/test/runtime/symlink.c
@@ -91,7 +91,6 @@ int main(int argc, char **argv)
 
     test_assert((faccessat(AT_FDCWD, "link", F_OK, AT_SYMLINK_NOFOLLOW) == 0));
     test_assert((faccessat(AT_FDCWD, "link", R_OK|W_OK, AT_SYMLINK_NOFOLLOW) == 0));
-    test_assert((faccessat(AT_FDCWD, "link", X_OK, AT_SYMLINK_NOFOLLOW) == -1 && (errno == EACCES)));
     test_assert((faccessat(AT_FDCWD, "link", F_OK, 0) == -1) && (errno == ENOENT));
 
     fd = open("target", O_RDWR | O_CREAT, S_IRWXU);
@@ -99,7 +98,6 @@ int main(int argc, char **argv)
     close(fd);
 
     test_assert((faccessat(AT_FDCWD, "link", F_OK, 0) == 0));
-    test_assert((faccessat(AT_FDCWD, "link", X_OK, AT_SYMLINK_NOFOLLOW) == -1 && (errno == EACCES)));
     test_assert((faccessat(AT_FDCWD, "link", X_OK|R_OK|W_OK, 0) == 0));
     test_assert((access("link", F_OK) == 0));
     test_assert((access("link", X_OK|R_OK|W_OK) == 0));


### PR DESCRIPTION
This change set implements new features that allow running TigerBeetle (https://github.com/tigerbeetle/tigerbeetle) on Nanos:
- io_uring supports accept, openat, statx, send and recv operations
- setrlimit() and prlimit64() allow changing the process stack limit
- file permissions returned by stat() and similar syscalls are retrieved from file metadata