### PR TITLE
x86 restore_ucontext(): validate user-modified contex values

### DIFF
--- a/src/x86_64/unix_machine.c
+++ b/src/x86_64/unix_machine.c
@@ -187,7 +187,11 @@ void restore_ucontext(struct ucontext * uctx, thread t)
     f[FRAME_RAX] = mcontext->rax;
     f[FRAME_RCX] = mcontext->rcx;
     f[FRAME_RSP] = mcontext->rsp;
-    f[FRAME_RIP] = mcontext->rip;
+    /* Do not copy non-canonical RIP values, otherwise the sysret instruction triggers a general
+     * protection fault in kernel mode on Intel CPUs. */
+    u64 rip_ext = mcontext->rip >> (VIRTUAL_ADDRESS_BITS - 1);
+    if ((rip_ext == 0) || (rip_ext == MASK(64 - VIRTUAL_ADDRESS_BITS + 1)))
+        f[FRAME_RIP] = mcontext->rip;
     f[FRAME_EFLAGS] = (f[FRAME_EFLAGS] & ~SAFE_EFLAGS) | (mcontext->eflags & SAFE_EFLAGS);
     /* Don't trust segment selector values (CS and SS) that may have been modified by the process,
      * because invalid values can cause a general protection fault (in kernel mode) when trying to

--- a/src/x86_64/unix_machine.c
+++ b/src/x86_64/unix_machine.c
@@ -202,8 +202,13 @@ void restore_ucontext(struct ucontext * uctx, thread t)
     else
         f[FRAME_CS] &= ~1;
     t->signal_mask = normalize_signal_mask(mcontext->oldmask);
-    if (mcontext->fpstate)
+    if (validate_user_memory(mcontext->fpstate, extended_frame_size, false)) {
+        context ctx = get_current_context(current_cpu());
+        if (context_set_err(ctx))
+            return;
         runtime_memcpy(frame_extended(t->context.frame), mcontext->fpstate, extended_frame_size);
+        context_clear_err(ctx);
+    }
 }
 
 void reg_copy_out(struct core_regs *r, thread t)


### PR DESCRIPTION
A signal handler can modify the machine context that is applied to the thread frame when the handler returns. The kernel should validate any user-modified values that might cause faults in kernel mode or leak kernel info to the user program.

Issues reported and fixes suggested by Niklas Femerstrand (@niklasfemerstrand).