### PR TITLE
network sockets: Convert outgoing "any" address to loopback

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -309,8 +309,15 @@ static inline void ip6addr_to_sockaddr(ip_addr_t *ip_addr,
         sizeof(addr->sin6_addr.s6_addr));
 }
 
+static inline boolean ip6addr_is_any(struct sockaddr_in6 *addr)
+{
+    u32 *addr_p = (u32 *)&addr->sin6_addr;
+    return !addr_p[0] && !addr_p[1] && !addr_p[2] && !addr_p[3];
+}
+
 static sysreturn sockaddr_to_addrport(netsock s, struct sockaddr *addr,
                                       socklen_t addrlen,
+                                      boolean tx,
                                       ip_addr_t *ip_addr, u16 *port)
 {
     *ip_addr = (ip_addr_t){};
@@ -318,13 +325,21 @@ static sysreturn sockaddr_to_addrport(netsock s, struct sockaddr *addr,
         if (addrlen < sizeof(struct sockaddr_in))
             return -EINVAL;
         struct sockaddr_in *sin = (struct sockaddr_in *)addr;
-        ip_addr_set_ip4_u32(ip_addr, sin->address);
+        if (tx && (sin->address == PP_NTOHL(IPADDR_ANY)))
+            ip4_addr_set_loopback(ip_2_ip4(ip_addr));
+        else
+            ip_addr_set_ip4_u32(ip_addr, sin->address);
         *port = ntohs(sin->port);
     } else {
         if (addrlen < sizeof(struct sockaddr_in6))
             return -EINVAL;
         struct sockaddr_in6 *sin6 = (struct sockaddr_in6 *)addr;
-        sockaddr_to_ip6addr(sin6, ip_addr);
+        if (tx && ip6addr_is_any(sin6)) {
+            IP_SET_TYPE_VAL(*ip_addr, IPADDR_TYPE_V6);
+            ip6_addr_set_loopback(ip_2_ip6(ip_addr));
+        } else {
+            sockaddr_to_ip6addr(sin6, ip_addr);
+        }
         *port = ntohs(sin6->port);
     }
     /* If this is an an IPv4 mapped address then this socket
@@ -829,6 +844,7 @@ static sysreturn socket_write_udp(netsock s, void *source, struct iovec *iov, u6
         if (context_set_err(ctx))
             return -EFAULT;
         sysreturn ret = sockaddr_to_addrport(s, dest_addr, addrlen,
+                                             true,
             &ipaddr, &port);
         context_clear_err(ctx);
         if (ret)
@@ -1516,7 +1532,7 @@ static sysreturn netsock_bind(struct sock *sock, struct sockaddr *addr,
     sysreturn ret;
     context ctx = get_current_context(current_cpu());
     if (!context_set_err(ctx)) {
-        ret = sockaddr_to_addrport(s, addr, addrlen, &ipaddr, &port);
+        ret = sockaddr_to_addrport(s, addr, addrlen, false, &ipaddr, &port);
         context_clear_err(ctx);
     } else {
         ret = -EFAULT;
@@ -1717,7 +1733,7 @@ static sysreturn netsock_connect(struct sock *sock, struct sockaddr *addr,
     sysreturn ret;
     context ctx = get_current_context(current_cpu());
     if (!context_set_err(ctx)) {
-        ret = sockaddr_to_addrport(s, addr, addrlen, &ipaddr, &port);
+        ret = sockaddr_to_addrport(s, addr, addrlen, true, &ipaddr, &port);
         context_clear_err(ctx);
     } else {
         ret = -EFAULT;

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -25,6 +25,12 @@
 
 #define NETSOCK_TEST_PEEK_COUNT 8
 
+struct netsock_thread_params {
+    int sock_type;
+    boolean ipv6;
+    struct sockaddr *addr;
+};
+
 static inline void timespec_sub(struct timespec *a, struct timespec *b, struct timespec *r)
 {
     r->tv_sec = a->tv_sec - b->tv_sec;
@@ -32,6 +38,28 @@ static inline void timespec_sub(struct timespec *a, struct timespec *b, struct t
     if (a->tv_nsec < b->tv_nsec) {
         r->tv_sec--;
         r->tv_nsec += 1000000000ull;
+    }
+}
+
+/* Finds an available port to bind to, starting from 1024. */
+static void netsock_bind(int fd, boolean ipv6, struct sockaddr *addr)
+{
+    int port = 1024;
+
+    while (1) {
+        int ret;
+
+        if (ipv6) {
+            ((struct sockaddr_in6 *)addr)->sin6_port = htons(port);
+            ret = bind(fd, addr, sizeof(struct sockaddr_in6));
+        } else {
+            ((struct sockaddr_in *)addr)->sin_port = htons(port);
+            ret = bind(fd, addr, sizeof(struct sockaddr_in));
+        }
+        if (ret == 0)
+            break;
+        test_assert((ret == -1) && (errno == EADDRINUSE));
+        port++;
     }
 }
 
@@ -947,6 +975,90 @@ static void netsock_test_timeout(void)
     close(listen_fd);
 }
 
