### PR TITLE
epoll: add support for polling on epoll file descriptors

### DIFF
--- a/src/unix/notify.c
+++ b/src/unix/notify.c
@@ -77,7 +77,7 @@ u64 notify_get_eventmask_union(notify_set s)
     return u;
 }
 
-void notify_dispatch_with_arg(notify_set s, u64 events, void *arg)
+boolean notify_dispatch_with_arg(notify_set s, u64 events, void *arg)
 {
     boolean consumed = false;
     spin_lock(&s->lock);
@@ -97,6 +97,7 @@ void notify_dispatch_with_arg(notify_set s, u64 events, void *arg)
         }
     }
     spin_unlock(&s->lock);
+    return consumed;
 }
 
 void notify_dispatch(notify_set s, u64 events)

--- a/src/unix/notify.h
+++ b/src/unix/notify.h
@@ -34,7 +34,7 @@ u64 notify_get_eventmask_union(notify_set s);
 
 void notify_dispatch(notify_set s, u64 events);
 
-void notify_dispatch_with_arg(notify_set s, u64 events, void *arg);
+boolean notify_dispatch_with_arg(notify_set s, u64 events, void *arg);
 
 #define notify_dispatch_for_thread  notify_dispatch_with_arg
 

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -635,6 +635,10 @@ sysreturn epoll_ctl(int epfd, int op, int fd, struct epoll_event *event)
 
     /* XXX verify that fd is not an epoll instance*/
     epoll e = resolve_fd(current->p, epfd);
+    if ((e->f.type != FDESC_TYPE_EPOLL) || (f == &e->f)) {
+        rv = -EINVAL;
+        goto out;
+    }
     spin_wlock(&e->fds_lock);
     switch(op) {
     case EPOLL_CTL_ADD:
@@ -655,6 +659,7 @@ sysreturn epoll_ctl(int epfd, int op, int fd, struct epoll_event *event)
     }
     spin_wunlock(&e->fds_lock);
 
+  out:
     fdesc_put(&e->f);
     return rv;
 }

--- a/test/runtime/epoll.c
+++ b/test/runtime/epoll.c
@@ -43,6 +43,9 @@ void test_ctl()
     event.data.fd = fd;
     event.events = EPOLLIN;
 
+    /* epoll operation on non-epoll file descriptor */
+    test_assert((epoll_ctl(fd, EPOLL_CTL_ADD, 0, &event) == -1) && (errno == EINVAL));
+
     if ((epoll_ctl(efd, EPOLL_CTL_ADD, fd, NULL) != -1) || (errno != EFAULT)) {
         test_error("NULL event pointer is not allowed for EPOLL_CTL_ADD");
     }


### PR DESCRIPTION
In addition, epoll_ctl() now returns -EINVAL if called on a non-epoll file descriptor, or if the file descriptor being added, deleted, or modified is the same as the epoll file descriptor on which epoll_ctl() is called.

Closes #1192.