### PR TITLE
Logging: add user-adjustable log levels ("err", "warn", "info")

### DIFF
--- a/klib/azure.c
+++ b/klib/azure.c
@@ -53,7 +53,7 @@ closure_function(1, 1, void, azure_instance_md_parsed,
 closure_func_basic(parse_error, void, azure_instance_md_err,
                    string data)
 {
-    msg_err("failed to parse JSON: %b\n", data);
+    msg_err("%s: failed to parse JSON: %b", func_ss, data);
 }
 
 closure_func_basic(value_handler, void, azure_instance_md_vh,
@@ -62,7 +62,7 @@ closure_func_basic(value_handler, void, azure_instance_md_vh,
     az_instance_md_req req_data = struct_from_closure(az_instance_md_req, vh);
     deallocate_value(req_data->req);
     if (!v) {
-        msg_err("failed to retrieve instance metadata\n");
+        msg_err("%s: failed to retrieve metadata", func_ss);
         goto done;
     }
     value start_line = get(v, sym(start_line));
@@ -74,7 +74,7 @@ closure_func_basic(value_handler, void, azure_instance_md_vh,
     else
         content = 0;
     if (!content) {
-        msg_err("unexpected metadata server response %v\n", v);
+        msg_err("%s: unexpected server response %v", func_ss, v);
         goto done;
     }
     tuple md = 0;
@@ -106,12 +106,12 @@ void azure_instance_md_get(az_instance_md_handler complete)
     req_params.method = HTTP_REQUEST_METHOD_GET;
     az_instance_md_req req_data = allocate(azure.h, sizeof(*req_data));
     if (req_data == INVALID_ADDRESS) {
-        msg_err("out of memory\n");
+        msg_err("%s: out of memory", func_ss);
         goto error;
     }
     tuple req = allocate_tuple();
     if (req == INVALID_ADDRESS) {
-        msg_err("out of memory\n");
+        msg_err("%s: out of memory", func_ss);
         deallocate(azure.h, req_data, sizeof(*req_data));
         goto error;
     }

--- a/klib/cloud_azure.c
+++ b/klib/cloud_azure.c
@@ -75,7 +75,7 @@ closure_func_basic(timer_handler, void, az_report_th,
     if (is_ok(s)) {
         az->goalstate_pending = true;
     } else {
-        msg_err("%v\n", s);
+        msg_err("%s error %v", func_ss, s);
         timm_dealloc(s);
     }
 }
@@ -85,7 +85,7 @@ static void az_report_status(azure az)
     heap h = az->h;
     buffer blob = allocate_buffer(h, KB);
     if (blob == INVALID_ADDRESS) {
-        msg_err("out of memory\n");
+        msg_err("%s: out of memory", func_ss);
         return;
     }
     status s;
@@ -169,7 +169,7 @@ static void az_report_status(azure az)
     s = net_http_req(req_params);
   done:
     if (!is_ok(s)) {
-        msg_err("%v\n", s);
+        msg_err("%s error %v", func_ss, s);
         timm_dealloc(s);
         deallocate_buffer(blob);
     }
@@ -184,7 +184,7 @@ closure_func_basic(value_handler, void, az_get_ext_vh,
     deallocate_value(req_data->req);
     deallocate(az->h, req_data, sizeof(*req_data));
     if (!v) {
-        msg_err("failed to get response\n");
+        msg_err("%s: failed to get response", func_ss);
         return;
     }
     buffer content = get(v, sym(content));
@@ -277,10 +277,10 @@ closure_func_basic(value_handler, void, az_get_ext_vh,
         return;
     }
   parse_error:
-    msg_err("failed to parse response\n");
+    msg_err("%s: failed to parse response", func_ss);
     return;
   alloc_error:
-    msg_err("out of memory\n");
+    msg_err("%s: out of memory", func_ss);
 }
 
 static void az_get_ext_config(azure az)
@@ -330,7 +330,7 @@ static void az_get_ext_config(azure az)
     if (req_data != INVALID_ADDRESS)
         deallocate(h, req_data, sizeof(*req_data));
     if (!is_ok(s)) {
-        msg_err("%v\n", s);
+        msg_err("%s error %v", func_ss, s);
         timm_dealloc(s);
     }
 }
@@ -340,7 +340,7 @@ closure_func_basic(value_handler, void, az_status_upload_vh,
 {
     azure az = struct_from_closure(azure, status_upload.vh);
     if (!v) {
-        msg_err("failed to get response\n");
+        msg_err("%s: failed to get response", func_ss);
         return;
     }
     value start_line = get(v, sym(start_line));
@@ -355,12 +355,12 @@ closure_func_basic(value_handler, void, az_status_upload_vh,
         if (is_ok(s)) {
             az->status_upload.last_update = kern_now(CLOCK_ID_REALTIME);
         } else {
-            msg_err("failed to upload blob page: %v\n", s);
+            msg_err("%s: failed to upload blob page: %v", func_ss, s);
             timm_dealloc(s);
             deallocate_buffer(req_params->body);
         }
     } else {
-        msg_err("unexpected response %v\n", v);
+        msg_err("%s: unexpected response %v", func_ss, v);
     }
 }
 
@@ -370,7 +370,7 @@ closure_func_basic(value_handler, void, az_goalstate_vh,
     azure az = struct_from_closure(azure, goalstate_vh);
     az->goalstate_pending = false;
     if (!v) {
-        msg_err("failed to get response\n");
+        msg_err("%s: failed to get response", func_ss);
         return;
     }
     buffer content = get(v, sym(content));
@@ -415,7 +415,7 @@ closure_func_basic(value_handler, void, az_goalstate_vh,
         return;
     }
   exit:
-    msg_err("failed to parse response %v\n", v);
+    msg_err("%s: failed to parse response %v", func_ss, v);
 }
 
 closure_func_basic(value_handler, void, az_ready_vh,

--- a/klib/mbedtls.c
+++ b/klib/mbedtls.c
@@ -220,7 +220,7 @@ int tls_set_cacert(void *cert, u64 len)
     mbedtls_x509_crt_init(&tls.cacert);
     int ret = mbedtls_x509_crt_parse(&tls.cacert, cert, len);
     if (ret < 0) {
-        msg_err("cannot parse certificate (%d)\n", ret);
+        msg_err("%s: cannot parse certificate (%d)", func_ss, ret);
         return ret;
     }
     mbedtls_ssl_conf_ca_chain(&tls.conf, &tls.cacert, NULL);
@@ -236,7 +236,7 @@ int tls_connect(ip_addr_t *addr, u16 port, connection_handler ch)
     mbedtls_ssl_init(&conn->ssl);
     int ret = mbedtls_ssl_setup(&conn->ssl, &tls.conf);
     if (ret) {
-        msg_err("cannot set up SSL context\n");
+        msg_err("%s: cannot set up SSL context", func_ss);
         goto err_ssl_setup;
     }
     conn->app_ch = ch;
@@ -265,7 +265,7 @@ int init(status_handler complete)
     mbedtls_ctr_drbg_init(&tls.ctr_drbg);
     mbedtls_entropy_init(&tls.entropy);
     if (mbedtls_ctr_drbg_seed(&tls.ctr_drbg, mbedtls_entropy_func, &tls.entropy, 0, 0)) {
-        rprintf("TLS init: cannot seed entropy source\n");
+        msg_err("TLS init: cannot seed entropy source");
         return KLIB_INIT_FAILED;
     }
     mbedtls_ssl_config_defaults(&tls.conf, MBEDTLS_SSL_IS_CLIENT,

--- a/klib/shmem.c
+++ b/klib/shmem.c
@@ -38,7 +38,7 @@ int init(status_handler complete)
 {
     shmem.fs = tmpfs_new();
     if (shmem.fs == INVALID_ADDRESS) {
-        rprintf("shmem: failed to create tmpfs\n");
+        msg_err("shmem: failed to create tmpfs");
         return KLIB_INIT_FAILED;
     }
     swap_syscall_handler(linux_syscalls, SYS_memfd_create, memfd_create);

--- a/klib/strace.c
+++ b/klib/strace.c
@@ -915,6 +915,6 @@ int init(status_handler complete)
     strace_misc_init();
     return KLIB_INIT_OK;
   oom:
-    msg_err("out of memory\n");
+    msg_err("strace: out of memory");
     return KLIB_INIT_FAILED;
 }

--- a/klib/test/lock.c
+++ b/klib/test/lock.c
@@ -5,31 +5,31 @@ static boolean klib_test_rw_spinlock(void)
     struct rw_spinlock l;
     spin_rw_lock_init(&l);
     if (!spin_tryrlock(&l)) {
-        msg_err("couldn't rlock unlocked spinlock\n");
+        msg_err("%s: couldn't rlock unlocked spinlock", func_ss);
         return false;
     }
     if (spin_trywlock(&l)) {
-        msg_err("could wlock rlocked spinlock\n");
+        msg_err("%s: could wlock rlocked spinlock", func_ss);
         return false;
     }
 #if defined(SMP_ENABLE)
     if (!spin_tryrlock(&l)) {
-        msg_err("couldn't rlock rlocked spinlock\n");
+        msg_err("%s: couldn't rlock rlocked spinlock", func_ss);
         return false;
     }
     spin_runlock(&l);
 #endif
     spin_runlock(&l);
     if (!spin_trywlock(&l)) {
-        msg_err("couldn't wlock unlocked spinlock\n");
+        msg_err("%s: couldn't wlock unlocked spinlock", func_ss);
         return false;
     }
     if (spin_tryrlock(&l)) {
-        msg_err("could rlock wlocked spinlock\n");
+        msg_err("%s: could rlock wlocked spinlock", func_ss);
         return false;
     }
     if (spin_trywlock(&l)) {
-        msg_err("could wlock wlocked spinlock\n");
+        msg_err("%s: could wlock wlocked spinlock", func_ss);
         return false;
     }
     spin_wunlock(&l);

--- a/klib/tmpfs.c
+++ b/klib/tmpfs.c
@@ -212,7 +212,7 @@ filesystem tmpfs_new(void)
         return INVALID_ADDRESS;
     status s = filesystem_init(&fs->fs, h, 0, 1, false);
     if (!is_ok(s)) {
-        msg_err("%v\n", s);
+        msg_err("%s error %v", func_ss, s);
         timm_dealloc(s);
         goto err_fsinit;
     }

--- a/klib/tun.c
+++ b/klib/tun.c
@@ -251,19 +251,19 @@ static void get_tun_config(sstring name, ip4_addr_t *ipaddr, ip4_addr_t *netmask
     if (ipb) {
         sstring ip = buffer_to_sstring(ipb);
         if (!ip4addr_aton(ip, ipaddr)) {
-            rprintf("tun: invalid ipaddress %s\n", ip);
+            msg_err("tun: invalid ipaddress %s", ip);
         }
     }
     buffer nmb = get(cfg, sym(netmask));
     if (nmb) {
         sstring nm = buffer_to_sstring(nmb);
         if (!ip4addr_aton(nm, netmask) || !ip4_addr_netmask_valid(netmask->addr)) {
-            rprintf("tun: invalid netmask %s\n", nm);
+            msg_err("tun: invalid netmask %s", nm);
         }
     }
     if (get_u64(cfg, sym(mtu), mtu)) {
         if (*mtu >= U64_FROM_BIT(16)) {
-            rprintf("tun: invalid mtu %ld; ignored\n", *mtu);
+            msg_err("tun: invalid mtu %ld; ignored", *mtu);
             *mtu = 0;
         }
     }
@@ -432,7 +432,7 @@ int init(status_handler complete)
         return KLIB_INIT_FAILED;
     tun_cfg = get(root, sym(tun));
     if (tun_cfg && !is_tuple(tun_cfg)) {
-        rprintf("invalid tun cfg\n");
+        msg_err("tun: invalid configuration");
         return KLIB_INIT_FAILED;
     }
     spec_file_open open = closure_func(tun_heap, spec_file_open, tun_open);

--- a/platform/pc/pci.c
+++ b/platform/pc/pci.c
@@ -171,13 +171,13 @@ void pci_platform_init_bar(pci_dev dev, int bar)
     if (base & (is_io ? ~PCI_BAR_B_IOPORT_MASK : ~PCI_BAR_B_MEMORY_MASK))
         return; /* BAR configured by BIOS */
     if (is_io) {
-        msg_err("I/O port resource allocation not supported (%d:%d:%d, bar %d)\n",
+        msg_err("%s: I/O port resource allocation not supported (%d:%d:%d, bar %d)", func_ss,
                 dev->bus, dev->slot, dev->function, bar);
         return;
     }
     id_heap iomem = pci_bus_get_iomem(dev->bus);
     if (!iomem) {
-        msg_err("I/O memory heap not available for bus %d\n", dev->bus);
+        msg_err("%s: I/O memory heap not available for bus %d", func_ss, dev->bus);
         return;
     }
     base = id_heap_alloc_subrange(iomem,
@@ -188,7 +188,7 @@ void pci_platform_init_bar(pci_dev dev, int bar)
         if (flags & PCI_BAR_F_64BIT)
             pci_cfgwrite(dev, PCIR_BAR(bar + 1), 4, base >> 32);
     } else {
-        msg_err("failed to allocate I/O memory (%d:%d:%d, bar %d)\n",
+        msg_err("%s: failed to allocate I/O memory (%d:%d:%d, bar %d)", func_ss,
                 dev->bus, dev->slot, dev->function, bar);
     }
 }

--- a/platform/pc/service.c
+++ b/platform/pc/service.c
@@ -212,7 +212,7 @@ void count_cpus_present(void)
         init_debug("ACPI reports %d processors", present_processors);
         return;
     }
-    rprintf("warning: ACPI MADT not found, default to 1 processor\n");
+    msg_warn("ACPI MADT not found, default to 1 processor");
 #endif
 
     present_processors = 1;

--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -528,7 +528,7 @@ void detect_devices(kernel_heaps kh, storage_attach sa)
         if (!is_ok(s))
             halt("Hyper-V probe failed: %v\n", s);
         if (!hv_storvsc_attached)
-            msg_err("cannot detect Hyper-V storage device\n");
+            msg_err("Hyper-V: cannot detect storage device");
     } else {
         init_virtio_network(kh);
         init_aws_ena(kh);

--- a/src/aarch64/interrupt.c
+++ b/src/aarch64/interrupt.c
@@ -480,7 +480,7 @@ void __attribute__((noreturn)) __stack_chk_fail(void)
 {
     cpuinfo ci = current_cpu();
     context ctx = get_current_context(ci);
-    rprintf("stack check failed on cpu %d\n", ci->id);
+    msg_err("stack check failed on cpu %d", ci->id);
     dump_context(ctx);
     vm_exit(VM_EXIT_FAULT);
 }

--- a/src/aarch64/rtc.c
+++ b/src/aarch64/rtc.c
@@ -115,7 +115,7 @@ static boolean rtc_detect(void)
             rtc.set_seconds = pl031_set_seconds;
             return true;
         }
-        rprintf("No RTC detected!\n");
+        msg_err("RTC not detected");
     }
     return !!rtc.get_seconds;
 }

--- a/src/boot/elf.c
+++ b/src/boot/elf.c
@@ -51,7 +51,7 @@ closure_function(2, 5, boolean, kernel_elf_map,
     }
     return true;
   alloc_fail:
-    msg_err("failed to allocate kernel bss mapping\n");
+    msg_err("%s: failed to allocate bss mapping", func_ss);
     return false;
 }
 

--- a/src/boot/uefi.c
+++ b/src/boot/uefi.c
@@ -64,14 +64,14 @@ u64 random_u64()
         efi_status status = UBS->locate_handle_buffer(by_protocol, &uefi_rng_proto, 0,
             &handle_count, &handle_buffer);
         if (EFI_ERROR(status)) {
-            msg_err("failed to locate RNG handles: %d\n", status);
+            msg_err("%s: failed to locate RNG handles: %d", func_ss, status);
             return 0;
         }
         for (u64 index = 0; index < handle_count; index++) {
             status = UBS->open_protocol(handle_buffer[index], &uefi_rng_proto, (void **)&rng,
                 uefi_image_handle, 0, EFI_OPEN_PROTOCOL_GET_PROTOCOL);
             if (EFI_ERROR(status))
-                msg_err("failed to open RNG protocol: %d\n", status);
+                msg_err("%s: failed to open RNG protocol: %d", func_ss, status);
             else
                 break;
         }
@@ -250,7 +250,7 @@ efi_status efi_main(void *image_handle, efi_system_table system_table)
     efi_status status = UBS->locate_handle_buffer(by_protocol, &uefi_block_io_proto, 0,
         &handle_count, &handle_buffer);
     if (EFI_ERROR(status)) {
-        msg_err("failed to locate block I/O handles: %d\n", status);
+        msg_err("%s: failed to locate block I/O handles: %d", func_ss, status);
         return status;
     }
     for (u64 index = 0; index < handle_count; index++) {
@@ -262,7 +262,7 @@ efi_status efi_main(void *image_handle, efi_system_table system_table)
         u8 mbr[SECTOR_SIZE];
         status = block_io->read_blocks(block_io, block_io->media->media_id, 0, SECTOR_SIZE, &mbr);
         if (EFI_ERROR(status)) {
-            msg_err("failed to read first sector: %d\n", status);
+            msg_warn("%s: failed to read first sector: %d", func_ss, status);
             continue;
         }
         struct partition_entry *bootfs_part = partition_get(mbr, PARTITION_BOOTFS);

--- a/src/drivers/acpi.c
+++ b/src/drivers/acpi.c
@@ -102,7 +102,7 @@ closure_function(1, 0, void, acpi_eject,
     arg_list.Pointer = &arg;
     ACPI_STATUS rv = AcpiEvaluateObject(device, "_EJ0", &arg_list, NULL);
     if (ACPI_FAILURE(rv))
-        msg_err("failed to eject device (%d)\n", rv);
+        msg_err("ACPI: failed to eject device (%d)", rv);
     closure_finish();
 }
 
@@ -119,7 +119,7 @@ static void acpi_pci_notify(ACPI_HANDLE device, UINT32 value, void *context)
     ACPI_STATUS rv = AcpiEvaluateObjectTyped(device, METHOD_NAME__ADR, NULL,
                                              &retb, ACPI_TYPE_INTEGER);
     if (ACPI_FAILURE(rv)) {
-        msg_err("failed to get device address (%d)\n", rv);
+        msg_err("%s: failed to get device address (%d)", func_ss, rv);
         return;
     }
     u32 adr = obj.Integer.Value;
@@ -135,7 +135,7 @@ static void acpi_pci_notify(ACPI_HANDLE device, UINT32 value, void *context)
         if (complete != INVALID_ADDRESS)
             pci_remove_device(&dev, complete);
         else
-            msg_err("failed to allocate device ejection closure\n");
+            msg_err("%s: failed to allocate device ejection closure", func_ss);
         break;
     }
 }
@@ -183,7 +183,7 @@ static ACPI_STATUS acpi_device_handler(ACPI_HANDLE object, u32 nesting_level, vo
             if (ACPI_SUCCESS(rv))
                 pci_bridge_set_iomem(ctx.bridge_window, iomem);
             else
-                msg_err("cannot retrieve PCI root bridge resources: %d\n", rv);
+                msg_err("ACPI: cannot retrieve PCI root bridge resources: %d", rv);
         }
         ACPI_FREE(dev_info);
     }
@@ -202,7 +202,7 @@ static ACPI_STATUS acpi_device_handler(ACPI_HANDLE object, u32 nesting_level, vo
             rv = AcpiInstallNotifyHandler(object, ACPI_SYSTEM_NOTIFY, acpi_pci_notify,
                                           pointer_from_u64(parent_info->Address));
             if (ACPI_FAILURE(rv))
-                msg_err("cannot install PCI notify handler: %d\n", rv);
+                msg_err("ACPI: cannot install PCI notify handler: %d", rv);
         }
         ACPI_FREE(parent_info);
     }
