### PR TITLE
virtio/net: fix processing of merged RX buffers

### DIFF
--- a/src/aarch64/machine.h
+++ b/src/aarch64/machine.h
@@ -212,6 +212,9 @@ static inline __attribute__((always_inline)) void memory_barrier(void)
     asm volatile("dmb sy" ::: "memory");
 }
 
+#define smp_write_barrier()    write_barrier()
+#define smp_read_barrier()     read_barrier()
+
 /* XXX something b0rked with ldset here...ordering, or asm constraints? */
 static inline __attribute__((always_inline)) u8 atomic_test_and_set_bit(u64 *target, u64 bit)
 {

--- a/src/kernel/mutex.c
+++ b/src/kernel/mutex.c
@@ -120,7 +120,7 @@ static inline boolean mutex_lock_internal(mutex m, boolean wait)
 
     /* prev write must occur before next */
     ci->mcs_prev = prev;
-    write_barrier();
+    smp_write_barrier();
     prev->mcs_next = ci;
 
     /* limited spin to acquire lock */

--- a/src/kernel/tracelog.c
+++ b/src/kernel/tracelog.c
@@ -122,7 +122,7 @@ static inline void put_tracelog_buffer(cpuinfo ci)
 {
     u64 v = u64_from_pointer(ci->tracelog_buffer);
     assert(v & TRACELOG_BUFFER_BUSY);
-    write_barrier();
+    smp_write_barrier();
     ci->tracelog_buffer = pointer_from_u64(v ^ TRACELOG_BUFFER_BUSY);
 }
 

--- a/src/kernel/vdso-now.c
+++ b/src/kernel/vdso-now.c
@@ -107,7 +107,7 @@ vdso_now(clock_id id)
         default:
             break;
         }
-        read_barrier();
+        smp_read_barrier();
     } while (__vdso_dat->vdso_gen != _gen);
 
     if (_now == VDSO_NO_NOW)

--- a/src/net/direct.c
+++ b/src/net/direct.c
@@ -45,7 +45,6 @@ closure_func_basic(thunk, void, direct_receive_service)
 {
     direct d = struct_from_closure(direct, receive_service);
     d->receive_service_scheduled = 0;
-    write_barrier();
     spin_lock(&d->conn_lock);
     list_foreach(&d->conn_head, l) {
         direct_conn dc = struct_from_list(l, direct_conn, l);

--- a/src/riscv64/machine.h
+++ b/src/riscv64/machine.h
@@ -222,6 +222,9 @@ static inline __attribute__((always_inline)) void memory_barrier(void)
     asm volatile("fence.tso" ::: "memory");
 }
 
+#define smp_write_barrier()    write_barrier()
+#define smp_read_barrier()     read_barrier()
+
 static inline __attribute__((always_inline)) word fetch_and_add(word *target, word num)
 {
     return __sync_fetch_and_add(target, num);

--- a/src/runtime/clock.h
+++ b/src/runtime/clock.h
@@ -73,7 +73,7 @@ static inline timestamp now(clock_id id)
     do {
         gen = __vdso_dat->vdso_gen & ~1ull;
         s64 last_raw = __vdso_dat->last_raw;
-        read_barrier();
+        smp_read_barrier();
 #endif
         t = apply(platform_monotonic_now);
 #if defined(KERNEL) || defined(BUILD_VDSO)
@@ -96,7 +96,7 @@ static inline timestamp now(clock_id id)
         default:
             break;
         }
-        read_barrier();
+        smp_read_barrier();
     } while (gen != __vdso_dat->vdso_gen);
 #endif
 

--- a/src/runtime/lock.h
+++ b/src/runtime/lock.h
@@ -61,7 +61,7 @@ static inline void spin_unlock(spinlock l)
 #ifdef LOCK_STATS
     LOCKSTATS_RECORD_UNLOCK(l->s);
 #endif
-    compiler_barrier();
+    smp_write_barrier();
     *(volatile u64 *)&l->w = 0;
 }
 

--- a/src/runtime/queue.h
+++ b/src/runtime/queue.h
@@ -58,7 +58,7 @@ static inline boolean _enqueue_common(queue q, void *p, boolean multi, int n)
         *dest = p;
     else
         runtime_memcpy(dest, p, sizeof(u64) * n);
