### PR TITLE
Syscalls: add stubs for sched_get_priority_min/max and sched_setscheduler

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2382,6 +2382,9 @@ void register_file_syscalls(struct syscall *map)
     register_syscall(map, fchdir, fchdir);
     register_syscall(map, sched_getaffinity, sched_getaffinity);
     register_syscall(map, sched_setaffinity, sched_setaffinity);
+    register_syscall(map, sched_get_priority_min, syscall_ignore);
+    register_syscall(map, sched_get_priority_max, syscall_ignore);
+    register_syscall(map, sched_setscheduler, syscall_ignore);
     register_syscall(map, getuid, syscall_ignore);
     register_syscall(map, geteuid, syscall_ignore);
     register_syscall(map, setgroups, syscall_ignore);


### PR DESCRIPTION
These syscalls are needed by the OpenJ9 (IBM Semeru Runtime) JVM, which fails during startup with a "Could not create the Java Virtual Machine" error if they are not implemented.
Since Nanos does not have configurable scheduling policies or priorities, just ignore these syscalls.

Closes #2109.