@@ -229,22 +229,22 @@ static UINT32 acpi_sleep(void *context)
     const u64 sleep_state = 3;  /* S3 state */
     ACPI_STATUS rv = AcpiEnterSleepStatePrep(sleep_state);
     if (ACPI_FAILURE(rv)) {
-        msg_err("failed to prepare to sleep (%d)\n", rv);
+        msg_err("ACPI: failed to prepare to sleep (%d)", rv);
         goto exit;
     }
     rv = AcpiEnterSleepState(sleep_state);
     if (ACPI_FAILURE(rv)) {
-        msg_err("failed to enter sleep state (%d)\n", rv);
+        msg_err("ACPI: failed to enter sleep state (%d)", rv);
         goto exit;
     }
     rv = AcpiLeaveSleepStatePrep(sleep_state);
     if (ACPI_FAILURE(rv)) {
-        msg_err("failed to prepare to leave sleep state (%d)\n", rv);
+        msg_err("ACPI: failed to prepare to leave sleep state (%d)", rv);
         goto exit;
     }
     rv = AcpiLeaveSleepState(sleep_state);
     if (ACPI_FAILURE(rv))
-        msg_err("failed to leave sleep state (%d)\n", rv);
+        msg_err("ACPI: failed to leave sleep state (%d)", rv);
   exit:
     return ACPI_INTERRUPT_HANDLED;
 }
@@ -292,7 +292,7 @@ static ACPI_STATUS acpi_pwrbtn_probe(ACPI_HANDLE object, u32 nesting_level, void
     ACPI_STATUS rv = AcpiInstallNotifyHandler(object, ACPI_DEVICE_NOTIFY,
                                               acpi_pwrbtn_handler, NULL);
     if (ACPI_FAILURE(rv))
-        msg_err("failed to install power button handler: %d\n", rv);
+        msg_err("ACPI: failed to install power button handler: %d", rv);
     return rv;
 }
 
@@ -332,7 +332,7 @@ static ACPI_STATUS acpi_ged_res_probe(ACPI_RESOURCE *resource, void *context)
             default:
                 rv = AcpiGetHandle(context, "_EVT", &event);
                 if (ACPI_FAILURE(rv)) {
-                    msg_err("failed to locate _EVT method: %d\n", rv);
+                    msg_err("ACPI GED: failed to locate _EVT method: %d", rv);
                     return rv;
                 }
             }

--- a/src/drivers/ata.c
+++ b/src/drivers/ata.c
@@ -257,7 +257,7 @@ void ata_io_cmd(void * _dev, int cmd, void * buf, range blocks, status_handler s
 
 timeout:
     err = ss("ata_io_cmd: device timeout");
-    msg_err("%s\n", err);
+    msg_err("%s", err);
     apply(s, timm_sstring(ss("result"), err));
 }
 
@@ -345,7 +345,7 @@ boolean ata_probe(struct ata *dev)
 
     // identify
     if (ata_wait(dev, 0) < 0) {
-        msg_err("drive busy\n");
+        msg_err("%s: drive busy", func_ss);
         return false;
     }
     ata_out8(dev, ATA_COMMAND, ATA_ATA_IDENTIFY);

--- a/src/drivers/console.c
+++ b/src/drivers/console.c
@@ -66,7 +66,7 @@ closure_function(1, 2, boolean, config_console_each,
                  value a, value v)
 {
     if (!is_string(v)) {
-        msg_err("value (attr %v) not a string\n", a);
+        msg_err("consoles: value (attr %v) not a string", a);
         return false;
     }
     if (buffer_length(v) < 2)
@@ -105,9 +105,9 @@ void config_console(tuple root)
     if (v == 0)
         return;
     if (!is_composite(v)) {
-        msg_err("consoles config is neither vector nor tuple\n");
+        msg_err("consoles config is neither vector nor tuple");
         return;
     }
     if (!iterate(v, stack_closure(config_console_each, root)))
-        msg_err("error parsing consoles from manifest\n");
+        msg_err("consoles parsing error");
 }

