### PR TITLE
netsock options: add support for SO_RCVTIMEO and SO_SNDTIMEO

### DIFF
--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -82,6 +82,8 @@ struct sock {
     blockq rxbq;
     blockq txbq;
     u64 rx_len;
+    timestamp rx_timeout;
+    timestamp tx_timeout;
     sysreturn (*bind)(struct sock *sock, struct sockaddr *addr,
             socklen_t addrlen);
     sysreturn (*listen)(struct sock *sock, int backlog);

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -855,6 +855,8 @@ struct io_uring_params {
 #define SO_PRIORITY     12
 #define SO_LINGER       13
 #define SO_REUSEPORT    15
+#define SO_RCVTIMEO     20
+#define SO_SNDTIMEO     21
 #define SO_TIMESTAMP    29
 #define SO_ACCEPTCONN   30
 #define SO_PROTOCOL     38


### PR DESCRIPTION
These options affect the behavior of network socket syscalls such as sendto(), recvfrom(), connect(), and accept().