-    write_barrier();
+    smp_write_barrier();
 
     /* multi-producer: wait for previous enqueues to commit */
     if (multi) {
@@ -100,7 +100,7 @@ static inline void _dequeue_common(queue q, void **p, boolean multi, int n)
         *p = *src;
     else
         runtime_memcpy(p, src, sizeof(u64) * n);
-    read_barrier();
+    smp_read_barrier();
 
     /* multi-consumer: wait for previous dequeues to commit */
     if (multi) {
@@ -202,7 +202,6 @@ static inline void queue_init(queue q, int order, void ** buf)
     q->d = buf;
     q->h = 0;
     zero(buf, queue_data_size(order));
-    write_barrier();
 }
 
 /* will round up size to next power-of-2 */

--- a/src/runtime/timer.h
+++ b/src/runtime/timer.h
@@ -109,7 +109,7 @@ static inline timestamp timer_expiry(timer t)
             break;
         }
         expiry -= clock_freq_adjust(interval);
-        read_barrier();
+        smp_read_barrier();
     } while (gen != __vdso_dat->vdso_gen);
 #endif
 

--- a/src/unix/blockq.c
+++ b/src/unix/blockq.c
@@ -138,7 +138,6 @@ unix_context blockq_wake_one(blockq bq)
        before the blockq lock is taken and the thread is added to the waiter
        list. See blockq_check_timeout() for more detail. */
     bq->wake = true;
-    write_barrier();
     blockq_unlock(bq);
     return INVALID_ADDRESS;
 }
