### PR TITLE
virtio_balloon: add support for MMIO devices

### DIFF
--- a/src/virtio/virtio.c
+++ b/src/virtio/virtio.c
@@ -122,7 +122,7 @@ status virtio_register_config_change_handler(vtdev dev, thunk handler)
 {
     switch (dev->transport) {
     case VTIO_TRANSPORT_MMIO:
-        return timm("status", "not implemented");
+        return vtmmio_register_config_change_handler((vtmmio)dev, handler);
     case VTIO_TRANSPORT_PCI:
         return vtpci_register_config_change_handler((vtpci)dev, handler);
     default:

--- a/src/virtio/virtio_balloon.c
+++ b/src/virtio/virtio_balloon.c
@@ -416,5 +416,12 @@ void init_virtio_balloon(kernel_heaps kh)
 {
     virtio_balloon_debug("%s\n", func_ss);
     heap h = heap_locked(kh);
-    register_pci_driver(closure(h, vtpci_balloon_probe, h, heap_linear_backed(kh), heap_physical(kh)), 0);
+    backed_heap backed = heap_linear_backed(kh);
+    id_heap physical = heap_physical(kh);
+    pci_probe probe = closure(h, vtpci_balloon_probe, h, backed, physical);
+    if (probe == INVALID_ADDRESS) {
+        msg_err("%s: out of memory", func_ss);
+        return;
+    }
+    register_pci_driver(probe, 0);
 }

--- a/src/virtio/virtio_balloon.c
+++ b/src/virtio/virtio_balloon.c
@@ -26,7 +26,9 @@
 #define VIRTIO_BALLOON_PAGE_ORDER PAGELOG
 
 /* These are units that we allocate from the physical heap. */
-#define VIRTIO_BALLOON_ALLOC_ORDER 21
+/* The maximum number of pages supported by AWS Firecracker in a single inflate descriptor is 256,
+ * which corresponds to 1 MB of memory, and the balloon allocation unit is sized accordingly. */
+#define VIRTIO_BALLOON_ALLOC_ORDER 20
 #define VIRTIO_BALLOON_ALLOC_SIZE U64_FROM_BIT(VIRTIO_BALLOON_ALLOC_ORDER)
 #define VIRTIO_BALLOON_PAGES_PER_ALLOC U64_FROM_BIT(VIRTIO_BALLOON_ALLOC_ORDER - \
                                                     VIRTIO_BALLOON_PAGE_ORDER)

--- a/src/virtio/virtio_balloon.c
+++ b/src/virtio/virtio_balloon.c
@@ -86,6 +86,8 @@ struct virtio_balloon_config {
 #define VIRTIO_BALLOON_R_NUM_PAGES (offsetof(struct virtio_balloon_config *, num_pages))
 #define VIRTIO_BALLOON_R_ACTUAL    (offsetof(struct virtio_balloon_config *, actual))
 
+#define VIRTIO_BALLOON_DRV_FEATURES (VIRTIO_BALLOON_F_STATS_VQ | VIRTIO_BALLOON_F_MUST_TELL_HOST)
+
 static inline boolean balloon_must_tell_host(void)
 {
     return (virtio_balloon.dev->features & VIRTIO_BALLOON_F_MUST_TELL_HOST) != 0;
@@ -406,8 +408,7 @@ closure_function(3, 1, boolean, vtpci_balloon_probe,
 
     virtio_balloon_debug("   attaching\n", __func__);
     vtdev v = (vtdev)attach_vtpci(bound(general), bound(backed), d,
-                                  (VIRTIO_BALLOON_F_STATS_VQ |
-                                   VIRTIO_BALLOON_F_MUST_TELL_HOST));
+                                  VIRTIO_BALLOON_DRV_FEATURES);
     return virtio_balloon_attach(bound(general), bound(backed), bound(physical), v);
 }
 

--- a/src/virtio/virtio_mmio.h
+++ b/src/virtio/virtio_mmio.h
@@ -32,6 +32,7 @@ typedef struct vtmmio_dev {
     closure_struct(vtdev_notify, notify);
     closure_struct(thunk, irq_handler);
     vector vq_handlers;
+    thunk cfg_chg_handler;
 } *vtmmio;
 
 #define vtmmio_get_u8(dev, offset) (*((volatile u8 *)((dev)->vbase + offset)))
@@ -67,3 +68,4 @@ void vtmmio_set_status(vtmmio dev, u8 status);
 boolean attach_vtmmio(heap h, backed_heap page_allocator, vtmmio d, u64 feature_mask);
 status vtmmio_alloc_virtqueue(vtmmio dev, sstring name, int idx, range cpu_affinity,
                               struct virtqueue **result);
+status vtmmio_register_config_change_handler(vtmmio dev, thunk handler);


### PR DESCRIPTION
This allows the virtio memory balloon driver to work with AWS Firecracker, which instantiates MMIO devices.