### PR TITLE
Aarch64 powerdown: add support for GPIO power key

### DIFF
--- a/platform/virt/Makefile
+++ b/platform/virt/Makefile
@@ -17,6 +17,7 @@ SRCS-kernel.elf= \
 	$(SRCDIR)/aarch64/crt0.S \
 	$(SRCDIR)/aarch64/elf64.c \
 	$(SRCDIR)/aarch64/gic.c \
+	$(SRCDIR)/aarch64/gpio.c \
 	$(SRCDIR)/aarch64/hyperv.c \
 	$(SRCDIR)/aarch64/interrupt.c \
 	$(SRCDIR)/aarch64/kernel_machine.c \

--- a/platform/virt/kernel_platform.h
+++ b/platform/virt/kernel_platform.h
@@ -32,6 +32,7 @@
 
 #define VIRT_PCIE_IRQ_BASE 3
 #define VIRT_PCIE_IRQ_NUM  4
+#define VIRT_GPIO_IRQ      7
 #define VIRT_MMIO_IRQ_BASE 16
 #define VIRT_MMIO_IRQ_NUM  32
 

--- a/src/aarch64/gpio.c
+++ b/src/aarch64/gpio.c
@@ -1,0 +1,17 @@
+#include <kernel.h>
+#include <gpio.h>
+
+#define PL061_GPIOIEV   0x40c
+#define PL061_GPIOIE    0x410
+#define PL061_GPIOIC    0x41c
+
+void gpio_irq_enable(u64 mask)
+{
+    mmio_write_32(mmio_base_addr(GPIO) + PL061_GPIOIEV, mask);
+    mmio_write_32(mmio_base_addr(GPIO) + PL061_GPIOIE, mask);
+}
+
+void gpio_irq_clear(u64 mask)
+{
+    mmio_write_32(mmio_base_addr(GPIO) + PL061_GPIOIC, mask);
+}

--- a/src/aarch64/gpio.h
+++ b/src/aarch64/gpio.h
@@ -1,0 +1,2 @@
+void gpio_irq_enable(u64 mask);
+void gpio_irq_clear(u64 mask);

--- a/src/devicetree/devicetree.h
+++ b/src/devicetree/devicetree.h
@@ -42,6 +42,9 @@ typedef struct dt_value {
 
 closure_type(dt_node_handler, boolean, dt_node n, sstring name);
 
+unsigned int dt_prop_cell_count(dt_prop prop);
+u32 dt_prop_get_cell(dt_prop prop, unsigned int index);
+
 typedef struct fdt {
     void *ptr, *end;
     char *strings_start, *strings_end;
@@ -72,6 +75,7 @@ dt_node fdt_next_node(fdt fdt);
 sstring fdt_node_name(fdt fdt, dt_node node);
 void fdt_get_cells(fdt fdt, u32 *acells, u32 *scells);
 boolean fdt_get_reg(fdt fdt, u32 acells, u32 scells, dt_reg_iterator *iter);
+dt_prop fdt_get_prop(fdt fdt, sstring name);
 
 #define fdt_foreach_node(fdt, node) \
     for (dt_node node = fdt_get_node(fdt); node; node = fdt_next_node(fdt))


### PR DESCRIPTION
If ACPI tables are not present in a given Qemu aarch64 instance (e.g. when running an instance with the "virt" machine type and without a UEFI firmware), upon reception of the "system_powerdown" command (which is used to gracefully shut down the instance), Qemu toggles the "poweroff" GPIO instead of generating an ACPI event.
This change set adds parsing of GPIO key information from the device tree, and if such information can be found, enables interrupt generation on the PL061 GPIO controller when the poweroff GPIO is toggled, so that the kernel can be shut down by the interrupt handler.
This allows a graceful shutdown to be performed when an on-prem instance launched with `ops run --arch=arm64` is terminated with CTRL-C.