### PR TITLE
sched_setaffinity: Validate user memory before reading CPU mask

### DIFF
--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -2220,7 +2220,7 @@ sysreturn sched_setaffinity(int pid, u64 cpusetsize, u64 *mask)
     context ctx = get_current_context(current_cpu());
     u64 first_cpu = -1ull;
     u64 i;
-    if (context_set_err(ctx))
+    if (!validate_user_memory(mask, cpusetsize, false) || context_set_err(ctx))
         return -EFAULT;
     for (i = 0; (first_cpu == -1ull) && (i + sizeof(u64) <= cpusetsize); i += sizeof(u64))
         first_cpu = i * 8 + lsb(mask[i / sizeof(u64)]);
@@ -2236,10 +2236,12 @@ sysreturn sched_setaffinity(int pid, u64 cpusetsize, u64 *mask)
     bitmap affinity = t->task.affinity;
     sysreturn rv;
     thread_lock(t);
-    if (!copy_from_user(mask, bitmap_base(affinity), cpusetsize)) {
+    if (context_set_err(ctx)) {
         rv = -EFAULT;
         goto out;
     }
+    runtime_memcpy(bitmap_base(affinity), mask, cpusetsize);
+    context_clear_err(ctx);
     u64 cpus = cpusetsize * 8;
     if (cpus < total_processors)
         bitmap_range_check_and_set(affinity, cpus, total_processors - cpus, false, false);


### PR DESCRIPTION
If the CPU mask pointer supplied as argument to sched_setaffinity() is not verified to belong to user memory, a program could pass an arbitrary address and determine from the syscall return value whether that address is mapped as kernel memory, thus defeating KASLR.
Add a call to validate_user_memory() before accessing the CPU mask pointer, and to avoid a double validation replace the copy_from_user() call with a direct memory copy.

Issue reported and fix suggested by Niklas Femerstrand (@niklasfemerstrand).