### PR TITLE
Add proper validation for user-supplied timespec and timeval struct pointers 

### DIFF
--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -137,17 +137,17 @@ closure_function(1, 1, void, futex_requeue_handler,
     closure_member(futex_bh, action, f) = bound(dest);
 }
 
-static timestamp get_timeout_timestamp(int futex_op, u64 val2)
+static sysreturn get_timeout_timestamp(int futex_op, u64 val2, timestamp *ts)
 {
     switch (futex_op) {
     case FUTEX_WAIT:
     case FUTEX_WAIT_BITSET:
-        return (val2) 
-            ? time_from_timespec((struct timespec *)pointer_from_u64(val2)) 
-            : 0;
-    default:
-        return 0;
+        if (val2)
+            return user_timespec_get((struct timespec *)pointer_from_u64(val2), ts);
+        break;
     }
+    *ts = 0;
+    return 0;
 }
 
 sysreturn futex(int *uaddr, int futex_op, int val,
@@ -165,7 +165,9 @@ sysreturn futex(int *uaddr, int futex_op, int val,
         return set_syscall_error(current, ENOMEM);
     
     op = futex_op & 127; // chuck the private bit
-    ts = get_timeout_timestamp(op, val2);
+    sysreturn ret = get_timeout_timestamp(op, val2, &ts);
+    if (ret)
+        return ret;
     clock_id clkid = (futex_op & FUTEX_CLOCK_REALTIME) ? CLOCK_ID_REALTIME :
             CLOCK_ID_MONOTONIC;
 

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -790,7 +790,7 @@ define_closure_function(2, 2, void, iour_timeout,
         iour_release(iour);
 }
 
-static void iour_timeout_add(io_uring iour, struct timespec *ts, u32 flags,
+static void iour_timeout_add(io_uring iour, timestamp tmo, u32 flags,
                              u64 off, u64 user_data)
 {
     iour_debug("flags 0x%x, off %ld", flags, off);
@@ -822,7 +822,7 @@ static void iour_timeout_add(io_uring iour, struct timespec *ts, u32 flags,
 
     list_push_back(&iour->timers, &iour_tim->l);
     register_timer(kernel_timers, &iour_tim->t, CLOCK_ID_MONOTONIC,
-        time_from_timespec(ts), flags & IORING_TIMEOUT_ABS, 0,
+        tmo, flags & IORING_TIMEOUT_ABS, 0,
         init_closure(&iour_tim->handler, iour_timeout, iour, iour_tim));
     iour_unlock(iour);
 done:
@@ -1009,15 +1009,14 @@ static boolean iour_submit(io_uring iour, struct io_uring_sqe *sqe)
         iour_poll_remove(iour, sqe->addr, sqe->user_data);
         break;
     case IORING_OP_TIMEOUT: {
-        struct timespec *ts = (struct timespec *)sqe->addr;
         if (sqe->ioprio || (sqe->len != 1) || sqe->buf_index) {
             res = -EINVAL;
             goto complete;
         }
-        if (!validate_user_memory(ts, sizeof(*ts), false)) {
-            res = -EFAULT;
+        timestamp ts;
+        res = user_timespec_get((struct timespec *)sqe->addr, &ts);
+        if (res)
             goto complete;
-        }
         iour_timeout_add(iour, ts, sqe->timeout_flags, sqe->off,
                          sqe->user_data);
         break;

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -920,7 +920,15 @@ sysreturn pselect(int nfds,
                   struct timespec *timeout,
                   const sigset_t * sigmask)
 {
-    return select_internal(nfds, readfds, writefds, exceptfds, timeout ? time_from_timespec(timeout) : infinity, sigmask);
+    timestamp tmo;
+    if (timeout) {
+        sysreturn ret = user_timespec_get(timeout, &tmo);
+        if (ret)
+            return ret;
+    } else {
+        tmo = infinity;
+    }
+    return select_internal(nfds, readfds, writefds, exceptfds, tmo, sigmask);
 }
 
 #ifdef __x86_64__
@@ -928,7 +936,15 @@ sysreturn select(int nfds,
                  u64 *readfds, u64 *writefds, u64 *exceptfds,
                  struct timeval *timeout)
 {
-    return select_internal(nfds, readfds, writefds, exceptfds, timeout ? time_from_timeval(timeout) : infinity, 0);
+    timestamp tmo;
+    if (timeout) {
+        sysreturn ret = user_timeval_get(timeout, &tmo);
+        if (ret)
+            return ret;
+    } else {
+        tmo = infinity;
+    }
+    return select_internal(nfds, readfds, writefds, exceptfds, tmo, 0);
 }
 #endif
 
@@ -1076,7 +1092,15 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
 
 sysreturn ppoll(struct pollfd *fds, nfds_t nfds, const struct timespec *tmo_p, const sigset_t *sigmask)
 {
-    return poll_internal(fds, nfds, tmo_p ? time_from_timespec(tmo_p) : infinity, sigmask);
+    timestamp tmo;
+    if (tmo_p) {
+        sysreturn ret = user_timespec_get(tmo_p, &tmo);
+        if (ret)
+            return ret;
+    } else {
+        tmo = infinity;
+    }
+    return poll_internal(fds, nfds, tmo, sigmask);
 }
 
 #ifdef __x86_64__

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -999,7 +999,7 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
                                timestamp timeout,
                                const sigset_t * sigmask)
 {
-    if (!validate_user_memory(fds, sizeof(struct pollfd) * nfds, true))
+    if (nfds && !validate_user_memory(fds, sizeof(struct pollfd) * nfds, true))
         return -EFAULT;
     epoll e = thread_get_epoll(EPOLL_TYPE_POLL);
     if (e == INVALID_ADDRESS)
@@ -1074,13 +1074,8 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
                                 CLOCK_ID_MONOTONIC, timeout != infinity ? timeout : 0, false);
 }
 
-/* archs like aarch64 don't have pause; glibc calls ppoll() with all null arguments to simulate... */
-extern sysreturn pause(void);
-
 sysreturn ppoll(struct pollfd *fds, nfds_t nfds, const struct timespec *tmo_p, const sigset_t *sigmask)
 {
-    if (nfds == 0 && !tmo_p)
-        return pause();
     return poll_internal(fds, nfds, tmo_p ? time_from_timespec(tmo_p) : infinity, sigmask);
 }
 

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -797,6 +797,8 @@ static sysreturn select_internal(int nfds,
                                  timestamp timeout,
                                  const sigset_t * sigmask)
 {
+    if (nfds < 0)
+        return -EINVAL;
     u64 set_bytes = pad(nfds, 64) / 8;
     if ((readfds && !fault_in_user_memory(readfds, set_bytes, true)) ||
         (writefds && !fault_in_user_memory(writefds, set_bytes, true)) ||
@@ -809,7 +811,8 @@ static sysreturn select_internal(int nfds,
 
     epoll_debug("nfds %d, readfds %p, writefds %p, exceptfds %p\n"
                 "   timeout %d\n", nfds, readfds, writefds, exceptfds, timeout);
-    bitmap_extend(e->fds, nfds - 1);
+    if (nfds)
+        bitmap_extend(e->fds, nfds - 1);
     u64 dummy = 0;
     u64 * rp = readfds ? readfds : &dummy;
     u64 * wp = writefds ? writefds : &dummy;
@@ -897,12 +900,14 @@ static sysreturn select_internal(int nfds,
     if (wt == INVALID_ADDRESS)
         return -ENOMEM;
     wt->nfds = nfds;
-    if (readfds)
-        wt->rset = bitmap_wrap(e->h, readfds, nfds);
-    if (writefds)
-        wt->wset = bitmap_wrap(e->h, writefds, nfds);
-    if (exceptfds)
-        wt->eset = bitmap_wrap(e->h, exceptfds, nfds);
+    if (nfds) {
+        if (readfds)
+            wt->rset = bitmap_wrap(e->h, readfds, nfds);
+        if (writefds)
+            wt->wset = bitmap_wrap(e->h, writefds, nfds);
+        if (exceptfds)
+            wt->eset = bitmap_wrap(e->h, exceptfds, nfds);
+    }
     epoll_check_epollfds(e, wt);
     return blockq_check_timeout(wt->t->thread_bq,
                                 contextual_closure(select_bh, wt, current, timeout), false,

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -91,6 +91,32 @@ void release_fdesc(fdesc f)
     deallocate_notify_set(f->ns);
 }
 
+sysreturn user_timeval_get(const struct timeval *tv, timestamp *t)
+{
+    if (!validate_user_memory(tv, sizeof(*tv), false))
+        return -EFAULT;
+    context ctx = get_current_context(current_cpu());
+    if (context_set_err(ctx)) {
+        return -EFAULT;
+    }
+    *t = time_from_timeval(tv);
+    context_clear_err(ctx);
+    return 0;
+}
+
+sysreturn user_timespec_get(const struct timespec *ts, timestamp *t)
+{
+    if (!validate_user_memory(ts, sizeof(*ts), false))
+        return -EFAULT;
+    context ctx = get_current_context(current_cpu());
+    if (context_set_err(ctx)) {
+        return -EFAULT;
+    }
+    *t = time_from_timespec(ts);
+    context_clear_err(ctx);
+    return 0;
+}
+
 boolean copy_from_user(const void *uaddr, void *kaddr, u64 len)
 {
     if (!validate_user_memory(uaddr, len, false))

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -70,11 +70,11 @@ sysreturn gettimeofday(struct timeval *tv, void *tz)
 sysreturn settimeofday(const struct timeval *tv, const void *tz)
 {
     if (tv) {
-        context ctx = get_current_context(current_cpu());
-        if (!validate_user_memory(tv, sizeof(struct timeval), false) || context_set_err(ctx))
-            return -EFAULT;
-        clock_reset_rtc(time_from_timeval(tv));
-        context_clear_err(ctx);
+        timestamp t;
+        sysreturn ret = user_timeval_get(tv, &t);
+        if (ret)
+            return ret;
+        clock_reset_rtc(t);
     }
     return 0;
 }
@@ -113,11 +113,10 @@ sysreturn nanosleep(const struct timespec *req, struct timespec *rem)
     if (rem && !validate_user_memory(rem, sizeof(struct timespec), true))
         return -EFAULT;
 
-    context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(req, sizeof(struct timespec), false) || context_set_err(ctx))
-        return -EFAULT;
-    timestamp interval = time_from_timespec(req);
-    context_clear_err(ctx);
+    timestamp interval;
+    sysreturn ret = user_timespec_get(req, &interval);
+    if (ret)
+        return ret;
     timestamp tnow = now(CLOCK_ID_MONOTONIC);
     return blockq_check_timeout(current->thread_bq,
                                 contextual_closure(nanosleep_bh, current, tnow,
@@ -141,11 +140,10 @@ sysreturn clock_nanosleep(clockid_t _clock_id, int flags, const struct timespec 
         return -EINVAL;
 
     clock_id id = (clock_id)_clock_id;
-    context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(req, sizeof(struct timespec), false) || context_set_err(ctx))
-        return -EFAULT;
-    timestamp treq = time_from_timespec(req);
-    context_clear_err(ctx);
+    timestamp treq;
+    sysreturn ret = user_timespec_get(req, &treq);
+    if (ret)
+        return ret;
     timestamp tnow = now(id);
 
     return blockq_check_timeout(current->thread_bq,
@@ -207,14 +205,14 @@ sysreturn clock_gettime(clockid_t clk_id, struct timespec *tp)
 
 sysreturn clock_settime(clockid_t clk_id, const struct timespec *tp)
 {
-    context ctx;
+    timestamp t;
+    sysreturn ret;
     switch (clk_id) {
     case CLOCK_REALTIME:
-        ctx = get_current_context(current_cpu());
-        if (!validate_user_memory(tp, sizeof(struct timespec), false) || context_set_err(ctx))
-            return -EFAULT;
-        clock_reset_rtc(time_from_timespec(tp));
-        context_clear_err(ctx);
+        ret = user_timespec_get(tp, &t);
+        if (ret)
+            return ret;
+        clock_reset_rtc(t);
         break;
     default:
         return -EINVAL;

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -725,6 +725,8 @@ void deallocate_fd(process p, int fd);
 
 void init_vdso(process p);
 
+sysreturn user_timeval_get(const struct timeval *tv, timestamp *t);
+sysreturn user_timespec_get(const struct timespec *ts, timestamp *t);
 boolean copy_from_user(const void *uaddr, void *kaddr, u64 len);
 boolean copy_to_user(void *uaddr, const void *kaddr, u64 len);
 

--- a/test/runtime/epoll.c
+++ b/test/runtime/epoll.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <fcntl.h>
 #include <pthread.h>
 #include <unistd.h>
@@ -390,6 +391,15 @@ static void test_select(void)
     test_assert(pselect(0, NULL, NULL, NULL, &ts, NULL) == 0);
 }
 
+static void test_poll(void)
+{
+    struct timespec ts;
+
+    ts.tv_sec = ts.tv_nsec = 0;
+    test_assert(poll(NULL, 0, 0) == 0);
+    test_assert(ppoll(NULL, 0, &ts, NULL) == 0);
+}
+
 int main(int argc, char **argv)
 {
     test_ctl();
@@ -399,6 +409,7 @@ int main(int argc, char **argv)
     test_epollexclusive();
     test_poll_nested();
     test_select();
+    test_poll();
 
     printf("test passed\n");
     return EXIT_SUCCESS;

--- a/test/runtime/epoll.c
+++ b/test/runtime/epoll.c
@@ -374,6 +374,22 @@ static void test_poll_nested(void)
     close(sock_fd);
 }
 
+static void test_select(void)
+{
+    fd_set fds;
+    struct timeval tv;
+    struct timespec ts;
+
+    test_assert((select(-1, NULL, NULL, NULL, NULL) == -1) && (errno == EINVAL));
+    tv.tv_sec = tv.tv_usec = 0;
+    test_assert(select(0, NULL, NULL, NULL, &tv) == 0);
+    FD_ZERO(&fds);
+    test_assert(select(0, &fds, NULL, NULL, &tv) == 0);
+
+    ts.tv_sec = ts.tv_nsec = 0;
+    test_assert(pselect(0, NULL, NULL, NULL, &ts, NULL) == 0);
+}
+
 int main(int argc, char **argv)
 {
     test_ctl();
@@ -382,6 +398,7 @@ int main(int argc, char **argv)
     test_eventfd_et();
     test_epollexclusive();
     test_poll_nested();
+    test_select();
 
     printf("test passed\n");
     return EXIT_SUCCESS;

--- a/test/runtime/epoll.c
+++ b/test/runtime/epoll.c
@@ -7,6 +7,7 @@
 #include <sys/epoll.h>
 #include <sys/socket.h>
 #include <sys/eventfd.h>
+#include <sys/syscall.h>
 #include <errno.h>
 #include <poll.h>
 
@@ -386,9 +387,14 @@ static void test_select(void)
     test_assert(select(0, NULL, NULL, NULL, &tv) == 0);
     FD_ZERO(&fds);
     test_assert(select(0, &fds, NULL, NULL, &tv) == 0);
+#ifdef __x86_64__
+    test_assert((syscall(SYS_select, 0, NULL, NULL, NULL, FAULT_ADDR) == -1) && (errno == EFAULT));
+#endif
 
     ts.tv_sec = ts.tv_nsec = 0;
     test_assert(pselect(0, NULL, NULL, NULL, &ts, NULL) == 0);
+    test_assert(syscall(SYS_pselect6, 0, NULL, NULL, NULL, FAULT_ADDR, NULL) == -1);
+    test_assert(errno == EFAULT);
 }
 
 static void test_poll(void)
@@ -398,6 +404,7 @@ static void test_poll(void)
     ts.tv_sec = ts.tv_nsec = 0;
     test_assert(poll(NULL, 0, 0) == 0);
     test_assert(ppoll(NULL, 0, &ts, NULL) == 0);
+    test_assert((syscall(SYS_ppoll, NULL, 0, FAULT_ADDR, NULL) == -1) && (errno == EFAULT));
 }
 
 int main(int argc, char **argv)

--- a/test/runtime/futex.c
+++ b/test/runtime/futex.c
@@ -356,6 +356,8 @@ static boolean futex_fault_test(void)
         printf("FUTEX_WAIT_BITSET fault test error (%d %d)\n", ret, errno);
         return false;
     }
+    ret = syscall(SYS_futex, &wait_test_futex, FUTEX_WAIT, FUTEX_INITIALIZER, fault_addr, NULL, 0);
+    test_assert((ret == -1) && (errno == EFAULT));
     return true;
 }
 


### PR DESCRIPTION
This change set fixes a missing or incomplete validation of struct timespec and struct timeval pointers supplied by user programs via futex, select, pselect, ppoll, and io_uring_enter syscalls, which could cause a syscall-induced kernel crash or allow a user program to read kernel memory via a timing side-channel.
The first 2 commits improve handling of the `nfds` argument by select/pselect/poll/ppoll, while the remaining commits implement proper validation of timeout struct pointers.

Thanks to Niklas Femerstrand (@niklasfemerstrand) for reporting the missing validation of timeout struct pointers.