### PR TITLE
Arm fault handler: add emulation of MRS instruction

### DIFF
--- a/src/aarch64/crt0.S
+++ b/src/aarch64/crt0.S
@@ -180,6 +180,11 @@ context_suspend:
         ldr     x0, [x18]
         b context_suspend_finish
 
+.globl sysreg_get_id_aa64zfr0
+sysreg_get_id_aa64zfr0:
+        .long (INSN_MRS(0) | SYSREG_ID_AA64ZFR0_EL1)
+        ret
+
         .globl arm_hvc
 arm_hvc:
         // incomplete, just enough to issue power off

--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -38,6 +38,7 @@
 #define ESR_EC_UNKNOWN        0x00
 #define ESR_EC_ILL_EXEC       0x0e
 #define ESR_EC_SVC_AARCH64    0x15
+#define ESR_EC_MSR_MRS        0x18
 #define ESR_EC_INST_ABRT_LEL  0x20
 #define ESR_EC_INST_ABRT      0x21
 #define ESR_EC_PC_ALIGN_FAULT 0x22
@@ -367,8 +368,11 @@ static inline boolean is_illegal_instruction(context_frame f)
 {
     u64 esr = esr_from_frame(f);
     u32 ec = field_from_u64(esr, ESR_EC);
-    if (ec == ESR_EC_UNKNOWN)
+    switch (ec) {
+    case ESR_EC_UNKNOWN:
+    case ESR_EC_MSR_MRS:
         return true;
+    }
     return false;
 }
 

--- a/src/riscv64/kernel_machine.h
+++ b/src/riscv64/kernel_machine.h
@@ -195,6 +195,8 @@ static inline cpuinfo current_cpu(void)
 
 extern void clone_frame_pstate(context_frame dest, context_frame src);
 
+#define insn_emulate(f) false
+
 static inline boolean is_pte_error(context_frame f)
 {
     // riscv equivalent?

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -269,7 +269,8 @@ closure_func_basic(fault_handler, context, unix_fault_handler,
     } else if (is_illegal_instruction(f)) {
         if (user) {
             pf_debug("invalid opcode fault in user mode, rip 0x%lx", fault_pc);
-            deliver_fault_signal(SIGILL, t, fault_pc, ILL_ILLOPC);
+            if (!insn_emulate(f))
+                deliver_fault_signal(SIGILL, t, fault_pc, ILL_ILLOPC);
             schedule_thread(t);
             return 0;
         } else {

--- a/src/x86_64/kernel_machine.h
+++ b/src/x86_64/kernel_machine.h
@@ -365,6 +365,8 @@ static inline void frame_disable_interrupts(context_frame f)
 extern void xsave(context_frame f);
 extern void clone_frame_pstate(context_frame dest, context_frame src);
 
+#define insn_emulate(f) false
+
 static inline boolean is_protection_fault(context_frame f)
 {
     return (f[FRAME_ERROR_CODE] & FRAME_ERROR_PF_P) != 0;


### PR DESCRIPTION
Starting with Go version 1.23, the Golang runtime for Arm64 during initialization tries to retrieve the values of some system registers (via the MRS instruction) in order to evaluate the features implemented by the processor. This instruction causes a CPU exception, which is not properly handled by the kernel; as a result, Go programs built with Go version 1.23 do to not work on Arm.
This change set adds emulation of the MRS instruction to retrieve the values of the system registers used by the Go runtime, so that Go 1.23 works properly on Arm.