@@ -207,7 +206,7 @@ sysreturn blockq_check_timeout(blockq bq, blockq_action a, boolean in_bh,
     */
 
     bq->wake = false;
-    write_barrier();
+    smp_write_barrier();
     sysreturn rv = apply(a, 0);
     if (rv != BLOCKQ_BLOCK_REQUIRED) {
         blockq_debug(" - direct return: %ld\n", rv);

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -505,7 +505,7 @@ static void iour_complete_locked(io_uring iour, u64 user_data, s32 res,
         cqe->user_data = user_data;
         cqe->res = res;
         cqe->flags = 0;
-        write_barrier();
+        smp_write_barrier();
         rings->cq_tail++;
     } else {
         iour_debug("overflow");
@@ -1211,7 +1211,6 @@ sysreturn io_uring_enter(int fd, unsigned int to_submit,
         }
     }
     io_rings rings = iour->rings;
-    read_barrier();
     iour_debug("SQ head %d, SQ tail %d", rings->sq_head, rings->sq_tail);
     unsigned int submitted;
     for (submitted = 0; submitted < to_submit;) {

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -194,7 +194,7 @@ boolean new_zeroed_pages(u64 v, vmap vm, pageflags flags)
         VMAP_PAGE_SHRINK(v, page_addr, page_size);
     }
     zero(m, page_size);
-    write_barrier();
+    smp_write_barrier();
     u64 p = physical_from_virtual(m);
     map(page_addr, p, page_size, flags);
     return true;

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -1793,7 +1793,7 @@ static sysreturn brk(void *addr)
         if (u64_from_pointer(addr) < p->heap_base ||
             !adjust_process_heap(p, irange(p->heap_base, new_end)))
             goto out;
-        write_barrier();
+        smp_write_barrier();
         unmap_and_free_phys(new_end, old_end - new_end);
     } else if (new_end > old_end) {
         u64 alloc = new_end - old_end;

--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -213,6 +213,7 @@ closure_func_basic(vqfinish, void, vnet_input,
             kern_pause();
         }
 
+        smp_read_barrier();
         struct virtio_net_hdr_mrg_rxbuf *saved_hdr = rx->hdr;
         boolean first_msg = (saved_hdr == 0);
         if (first_msg) {
@@ -238,6 +239,7 @@ closure_func_basic(vqfinish, void, vnet_input,
                 pkt_complete = true;
             }
         }
+        smp_write_barrier();
         rx->seqno++;
         if (!pkt_complete)
             goto out;

--- a/src/x86_64/machine.h
+++ b/src/x86_64/machine.h
@@ -165,6 +165,12 @@ static inline __attribute__((always_inline)) void memory_barrier(void)
     asm volatile("mfence" ::: "memory");
 }
 
+/* For cached memory, the architecture guarantees LoadLoad and StoreStore ordering, thus a memory
+ * fence is not needed.
+ */
+#define smp_write_barrier()    compiler_barrier()
+#define smp_read_barrier()     compiler_barrier()
+
 static inline __attribute__((always_inline)) word fetch_and_add(word *variable, word value)
 {
     return __sync_fetch_and_add(variable, value);

--- a/test/runtime/io_uring.c
+++ b/test/runtime/io_uring.c
@@ -265,7 +265,7 @@ static void iour_setup_sqe(struct iour *iour, uint8_t opcode, int fd,
     sqe->len = len;
     sqe->off = offset;
     sqe->user_data = user_data;
-    write_barrier();
+    smp_write_barrier();
     (*iour->sq_tail)++;
 }
 
@@ -303,7 +303,7 @@ static void iour_setup_rw_fixed(struct iour *iour, int fd, uint16_t buf_index,
     sqe->len = len;
     sqe->user_data = user_data;
     sqe->buf_index = buf_index;
-    write_barrier();
+    smp_write_barrier();
     (*iour->sq_tail)++;
 }
 
@@ -318,7 +318,7 @@ static void iour_setup_poll_add(struct iour *iour, int fd, uint16_t events,
     sqe->fd = fd;
     sqe->poll_events = events;
     sqe->user_data = user_data;
-    write_barrier();
+    smp_write_barrier();
     (*iour->sq_tail)++;
 }
 
@@ -340,7 +340,7 @@ static void iour_setup_poll_fixed_file(struct iour *iour, int fd_index,
     sqe->fd = fd_index;
     sqe->poll_events = events;
     sqe->user_data = user_data;
-    write_barrier();
+    smp_write_barrier();
     (*iour->sq_tail)++;
 }
 
@@ -358,7 +358,7 @@ static void iour_setup_timeout(struct iour *iour, struct timespec *ts,
     sqe->len = 1;
     sqe->timeout_flags = flags;
     sqe->user_data = user_data;
-    write_barrier();
+    smp_write_barrier();
     (*iour->sq_tail)++;
 }
 
@@ -407,7 +407,7 @@ static void iour_setup_accept(struct iour *iour, int fd, struct sockaddr *addr, 
     sqe->addr2 = (uint64_t)addr_len;
     sqe->accept_flags = flags;
     sqe->user_data = user_data;
-    write_barrier();
+    smp_write_barrier();
     (*iour->sq_tail)++;
 }
 
@@ -426,7 +426,7 @@ static void iour_setup_txrx(struct iour *iour, boolean tx, int fd, uint8_t *buf,
     sqe->msg_flags = flags;
     sqe->user_data = user_data;
     sqe->buf_index = 0;
-    write_barrier();
+    smp_write_barrier();
     (*iour->sq_tail)++;
 }
 
@@ -441,7 +441,7 @@ static struct io_uring_cqe *iour_get_cqe(struct iour *iour)
 {
     struct io_uring_cqe *cqe;
 
-    read_barrier();
+    smp_read_barrier();
     if (*iour->cq_tail == *iour->cq_head)
         return NULL;
     test_assert(*iour->cq_tail > *iour->cq_head);

--- a/test/unit/queue_test.c
+++ b/test/unit/queue_test.c
@@ -116,7 +116,7 @@ static void thread_test(void)
     vec_count = RESULTS_VEC_SIZE;
     zero(results, RESULTS_VEC_SIZE * sizeof(u64));
     drain_and_exit = false;
-    write_barrier();
+    smp_write_barrier();
     queuetest_debug("spawning threads...\n");
     for (int i = 0; i < N_THREADS; i++) {
         if (pthread_create(&threads[i], NULL, test_child, q))


### PR DESCRIPTION
When the virtio net feature that allows merging of RX buffers is enabled, buffers belonging to a merged set must be processed in strict sequential order; to achieve this, the seqno field of the vnet_rx structure is used to prevent different CPUS from processing RX buffers simultaneously.
This change set fixes a few flaws in the implementation of the critical section which can cause corruption of the pbuf structure holding received data, and can lead to failure to process incoming network traffic. The memory barriers needed to ensure correct synchronization between CPUs have been added via the newly defined smp_read_barrier() and smp_write_barrier() macros, which are more efficient than read_barrier() and write_barrier() on architectures (such as x86) with strong memory ordering. As part of the commit that introduces these new macros, existing calls to read_barrier() and write_barrier() have been replaced by calls to smp_read_barrier() and smp_write_barrier() where appropriate (i.e where memory is not used for device I/O).

Closes #2099.