### PR TITLE
netsock_poll(): poll all network interfaces

### DIFF
--- a/platform/pc/boot/Makefile
+++ b/platform/pc/boot/Makefile
@@ -149,7 +149,7 @@ msg_uefi_ld=    LD	$@
 cmd_uefi_ld=    $(LD) $(LDLAGS-uefi) $(OBJS-uefi) -o $@
 
 msg_uefi_objcopy=    OBJCOPY	$(OBJDIR)/bootx64.efi
-cmd_uefi_objcopy=    $(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .dynsym  -j .rel -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* -j .reloc --target efi-app-x86_64 --subsystem=10 $< $@
+cmd_uefi_objcopy=    $(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .dynsym  -j .rel -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* -j .reloc -O efi-app-x86_64 --subsystem=10 $< $@
 
 $(OBJDIR-uefi)/x86_64/uefi-crt0.o:	$(SRCDIR)/x86_64/uefi-crt0.s
 	$(call cmd,uefi_as)


### PR DESCRIPTION
When the destination address of a network packet coincides with the address of a network interface, the packet is queued in the loopback queue of that interface. The netsock_poll() function is only polling the loopback interface, therefore it misses packets whose destination is the address of a non-loopback interface.
This change set ensures that the netsock_poll() function polls all interfaces instead of just the loopback interface.
This first commit is an unrelated fix for a build error that occurs with binutils version 2.46.