### PR TITLE
net: direct: invoke TCP connection error callback asynchronously

### DIFF
--- a/src/net/direct.c
+++ b/src/net/direct.c
@@ -390,7 +390,7 @@ static void direct_connect_err(void *arg, err_t err)
 {
     direct d = arg;
     direct_debug("d %p, err %d\n", d, err);
-    apply(d->new, 0);
+    async_apply_1(d->new, 0);
     d->p = 0;
     direct_dealloc(d);
 }


### PR DESCRIPTION
When a TCP connection attempt fails, if the connection handler is invoked directly from within the lwIP TCP error callback, the lwIP TCP core is locked, which means that if the application layer tries to call other TCP core functions from the connection handler (e.g. to try connecting to another server), it will deadlock.
To fix this issue, invoke the connection handler asynchronously so that no lwIP locks are held, similarly to how the handler is invoked in case of successful connection.
This issue was discovered when loading the userdata klib on an instance that does not have a metadata server.