### PR TITLE
mmap() and mremap() security fixes

### DIFF
--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -781,7 +781,7 @@ sysreturn mremap(void *old_address, u64 old_size, u64 new_size, int flags, void 
             goto unlock_out;
         }
         new = irangel(u64_from_pointer(new_address), new_size);
-        if ((new.start & PAGEMASK) || ranges_intersect(old, new)) {
+        if ((new.start & PAGEMASK) || ranges_intersect(old, new) || !validate_mmap_range(p, new)) {
             rv = -EINVAL;
             goto unlock_out;
         }

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -1322,7 +1322,8 @@ static sysreturn mmap(void *addr, u64 length, int prot, int flags, int fd, u64 o
             assert(fsf);
             allowed_flags = file_perms(p, f);
             if (!(vmflags & VMAP_FLAG_SHARED)) {
-                allowed_flags |= VMAP_FLAG_WRITABLE;
+                if (!(allowed_flags & VMAP_FLAG_EXEC) || !proc_is_exec_protected(p))
+                    allowed_flags |= VMAP_FLAG_WRITABLE;
             } else {
                 filesystem fs = fsf->fs;
                 if (fs->get_seals) {

--- a/test/runtime/mmap.c
+++ b/test/runtime/mmap.c
@@ -865,6 +865,11 @@ void mremap_test(void)
     if (errno != EINVAL)
         test_error("EINVAL expected, got %d", errno);
 
+    /* fixed mremap to invalid address (upper half of 64-bit address space) */
+    tmp = mremap(map_addr, __mremap_INIT_SIZE, __mremap_INIT_SIZE, MREMAP_FIXED | MREMAP_MAYMOVE,
+                 (1ULL << 63));
+    test_assert((tmp == MAP_FAILED) && (errno == EINVAL));
+
     /* test move to fixed address */
     tmp = mremap(map_addr, __mremap_INIT_SIZE, __mremap_INIT_SIZE,
                  MREMAP_FIXED | MREMAP_MAYMOVE, new_addr);

--- a/test/runtime/mmap.c
+++ b/test/runtime/mmap.c
@@ -211,7 +211,6 @@ static void mmap_newfile_test(void)
 }
 
 /*
- * Try to mmap a non-executable file with exec access
  * Checks that mmap fails and sets errno to EACCES
  */
 static void check_exec_perm_test(void)
@@ -220,6 +219,7 @@ static void check_exec_perm_test(void)
     const size_t maplen = 1;
     void *addr;
 
+    /* Try to mmap a non-executable file with exec access. */
     fd = open("new_file_noexec", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
     if (fd < 0) {
         test_perror("new file open");
@@ -233,6 +233,13 @@ static void check_exec_perm_test(void)
     if (close(fd) < 0) {
         test_perror("new file close");
     }
+
+    /* Try to mmap an executable file with write access. */
+    fd = open("/proc/self/exe", O_RDONLY);
+    test_assert(fd >= 0);
+    addr = mmap(NULL, maplen, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+    test_assert((addr == MAP_FAILED) && (errno == EACCES));
+    close(fd);
 }
 
 /*


### PR DESCRIPTION
The first commit adds a missing validation of the user-supplied address in the mremap() syscall.
The second commit enforces read-only access on executable mappings when exec protection is enabled.

Thanks to Niklas Femerstrand (@niklasfemerstrand) for reporting these issues.