### PR TITLE
fsfile_open(): follow symbolic links

### DIFF
--- a/src/kernel/stage3.c
+++ b/src/kernel/stage3.c
@@ -50,11 +50,10 @@ static void init_kernel_heaps_management(tuple root)
     set(root, sym(heaps), heaps);
 }
 
-closure_function(6, 0, void, startup,
-                 kernel_heaps, kh, tuple, root, filesystem, fs, merge, m, status_handler, start, status_handler, completion)
+closure_function(5, 0, void, startup,
+                 tuple, root, filesystem, fs, merge, m, status_handler, start, status_handler, completion)
 {
     status s = STATUS_OK;
-    kernel_heaps kh = bound(kh);
     tuple root = bound(root);
     filesystem fs = bound(fs);
 
@@ -63,7 +62,6 @@ closure_function(6, 0, void, startup,
 #endif
 
     status_handler start = bound(start);
-    heap general = heap_locked(kh);
 
     /* register root tuple with management and kick off interfaces, if any */
     init_management_root(root);
@@ -72,10 +70,6 @@ closure_function(6, 0, void, startup,
         filesystem_set_readonly(fs);
     value p = get(root, sym(program));
     assert(p && is_string(p));
-    tuple pro = resolve_path(filesystem_getroot(fs), split(general, p, '/'));
-    if (!pro)
-        halt("unable to resolve program path \"%b\"\n", p);
-    program_set_perms(root, pro);
     init_network_iface(root, bound(m));
     closure_member(program_start, start, path) = (string)p;
     msg_info("gitversion: %s", gitversion);
@@ -94,7 +88,7 @@ thunk create_init(kernel_heaps kh, tuple root, filesystem fs, merge *m)
     heap h = heap_locked(kh);
     status_handler start = closure(h, program_start, kp, 0, false);
     *m = allocate_merge(h, start);
-    return closure(h, startup, kh, root, fs, *m, start, apply_merge(*m));
+    return closure(h, startup, root, fs, *m, start, apply_merge(*m));
 }
 
 closure_function(5, 1, status, kernel_read_complete,

--- a/src/unix/exec.c
+++ b/src/unix/exec.c
@@ -550,6 +550,7 @@ void exec_elf(process kp, string program_path, status_handler complete)
         apply(complete, timm("result", "unable to open program file %v", program_path));
         return;
     }
+    program_set_perms(root, f->md);
 
     /* any of these options force a full program read */
     boolean static_map = get(root, sym(ltrace)) || get(root, sym(static_map_program));

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -658,7 +658,7 @@ fsfile fsfile_open(sstring file_path)
     filesystem fs = get_root_fs();
     int s = filesystem_get_node(&fs, fs->get_inode(fs, filesystem_getroot(fs)),
                                       file_path,
-                                      true, false, false, false, &file, &fsf);
+                                      false, false, false, false, &file, &fsf);
     if (s == 0) {
         filesystem_put_node(fs, file);
         return fsf;


### PR DESCRIPTION
This allows an application to be run on images where the files at the program path and interpreter (dynamic loader) path are symbolic links.