### PR TITLE
Fix readonly_rootfs blocking writes to device files

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -856,7 +856,7 @@ int file_open(filesystem fs, tuple n, tuple parent, int flags, fsfile fsf)
         break;
     case O_WRONLY:
     case O_RDWR:
-        if (filesystem_is_readonly(fs)) {
+        if (filesystem_is_readonly(fs) && !get(n, sym(special))) {
             return -EROFS;
         }
         if (!(file_meta_perms(p, n) & ACCESS_PERM_WRITE)) {


### PR DESCRIPTION
Fixes https://github.com/nanovms/nanos/issues/2134

`open()` with `O_WRONLY` or `O_RDWR` on device files like `/dev/null` returns `EROFS` when `readonly_rootfs` is enabled. Device writes go to the driver, not the filesystem, so special files should be exempt from the read-only check.