### PR TITLE
Network socket options: add support for IPPROTO_IP/IP_MTU_DISCOVER

### DIFF
--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -863,6 +863,7 @@ struct io_uring_params {
 #define IP_TOS              1
 #define IP_TTL              2
 #define IP_OPTIONS          4
+#define IP_MTU_DISCOVER     10
 #define IP_MINTTL           21
 #define IP_MULTICAST_IF     32
 #define IP_MULTICAST_TTL    33


### PR DESCRIPTION
This socket option controls the setting of the DF (don't fragment) flag in output IPv4 packets.
Depends on https://github.com/nanovms/lwip/pull/14.