+static void *netsock_test_txrx_thread(void *arg)
+{
+    struct netsock_thread_params *params = arg;
+    int fd;
+    socklen_t addrlen = params->ipv6 ? sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
+    uint8_t buf[KB];
+
+    fd = socket(params->ipv6 ? AF_INET6 : AF_INET, params->sock_type, 0);
+    test_assert(fd > 0);
+    if (params->sock_type == SOCK_STREAM) {
+        test_assert(connect(fd, params->addr, addrlen) == 0);
+        test_assert(send(fd, buf, sizeof(buf), 0) > 0);
+        test_assert(recv(fd, buf, sizeof(buf), 0) > 0);
+    } else {
+        test_assert(sendto(fd, buf, sizeof(buf), 0, params->addr, addrlen) > 0);
+        test_assert(recvfrom(fd, buf, sizeof(buf), 0, params->addr, &addrlen) > 0);
+    }
+    close(fd);
+    return NULL;
+}
+
+/* Tests connection to the "any" address (0.0.0.0 for IPv4, [::] for IPv6), which should be remapped
+ * to the loopback address. */
+static void netsock_test_addr_any(int sock_type, boolean ipv6)
+{
+    int fd;
+    struct sockaddr_in addr4;
+    struct sockaddr_in6 addr6;
+    struct sockaddr *addr;
+    struct netsock_thread_params params;
+    pthread_t thread;
+    uint8_t buf[KB];
+    int ret;
+
+    fd = socket(ipv6 ? AF_INET6 : AF_INET, sock_type, 0);
+    test_assert(fd > 0);
+    if (ipv6) {
+        memset(&addr6, 0, sizeof(addr6));
+        addr6.sin6_family = AF_INET6;
+        addr6.sin6_addr = in6addr_any;
+        addr = (struct sockaddr *)&addr6;
+    } else {
+        addr4.sin_family = AF_INET;
+        addr4.sin_addr.s_addr = htonl(INADDR_ANY);
+        addr = (struct sockaddr *)&addr4;
+    }
+    netsock_bind(fd, ipv6, addr);
+    params.sock_type = sock_type;
+    params.ipv6 = ipv6;
+    params.addr = addr;
+    if (sock_type == SOCK_STREAM) {
+        int conn_fd;
+
+        test_assert(listen(fd, 1) == 0);
+        ret = pthread_create(&thread, NULL, netsock_test_txrx_thread, &params);
+        test_assert(ret == 0);
+        conn_fd = accept(fd, NULL, NULL);
+        test_assert(conn_fd > 0);
+        test_assert(recv(conn_fd, buf, sizeof(buf), 0) > 0);
+        test_assert(send(conn_fd, buf, sizeof(buf), 0) > 0);
+        close(conn_fd);
+    } else {
+        struct sockaddr_in peer_addr4;
+        struct sockaddr_in6 peer_addr6;
+        socklen_t addrlen;
+
+        ret = pthread_create(&thread, NULL, netsock_test_txrx_thread, &params);
+        test_assert(ret == 0);
+        if (ipv6) {
+            addr = (struct sockaddr *)&peer_addr6;
+            addrlen = sizeof(peer_addr6);
+        } else {
+            addr = (struct sockaddr *)&peer_addr4;
+            addrlen = sizeof(peer_addr4);
+        }
+        ret = recvfrom(fd, buf, sizeof(buf), 0, addr, &addrlen);
+        test_assert(ret > 0);
+        ret = sendto(fd, buf, sizeof(buf), 0, addr, addrlen);
+        test_assert(ret > 0);
+    }
+    test_assert(pthread_join(thread, NULL) == 0);
+    close(fd);
+}
+
 int main(int argc, char **argv)
 {
     netsock_test_basic(SOCK_STREAM);
@@ -962,6 +1074,10 @@ int main(int argc, char **argv)
     netsock_test_msg(SOCK_DGRAM);
     netsock_test_fault();
     netsock_test_timeout();
+    netsock_test_addr_any(SOCK_STREAM, false);
+    netsock_test_addr_any(SOCK_STREAM, true);
+    netsock_test_addr_any(SOCK_DGRAM, false);
+    netsock_test_addr_any(SOCK_DGRAM, true);
     printf("Network socket tests OK\n");
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Even though the "any" IP address (i.e. 0.0.0.0 for IPv4, [::] for IPv6) is not a valid routable destination address according to RFC standards (is only valid for binding a server to listen on all available interfaces), on Unix-like OSes outgoing network packets destined to this address are redirected to the loopback address. And a few user programs rely on this behavior.