--- a/src/drivers/gve.c
+++ b/src/drivers/gve.c
@@ -319,7 +319,7 @@ static boolean gve_adminq_execute_cmd(gve adapter, struct gve_adminq_command *cm
 {
     u32 index = gve_adminq_issue_cmd(adapter);
     if (!gve_adminq_wait(adapter, index)) {
-        msg_err("command %d timed out\n", be32toh(cmd->opcode));
+        msg_err("%s: command %d timed out", func_ss, be32toh(cmd->opcode));
         return false;
     }
     read_barrier();
@@ -544,7 +544,7 @@ closure_func_basic(thunk, void, gve_rx_service)
         if (length <= GVE_RX_PADDING)
             continue;
         if (desc->flags_seq & (GVE_RXF_ERR | GVE_RXF_PKT_CONT)) {
-            msg_err("unexpected flags 0x%x\n", desc->flags_seq);
+            msg_err("%s: unexpected flags 0x%x", func_ss, desc->flags_seq);
             continue;
         }
         u32 qpl_index = rx->qpl_head + rx->qpl_available;
@@ -565,7 +565,7 @@ closure_func_basic(thunk, void, gve_rx_service)
             if (p) {
                 pbuf_take(p, payload, length);
             } else {
-                msg_err("failed to allocate pbuf\n");
+                msg_err("%s: failed to allocate pbuf", func_ss);
                 continue;
             }
         }
@@ -796,19 +796,19 @@ static boolean gve_init(gve adapter)
     pci_bar_write_4(&adapter->reg_bar, GVE_REG_ADMINQ_PFN,
                     htobe32(physical_from_virtual(adapter->adminq) >> PAGELOG));
     if (!gve_describe_device(adapter)) {
-        msg_err("failed to describe device\n");
+        msg_err("GVE: failed to describe device");
         goto err1;
     }
     if (!gve_cfg_device_resources(adapter)) {
-        msg_err("failed to configure device resources\n");
+        msg_err("GVE: failed to configure device resources");
         goto err1;
     }
     if (!gve_init_interrupts(adapter)) {
-        msg_err("failed to initialize interrupts\n");
+        msg_err("GVE: failed to initialize interrupts");
         goto err2;
     }
     if (!gve_setup_queues(adapter)) {
-        msg_err("failed to set up TX/RX queues\n");
+        msg_err("GVE: failed to set up TX/RX queues");
         goto err3;
     }
     return true;

--- a/src/drivers/netconsole.c
+++ b/src/drivers/netconsole.c
@@ -54,7 +54,7 @@ static void netconsole_config(void *_d, tuple r)
     netconsole_driver nd = _d;
     nd->pcb = udp_new_ip_type(IPADDR_TYPE_ANY);
     if (!nd->pcb) {
-        msg_err("failed to allocate pcb\n");
+        msg_err("netconsole: failed to allocate pcb");
         return;
     }
 
@@ -62,23 +62,23 @@ static void netconsole_config(void *_d, tuple r)
     sstring b = dst_ip ? buffer_to_sstring(dst_ip) : ss(DEFAULT_IP);
 
     if (b.len > IPADDR_STRLEN_MAX) {
-        msg_err("ip address too long\n");
+        msg_err("netconsole: ip address too long");
         return;
     }
 
     if (!ipaddr_aton(b, &nd->dst_ip)) {
-        msg_err("failed to translate ip address\n");
+        msg_err("netconsole: failed to translate ip address");
         return;
     }
 
     buffer dst_port = get(r, sym(netconsole_port));
     u64 port = DEFAULT_PORT;
     if (dst_port && !parse_int(dst_port, 10, &port)) {
-        msg_err("failed to parse port\n");
+        msg_err("netconsole: failed to parse port");
         return;
     }
     if (port >= U64_FROM_BIT(16)) {
-        msg_err("port out of range\n");
+        msg_err("netconsole: port out of range");
         return;
     }
     nd->port = (u16)port;

--- a/src/fs/9p.c
+++ b/src/fs/9p.c
@@ -205,7 +205,7 @@ closure_func_basic(status_handler, void, p9fsf_sync_complete,
                    status s)
 {
     if (!is_ok(s)) {
-        msg_err("failed to sync page cache node: %v\n", s);
+        msg_err("9p: failed to sync page cache node: %v", s);
         timm_dealloc(s);
     }
     fsfile f = struct_from_closure(fsfile, sync_complete);

--- a/src/fs/fs.c
+++ b/src/fs/fs.c
@@ -435,7 +435,7 @@ closure_func_basic(status_handler, void, fs_free,
                    status s)
 {
     if (!is_ok(s)) {
-        msg_warn("failed to flush filesystem: %v\n", s);
+        msg_warn("filesystem failed to flush: %v", s);
         timm_dealloc(s);
     }
     filesystem fs = struct_from_closure(filesystem, free);
@@ -1095,7 +1095,7 @@ int filesystem_resolve_sstring(filesystem *fs, tuple cwd, sstring f, tuple *entr
     while (!sstring_is_empty(f)) {
         c = utf8_decode(f, &nbytes);
         if (!nbytes) {
-            msg_err("Invalid UTF-8 sequence.\n");
+            msg_warn("%s: invalid UTF-8 sequence", func_ss);
             err = -ENOENT;
             p = false;
             goto done;

--- a/src/fs/tfs.c
+++ b/src/fs/tfs.c
@@ -154,7 +154,7 @@ void ingest_extent(tfsfile f, symbol off, tuple value)
     tfs fs = tfs_from_file(f);
     if (!filesystem_reserve_storage(fs, storage_blocks)) {
         /* soft error... */
-        msg_err("unable to reserve storage blocks %R\n", storage_blocks);
+        msg_err("TFS %s: unable to reserve storage blocks %R", func_ss, storage_blocks);
     }
     range r = irangel(file_offset, length);
     extent ex = allocate_extent(fs->fs.h, r, storage_blocks);
@@ -427,7 +427,7 @@ static void destroy_extent(tfs fs, extent ex)
 {
     range q = irangel(ex->start_block, ex->allocated);
     if (!filesystem_free_storage(fs, q))
-        msg_err("failed to mark extent at %R as free", q);
+        msg_err("TFS: failed to mark extent at %R as free", q);
     if (ex->uninited && ex->uninited != INVALID_ADDRESS)
         refcount_release(&ex->uninited->refcount);
     deallocate(fs->fs.h, ex, sizeof(*ex));
@@ -1069,7 +1069,7 @@ int filesystem_mkentry(filesystem fs, tuple cwd, sstring fp, tuple entry, boolea
                     continue;
                 }
 
-                msg_err("a path component (\"%s\") is missing\n", token);
+                msg_err("%s: a path component (\"%s\") is missing", func_ss, token);
                 status = -ENOENT;
                 break;
             }
@@ -1237,7 +1237,7 @@ closure_func_basic(status_handler, void, tfsfile_sync_complete,
                    status s)
 {
     if (!is_ok(s)) {
-        msg_err("failed to purge page cache node: %v\n", s);
+        msg_err("TFS: failed to purge page cache node: %v", s);
         timm_dealloc(s);
     }
     tfsfile f = (tfsfile)struct_from_closure(fsfile, sync_complete);

--- a/src/fs/tlog.c
+++ b/src/fs/tlog.c
@@ -502,7 +502,7 @@ closure_function(2, 1, void, log_switch_complete,
     rangemap_foreach(to_be_destroyed->extensions, ext) {
         tlog_debug("  deallocating extension at %R\n", __func__, ext->r);
         if (!filesystem_free_storage(fs, ext->r))
-            msg_err("failed to mark to_be_destroyed log at %R as free", ext->r);
+            msg_err("tlog: failed to mark to_be_destroyed log at %R as free", ext->r);
     }
 
     run_flush_completions(old_tl, s);
@@ -578,7 +578,7 @@ void log_flush(log tl, status_handler completion)
   fail_log_ext_close:
         close_log_extension(new_ext);
         if (!filesystem_free_storage(fs, new_ext->sectors))
-            msg_err("failed to mark new_ext at %R as free", new_ext->sectors);
+            msg_err("tlog: failed to mark new_ext at %R as free", new_ext->sectors);
   fail_log_destroy:
         log_destroy(new_tl);
     }
@@ -886,7 +886,7 @@ log log_create(heap h, tfs fs, boolean initialize, status_handler sh)
 #ifndef TLOG_READ_ONLY
     range sectors = irange(0, TFS_LOG_INITIAL_SIZE >> fs->fs.blocksize_order);
     if (!filesystem_reserve_storage(fs, sectors)) {
-        msg_err("failed to reserve sectors in allocation map");
+        msg_err("tlog: failed to reserve sectors in allocation map");
         return INVALID_ADDRESS;
     }
 #endif

--- a/src/gdb/gdbstub.c
+++ b/src/gdb/gdbstub.c
@@ -447,7 +447,7 @@ static boolean handle_request(gdb g, buffer b, buffer output)
                     if (breakpoint_remove(g->h, addr, closure(g->h, send_ok, g)))
                         return false;
                     else {
-                        rprintf("hardware breakpoint could not be found\n");
+                        msg_err("gdbserver: hardware breakpoint could not be found");
                         bprintf(output, "E08");
                     }
                 }
@@ -462,7 +462,7 @@ static boolean handle_request(gdb g, buffer b, buffer output)
             check(b, ',');
             parse_hex_pair(b, &addr, &length);
             if (addr >= USER_LIMIT) {
-                rprintf("kernel breakpoints not currently allowed\n");
+                msg_err("gdbserver: kernel breakpoints not currently allowed");
                 bprintf(output, "E08");
                 break;
             }
@@ -472,7 +472,7 @@ static boolean handle_request(gdb g, buffer b, buffer output)
                     if (breakpoint_insert(g->h, addr, 0, 8, closure(g->h, send_ok, g)))
                         return false;
                     else {
-                        rprintf("maximum number of hardware breakpoints reached\n");
+                        msg_err("gdbserver: maximum number of hardware breakpoints reached");
                         bprintf(output, "E08");
                     }
                 }

--- a/src/gdb/gdbutil.c
+++ b/src/gdb/gdbutil.c
@@ -76,7 +76,7 @@ void putpacket_deferred(gdb g, string b)
     u64 flags = spin_lock_irq(&g->send_lock);
     if (g->sending) {
         spin_unlock_irq(&g->send_lock, flags);
-        rprintf("putpacket_deferred dropped, already sending\n");
+        msg_err("gdbserver: %s dropped, already sending", func_ss);
         return;
     }
     g->sending = true;
@@ -90,7 +90,7 @@ void putpacket(gdb g, string b)
     u64 flags = spin_lock_irq(&g->send_lock);
     if (g->sending) {
         spin_unlock_irq(&g->send_lock, flags);
-        rprintf("putpacket dropped, already sending\n");
+        msg_err("gdbserver: %s dropped, already sending", func_ss);
         return;
     }
     put_sendstring(g, b);

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -254,7 +254,7 @@ closure_function(1, 1, status, http_recv,
             if (x == '\r') {
                 if (p->s == sym(Content-Length)) {
                     if (!parse_int(p->word, 10, &p->content_length))
-                        msg_err("failed to parse content length\n");
+                        msg_err("%s: failed to parse content length", func_ss);
 
                     /* unconsume the bytes consumed by parse_int() */
                     p->word->start = 0;

--- a/src/hyperv/netvsc/netvsc.c
+++ b/src/hyperv/netvsc/netvsc.c
@@ -289,7 +289,7 @@ closure_function(1, 3, boolean, netvsc_probe,
 {
     status s = netvsc_attach(bound(kh), device);
     if (!is_ok(s)) {
-        msg_err("attach failed with status %v\n", s);
+        msg_err("netvsc attach failed with status %v", s);
         return false;
     }
     return true;
@@ -404,7 +404,7 @@ netvsc_recv(struct hv_device *device_ctx, netvsc_packet *packet)
 
     err_enum_t err = n->input((struct pbuf *)x, n);
     if (err != ERR_OK) {
-        msg_err("netvsc: rx drop by stack, err %d\n", err);
+        msg_err("netvsc: rx drop by stack, err %d", err);
         receive_buffer_release((struct pbuf *)x);
     }
     return 0;

--- a/src/hyperv/storvsc/storvsc.c
+++ b/src/hyperv/storvsc/storvsc.c
@@ -521,7 +521,7 @@ static int hv_storvsc_io_request(struct storvsc_softc *sc, struct hv_storvsc_req
     }
 
     if (ret != 0) {
-        rprintf("Unable to send packet %p ret %d", vstor_packet, ret);
+        msg_err("storvsc: unable to send packet %p, ret %d", vstor_packet, ret);
     } else {
         fetch_and_add_32(&sc->hs_num_out_reqs, 1);
     }
@@ -1308,7 +1308,7 @@ closure_function(1, 3, boolean, storvsc_probe,
 {
     status s = storvsc_attach(bound(kh), device, a);
     if (!is_ok(s)) {
-        msg_err("attach failed with status %v\n", s);
+        msg_err("storvsc attach failed with status %v", s);
         return false;
     }
     *storvsc_attached = true;

--- a/src/hyperv/utilities/vmbus_shutdown.c
+++ b/src/hyperv/utilities/vmbus_shutdown.c
@@ -135,7 +135,7 @@ closure_function(1, 3, boolean, vmbus_shutdown_probe,
 {
     status s = vmbus_shutdown_attach(bound(kh), device);
     if (!is_ok(s)) {
-        msg_err("attach failed with status %v\n", s);
+        msg_err("vmbus_shutdown attach failed with status %v", s);
         return false;
     }
     return true;

--- a/src/hyperv/vmbus/hyperv.c
+++ b/src/hyperv/vmbus/hyperv.c
@@ -106,7 +106,7 @@ init_vmbus(kernel_heaps kh)
 
     status s = vmbus_attach(kh, &hyperv_info.vmbus);
     if (!is_ok(s)) {
-        msg_err("attach failed with status %v\n", s);
+        msg_err("vmbus attach failed with status %v", s);
         return;
     }
 

--- a/src/hyperv/vmbus/vmbus_xact.c
+++ b/src/hyperv/vmbus/vmbus_xact.c
@@ -223,7 +223,7 @@ vmbus_xact_return(struct vmbus_xact *xact, size_t *resp_len)
          * Orphaned and no response was received yet; fake up
          * an one byte response.
          */
-        rprintf("vmbus: xact ctx was orphaned w/ pending xact\n");
+        msg_err("vmbus: xact ctx was orphaned w/ pending xact");
         vmbus_xact_save_resp(ctx->xc_active, &b, sizeof(b));
     }
     assert(xact->x_resp != NULL); //no response
@@ -324,7 +324,7 @@ vmbus_xact_save_resp(struct vmbus_xact *xact, const void *data, size_t dlen)
     size_t cplen = dlen;
 
     if (cplen > ctx->xc_resp_size) {
-        rprintf("vmbus: xact response truncated %zu -> %zu\n",
+        msg_warn("vmbus: xact response truncated %zu -> %zu",
             cplen, ctx->xc_resp_size);
         cplen = ctx->xc_resp_size;
     }
@@ -349,7 +349,7 @@ vmbus_xact_wakeup(struct vmbus_xact *xact, const void *data, size_t dlen)
         vmbus_xact_save_resp(xact, data, dlen);
     } else {
         assert(ctx->xc_flags & VMBUS_XACT_CTXF_DESTROY); //no active xact pending
-        rprintf("vmbus: drop xact response\n");
+        msg_warn("vmbus: drop xact response");
     }
     spin_unlock_irq(&ctx->xc_lock, flags);
 }

--- a/src/kernel/elf.c
+++ b/src/kernel/elf.c
@@ -55,7 +55,7 @@ void elf_symbols(buffer elf, elf_sym_handler each)
     }
 
     if (!symbols || !symbol_strings) {
-        msg_warn("failed: symtab not found\n");
+        msg_warn("%s failed: symtab not found", func_ss);
         return;
     }
 
@@ -70,7 +70,7 @@ void elf_symbols(buffer elf, elf_sym_handler each)
     }
     return;
   out_elf_fail:
-    msg_err("failed to parse elf file, len %d; check file image consistency\n", buffer_length(elf));
+    msg_err("%s: failed to parse file, len %d", func_ss, buffer_length(elf));
 }
 
 closure_function(6, 1, boolean, elf_sym_relocate,
@@ -170,7 +170,7 @@ boolean elf_dyn_parse(buffer elf, Elf64_Shdr **symtab, Elf64_Shdr **strtab, Elf6
     ELF_CHECK_PTR(*strtab, Elf64_Shdr);
     return true;
   out_elf_fail:
-    msg_err("failed to parse elf, len %d\n", buffer_length(elf));
+    msg_err("%s failed, len %d", func_ss, buffer_length(elf));
     return false;
 }
 
@@ -313,8 +313,8 @@ void *load_elf(buffer elf, u64 load_offset, elf_map_handler mapper)
                   p->p_memsz - p->p_filesz, flags);
         if (!apply(mapper, p->p_vaddr + load_offset, p->p_offset, p->p_filesz,
                    p->p_memsz - p->p_filesz, flags)) {
-            msg_err("call to mapper %F failed (vaddr 0x%lx, offset 0x%lx, "
-                    "data size 0x%lx, bss size 0x%lx, flags 0x%lx)\n",
+            msg_err("elf load: call to mapper %F failed (vaddr 0x%lx, offset 0x%lx, "
+                    "data size 0x%lx, bss size 0x%lx, flags 0x%lx)",
                     mapper, p->p_vaddr + load_offset, p->p_offset, p->p_filesz,
                     p->p_memsz - p->p_filesz, flags);
             goto out_elf_fail;
@@ -324,7 +324,7 @@ void *load_elf(buffer elf, u64 load_offset, elf_map_handler mapper)
     elf_debug("   done; entry 0x%lx\n", entry);
     return pointer_from_u64(entry);
   out_elf_fail:
-    msg_err("failed to parse elf file, len %d; check file image consistency\n", buffer_length(elf));
+    msg_err("elf load: failed to parse file, len %d", buffer_length(elf));
     return INVALID_ADDRESS;
 }
 

--- a/src/kernel/klib.c
+++ b/src/kernel/klib.c
@@ -99,7 +99,7 @@ closure_function(2, 5, boolean, klib_elf_map,
     }
     return true;
   alloc_fail:
-    msg_err("failed to allocate klib mapping\n");
+    msg_err("%s: failed to allocate mapping", func_ss);
     return false;
 }
 

--- a/src/kernel/kvm_platform.c
+++ b/src/kernel/kvm_platform.c
@@ -43,7 +43,7 @@ static boolean probe_kvm_pvclock(kernel_heaps kh, u32 cpuid_fn)
     kvm_debug("after write msr");
     if (vc->system_time == 0) {
         /* noise, but we should know if this happens */
-        msg_err("kvm pvclock probe failed: detected kvm pvclock, but system_time == 0\n");
+        msg_err("kvm pvclock probe failed: detected kvm pvclock, but system_time == 0");
         return false;
     }
     init_pvclock(heap_general(kh), vc, (struct pvclock_wall_clock *)(vc + 1));
@@ -65,7 +65,7 @@ boolean kvm_detect(kernel_heaps kh)
     if (fn == KVM_CPUID_END)
         return false;
     if (!probe_kvm_pvclock(kh, fn)) {
-        msg_err("unable to probe pvclock\n");
+        msg_err("kvm: unable to probe pvclock");
         return false;
     }
 

--- a/src/kernel/lockstats.c
+++ b/src/kernel/lockstats.c
@@ -185,7 +185,7 @@ static boolean log_output(pqueue pq, buffer b)
     return true;
 }
 
-#define catch_err(s) do {if (!is_ok(s)) msg_err("lockstat: failed to send HTTP response: %v\n", (s));} while(0)
+#define catch_err(s) do {if (!is_ok(s)) msg_err("lockstats: failed to send HTTP response: %v", (s));} while(0)
 
 static void
 lockstats_send_http_response(http_responder handler, buffer b)
@@ -281,7 +281,7 @@ init_http_listener(void)
 
     lockstats_hl = allocate_http_listener(lockstats_heap, LOCKSTATS_PORT);
     if (lockstats_hl == INVALID_ADDRESS) {
-        msg_err("could not allocate lock stat HTTP listener\n");
+        msg_err("lockstats: could not allocate HTTP listener");
         return -1;
     }
 
@@ -295,14 +295,14 @@ init_http_listener(void)
         connection_handler_from_http_listener(lockstats_hl)
     );
     if (!is_ok(s)) {
-        msg_err("listen_port(port=%d) failed for lockstat HTTP listener\n",
+        msg_err("lockstats: listen_port(port=%d) failed",
             LOCKSTATS_PORT
         );
         deallocate_http_listener(lockstats_heap, lockstats_hl);
         return -1;
     }
 
-    rprintf("started lockstat http listener on port %d\n", LOCKSTATS_PORT);
+    msg_info("lockstats: started HTTP listener on port %d", LOCKSTATS_PORT);
 
     return 0;
 }
@@ -320,5 +320,5 @@ void lockstats_init(kernel_heaps kh)
     }
     int ret = init_http_listener();
     if (ret != 0)
-        msg_err("failed to start http listener\n");
+        msg_err("lockstats: failed to start HTTP listener");
 }

--- a/src/kernel/log.h
+++ b/src/kernel/log.h
@@ -11,6 +11,8 @@ typedef struct klog_dump {
     char msgs[KLOG_DUMP_SIZE - 16]; /* total size of the struct must match KLOG_DUMP_SIZE */
 } __attribute__((packed)) *klog_dump;
 
+#ifdef KERNEL
+
 void klog_write(const char *s, bytes count);
 
 void klog_disk_setup(u64 disk_offset, storage_req_handler req_handler);
@@ -18,3 +20,8 @@ void klog_set_boot_id(u64 id);
 void klog_load(klog_dump dest, status_handler sh);
 void klog_save(int exit_code, status_handler sh);
 void klog_dump_clear(void);
+
+void klog_set_level(string level);
+boolean klog_level_enabled(enum log_level level);
+
+#endif

--- a/src/kernel/ltrace.c
+++ b/src/kernel/ltrace.c
@@ -117,7 +117,7 @@ void ltrace_init(value cfg, buffer exe, u64 load_offset)
     if (!elf_dyn_parse(exe, &symtab, &strtab, &reltab, &relcount))
         halt("ltrace: failed to parse dynamic section\n");
     if (!symtab || !strtab || !reltab) {
-        rprintf("ltrace: not a dynamically linked executable\n");
+        msg_err("ltrace: not a dynamically linked executable");
         return;
     }
     u64 plt_addr, plt_offset, plt_size;

--- a/src/kernel/management_telnet.c
+++ b/src/kernel/management_telnet.c
@@ -45,5 +45,5 @@ void init_management_telnet(heap h, value meta)
 {
     // XXX config port
     listen_port(h, 9090, closure(h, each_telnet_connection, h));
-    rprintf("Debug telnet server started on port 9090\n");
+    msg_info("Debug telnet server started on port 9090");
 }

--- a/src/kernel/page.c
+++ b/src/kernel/page.c
@@ -75,7 +75,7 @@ void *allocate_table_page(u64 *phys)
         page_init_debug(" [new alloc, pa: ");
         u64 pa = allocate_u64(pagemem.pageheap, PAGEMEM_ALLOC_SIZE);
         if (pa == INVALID_PHYSICAL) {
-            msg_err("failed to allocate page table memory\n");
+            msg_err("page table: failed to allocate memory");
             return INVALID_ADDRESS;
         }
         page_init_debug_u64(pa);
@@ -485,7 +485,6 @@ static boolean map_level(u64 *table_ptr, int level, range v, u64 *p, u64 flags, 
                 void *tp;
                 u64 tp_phys;
                 if ((tp = allocate_table_page(&tp_phys)) == INVALID_ADDRESS) {
-                    msg_err("failed to allocate page table memory\n");
                     return false;
                 }
                 /* user and writable are AND of flags from all levels */
@@ -559,7 +558,6 @@ void map(u64 v, physical p, u64 length, pageflags flags)
     u64 *table_ptr = pointer_from_pteaddr(get_pagetable_base(v));
     if (!map_level(table_ptr, PT_FIRST_LEVEL, r, &p, flags.w, fe)) {
         pagetable_unlock();
-        rprintf("ra %p\n", __builtin_return_address(0));
         print_frame_trace_from_here();
         halt("map failed for v 0x%lx, p 0x%lx, len 0x%lx, flags 0x%lx\n",
              v, p, length, flags.w);

--- a/src/kernel/page_backed_heap.c
+++ b/src/kernel/page_backed_heap.c
@@ -15,7 +15,7 @@ void page_backed_dealloc_virtual(backed_heap bh, u64 x, bytes length)
     page_backed_heap pbh = (page_backed_heap)bh;
     u64 padlen = pad(length, pbh->bh.h.pagesize);
     if (x & (pbh->bh.h.pagesize - 1)) {
-	msg_err("attempt to free unaligned area at %lx, length %x; leaking\n", x, length);
+	msg_err("%s error: unaligned area at %lx, length %x; leaking", func_ss, x, length);
 	return;
     }
 
@@ -48,7 +48,7 @@ static inline void page_backed_dealloc_unmap(backed_heap bh, void *virt, u64 phy
 {
     page_backed_heap pbh = (page_backed_heap)bh;
     if (u64_from_pointer(virt) & (pbh->bh.h.pagesize - 1)) {
-        msg_err("attempt to free unaligned area at %lx, length %x; leaking\n", virt, len);
+        msg_err("%s error: unaligned area at %lx, length %x; leaking", func_ss, virt, len);
         return;
     }
     if (phys == 0) {

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -280,7 +280,7 @@ closure_function(3, 1, void, pagecache_read_page_complete,
 
     if (!is_ok(s)) {
         /* TODO need policy for capturing/reporting I/O errors... */
-        msg_err("error reading page 0x%lx: %v\n", page_offset(pp) << pc->page_order, s);
+        msg_err("pagecache: error reading page 0x%lx: %v", page_offset(pp) << pc->page_order, s);
     }
     pagecache_lock_state(pc);
     change_page_state_locked(bound(pc), pp, PAGECACHE_PAGESTATE_NEW);
@@ -951,7 +951,7 @@ define_closure_function(3, 1, void, pagecache_commit_dirty_ranges,
         rp->end = MIN(rp->end, limit);
         sg_list sg = allocate_sg_list();
         if (sg == INVALID_ADDRESS) {
-            msg_err("unable to allocate sg list\n");
+            msg_err("%s: unable to allocate sg list", func_ss);
             if (committing == 0)
                 s = timm("result", "unable to allocate sg list");
             break;
@@ -973,7 +973,7 @@ define_closure_function(3, 1, void, pagecache_commit_dirty_ranges,
             } else {
                 sgb = sg_list_tail_add(sg, len);
                 if (sgb == INVALID_ADDRESS) {
-                    msg_warn("sgbuf alloc fail\n");
+                    msg_warn("%s: sgbuf alloc fail", func_ss);
                     if (committing == 0)
                         s = timm("result", "unable to allocate sg buffer");
                     r.end = start;

--- a/src/kernel/pci.c
+++ b/src/kernel/pci.c
@@ -273,7 +273,7 @@ void pci_probe_device(pci_dev dev)
     if (dev_index < 0) {
         pci_dev new_dev = allocate(devices->h, sizeof(*new_dev));
         if (new_dev == INVALID_ADDRESS) {
-            msg_err("cannot allocate memory for PCI device\n");
+            msg_err("PCI: cannot allocate memory for device");
             spin_unlock(&pci_lock);
             return;
         }
@@ -356,7 +356,7 @@ void pci_remove_device(pci_dev dev, thunk completion)
         if (pci_completion != INVALID_ADDRESS)
             completion = pci_completion;
         else
-            msg_err("cannot allocate completion closure\n");
+            msg_err("%s: cannot allocate completion closure", func_ss);
         driver = d->driver;
         driver_data = d->driver_data;
         d->driver_data = 0;

--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -78,10 +78,7 @@ closure_function(6, 0, void, startup,
     program_set_perms(root, pro);
     init_network_iface(root, bound(m));
     closure_member(program_start, start, path) = (string)p;
-    if (trace_get_flags(get(root, sym(trace))) & TRACE_OTHER) {
-        rprintf("read program complete: %p ", root);
-        rprintf("gitversion: %s\n", gitversion);
-    }
+    msg_info("gitversion: %s", gitversion);
     storage_when_ready(apply_merge(bound(m)));
     apply(bound(completion), s);
     closure_finish();

--- a/src/kernel/storage.c
+++ b/src/kernel/storage.c
@@ -111,7 +111,7 @@ closure_function(2, 2, void, volume_link,
         inode mount_dir = bound(mount_dir);
         int fss = filesystem_mount(storage.root_fs, mount_dir, fs);
         if (fss != 0) {
-            msg_err("cannot mount filesystem: %s\n", string_from_errno(-fss));
+            msg_err("%s: cannot mount filesystem: %s", func_ss, string_from_errno(-fss));
         } else {
             v->fs = fs;
             v->mount_dir = mount_dir;
@@ -119,7 +119,7 @@ closure_function(2, 2, void, volume_link,
             notify_mount_change_locked();
         }
     } else {
-        msg_err("cannot mount filesystem: %v\n", s);
+        msg_err("%s: cannot mount filesystem: %v", func_ss, s);
     }
     v->mounting = false;
     if (!v->fs && (fs != INVALID_ADDRESS))
@@ -145,20 +145,20 @@ static void volume_mount(volume v, buffer mount_point)
     int fss = filesystem_get_node(&fs, fs->get_inode(fs, root), cmount_point,
         false, false, false, false, &mount_dir_t, 0);
     if (fss != 0) {
-        msg_err("mount point %s not found\n", cmount_point);
+        msg_err("storage: mount point %s not found", cmount_point);
         return;
     }
     inode mount_dir = fs->get_inode(fs, mount_dir_t);
     boolean ok = (fs == storage.root_fs) && (mount_dir_t != root) && children(mount_dir_t);
     filesystem_put_node(fs, mount_dir_t);
     if (!ok) {
-        msg_err("invalid mount point %s\n", cmount_point);
+        msg_err("storage: invalid mount point %s", cmount_point);
         return;
     }
     filesystem_complete complete = closure(storage.h, volume_link,
         v, mount_dir);
     if (complete == INVALID_ADDRESS) {
-        msg_err("cannot allocate closure\n");
+        msg_err("%s: cannot allocate closure", func_ss);
         return;
     }
     storage_debug("mounting volume%s at %s", readonly ? ss(" readonly") : sstring_empty(),

--- a/src/kernel/symtab.c
+++ b/src/kernel/symtab.c
@@ -45,16 +45,14 @@ closure_function(1, 4, void, elf_symtable_add,
     range r = irangel(a + bound(load_offset), len);
     boolean match = rangemap_range_intersects(elf_symtable, r);
     if (match) {
-#ifdef ELF_SYMTAB_DEBUG
-	msg_err("\"%s\" %R would overlap in rangemap; skipping\n", name, r);
-#endif
+	msg_warn("%s: \"%s\" %R would overlap in rangemap; skipping", func_ss, name, r);
 	return;
     }
 
     elfsym es = allocate_elfsym(r, name);
     if (!rangemap_insert(elf_symtable, &es->node)) {
         /* shouldn't ever happen, so bark if it does */
-        msg_err("unable to add symbol \"%s\" of range %R to map; skipping\n",
+        msg_err("%s: unable to add symbol \"%s\" of range %R to map; skipping", func_ss,
                 name, r);
     }
 }

--- a/src/kernel/tracelog.c
+++ b/src/kernel/tracelog.c
@@ -632,11 +632,11 @@ static void init_tracelog_file_writer(value v)
     }
     filesystem fs = get_root_fs();
     tuple root = filesystem_getroot(fs);
-    fs_status s = filesystem_get_node(&fs, fs->get_inode(fs, root),
+    int s = filesystem_get_node(&fs, fs->get_inode(fs, root),
                                       buffer_to_sstring((buffer)v),
                                       true, true, false, false, &file, &fsf);
-    if (s != FS_STATUS_OK) {
-        msg_err("failed to open tracelog file: %s\n", string_from_fs_status(s));
+    if (s < 0) {
+        msg_err("failed to open tracelog file: %s\n", string_from_errno(-s));
         return;
     }
     filesystem_put_node(fs, file);

--- a/src/net/direct.c
+++ b/src/net/direct.c
@@ -113,7 +113,7 @@ static direct direct_alloc(heap h, connection_handler ch)
         return d;
     d->p = tcp_new_ip_type(IPADDR_TYPE_ANY);
     if (!d->p) {
-        msg_err("PCB creation failed\n");
+        msg_err("DNET: PCB creation failed");
         deallocate(h, d, sizeof(struct direct));
         return INVALID_ADDRESS;
     }
@@ -215,7 +215,7 @@ static void direct_conn_send_internal(direct_conn dc, qbuf q, boolean lwip_locke
 
         err = tcp_output(dc->p);
         if (err != ERR_OK) {
-            msg_err("tcp_output failed with %d\n", err);
+            msg_err("DNET: tcp_output failed with %d", err);
             break;
         }
 
@@ -290,7 +290,7 @@ static void direct_conn_err(void *z, err_t err)
         direct_conn_enqueue(dc, 0);
         return;
     }
-    msg_err("dc %p, err %d\n", dc, err);
+    msg_err("%s: dc %p, err %d", func_ss, dc, err);
     dc->pending_err = err;
 }
 
@@ -326,14 +326,14 @@ static direct_conn direct_conn_alloc(direct d, struct tcp_pcb *pcb)
   fail_dealloc:
     deallocate(d->h, dc, sizeof(struct direct_conn));
   fail:
-    msg_err("failed to establish direct connection\n");
+    msg_err("%s failed", func_ss);
     return INVALID_ADDRESS;
 }
 
 static void direct_listen_err(void *z, err_t err)
 {
     direct d = z;
-    msg_err("d %p, err %d\n", d, err);
+    msg_err("%s: d %p, err %d", func_ss, d, err);
     /* XXX TODO */
 }
 

--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -9,8 +9,7 @@
 #define ARP_QUEUEING 1
 //#define LWIP_DEBUG
 #ifdef LWIP_DEBUG
-#define lwip_debug(fmt, ...)    lwip_debug_sstring(ss(fmt), ##__VA_ARGS__)
-#define LWIP_PLATFORM_DIAG(x) do {lwip_debug x;} while(0)
+#define LWIP_PLATFORM_DIAG(x) do {rprintf x;} while(0)
 #define LWIP_DBG_MIN_LEVEL		LWIP_DBG_LEVEL_ALL
 #define ETHARP_DEBUG                    LWIP_DBG_ON
 #define NETIF_DEBUG                     LWIP_DBG_ON
@@ -142,7 +141,6 @@ struct tcpip_api_call_data
 #define SYS_LIGHTWEIGHT_PROT    0
 
 typedef unsigned long long time; 
-extern void lwip_debug_sstring(sstring format, ...);
 
 #define MEM_LIBC_MALLOC 1
 

--- a/src/riscv64/interrupt.c
+++ b/src/riscv64/interrupt.c
@@ -198,7 +198,7 @@ void riscv_timer(void)
 static boolean invoke_handlers_for_vector(cpuinfo ci, int v)
 {
     if (list_empty(&handlers[v])) {
-        rprintf("\nno handler for %s %d\n", v <= PLIC_MAX_INT ? ss("interrupt") : ss("IPI"), v);
+        msg_err("irq: no handler for %s %d", v <= PLIC_MAX_INT ? ss("interrupt") : ss("IPI"), v);
         return false;
     }
 
@@ -253,7 +253,7 @@ void trap_interrupt(void)
                      (f[FRAME_STATUS] & STATUS_SPP) ? ss("false") : ss("true"));
 
             if (i > PLIC_MAX_INT) {
-                rprintf("\ndispatched interrupt %d exceeds PLIC_MAX_INT\n", i);
+                msg_err("%s: dispatched interrupt %d exceeds PLIC_MAX_INT", func_ss, i);
                 goto exit_fault;
             }
 
@@ -454,7 +454,7 @@ void __attribute__((noreturn)) __stack_chk_fail(void)
 {
     cpuinfo ci = current_cpu();
     context ctx = get_current_context(ci);
-    rprintf("stack check failed on cpu %d\n", ci->id);
+    msg_err("stack check failed on cpu %d", ci->id);
     dump_context(ctx);
     vm_exit(VM_EXIT_FAULT);
 }

--- a/src/riscv64/kernel_machine.c
+++ b/src/riscv64/kernel_machine.c
@@ -168,7 +168,7 @@ void count_cpus_present(void)
     vector_set(hartids_by_cpuid, 0, (void*)boot_hartid);
     dt_node n = dtb_find_node_by_path(DEVICETREE, ss("/cpus"));
     if (n == INVALID_ADDRESS) {
-        msg_err("unable to find \"/cpus/cpu-map/cluster0\" in device tree; resorting to single cpu\n");
+        msg_err("device tree: unable to find \"/cpus/cpu-map/cluster0\"; resorting to single cpu");
         return;
     }
 

--- a/src/runtime/bitmap.c
+++ b/src/runtime/bitmap.c
@@ -191,13 +191,13 @@ boolean bitmap_dealloc(bitmap b, u64 bit, u64 size)
     assert(mapbase);
 
     if (bit + size > b->maxbits) {
-	msg_err("bitmap %p, bit %ld, order %ld: exceeds bit length %ld\n",
+	msg_err("bitmap %p, bit %ld, order %ld: exceeds bit length %ld",
 		b, bit, order, b->maxbits);
 	return false;
     }
 
     if (!for_range_in_map(mapbase, bit, size, false, true)) {
-	msg_err("bitmap %p, bit %ld, order %ld: not allocated in map; leaking\n",
+	msg_err("bitmap %p, bit %ld, order %ld: not allocated in map; leaking",
 		b, bit, order);
 	return false;
     }

--- a/src/runtime/clock.h
+++ b/src/runtime/clock.h
@@ -83,7 +83,8 @@ static inline timestamp now(clock_id id)
         s64 interval = t - last_raw;
         t += clock_freq_adjust(interval);
         if (t < last_raw) {
-            msg_err("t(%T) < last_raw(%T) after freq adjust (%f)\n", t, last_raw, __vdso_dat->base_freq);
+            msg_err("%s error: t(%T) < last_raw(%T) after freq adjust (%f)",
+                    func_ss, t, last_raw, __vdso_dat->base_freq);
             t = last_raw;
         }
         switch (id) {

--- a/src/runtime/format.c
+++ b/src/runtime/format.c
@@ -97,23 +97,6 @@ void vbprintf(buffer d, sstring fmt, vlist *ap)
     }
 }
 
-// XXX fixme
-/* XXX the various debug stuff needs to be folded into one log facility...somewhere */
-void log_vprintf(sstring prefix, sstring log_format, vlist *a)
-{
-    buffer b = little_stack_buffer(1024);
-    bprintf(b, "[%T] %s: ", now(CLOCK_ID_BOOTTIME), prefix);
-    vbprintf(b, log_format, a);
-    buffer_print(b);
-}
-
-void log_printf(sstring prefix, sstring log_format, ...)
-{
-    vlist a;
-    vstart(a, log_format);
-    log_vprintf(prefix, log_format, &a);
-}
-
 buffer aprintf_sstring(heap h, sstring fmt, ...)
 {
     buffer b = allocate_buffer(h, 80);
@@ -136,7 +119,7 @@ int rsnprintf_sstring(char *str, u64 size, sstring fmt, ...)
 {
     buffer b = allocate_buffer(transient, size);
     if (b == INVALID_ADDRESS) {
-        msg_err("buffer allocation failed\n");
+        msg_err("%s: buffer allocation failed", func_ss);
         if (size > 0)
             str[0] = '\0';
         return 0;

--- a/src/runtime/format.h
+++ b/src/runtime/format.h
@@ -1,8 +1,5 @@
 extern void vbprintf(buffer s, sstring fmt, vlist *ap);
 
-extern void log_vprintf(sstring prefix, sstring log_format, vlist *a);
-extern void log_printf(sstring prefix, sstring log_format, ...);
-
 struct formatter_state {
     int state;
     int format;    // format character ('s', 'd', ...)

--- a/src/runtime/heap/freelist.c
+++ b/src/runtime/heap/freelist.c
@@ -24,7 +24,6 @@ static void freelist_deallocate(heap h, u64 x, bytes size)
     freelist f = (freelist)h;
     *(void **)pointer_from_u64(x) = f->free;
     f->free = pointer_from_u64(x);
-    //    rprintf("freelist deallocate %p\n", x);
     size = MAX(size, sizeof(void *));
     assert(f->count >= size);
     f->count -= size;

--- a/src/runtime/heap/mcache.c
+++ b/src/runtime/heap/mcache.c
@@ -304,18 +304,18 @@ heap allocate_mcache(heap meta, heap parent, int min_order, int max_order, bytes
 {
     if (pagesize < parent->pagesize ||
 	((pagesize - 1) & pagesize)) {
-	msg_err("pagesize (%d) must be a power-of-2 >= parent pagesize (%d)\n",
+	msg_err("mcache pagesize (%d) must be a power-of-2 >= parent pagesize (%d)",
 		pagesize, parent->pagesize);
 	return INVALID_ADDRESS;
     }
 
     if (U64_FROM_BIT(max_order) >= pagesize) {
-	msg_err("max obj size (%d) must be less than pagesize %d\n", U64_FROM_BIT(max_order), pagesize);
+	msg_err("mcache max obj size (%d) must be less than pagesize %d", U64_FROM_BIT(max_order), pagesize);
 	return INVALID_ADDRESS;
     }
 
     if (min_order > max_order) {
-	msg_err("min_order (%d) cannot exceed max_order (%d)\n", min_order, max_order);
+	msg_err("mcache min_order (%d) cannot exceed max_order (%d)", min_order, max_order);
 	return INVALID_ADDRESS;
     }
 

--- a/src/runtime/range.c
+++ b/src/runtime/range.c
@@ -25,7 +25,7 @@ boolean rangemap_insert(rangemap rm, rmnode n)
             break;
         range i = range_intersection(curr->r, n->r);
         if (range_span(i)) {
-            msg_warn("attempt to insert %p (%R) but overlap with %p (%R)\n",
+            msg_warn("rangemap: attempt to insert %p (%R) but overlap with %p (%R)",
                      n, n->r, curr, curr->r);
             return false;
         }

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -181,17 +181,32 @@ typedef struct flush_entry *flush_entry;
 #include <vector.h>
 #include <format.h>
 
-/* XXX: Note that printing function names will reveal our internals to
-   some degree. All the logging stuff needs more time in the oven. */
+#ifdef KERNEL
 
-#define msg_err(fmt, ...) rprintf("%s error: " fmt, func_ss,    \
-				  ##__VA_ARGS__)
+enum log_level {
+    LOG_ALWAYS = -1,
+    LOG_ERR,
+    LOG_WARN,
+    LOG_INFO,
+};
+
+#define msg_print(fmt, ...) log_printf(LOG_ALWAYS, ss(fmt), ##__VA_ARGS__)
+#define msg_err(fmt, ...)   log_printf(LOG_ERR, ss(fmt), ##__VA_ARGS__)
+#define msg_warn(fmt, ...)  log_printf(LOG_WARN, ss(fmt), ##__VA_ARGS__)
+#define msg_info(fmt, ...)  log_printf(LOG_INFO, ss(fmt), ##__VA_ARGS__)
+
+void log_printf(enum log_level level, sstring fmt, ...);
+
+#else
+
+#define msg_err(fmt, ...)   rprintf(fmt "\n", ##__VA_ARGS__)
 
 #ifdef ENABLE_MSG_WARN
-#define msg_warn(fmt, ...) rprintf("%s warning: " fmt, func_ss, \
-				  ##__VA_ARGS__)
+#define msg_warn(fmt, ...)  rprintf(fmt "\n", ##__VA_ARGS__)
 #else
 #define msg_warn(fmt, ...)
+#endif
+
 #endif
 
 #ifdef ENABLE_MSG_DEBUG

--- a/src/runtime/tuple.c
+++ b/src/runtime/tuple.c
@@ -451,7 +451,7 @@ value decode_value(heap h, table dictionary, buffer source, u64 *total,
                 return null_value;
             }
             if (!old_encoding)
-                rprintf("%s: warning: untyped buffer, len %ld, offset %d: %B\n", func_ss,
+                msg_warn("%s: untyped buffer, len %ld, offset %d: %B", func_ss,
                         len, source->start, alloca_wrap_buffer(buffer_ref(source, 0), len));
 
             /* address a long-standing bug in bootloaders; untyped buffers must be tagged */
@@ -510,7 +510,7 @@ static void encode_value_internal(buffer dest, table dictionary, value v, u64 *t
         encode_string(dest, (string)v);
     } else {
         if (v != null_value) {
-            rprintf("%s: untyped value %v, len %d, from %p\n", func_ss, v,
+            msg_err("%s: untyped value %v, len %d, from %p", func_ss, v,
                     buffer_length((buffer)v), __builtin_return_address(0));
             print_frame_trace_from_here();
         }

--- a/src/unix/eventfd.c
+++ b/src/unix/eventfd.c
@@ -183,7 +183,7 @@ int do_eventfd2(unsigned int count, int flags)
     }
     efd = allocate(h, sizeof(*efd));
     if (efd == INVALID_ADDRESS) {
-        msg_err("failed to allocate eventfd structure\n");
+        msg_err("eventfd: failed to allocate structure");
         goto err_efd;
     }
 
@@ -199,13 +199,13 @@ int do_eventfd2(unsigned int count, int flags)
 
     efd->read_bq = allocate_blockq(h, ss("eventfd read"));
     if (efd->read_bq == INVALID_ADDRESS) {
-        msg_err("failed to allocated blockq\n");
+        msg_err("eventfd: failed to allocate read blockq");
         goto err_read_bq;
     }
 
     efd->write_bq = allocate_blockq(h, ss("eventfd write"));
     if (efd->write_bq == INVALID_ADDRESS) {
-        msg_err("failed to allocate blockq\n");
+        msg_err("eventfd: failed to allocate write blockq");
         goto err_write_bq;
     }
 
@@ -213,7 +213,7 @@ int do_eventfd2(unsigned int count, int flags)
     efd->io_event = false;
     efd->fd = allocate_fd(current->p, efd);
     if (efd->fd == INVALID_PHYSICAL) {
-        msg_err("failed to allocate fd\n");
+        msg_err("eventfd: failed to allocate fd");
         apply(efd->f.close, 0, io_completion_ignore);
         return -EMFILE;
     }

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -52,7 +52,7 @@ closure_function(1, 2, boolean, fill_arguments_each,
 {
     u64 i;
     if (!u64_from_attribute(a, &i)) {
-        msg_err("arguments attribute %v is not an index\n", a);
+        msg_err("arguments attribute %v is not an index", a);
         return false;
     }
     vector_set(bound(r), i, v);
@@ -260,7 +260,7 @@ closure_function(4, 5, boolean, static_map,
     }
     return true;
   alloc_fail:
-    msg_err("failed to allocate interp vmap\n");
+    msg_err("exec: failed to allocate vmap");
     return false;
 }
 
@@ -306,7 +306,7 @@ closure_function(4, 5, boolean, faulting_map,
     }
     return true;
   alloc_fail:
-    msg_err("failed to allocate vmap\n");
+    msg_err("exec: failed to allocate vmap");
     return false;
 }
 

--- a/src/unix/ftrace.c
+++ b/src/unix/ftrace.c
@@ -236,7 +236,7 @@ printer_init(struct ftrace_printer * p, unsigned long flags)
 {
     p->b = allocate_buffer(ftrace_heap, TRACE_PRINTER_INIT_SIZE);
     if (p->b == INVALID_ADDRESS) {
-        msg_err("failed to allocate ftrace buffer\n");
+        msg_err("ftrace: failed to allocate buffer");
         return -1;
     }
     init_timer(&p->t);
@@ -442,7 +442,7 @@ rbuf_init(struct rbuf * rbuf, unsigned long buffer_size_kb)
     rbuf->trace_array = allocate(rbuf_heap,
             sizeof(struct rbuf_entry) * rbuf->size);
     if (rbuf->trace_array == INVALID_ADDRESS) {
-        msg_err("failed to allocate ftrace trace array\n");
+        msg_err("ftrace: failed to allocate trace array");
         return -ENOMEM;
     }
     spin_lock_init(&rbuf->rb_lock);
@@ -1420,7 +1420,7 @@ FTRACE_FN(trace_pipe, events)(file f)
 static sysreturn
 FTRACE_FN(tracing_enable_on, get)(struct ftrace_printer * p)
 {
-    rprintf("ftrace recording on\n");
+    msg_info("ftrace recording on");
     tracing_on = 1;
     return 0;
 }
@@ -1429,7 +1429,7 @@ static sysreturn
 FTRACE_FN(tracing_enable_off, get)(struct ftrace_printer * p)
 {
     tracing_on = 0;
-    rprintf("ftrace recording off\n");
+    msg_info("ftrace recording off");
     return 0;
 }
 
@@ -1596,7 +1596,7 @@ ftrace_send_http_chunked_response(http_responder handler)
 
     s = send_http_chunked_response(handler, timm("ContentType", "text/html"));
     if (!is_ok(s))
-        msg_err("ftrace: failed to send HTTP response\n");
+        msg_err("ftrace: failed to send HTTP response");
 }
 
 static void
@@ -1606,7 +1606,7 @@ ftrace_send_http_response(http_responder handler, buffer b)
 
     s = send_http_response(handler, timm("ContentType", "text/html"), b);
     if (!is_ok(s))
-        msg_err("ftrace: failed to send HTTP response\n");
+        msg_err("ftrace: failed to send HTTP response");
 }
 
 static void
@@ -1619,7 +1619,7 @@ ftrace_send_http_uri_not_found(http_responder handler)
                    "<body><h1>Not Found</h1></body></html>\r\n")
     );
     if (!is_ok(s))
-        msg_err("ftrace: failed to send HTTP response\n");
+        msg_err("ftrace: failed to send HTTP response");
 }
 
 static void
@@ -1632,7 +1632,7 @@ ftrace_send_http_no_method(http_responder handler, http_method method)
                    "<body><h1>Not Implemented</h1></body></html>\r\n")
     );
     if (!is_ok(s))
-        msg_err("ftrace: failed to send HTTP response\n");
+        msg_err("ftrace: failed to send HTTP response");
 }
 
 static void
@@ -1645,7 +1645,7 @@ ftrace_send_http_server_error(http_responder handler)
                    "<body><h1>Internal Server Error</h1></body></html>\r\n")
     );
     if (!is_ok(s))
-        msg_err("ftrace: failed to send HTTP response\n");
+        msg_err("ftrace: failed to send HTTP response");
 }
 
 
@@ -1658,7 +1658,7 @@ __ftrace_send_http_chunk_internal(struct ftrace_routine * routine, struct ftrace
 
     /* no real error handling for http get here */
     if (ret < 0) {
-        msg_err("get failed with %d\n", ret);
+        msg_err("ftrace HTTP: get failed with %d", ret);
         return false;
     }
 
@@ -1670,7 +1670,7 @@ __ftrace_send_http_chunk_internal(struct ftrace_routine * routine, struct ftrace
         /* reset printer for next chunk */
         p->flags &= ~TRACE_FLAG_HEADER;
         if (printer_init(p, p->flags) < 0) {
-            msg_err("printer_init failed (alloc)\n");
+            msg_err("ftrace HTTP: printer_init failed (alloc)");
             return false;
         }
 
@@ -1699,7 +1699,7 @@ __ftrace_send_http_chunk_internal(struct ftrace_routine * routine, struct ftrace
     return false;
 
 send_http_chunk_failed:
-    msg_err("send_http_chunk failed with %v\n", s);
+    msg_err("ftrace: send_http_chunk failed with %v", s);
     return false;
 }
 
@@ -1853,7 +1853,7 @@ init_http_listener(void)
 
     ftrace_hl = allocate_http_listener(ftrace_heap, FTRACE_TRACE_PORT);
     if (ftrace_hl == INVALID_ADDRESS) {
-        msg_err("could not allocate ftrace HTTP listener\n");
+        msg_err("ftrace: could not allocate HTTP listener");
         return -1;
     }
 
@@ -1867,14 +1867,14 @@ init_http_listener(void)
         connection_handler_from_http_listener(ftrace_hl)
     );
     if (!is_ok(s)) {
-        msg_err("listen_port(port=%d) failed for ftrace HTTP listener\n",
+        msg_err("ftrace HTTP: listen_port(port=%d) failed",
             FTRACE_TRACE_PORT
         );
         deallocate_http_listener(ftrace_heap, ftrace_hl);
         return -1;
     }
 
-    rprintf("started DEBUG http listener on port %d\n", FTRACE_TRACE_PORT);
+    msg_info("ftrace: started HTTP listener on port %d", FTRACE_TRACE_PORT);
 
     return 0;
 }
@@ -1890,7 +1890,7 @@ ftrace_init(unix_heaps uh, filesystem fs)
 
     cpu_rbufs = allocate_vector(ftrace_heap, total_processors);
     if (cpu_rbufs == INVALID_ADDRESS) {
-        msg_err("unable to allocate rbufs vector\n");
+        msg_err("ftrace: unable to allocate rbufs vector");
         return -1;
     }
     u64 per_cpu_kb = DEFAULT_TRACE_ARRAY_SIZE_KB / total_processors;
@@ -1898,7 +1898,7 @@ ftrace_init(unix_heaps uh, filesystem fs)
     vector_foreach(cpuinfos, ci) {
         struct rbuf *rb = allocate_rbuf(ftrace_heap, per_cpu_kb);
         if (rb == INVALID_ADDRESS) {
-            msg_err("unable to allocate cpu rbuf\n");
+            msg_err("ftrace: unable to allocate cpu rbuf");
             return -1;
         }
         vector_set(cpu_rbufs, ci->id, rb);
@@ -1936,7 +1936,7 @@ ftrace_cpu_init(cpuinfo ci)
         sizeof(struct ftrace_graph_entry) * FTRACE_RETFUNC_DEPTH
     );
     if (ci->graph_stack == INVALID_ADDRESS) {
-        msg_err("failed to allocare ftrace return stack array\n");
+        msg_err("ftrace: failed to allocate return stack array");
         return -ENOMEM;
     }
 

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -32,14 +32,14 @@ static struct futex * soft_create_futex(process p, u64 key)
 
     f = allocate(h, sizeof(struct futex));
     if (f == INVALID_ADDRESS) {
-        msg_err("failed to allocate futex\n");
+        msg_err("futex: failed to allocate structure");
         goto out;
     }
 
     f->h = h;
     f->bq = allocate_blockq(f->h, ss("futex"));
     if (f->bq == INVALID_ADDRESS) {
-        msg_err("failed to allocate futex blockq\n");
+        msg_err("futex: failed to allocate blockq");
         deallocate(f->h, f, sizeof(struct futex));
         f = INVALID_ADDRESS;
         goto out;
@@ -302,14 +302,9 @@ sysreturn futex(int *uaddr, int futex_op, int val,
         return rv;
     }
 
-    case FUTEX_REQUEUE: rprintf("futex_requeue not implemented\n"); break;
-    case FUTEX_WAKE_BITSET: rprintf("futex_wake_bitset not implemented\n"); break;
-    case FUTEX_LOCK_PI: rprintf("futex_lock_pi not implemented\n"); break;
-    case FUTEX_TRYLOCK_PI: rprintf("futex_trylock_pi not implemented\n"); break;
-    case FUTEX_UNLOCK_PI: rprintf("futex_unlock_pi not implemented\n"); break;
-    case FUTEX_CMP_REQUEUE_PI: rprintf("futex_cmp_requeue_pi not implemented\n"); break;
-    case FUTEX_WAIT_REQUEUE_PI: rprintf("futex_wait_requeue_pi not implemented\n"); break;
-    default: rprintf("futex op %d not implemented\n", op); break;
+    default:
+        msg_err("futex op %d not implemented", op);
+        break;
     }
 
     return set_syscall_error(current, ENOSYS);

--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -318,7 +318,7 @@ static void nl_enqueue(nlsock s, void *msg, u64 msg_len)
         blockq_wake_one(s->sock.rxbq);
         fdesc_notify_events(&s->sock.f);
     } else {
-        msg_err("failed to enqueue message\n");
+        msg_err("netlink: failed to enqueue message");
         deallocate(s->sock.h, msg, msg_len);
     }
 }
@@ -331,7 +331,7 @@ static void nl_enqueue_ifinfo(nlsock s, u16 type, u16 flags, u32 seq, u32 pid, s
         resp_len += RTA_SPACE(netif->hwaddr_len);
     struct nlmsghdr *hdr = allocate(s->sock.h, resp_len);
     if (hdr == INVALID_ADDRESS) {
-        msg_err("failed to allocate message\n");
+        msg_err("%s: failed to allocate message", func_ss);
         return;
     }
     hdr->nlmsg_len = resp_len;
@@ -369,7 +369,7 @@ static void nl_enqueue_ifaddr(nlsock s, u16 type, u16 flags, u32 seq, u32 pid, s
         RTA_SPACE(addr_len) + RTA_SPACE(sizeof(netif->name) + 2));
     struct nlmsghdr *hdr = allocate(s->sock.h, resp_len);
     if (hdr == INVALID_ADDRESS) {
-        msg_err("failed to allocate message\n");
+        msg_err("%s: failed to allocate message", func_ss);
         return;
     }
     hdr->nlmsg_len = resp_len;
@@ -441,7 +441,7 @@ static void nl_enqueue_rtmsg(nlsock s, u16 type, u16 flags, u32 seq, u32 pid, st
     }
     struct nlmsghdr *hdr = allocate(s->sock.h, resp_len);
     if (hdr == INVALID_ADDRESS) {
-        msg_err("failed to allocate message\n");
+        msg_err("%s: failed to allocate message", func_ss);
         return;
     }
     hdr->nlmsg_len = resp_len;
@@ -505,7 +505,7 @@ static void nl_enqueue_done(nlsock s, struct nlmsghdr *req)
 {
     struct nlmsghdr *hdr = allocate(s->sock.h, NLMSG_HDRLEN);
     if (hdr == INVALID_ADDRESS) {
-        msg_err("failed to allocate message\n");
+        msg_err("%s: failed to allocate message", func_ss);
         return;
     }
     hdr->nlmsg_len = NLMSG_HDRLEN;
@@ -521,7 +521,7 @@ static void nl_enqueue_error(nlsock s, struct nlmsghdr *msg, int errno)
     int errmsg_len = NLMSG_ALIGN(sizeof(struct nlmsghdr) + sizeof(struct nlmsgerr));
     struct nlmsghdr *hdr = allocate(s->sock.h, errmsg_len);
     if (hdr == INVALID_ADDRESS) {
-        msg_err("failed to allocate message\n");
+        msg_err("%s: failed to allocate message", func_ss);
         return;
     }
     hdr->nlmsg_len = errmsg_len;

--- a/src/unix/pipe.c
+++ b/src/unix/pipe.c
@@ -276,7 +276,7 @@ int do_pipe2(int fds[2], int flags)
 {
     pipe pipe = unix_cache_alloc(get_unix_heaps(), pipe);
     if (pipe == INVALID_ADDRESS) {
-        msg_err("failed to allocate struct pipe\n");
+        msg_err("pipe: failed to allocate structure");
         return -ENOMEM;
     }
 
@@ -284,7 +284,7 @@ int do_pipe2(int fds[2], int flags)
         return -EINVAL;
 
     if (flags & O_DIRECT) {
-        msg_err("O_DIRECT unsupported\n");
+        msg_err("pipe: O_DIRECT unsupported");
         return -EOPNOTSUPP;
     }
 
@@ -305,7 +305,7 @@ int do_pipe2(int fds[2], int flags)
 
     pipe->data = allocate_buffer(pipe->h, INITIAL_PIPE_DATA_SIZE);
     if (pipe->data == INVALID_ADDRESS) {
-        msg_err("failed to allocate pipe's data buffer\n");
+        msg_err("pipe: failed to allocate data buffer");
         goto err;
     }
     spin_lock_init(&pipe->lock);
@@ -323,13 +323,13 @@ int do_pipe2(int fds[2], int flags)
 
         reader->bq = allocate_blockq(pipe->h, ss("pipe read"));
         if (reader->bq == INVALID_ADDRESS) {
-            msg_err("failed to allocate blockq\n");
+            msg_err("pipe: failed to allocate blockq");
             apply(reader->f.close, 0, io_completion_ignore);
             return -ENOMEM;
         }
         reader->fd = fds[PIPE_READ] = allocate_fd(pipe->proc, reader);
         if (reader->fd == INVALID_PHYSICAL) {
-            msg_err("failed to allocate fd\n");
+            msg_err("pipe: failed to allocate fd");
             apply(reader->f.close, 0, io_completion_ignore);
             return -EMFILE;
         }
@@ -348,7 +348,7 @@ int do_pipe2(int fds[2], int flags)
 
         writer->bq = allocate_blockq(pipe->h, ss("pipe write"));
         if (writer->bq == INVALID_ADDRESS) {
-            msg_err("failed to allocate blockq\n");
+            msg_err("pipe: failed to allocate blockq");
             apply(writer->f.close, 0, io_completion_ignore);
             deallocate_fd(pipe->proc, fds[PIPE_READ]);
             fdesc_put(&pipe->files[PIPE_READ].f);
@@ -356,7 +356,7 @@ int do_pipe2(int fds[2], int flags)
         }
         writer->fd = fds[PIPE_WRITE] = allocate_fd(pipe->proc, writer);
         if (writer->fd == INVALID_PHYSICAL) {
-            msg_err("failed to allocate fd\n");
+            msg_err("pipe: failed to allocate fd");
             apply(writer->f.close, 0, io_completion_ignore);
             deallocate_fd(pipe->proc, fds[PIPE_READ]);
             fdesc_put(&pipe->files[PIPE_READ].f);

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -687,7 +687,7 @@ sysreturn epoll_ctl(int epfd, int op, int fd, struct epoll_event *event)
             rv = epoll_add_fd(e, fd, event->events, event->data);
         break;
     default:
-        msg_err("unknown op %d\n", op);
+        msg_warn("%s: unknown op %d", func_ss, op);
         rv = -EINVAL;
     }
     spin_wunlock(&e->fds_lock);

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -430,18 +430,18 @@ sysreturn rt_sigaction(int signum,
 
     /* XXX we should sanitize values ... */
     if (act->sa_flags & SA_NOCLDSTOP)
-        msg_warn("Warning: SA_NOCLDSTOP unsupported.\n");
+        msg_warn("sigaction flag SA_NOCLDSTOP unsupported");
 
     if (act->sa_flags & SA_NOCLDWAIT)
-        msg_warn("Warning: SA_NOCLDWAIT unsupported.\n");
+        msg_warn("sigaction flag SA_NOCLDWAIT unsupported");
 
     if (act->sa_flags & SA_RESETHAND)
-        msg_warn("Warning: SA_RESETHAND unsupported.\n");
+        msg_warn("sigaction flag SA_RESETHAND unsupported");
 
 #ifdef __x86_64__
     /* libc should always set this on x64 ... */
     if (!(act->sa_flags & SA_RESTORER)) {
-        msg_err("sigaction without SA_RESTORER not supported.\n");
+        msg_err("sigaction without SA_RESTORER not supported");
         return -EINVAL;
     }
 #endif
@@ -968,7 +968,7 @@ static sysreturn allocate_signalfd(const u64 *mask, int flags)
   err_mem_bq:
     deallocate(h, sfd, sizeof(*sfd));
   err_mem:
-    msg_err("failed to allocate\n");
+    msg_err("signalfd: failed to allocate structure");
     return set_syscall_error(current, ENOMEM);
 }
 
@@ -1087,7 +1087,6 @@ static void default_signal_action(thread t, queued_signal qs)
             dump_context(&t->syscall->uc.kc.context);
         }
     }
-    thread_log(t, "%s", fate);
     halt_with_code(VM_EXIT_SIGNAL(signum), ss("%s\n"), fate);
 }
 

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -591,7 +591,7 @@ static sysreturn unixsock_listen(struct sock *sock, int backlog)
         if (!s->conn_q) {
             s->conn_q = allocate_queue(sock->h, backlog);
             if (s->conn_q == INVALID_ADDRESS) {
-                msg_err("failed to allocate connection queue\n");
+                msg_err("%s: failed to allocate connection queue", func_ss);
                 s->conn_q = 0;
                 ret = -ENOMEM;
             }
@@ -832,7 +832,7 @@ static sysreturn unixsock_getsockopt(struct sock *sock, int level,
     rv = sockopt_copy_to_user(optval, optlen, &ret_optval, ret_optlen);
     goto out;
 unimplemented:
-    msg_err("getsockopt unimplemented optname: fd %d, level %d, optname %d\n",
+    msg_err("getsockopt unimplemented: fd %d, level %d, optname %d",
             sock->fd, level, optname);
     rv = -ENOPROTOOPT;
 out:
@@ -911,16 +911,16 @@ static unixsock unixsock_alloc(heap h, int type, u32 flags, boolean alloc_fd)
 {
     unixsock s = allocate(h, sizeof(*s));
     if (s == INVALID_ADDRESS) {
-        msg_err("failed to allocate socket structure\n");
+        msg_err("unixsock: failed to allocate socket structure");
         return 0;
     }
     s->data = allocate_queue(h, UNIXSOCK_QUEUE_MAX_LEN);
     if (s->data == INVALID_ADDRESS) {
-        msg_err("failed to allocate data buffer\n");
+        msg_err("unixsock: failed to allocate data buffer");
         goto err_queue;
     }
     if (socket_init(h, AF_UNIX, type, flags, &s->sock) < 0) {
-        msg_err("failed to initialize socket\n");
+        msg_err("unixsock: failed to initialize socket");
         goto err_socket;
     }
     s->sock.f.read = init_closure_func(&s->read, file_io, unixsock_read);

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -115,12 +115,12 @@ static inline int socket_init(heap h, int domain, int type, u32 flags, struct so
     runtime_memset((u8 *) s, 0, sizeof(*s));
     s->rxbq = allocate_blockq(h, ss("sock receive"));
     if (s->rxbq == INVALID_ADDRESS) {
-        msg_err("failed to allocate blockq\n");
+        msg_err("%s: failed to allocate blockq", func_ss);
         goto err_rx;
     }
     s->txbq = allocate_blockq(h, ss("sock transmit"));
     if (s->txbq == INVALID_ADDRESS) {
-        msg_err("failed to allocate blockq\n");
+        msg_err("%s: failed to allocate blockq", func_ss);
         goto err_tx;
     }
     s->rx_len = 0;

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -123,7 +123,7 @@ closure_function(1, 4, void, mounts_handler,
             }
         }
         /* something has gone wrong looking up mount point */
-        msg_err("error looking up mount point for volume '%s'\n", label);
+        msg_err("%s: error looking up mount point for volume '%s'", func_ss, label);
         b->end = saved_end;
         return;
     } else {    /* root filesystem */

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -55,7 +55,7 @@ static sysreturn clone_internal(struct clone_args_internal *args)
           return -EINVAL;
 
      if (!(flags & CLONE_THREAD)) {
-          thread_log(current, "attempted to create new process, aborting.");
+          msg_warn("clone: attempted to create new process");
           return -ENOSYS;
      }
 
@@ -478,7 +478,7 @@ thread create_thread(process p, u64 tid)
     destruct_context(&t->context);
     deallocate(h, t, sizeof(struct thread));
   fail:
-    msg_err("failed to allocate\n");
+    msg_err("thread: failed to allocate structure");
     return INVALID_ADDRESS;
 }
 

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -557,7 +557,7 @@ sysreturn timer_create(int clockid, struct sigevent *sevp, u32 *timerid)
             break;
         case SIGEV_THREAD:
             /* should never see this, but bark if we do */
-            msg_err("SIGEV_THREAD should be handled by libc / nptl\n");
+            msg_err("%s: SIGEV_THREAD should be handled by libc / nptl", func_ss);
             /* no break */
         default:
             rv = -EINVAL;
@@ -634,7 +634,7 @@ sysreturn timer_create(int clockid, struct sigevent *sevp, u32 *timerid)
 sysreturn getitimer(int which, struct itimerval *curr_value)
 {
     if (which == ITIMER_VIRTUAL) {
-        msg_err("timer type %d not yet supported\n", which);
+        msg_err("%s: timer type %d not supported", func_ss, which);
         return -EOPNOTSUPP;
     } else if ((which != ITIMER_REAL) && (which != ITIMER_PROF)) {
         return -EINVAL;
@@ -755,7 +755,7 @@ sysreturn setitimer(int which, const struct itimerval *new_value,
                     struct itimerval *old_value)
 {
     if (which == ITIMER_VIRTUAL) {
-        msg_err("timer type %d not yet supported\n", which);
+        msg_err("%s: timer type %d not supported", func_ss, which);
         return -EOPNOTSUPP;
     } else if ((which != ITIMER_REAL) && (which != ITIMER_PROF)) {
         return -EINVAL;

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -442,7 +442,7 @@ static boolean create_stdfiles(unix_heaps uh, process p)
     file in = unix_cache_alloc(uh, file);
     file out = unix_cache_alloc(uh, file);
     file err = unix_cache_alloc(uh, file);
-    if (!in || !out || !err) {
+    if ((in == INVALID_ADDRESS) || (out == INVALID_ADDRESS) || (err == INVALID_ADDRESS)) {
         msg_err("failed to allocate files\n");
         return false;
     }

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -130,7 +130,7 @@ sysreturn clock_nanosleep(clockid_t _clock_id, int flags, const struct timespec 
 
     /* Report any attempted use of CLOCK_PROCESS_CPUTIME_ID */
     if (_clock_id == CLOCK_PROCESS_CPUTIME_ID) {
-        rprintf("%s: CLOCK_PROCESS_CPUTIME_ID not yet supported\n", func_ss);
+        msg_err("%s: CLOCK_PROCESS_CPUTIME_ID not supported", func_ss);
         return -EINVAL;
     }
 

--- a/src/unix_process/socket_user.c
+++ b/src/unix_process/socket_user.c
@@ -394,7 +394,7 @@ notifier create_epoll_notifier(heap h)
 {
     descriptor f;
     if ((f = epoll_create(1)) < 0) {
-	msg_err("epoll_create failed, %s (%d)\n", errno_sstring(), errno);
+	msg_err("epoll_create failed, %s (%d)", errno_sstring(), errno);
 	return 0;
     }
     epoll_notifier e = allocate(h, sizeof(struct epoll_notifier));
@@ -526,7 +526,7 @@ void connection(heap h,
     // this is still blocking!
     int res = connect(s, (struct sockaddr *)&where, sizeof(struct sockaddr_in));
     if (res) {
-        rprintf("zikkay %d %p\n", res, failure);        
+        msg_err("zikkay %d %p", res, failure);
         apply(failure, timm("errno", "%d", errno));
     } else {
         register_descriptor_write(h, n, s, closure(h, connection_start, h, s, n, c));

--- a/src/virtio/virtio_9p.c
+++ b/src/virtio/virtio_9p.c
@@ -99,7 +99,7 @@ static boolean v9p_dev_attach(heap general, backed_heap backed, vtdev dev)
     v9p_debug("  attachment ID %ld\n", attach_id);
     status s = virtio_alloc_virtqueue(dev, ss("virtio 9p"), 0, &v9p->vq);
     if (!is_ok(s)) {
-        msg_err("failed to allocate virtqueue: %v\n", s);
+        msg_err("v9p: failed to allocate virtqueue: %v", s);
         goto err;
     }
     spin_lock_init(&v9p->lock);
@@ -112,7 +112,7 @@ static boolean v9p_dev_attach(heap general, backed_heap backed, vtdev dev)
     if (!volume_add(uuid, label, v9p,
                     init_closure_func(&v9p->fs_init, fs_init_handler, v9p_fs_init),
                     (int)attach_id)) {
-        msg_err("failed to add volume\n");
+        msg_err("v9p: failed to add volume");
         goto err;
     }
     return true;
@@ -578,7 +578,7 @@ int v9p_version(void *priv, u32 msize, sstring version, u32 *ret_msize)
             *ret_msize = resp->msize;
             s = 0;
         } else {
-            msg_err("version %s not supported\n", version);
+            msg_err("v9p version %s not supported", version);
             s = -EINVAL;
         }
     } else {

--- a/src/virtio/virtio_balloon.c
+++ b/src/virtio/virtio_balloon.c
@@ -152,7 +152,7 @@ static u64 virtio_balloon_inflate(u64 n_balloon_pages)
                or assertion failure, however we can't completely account for
                effects of fragmentation in the physical id heap. Emit a
                warning and quit inflating for now. */
-            msg_err("failed to allocate balloon page from physical heap\n");
+            msg_err("%s: failed to allocate balloon page from physical heap", func_ss);
             break;
         }
 
@@ -392,7 +392,7 @@ static boolean virtio_balloon_attach(heap general, backed_heap backed, id_heap p
         virtio_balloon_init_statsq();
     return true;
   fail:
-    msg_err("failed to attach: %v\n", s);
+    msg_err("vtbln failed to attach: %v", s);
     return false;
 }
 

--- a/src/virtio/virtio_mmio.c
+++ b/src/virtio/virtio_mmio.c
@@ -137,7 +137,7 @@ static boolean vtmmio_negotatiate_features(vtmmio dev, u64 mask)
     virtio_mmio_debug("device features 0x%lx, mask 0x%lx",
                       virtio_dev->dev_features, mask);
     if (!(virtio_dev->dev_features & VIRTIO_F_VERSION_1)) {
-        msg_err("unsupported device features 0x%lx for device at 0x%x\n",
+        msg_err("vtmmio: unsupported device features 0x%lx for device at 0x%x",
             virtio_dev->dev_features, dev->membase);
         return false;
     }
@@ -162,7 +162,7 @@ boolean attach_vtmmio(heap h, backed_heap page_allocator, vtmmio d, u64 feature_
     virtio_mmio_debug("attaching device at 0x%lx, irq %d", d->membase, d->irq);
     vtmmio_set_status(d, VIRTIO_CONFIG_STATUS_DRIVER);
     if (!vtmmio_negotatiate_features(d, feature_mask)) {
-        msg_err("could not negotiate features for device at 0x%x\n",
+        msg_err("vtmmio: could not negotiate features for device at 0x%x",
             d->membase);
         return false;
     }

--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -369,7 +369,7 @@ closure_function(2, 1, void, vnet_cmd_mq_complete,
     if (s == STATUS_OK) {
         netif_set_link_up(&bound(vn)->ndev.n);
     } else {
-        msg_err("status %v\n", s);
+        msg_err("%s error %v", func_ss, s);
         timm_dealloc(s);
     }
     closure_finish();
@@ -421,7 +421,7 @@ closure_func_basic(netif_dev_setup, boolean, virtio_net_setup,
     if (dev->features & VIRTIO_NET_F_MQ) {
         max_vq_pairs = vtdev_cfg_read_2(dev, VIRTIO_NET_R_MAX_VQ);
         if (max_vq_pairs == 0) {
-            msg_err("device reports 0 virtqueue pairs\n");
+            msg_err("%s error: device reports 0 virtqueue pairs", func_ss);
             return false;
         }
         if (config && get_u64(config, sym_this("io-queues"), &vq_pairs) && (vq_pairs > 0))
@@ -453,7 +453,7 @@ closure_func_basic(netif_dev_setup, boolean, virtio_net_setup,
         int vq_index = 2 * i;
         status s = virtio_alloc_vq_aff(dev, ss("virtio net rx"), vq_index, cpu_affinity, &vq);
         if (!is_ok(s)) {
-            msg_err("failed to allocate vq: %v\n", s);
+            msg_err("%s: failed to allocate vq: %v", func_ss, s);
             timm_dealloc(s);
             goto err2;
         }
@@ -464,7 +464,7 @@ closure_func_basic(netif_dev_setup, boolean, virtio_net_setup,
         vq_index++;
         s = virtio_alloc_vq_aff(dev, ss("virtio net tx"), vq_index, cpu_affinity, &vq);
         if (!is_ok(s)) {
-            msg_err("failed to allocate vq: %v\n", s);
+            msg_err("%s: failed to allocate vq: %v", func_ss, s);
             timm_dealloc(s);
             goto err2;
         }
@@ -476,7 +476,7 @@ closure_func_basic(netif_dev_setup, boolean, virtio_net_setup,
     if (vq_pairs > 1) {
         status s = virtio_alloc_virtqueue(dev, ss("virtio net ctrl"), 2 * max_vq_pairs, &vn->ctl);
         if (!is_ok(s)) {
-            msg_err("failed to allocate vq: %v\n", s);
+            msg_err("%s: failed to allocate vq: %v", func_ss, s);
             timm_dealloc(s);
             goto err2;
         }
@@ -498,7 +498,7 @@ closure_func_basic(netif_dev_setup, boolean, virtio_net_setup,
         goto err3;
     for (u16 i = 0; i < vq_pairs; i++)
         if (post_receive(vn, vn->rx + i) == 0) {
-            msg_err("failed to fill rx queues (%d)\n", rxq_entries);
+            msg_err("%s: failed to fill rx queues (%d)", func_ss, rxq_entries);
             goto err4;
         }
     if (vq_pairs > 1) {
@@ -529,7 +529,7 @@ closure_func_basic(netif_dev_setup, boolean, virtio_net_setup,
   err1:
     deallocate(h, rx, vq_pairs * sizeof(*rx));
   err:
-    msg_err("vq pairs %d (max %d)\n", vq_pairs, max_vq_pairs);
+    msg_err("%s error: vq pairs %d (max %d)", func_ss, vq_pairs, max_vq_pairs);
     return false;
 }
 

--- a/src/virtio/virtio_rng.c
+++ b/src/virtio/virtio_rng.c
@@ -118,7 +118,7 @@ static boolean virtio_rng_attach(heap general, backed_heap backed, vtdev v)
     preferred_get_seed = virtio_rng_get_seed;
     return true;
   fail:
-    msg_err("failed to attach: %v\n", s);
+    msg_err("vtrng failed to attach: %v", s);
     return false;
 }
 

--- a/src/virtio/virtio_scsi.c
+++ b/src/virtio/virtio_scsi.c
@@ -163,7 +163,7 @@ static void virtio_scsi_detach_disk(virtio_scsi s, u16 target, u16 lun)
         return;
     }
     spin_unlock(&s->lock);
-    msg_err("target %d lun %d not found\n", target, lun);
+    msg_err("%s: target %d lun %d not found", func_ss, target, lun);
 }
 
 closure_function(2, 1, void, virtio_scsi_event_complete,
@@ -174,7 +174,7 @@ closure_function(2, 1, void, virtio_scsi_event_complete,
     virtio_scsi s = bound(s);
     virtio_scsi_debug("event 0x%x\n", e->event);
     if (e->event & VIRTIO_SCSI_EVENT_LOST)
-        msg_err("scsi event reported lost due to missing buffers\n");
+        msg_err("vitio_scsi event lost due to missing buffers");
     switch (e->event & ~VIRTIO_SCSI_EVENT_LOST) {
     case VIRTIO_SCSI_T_TRANSPORT_RESET: {
         u16 target = e->lun[1];
@@ -472,7 +472,7 @@ closure_function(5, 2, void, virtio_scsi_read_capacity_done,
     spin_unlock(&s->lock);
     d = allocate(s->v->virtio_dev.general, sizeof(*d));
     if (d == INVALID_ADDRESS) {
-        msg_err("cannot allocate SCSI disk\n");
+        msg_err("virtio_scsi: cannot allocate disk");
         goto out;
     }
 
@@ -619,7 +619,7 @@ static void send_lun_inquiry(virtio_scsi s, u16 target, u16 lun)
     vsr_complete completion = closure(s->v->virtio_dev.general, virtio_scsi_inquiry_done, s->sa,
                                       target, lun, -1, 0, 0);
     if (completion == INVALID_ADDRESS) {
-        msg_err("failed to allocate completion\n");
+        msg_err("virtio_scsi LUN inquiry: failed to allocate completion");
         return;
     }
     virtio_scsi_inquiry_vpd(s, target, lun, SCSI_VPD_DEVID, completion);
@@ -723,7 +723,7 @@ static void virtio_scsi_attach(heap general, storage_attach a, backed_heap page_
         for (int i = 0; i < VIRTIO_SCSI_NUM_EVENTS; i++)
             virtio_scsi_enqueue_event(s, s->events + i, 0);
     else
-        msg_err("failed to allocate events\n");
+        msg_err("%s: failed to allocate events", func_ss);
 
     // scan bus
     for (u16 target = 0; target <= s->max_target; target++)

--- a/src/virtio/virtio_socket.c
+++ b/src/virtio/virtio_socket.c
@@ -102,13 +102,13 @@ static boolean virtio_sock_dev_attach(heap general, backed_heap backed, vtdev de
     virtio_sock_debug("  guest CID %d", vs->guest_cid);
     status s = virtio_alloc_virtqueue(dev, ss("virtio socket rx"), 0, &vs->rxq);
     if (!is_ok(s)) {
-        msg_err("failed to allocate rx virtqueue: %v\n", s);
+        msg_err("%s: failed to allocate rx virtqueue: %v", func_ss, s);
         timm_dealloc(s);
         goto err;
     }
     s = virtio_alloc_virtqueue(dev, ss("virtio socket tx"), 1, &vs->txq);
     if (!is_ok(s)) {
-        msg_err("failed to allocate tx virtqueue: %v\n", s);
+        msg_err("%s: failed to allocate tx virtqueue: %v", func_ss, s);
         timm_dealloc(s);
         goto err;
     }
@@ -117,7 +117,7 @@ static boolean virtio_sock_dev_attach(heap general, backed_heap backed, vtdev de
      * about an "attempt to use virtio queue that is not marked ready". */
     s = virtio_alloc_virtqueue(dev, ss("virtio socket events"), 2, &vs->eventq);
     if (!is_ok(s)) {
-        msg_err("failed to allocate event virtqueue: %v\n", s);
+        msg_err("%s: failed to allocate event virtqueue: %v", func_ss, s);
         timm_dealloc(s);
         goto err;
     }

--- a/src/virtio/virtio_storage.c
+++ b/src/virtio/virtio_storage.c
@@ -166,7 +166,7 @@ static inline void storage_rw_internal(storage st, boolean write, void * buf,
     vqmsg_commit(vq, m, c);
     return;
   out_inval:
-    msg_err("%s", err);               /* yes, bark */
+    msg_err("vtblk R/W error: %s", err);
     apply(sh, timm("result", "%s", err));
 }
 

--- a/src/vmware/pvscsi.c
+++ b/src/vmware/pvscsi.c
@@ -180,7 +180,7 @@ closure_function(6, 0, void, pvscsi_io_done,
                                     bound(len));
             return;
         }
-        rprintf("scsi_status not ok: %d\n", hcb->scsi_status);
+        msg_err("pvscsi: scsi_status not ok: %d", hcb->scsi_status);
         scsi_dump_sense(hcb->sense, sizeof(hcb->sense));
         st = timm("result", "status %d", hcb->scsi_status);
     }
@@ -237,7 +237,7 @@ closure_function(5, 0, void, pvscsi_read_capacity_done,
 
     pvscsi_disk d = allocate(s->general, sizeof(*d));
     if (d == INVALID_ADDRESS) {
-        msg_err("cannot allocate PVSCSI disk\n");
+        msg_err("pvscsi: cannot allocate disk");
         goto out;
     }
 

--- a/src/vmware/vmxnet3_net.c
+++ b/src/vmware/vmxnet3_net.c
@@ -253,7 +253,7 @@ closure_function(1, 0, void, vmxnet3_rx_service_bh,
             struct netif *n = &vn->ndev.n;
             err_enum_t err = n->input((struct pbuf *)rxb, n);
             if (err != ERR_OK) {
-                msg_err("vmxnet3: rx drop by stack, err %d\n", err);
+                msg_err("vmxnet3: rx drop by stack, err %d", err);
                 receive_buffer_release((struct pbuf *)rxb);
             }
         }

--- a/src/x86_64/hpet.c
+++ b/src/x86_64/hpet.c
@@ -188,7 +188,7 @@ closure_function(0, 0, timestamp, hpet_now)
 boolean init_hpet(kernel_heaps kh) {
     void *hpet_page = allocate((heap)heap_virtual_page(kh), PAGESIZE);
     if (hpet_page == INVALID_ADDRESS) {
-        msg_err("failed to allocate page for HPET\n");
+        msg_err("HPET: failed to allocate page");
         return false;
     }
 
@@ -214,6 +214,6 @@ boolean init_hpet(kernel_heaps kh) {
                                       0 /* no per-cpu init */);
         return true;
     }
-    msg_err("failed to initialize HPET; main counter not incrementing\n");
+    msg_err("HPET init failed; main counter not incrementing");
     return false;
 }

--- a/src/x86_64/interrupt.c
+++ b/src/x86_64/interrupt.c
@@ -403,7 +403,7 @@ void __attribute__((noreturn)) __stack_chk_fail(void)
 {
     cpuinfo ci = current_cpu();
     context ctx = get_current_context(ci);
-    rprintf("stack check failed on cpu %d\n", ci->id);
+    msg_err("stack check failed on cpu %d", ci->id);
     dump_context(ctx);
     vm_exit(VM_EXIT_FAULT);
 }

--- a/src/xen/xennet.c
+++ b/src/xen/xennet.c
@@ -272,7 +272,8 @@ static void xennet_service_tx_ring(xennet_dev xd)
 
             if (tx->status != NETIF_RSP_OKAY) {
                 /* XXX counters */
-                msg_err("cons %d, tx resp id %d, status %d\n", cons, tx->id, tx->status);
+                msg_err("%s error: cons %d, tx resp id %d, status %d",
+                        func_ss, cons, tx->id, tx->status);
             }
 
             xennet_tx_page txp = xennet_get_tx_page(txb, xennet_tx_page_idx_from_id(tx->id));
@@ -543,7 +544,7 @@ static void xennet_populate_rx_ring(xennet_dev xd)
         xennet_rx_buf rxb = xennet_get_rxbuf(xd);
         if (!rxb) {
             /* not a ring underrun, but we still want to know if we're close */
-            msg_err("xennet_get_rxbuf underrun\n");
+            msg_err("xennet_get_rxbuf underrun");
             break;
         }
 
@@ -635,7 +636,7 @@ closure_function(1, 0, void, xennet_rx_service_bh,
             struct netif *n = &xd->ndev.n;
             err_enum_t err = n->input((struct pbuf *)&rxb->p, n);
             if (err != ERR_OK) {
-                msg_err("xennet: rx drop by stack, err %d\n", err);
+                msg_err("xennet: rx drop by stack, err %d", err);
                 xennet_return_rxbuf((struct pbuf *)&rxb->p);
             }
         }
@@ -840,7 +841,7 @@ closure_function(1, 3, boolean, xennet_probe,
     xennet_debug("probe for id %d, meta: %v", id, meta);
     status s = xennet_attach(bound(kh), id, frontend, meta);
     if (!is_ok(s)) {
-        msg_err("attach failed with status %v\n", s);
+        msg_err("xennet attach failed with status %v", s);
         return false;
     }
     return true;

--- a/test/runtime/mmap.c
+++ b/test/runtime/mmap.c
@@ -1081,7 +1081,7 @@ static void filebacked_test(heap h)
     sha256(sha, b);
     munmap(p, PAGESIZE);
     if (!buffer_compare(sha, test)) {
-        rprintf("   sha mismatch for faulted page: %X\n", sha);
+        msg_err("%s: sha mismatch for faulted page: %X", func_ss, sha);
         close(fd);
         exit(EXIT_FAILURE);
     }
@@ -1126,7 +1126,7 @@ static void filebacked_test(heap h)
     munmap(p, PAGESIZE);
     close(fd);
     if (!buffer_compare(sha, test)) {
-        rprintf("   sha mismatch for faulted page 2: %X\n", sha);
+        msg_err("%s: sha mismatch for faulted page 2: %X", func_ss, sha);
         close(fd);
         exit(EXIT_FAILURE);
     }

--- a/test/unit/bitmap_test.c
+++ b/test/unit/bitmap_test.c
@@ -12,7 +12,7 @@ bitmap test_alloc(heap h) {
     bitmap b = allocate_bitmap(h, h, 4096);
     bitmap_foreach_set(b, i) {
         if (i) {
-            msg_err("!!! allocation failed for bitmap\n");
+            msg_err("%s failed for bitmap", func_ss);
             return NULL; 
         }
     }
@@ -32,12 +32,12 @@ boolean test_clone(bitmap b) {
     bitmap_foreach_set(b, j) {
         // implicit test for bitmap_foreach_set
         if (!bitmap_get(b, j)) {
-            msg_err("!!! foreach_set failed for bitmap\n");
+            msg_err("%s: foreach_set failed for bitmap", func_ss);
             deallocate_bitmap(b_cpy);
             return false;
         }
         if (!bitmap_get(b_cpy, j)) {
-            msg_err("!!! cloning failed for bitmap\n");
+            msg_err("%s: cloning failed for bitmap", func_ss);
             deallocate_bitmap(b_cpy);
             return false;
         }
@@ -46,12 +46,12 @@ boolean test_clone(bitmap b) {
     bitmap_foreach_set(b_cpy, j) {
         // implicit test for bitmap_foreach_set
         if (!bitmap_get(b_cpy, j)) {
-            msg_err("!!! foreach_set failed for bitmap\n");
+            msg_err("%s: foreach_set failed for bitmap", func_ss);
             deallocate_bitmap(b_cpy);
             return false;
         }
         if (!bitmap_get(b, j)) {
-            msg_err("!!! cloning failed for bitmap\n");
+            msg_err("%s: cloning failed for bitmap", func_ss);
             deallocate_bitmap(b_cpy);
             return false;
         }
@@ -76,12 +76,12 @@ boolean test_copy(heap h, bitmap b) {
     bitmap_foreach_set(b, j) {
         // implicit test for bitmap_foreach_set
         if (!bitmap_get(b, j)) {
-            msg_err("!!! foreach_set failed for bitmap\n");
+            msg_err("%s: foreach_set failed for bitmap", func_ss);
             deallocate_bitmap(b_cpy);
             return false;
         }
         if (!bitmap_get(b_cpy, j)) {
-            msg_err("!!! cloning failed for bitmap\n");
+            msg_err("%s: copy failed for bitmap", func_ss);
             deallocate_bitmap(b_cpy);
             return false;
         }
@@ -90,12 +90,12 @@ boolean test_copy(heap h, bitmap b) {
     bitmap_foreach_set(b_cpy, j) {
         // implicit test for bitmap_foreach_set
         if (!bitmap_get(b_cpy, j)) {
-            msg_err("!!! foreach_set failed for bitmap\n");
+            msg_err("%s: foreach_set failed for bitmap", func_ss);
             deallocate_bitmap(b_cpy);
             return false;
         }
         if (!bitmap_get(b, j)) {
-            msg_err("!!! cloning failed for bitmap\n");
+            msg_err("%s: copy failed for bitmap", func_ss);
             deallocate_bitmap(b_cpy);
             return false;
         }
@@ -112,7 +112,7 @@ boolean test_set_and_get(bitmap b) {
     u64 i = rand();
     bitmap_set(b, i, 1);
     if (!bitmap_get(b, i)) {
-        msg_err("!!! set and get failed for bitmap\n");
+        msg_err("%s failed for bitmap", func_ss);
         return false;
     }
     return true;
@@ -129,7 +129,7 @@ boolean test_wrap(heap h) {
     for (int i = 0; i < 64; i++) {
         if (((map & (1ULL << i)) && !bitmap_get(b, i)) || 
             (!(map & (1ULL << i)) && bitmap_get(b, i))) {
-            msg_err("!!! wrap failed for bitmap at bit %d | map: %ld bitmap: %ld\n", 
+            msg_err("%s: wrap failed for bitmap at bit %d | map: %ld bitmap: %ld", func_ss,
                 i, (map & (1ULL << i)), bitmap_get(b, i));
             bitmap_unwrap(b);
             return false;
@@ -150,7 +150,7 @@ boolean test_bitmap_alloc(bitmap b, u64 start, u64 end) {
         first = bitmap_alloc_within_range(b, nbits, start, end);
         if (first != INVALID_PHYSICAL) {
             if (nbits > (end-start)) {
-                msg_err("!!! invalid value for nbits: %ld end-start: %ld\n", nbits, (end-start));
+                msg_err("%s: nbits (%ld) > end-start (%ld)", func_ss, nbits, (end-start));
                 return false;
             }
             break;
@@ -161,16 +161,16 @@ boolean test_bitmap_alloc(bitmap b, u64 start, u64 end) {
     // check that specified range is set properly
     for (int i = first; i < first + nbits; i++) {
         if (bitmap_get(b, i) != 1) {
-            msg_err("!!! bitmap_alloc failed for bitmap at bit %d | expected: %d actual: %d\n", 
+            msg_err("%s failed at bit %d | expected: %d actual: %d", func_ss,
                 i, 1, bitmap_get(b, i));
             if (!bitmap_dealloc(b, first, nbits))
-                msg_err("!!! bitmap_dealloc failed for bitmap\n");
+                msg_err("%s: bitmap_dealloc failed", func_ss);
             return false;
         }
     }
     // check that dealloc is successful
     if (!bitmap_dealloc(b, first, nbits)) {
-        msg_err("!!! bitmap_dealloc failed for bitmap\n");
+        msg_err("%s: bitmap_dealloc failed", func_ss);
         return false;
     }
     return true;
@@ -188,7 +188,7 @@ boolean test_range_check_set(bitmap b) {
     // check that specified range is set properly
     for (int i = start; i < start + nbits; i++) {
         if (bitmap_get(b, i) != set) {
-            msg_err("!!! range check and set failed for bitmap at bit %d | expected: %d actual: %d\n", 
+            msg_err("%s failed for bitmap at bit %d | expected: %d actual: %d", func_ss,
                 i, set, bitmap_get(b, i));
             return false;
         }
@@ -201,12 +201,12 @@ boolean test_range_get_first(bitmap b) {
         u64 first = bitmap_range_get_first(b, start, nbits);
         if (first != INVALID_PHYSICAL) {
             if (!point_in_range(irangel(start, nbits), first)) {
-                msg_err("range_get_first() returned %ld, expected range %R\n", first,
+                msg_err("%s error: returned %ld, expected range %R", func_ss, first,
                     irangel(start, nbits));
                 return false;
             }
             if (!bitmap_get(b, first)) {
-                msg_err("range_get_first() failed at bit %ld, expected 1 (start %ld, nbits %ld)\n",
+                msg_err("%s failed at bit %ld, expected 1 (start %ld, nbits %ld)", func_ss,
                     first, start, nbits);
                 return false;
             }
@@ -215,8 +215,8 @@ boolean test_range_get_first(bitmap b) {
         }
         for (u64 i = start; i < first; i++) {
             if (bitmap_get(b, i)) {
-                msg_err("range_get_first() failed at bit %ld, expected 0 "
-                    "(start %ld, nbits %ld, first %ld)\n", i, start, nbits, first);
+                msg_err("%s failed at bit %ld, expected 0 (start %ld, nbits %ld, first %ld)",
+                        func_ss, i, start, nbits, first);
                 return false;
             }
         }
@@ -272,7 +272,7 @@ int main(int argc, char **argv)
     msg_debug("test passed\n");
     exit(EXIT_SUCCESS);
   fail:
-    msg_err("test failed\n");
+    msg_err("Bitmap test failed");
     exit(EXIT_FAILURE);
 }
 

--- a/test/unit/buffer_test.c
+++ b/test/unit/buffer_test.c
@@ -10,7 +10,7 @@
 
 #define test_assert(expr) do { \
 if (expr) ; else { \
-	msg_err("%s -- failed at %s:%d\n", ss(#expr), file_ss, __LINE__); \
+	msg_err("%s: %s -- failed at %s:%d", func_ss, ss(#expr), file_ss, __LINE__); \
 	goto fail; \
 } \
 } while (0)
@@ -369,7 +369,7 @@ int main(int argc, char **argv)
     failure |= ringbuf_tests(h);
 
     if (failure) {
-        msg_err("Test failed\n");
+        msg_err("Buffer test failed");
         exit(EXIT_FAILURE);
     }
     exit(EXIT_SUCCESS);

--- a/test/unit/network_test.c
+++ b/test/unit/network_test.c
@@ -102,7 +102,7 @@ closure_function(8, 0, void, startconn,
 closure_func_basic(status_handler, void, connection_error,
                    status s)
 {
-    rprintf("connection error! %v\n", s);
+    msg_err("connection error %v", s);
     exit(1);
 }
 

--- a/test/unit/objcache_test.c
+++ b/test/unit/objcache_test.c
@@ -15,7 +15,7 @@
 static inline boolean validate(heap h)
 {
     if (!objcache_validate(h)) {
-	msg_err("objcache_validate failed\n");
+	msg_err("objcache_validate failed");
 	return false;
     }
 
@@ -26,7 +26,7 @@ static inline boolean validate_obj(heap h, void * obj)
 {
     heap o = objcache_from_object(u64_from_pointer(obj), TEST_PAGESIZE);
     if (o != h) {
-	msg_err("objcache_from_object returned %p, doesn't match heap %p\n", o, h);
+	msg_err("objcache_from_object returned %p, doesn't match heap %p", o, h);
 	return false;
     }
     return true;
@@ -35,7 +35,7 @@ static inline boolean validate_obj(heap h, void * obj)
 static boolean alloc_vec(heap h, int n, int s, vector v)
 {
     if (!validate(h)) {
-        msg_err("tb: failed first heap validation\n");
+        msg_err("%s: failed first heap validation", func_ss);
         return false;
     }
     for (int i=0; i < n; i++) {
@@ -43,14 +43,14 @@ static boolean alloc_vec(heap h, int n, int s, vector v)
         if (p == INVALID_ADDRESS)
             return false;
         if (!validate_obj(h, p)) {
-            msg_err("tb: failed object validation\n");
+            msg_err("%s: failed object validation", func_ss);
             return false;
         }
 
         vector_set(v, i, p);
     }
     if (!validate(h)) {
-        msg_err("tb: failed second heap validation\n");
+        msg_err("%s: failed second heap validation", func_ss);
         return false;
     }
 
@@ -87,14 +87,14 @@ boolean objcache_test(heap meta, heap parent, int objsize)
     msg_debug("objs %p, heap %p\n", objs, h);
 
     if (h == INVALID_ADDRESS) {
-        msg_err("tb: failed to allocate objcache heap\n");
+        msg_err("%s: failed to allocate objcache heap", func_ss);
         deallocate_vector(objs);
         return false;
     }
 
     /* allocate a page's worth */
     if (!alloc_vec(h, opp, objsize, objs)) {
-        msg_err("tb: failed to allocate object\n");
+        msg_err("%s: failed to allocate object", func_ss);
         return false;
     }
 
@@ -104,7 +104,7 @@ boolean objcache_test(heap meta, heap parent, int objsize)
 
     /* re-allocate a page's worth + 1 to trigger parent allocation */
     if (!alloc_vec(h, opp + 1, objsize, objs)) {
-        msg_err("tb: failed to allocate object\n");
+        msg_err("%s: failed to allocate object", func_ss);
         return false;
     }
 
@@ -113,7 +113,7 @@ boolean objcache_test(heap meta, heap parent, int objsize)
         return false;
 
     if (heap_allocated(h) > 0) {
-        msg_err("allocated (%d) should be 0; fail\n", heap_allocated(h));
+        msg_err("%s: allocated (%d) should be 0; fail", func_ss, heap_allocated(h));
         return false;
     }
     destroy_heap(h);
@@ -135,7 +135,7 @@ boolean preallocated_objcache_test(heap meta, heap parent, int objsize, boolean 
     msg_debug("objs %p, heap %p\n", objs, h);
 
     if (h == INVALID_ADDRESS) {
-        msg_err("tb: failed to allocate objcache heap\n");
+        msg_err("%s: failed to allocate objcache heap", func_ss);
         deallocate_vector(objs);
         return false;
     }
@@ -155,7 +155,7 @@ boolean preallocated_objcache_test(heap meta, heap parent, int objsize, boolean 
 
     /* re-allocate a page + 1 worth to trigger parent allocation */
     if (!(alloc_vec(h, opp + 1, objsize, objs) != prealloc_only)) {
-        msg_err("tb: unexpectedly %s to allocate object\n",
+        msg_err("%s: unexpectedly %s to allocate object", func_ss,
                 prealloc_only ? ss("able") : ss("failed"));
         return false;
     }
@@ -166,7 +166,7 @@ boolean preallocated_objcache_test(heap meta, heap parent, int objsize, boolean 
             return false;
 
         if (heap_allocated(h) > 0) {
-            msg_err("allocated (%d) should be 0; fail\n", heap_allocated(h));
+            msg_err("%s: allocated (%d) should be 0; fail", func_ss, heap_allocated(h));
             return false;
         }
     }

--- a/test/unit/parser_test.c
+++ b/test/unit/parser_test.c
@@ -8,14 +8,14 @@
 /* s must be a string literal */
 #define test_strings_equal(b, s) do {        \
 if (buffer_strcmp(b, s) != 0) {                         \
-    msg_err("\"%b\" != \"%s\" -- failed at %s:%d\n", b, ss(s), file_ss, __LINE__); \
+    msg_err("%s: \"%b\" != \"%s\" -- failed at %s:%d", func_ss, b, ss(s), file_ss, __LINE__); \
     return false; \
 } \
 } while (0)
 
 #define test_no_errors() do { \
     if (errors_count) { \
-        msg_err("%d parse error(s), last: %b\n", errors_count, last_error); \
+        msg_err("%s: %d parse error(s), last: %b", func_ss, errors_count, last_error); \
     } \
     test_assert(errors_count == 0); \
 } while (0)
@@ -864,7 +864,8 @@ int main(int argc, char **argv)
     }
 
     if (failure) {
-        msg_err("Test failed\n"); exit(EXIT_FAILURE);
+        msg_err("Parser test failed");
+        exit(EXIT_FAILURE);
     }
     exit(EXIT_SUCCESS);
 }

--- a/test/unit/pqueue_test.c
+++ b/test/unit/pqueue_test.c
@@ -387,6 +387,6 @@ int main(int argc, char **argv)
     msg_debug("pqueue test passed\n");
     exit(EXIT_SUCCESS);
   fail:
-    msg_err("pqueue test failed\n");
+    msg_err("Pqueue test failed");
     exit(EXIT_FAILURE);
 }

--- a/test/unit/random_test.c
+++ b/test/unit/random_test.c
@@ -120,14 +120,14 @@ static int ent_get_stats(char *path, struct ent_stat_entry *stats)
 
     f = popen(&ent_cmd[0], "r");
     if (!f) {
-        msg_err("Can't start ent, perhaps it is not installed?\n");
+        msg_err("%s failed to start ent", func_ss);
         return -1;
     }
 
     matched = fread(&ent_buf[0], 1024, 1, f);
     if (ferror(f)) {
         pclose(f);
-        msg_err("Can't read ent statistics, matched=%d.\n", matched);
+        msg_err("%s failed to read ent statistics, matched=%d", func_ss, matched);
         return -1;
     }
 
@@ -153,7 +153,7 @@ static int ent_get_stats(char *path, struct ent_stat_entry *stats)
         else if (linenum == 1)
             sscanf(s, "%lf", &stats[nfield - (ENT_NSTATS + 1)].val);
         else if (linenum < 0) {
-            msg_err("unable to parse\n");
+            msg_err("%s error: unable to parse", func_ss);
             pclose(f);
             return -1;
         }
@@ -187,7 +187,7 @@ static int ent_test(struct ent_stat_entry *stats)
     double val;
 
     if (!ent_stat_get(stats, "Entropy", &val)) {
-        msg_err("Cannot get bytestream entropy.\n");
+        msg_err("%s failed to get bytestream entropy", func_ss);
         goto out_fail;
     }
 
@@ -199,12 +199,12 @@ static int ent_test(struct ent_stat_entry *stats)
     }
 
     if (comp > COMPRESS_PASS_THRESH) {
-        msg_err("Insufficient entropy.\n");
+        msg_err("%s error: insufficient entropy", func_ss);
         goto out_fail;
     }
 
     if (!ent_stat_get(stats, "Mean", &val)) {
-        msg_err("Cannot get sequence mean\n");
+        msg_err("%s failed to get sequence mean", func_ss);
         goto out_fail;
     }
 
@@ -216,7 +216,7 @@ static int ent_test(struct ent_stat_entry *stats)
     }
 
     if (fabs(mean_dev) > MEAN_DEV_THRESH) {
-        msg_err("Mean deviation too large.\n");
+        msg_err("%s error: mean deviation too large", func_ss);
         goto out_fail;
     }
 
@@ -262,7 +262,7 @@ int main(int argc, char **argv)
     rm_bytestream("/tmp/test");
 
     if (result != EXIT_SUCCESS)
-        msg_err("Test failed.\n");
+        msg_err("Random test failed");
 
     exit(result);
 }

--- a/test/unit/range_test.c
+++ b/test/unit/range_test.c
@@ -29,12 +29,12 @@ closure_func_basic(rmnode_handler, boolean, basic_test_validate,
     range r = range_from_rmnode(node);
     int val = ((test_node)node)->val;
     if (count >= nresults) {
-        msg_err("range lookup extraneous result: %R, %p\n", r, val);
+        msg_err("%s error: range lookup extraneous result: %R, %p", func_ss, r, val);
         exit(EXIT_FAILURE);
     }
     if (!range_equal(r, rm_results[count].r) || val != rm_results[count].val) {
-        msg_err("count %d, range lookup result mismatch, expected %R, %d but got %R, %d\n",
-                count, rm_results[count].r, rm_results[count].val, r, val);
+        msg_err("%s error: count %d, range lookup result mismatch, expected %R, %d, got %R, %d",
+                func_ss, count, rm_results[count].r, rm_results[count].val, r, val);
         exit(EXIT_FAILURE);
     }
     count++;
@@ -65,7 +65,7 @@ boolean basic_test(heap h)
     char * msg = "";
     rangemap rm = allocate_rangemap(h);
     if (rm == INVALID_ADDRESS) {
-        msg_err("failed to allocate rangemap\n");
+        msg_err("%s failed to allocate rangemap", func_ss);
         return false;
     }
 
@@ -182,7 +182,8 @@ static void rangemap_verify_ranges(rangemap rm, int expected_count, u64 expected
     u64 previous_end = 0;
     rangemap_foreach(rm, n) {
         if ((count++ > 0) && (n->r.start <= previous_end)) {
-            msg_err("unexpected range %R, previous end %ld)\n", n->r, previous_end);
+            msg_err("%s error: unexpected range %R, previous end %ld)",
+                    func_ss, n->r, previous_end);
             exit(EXIT_FAILURE);
         }
         length += range_span(n->r);
@@ -205,7 +206,7 @@ static boolean rangemap_merge_test(heap h)
 {
     rangemap rm = allocate_rangemap(h);
     if (rm == INVALID_ADDRESS) {
-        msg_err("failed to allocate rangemap\n");
+        msg_err("%s failed to allocate rangemap", func_ss);
         return false;
     }
     rangemap_verify_ranges(rm, 0, 0);
@@ -257,6 +258,6 @@ int main(int argc, char **argv)
     msg_debug("range test passed\n");
     exit(EXIT_SUCCESS);
   fail:
-    msg_err("range test failed\n");
+    msg_err("Range test failed");
     exit(EXIT_FAILURE);
 }

--- a/test/unit/table_test.c
+++ b/test/unit/table_test.c
@@ -27,14 +27,14 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
     table_validate(t, ss("basic_table_tests: alloc"));
 
     if (table_elements(t) != 0) {
-        msg_err("table_elements() not zero on empty table\n");
+        msg_err("%s error: table_elements() not zero on empty table", func_ss);
         return false;
     }
 
     table_foreach(t, n, v) {
         (void) n;
         (void) v;
-        msg_err("table_foreach() on empty table\n");
+        msg_err("%s error: table_foreach() on empty table", func_ss);
         return false;
     }
 
@@ -52,15 +52,15 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
     count = 0;
     table_foreach(t, n, v) {
         if ((u64)v != (u64)n + 1) {
-            msg_err("table_foreach() invalid value %d for name %d, "
-                    "should be %d\n", (u64)v, (u64)n, (u64)n + 1);
+            msg_err("%s error: table_foreach() invalid value %ld for name %ld, should be %ld",
+                    func_ss, (u64)v, (u64)n, (u64)n + 1);
             return false;
         }
         count++;
     }
 
     if (count != n_elem) {
-        msg_err("table_foreach() invalid iteration count %d\n", count);
+        msg_err("%s error: table_foreach() invalid iteration count %ld", func_ss, count);
         return false;
     }
 
@@ -68,30 +68,30 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
         u64 v = (u64)table_find(t, (void *)count);
 
         if (!v) {
-            msg_err("element %d not found\n", count);
+            msg_err("%s error: element %ld not found", func_ss, count);
             return false;
         }
         if (v != count + 1) {
-            msg_err("element %d invalid value %d, should be %d\n", count, v,
+            msg_err("%s error: element %ld invalid value %ld, should be %ld", func_ss, count, v,
                     count + 1);
             return false;
         }
     }
 
     if (table_find(t, (void *)count)) {
-        msg_err("found unexpected element %d\n", count);
+        msg_err("%s error: unexpected element %ld", func_ss, count);
         return false;
     }
 
     if (table_set_noreplace(t, pointer_from_u64(n_elem / 2), pointer_from_u64(1))) {
-        msg_err("could replace element %ld\n", n_elem / 2);
+        msg_err("%s error: could replace element %ld", func_ss, n_elem / 2);
         return false;
     }
 
     /* Remove one element from the table. */
     table_set(t, 0, 0);
     if (table_find(t, 0)) {
-        msg_err("found unexpected element 0\n");
+        msg_err("%s error: unexpected element 0", func_ss);
         return false;
     }
 
@@ -99,21 +99,21 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
 
     count = table_elements(t);
     if (count != n_elem - 1) {
-        msg_err("invalid table_elements() %d, should be %d\n", count,
+        msg_err("%s error: invalid table_elements() %ld, should be %ld", func_ss, count,
                 n_elem - 1);
         return false;
     }
 
     val = u64_from_pointer(table_remove(t, (pointer_from_u64(1))));
     if (val != 2) {
-        msg_err("invalid element %ld removed, should be 2\n", val);
+        msg_err("%s error: invalid element %ld removed, should be 2", func_ss, val);
         return false;
     }
     table_validate(t, ss("basic_table_tests: after table_remove()"));
     count = table_elements(t);
     if (count != n_elem - 2) {
-        msg_err("invalid table_elements() %ld after table_remove(), should be %ld\n",
-                count, n_elem - 2);
+        msg_err("%s error: invalid table_elements() %ld after table_remove(), should be %ld",
+                func_ss, count, n_elem - 2);
         return false;
     }
 
@@ -131,23 +131,25 @@ static boolean basic_table_tests(heap h, u64 (*key_function)(void *x), u64 n_ele
 
     count = table_elements(t);
     if (count != 0) {
-        msg_err("invalid table_elements() %d, should be 0\n");
+        msg_err("%s error: invalid table_elements() %ld, should be 0", func_ss, count);
         return false;
     }
 
     if (!table_set_noreplace(t, pointer_from_u64(0), pointer_from_u64(n_elem))) {
-        msg_err("could not set element at 0\n");
+        msg_err("%s failed to set element at 0", func_ss);
         return false;
     }
     val = u64_from_pointer(table_find(t, pointer_from_u64(0)));
     if (val != n_elem) {
-        msg_err("unexpected element %ld at 0 after table_set_noreplace()\n", val);
+        msg_err("%s error: unexpected element %ld at 0 after table_set_noreplace()",
+                func_ss, val);
         return false;
     }
 
     deallocate_table(t);
     if (heap_allocated(h) != heap_occupancy) {
-        msg_err("leak: heap_allocated(h) %ld, originally %ld\n", heap_allocated(h), heap_occupancy);
+        msg_err("%s leak: heap_allocated(h) %ld, originally %ld",
+                func_ss, heap_allocated(h), heap_occupancy);
         return false;
     }
     return true;
@@ -170,25 +172,25 @@ static boolean one_elem_table_tests(heap h, u64 n_elem)
     count = 0;
     table_foreach(t, n, v) {
         if (n != 0) {
-            msg_err("table_foreach() invalid name %d\n", (u64)n);
+            msg_err("%s error: table_foreach() invalid name %ld", func_ss, (u64)n);
             return false;
         }
         if ((u64)v != n_elem) {
-            msg_err("table_foreach() invalid value %d for name %d, "
-                    "should be %d\n", (u64)v, (u64)n, n_elem);
+            msg_err("%s error: table_foreach() invalid value %ld for name %ld, should be %ld",
+                    func_ss, (u64)v, (u64)n, n_elem);
             return false;
         }
         count++;
     }
 
     if (count != 1) {
-        msg_err("table_foreach() invalid iteration count %d\n", count);
+        msg_err("%s error: table_foreach() invalid iteration count %ld", func_ss, count);
         return false;
     }
 
     count = table_elements(t);
     if (count != 1) {
-        msg_err("invalid table_elements() %d, should be 1\n", count);
+        msg_err("%s error: invalid table_elements() %ld, should be 1", func_ss, count);
         return false;
     }
 
@@ -196,35 +198,36 @@ static boolean one_elem_table_tests(heap h, u64 n_elem)
         u64 v = (u64)table_find(t, (void *)count);
 
         if (!v) {
-            msg_err("element %d not found\n", count);
+            msg_err("%s error: element %ld not found", func_ss, count);
             return false;
         }
         if (v != n_elem) {
-            msg_err("element %d invalid value %d, should be %d\n", count, v,
+            msg_err("%s error: element %ld invalid value %ld, should be %ld", func_ss, count, v,
                     n_elem);
             return false;
         }
     }
 
     if (!table_find(t, (void *)count)) {
-        msg_err("element %d not found\n", count);
+        msg_err("%s error: element %ld not found", func_ss, count);
         return false;
     }
 
     table_clear(t);
     if (table_find(t, (void *)count)) {
-        msg_err("element found after table_clear()\n");
+        msg_err("%s error: element found after table_clear()", func_ss);
         return false;
     }
     count = table_elements(t);
     if (count != 0) {
-        msg_err("invalid table_elements() %d after table_clear()\n", count);
+        msg_err("%s error: invalid table_elements() %ld after table_clear()", func_ss, count);
         return false;
     }
 
     deallocate_table(t);
     if (heap_allocated(h) != heap_occupancy) {
-        msg_err("leak: heap_allocated(h) %ld, originally %ld\n", heap_allocated(h), heap_occupancy);
+        msg_err("%s leak: heap_allocated(h) %ld, originally %ld",
+                func_ss, heap_allocated(h), heap_occupancy);
         return false;
     }
     return true;
@@ -248,7 +251,7 @@ static boolean preallocated_table_tests(heap h, u64 (*key_function)(void *x), u6
     table_validate(t, ss("preallocated_table_tests: alloc"));
 
     if (table_elements(t) != 0) {
-        msg_err("table_elements() not zero on empty table\n");
+        msg_err("%s error: table_elements() not zero on empty table", func_ss);
         return false;
     }
     for (count = 0; count < n_elem; count++) {
@@ -258,13 +261,14 @@ static boolean preallocated_table_tests(heap h, u64 (*key_function)(void *x), u6
     table_validate(t, ss("preallocated_table_tests: after fill"));
 
     if (heap_allocated(h) != heap_occupancy) {
-        msg_err("unexpected allocation: heap_allocated(h) %llu, originally %llu\n", heap_allocated(h), heap_occupancy);
+        msg_err("%s error: unexpected allocation: heap_allocated(h) %lu, originally %lu",
+                func_ss, heap_allocated(h), heap_occupancy);
         return false;
     }
 
     table_set(t, 0, 0);
     if (table_find(t, 0)) {
-        msg_err("found unexpected element 0\n");
+        msg_err("%s error: unexpected element 0", func_ss);
         return false;
     }
     table_validate(t, ss("preallocated_table_tests: after remove one"));
@@ -277,7 +281,8 @@ static boolean preallocated_table_tests(heap h, u64 (*key_function)(void *x), u6
     destroy_heap(pageheap);
 
     if (heap_allocated(h) != heap_occupancy_before) {
-        msg_err("leak: heap_allocated(h) %ld, originally %ld\n", heap_allocated(h), heap_occupancy_before);
+        msg_err("%s leak: heap_allocated(h) %lu, originally %lu",
+                func_ss, heap_allocated(h), heap_occupancy_before);
         return false;
     }
     return true;

--- a/test/unit/tuple_test.c
+++ b/test/unit/tuple_test.c
@@ -9,7 +9,7 @@
 
 #define test_assert(expr) do { \
 if (expr) ; else { \
-    msg_err("%s -- failed at %s:%d\n", ss(#expr), file_ss, __LINE__); \
+    msg_err("%s: %s -- failed at %s:%d", func_ss, ss(#expr), file_ss, __LINE__); \
     goto fail; \
 } \
 } while (0)
@@ -371,7 +371,7 @@ int main(int argc, char **argv)
     failure |= encode_decode_lengthy_test(h);
 
     if (failure) {
-        msg_err("Test failed\n");
+        msg_err("Tuple test failed");
         exit(EXIT_FAILURE);
     }
     exit(EXIT_SUCCESS);

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -157,7 +157,7 @@ closure_function(3, 2, void, fsc,
     heap h = bound(h);
 
     if (!is_ok(s)) {
-        rprintf("failed to initialize filesystem: %v\n", s);
+        msg_err("dump: failed to initialize filesystem: %v", s);
         exit(EXIT_FAILURE);
     }
 

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -243,7 +243,7 @@ closure_func_basic(parse_finish, void, finish,
 closure_func_basic(parse_error, void, perr,
                    string s)
 {
-    rprintf("manifest parse error %b\n", s);
+    msg_err("manifest parse error: %b", s);
     exit(EXIT_FAILURE);
 }
 
@@ -341,7 +341,7 @@ closure_func_basic(io_status_handler, void, mkfs_write_handler,
                    status s, bytes length)
 {
     if (!is_ok(s)) {
-        rprintf("write failed with %v\n", s);
+        msg_err("write failed with %v", s);
         exit(EXIT_FAILURE);
     }
 }
@@ -584,7 +584,7 @@ closure_func_basic(parse_finish, void, cmdline_tuple_finish,
                    void *v)
 {
     if (!is_tuple(v)) {
-        rprintf("parsed cmdline value is not a tuple: %v\n", v);
+        msg_err("cmdline value is not a tuple: %v", v);
         exit(EXIT_FAILURE);
     }
     vector_push(cmdline_tuples, v);
@@ -593,7 +593,7 @@ closure_func_basic(parse_finish, void, cmdline_tuple_finish,
 closure_func_basic(parse_error, void, cmdline_tuple_err,
                    string s)
 {
-    rprintf("cmdline tuple parse error %b\n", s);
+    msg_err("cmdline tuple parse error: %b", s);
     exit(EXIT_FAILURE);
 }
 

--- a/tools/tfs-fuse.c
+++ b/tools/tfs-fuse.c
@@ -825,7 +825,7 @@ closure_func_basic(filesystem_complete, void, fsc,
                    filesystem fs, status s)
 {
     if (!is_ok(s)) {
-        rprintf("failed to initialize filesystem: %v\n", s);
+        msg_err("tfs-fuse: failed to initialize filesystem: %v", s);
         exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
The msg_{err,warn,info} macros have been repurposed so that in kernel code they expand to log_printf() function calls, which print the supplied message to the console if the log level (supplied as an additional argument) is lower than or equal to the configured kernel log level. The default log level is "err".
Example Ops configuration to set the log level to "info":
```
  "ManifestPassthrough": {
    "log_level": "info"
  }
```