### PR TITLE
tests: Go: Adapt to latest Ops code

### DIFF
--- a/test/go/go.mod
+++ b/test/go/go.mod
@@ -1,17 +1,17 @@
 module github.com/nanovms/nanos/test/go
 
-go 1.25.0
+go 1.26.0
 
-require github.com/nanovms/ops v0.0.0-20251025012253-27e89baa017a
+require github.com/nanovms/ops v0.0.0-20260311025755-01a8a465636a
 
 require (
-	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/schollz/progressbar/v3 v3.7.3 // indirect
+	github.com/schollz/progressbar/v3 v3.8.0 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 )

--- a/test/go/go_test.go
+++ b/test/go/go_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/nanovms/ops/lepton"
+	"github.com/nanovms/ops/qemu"
 	"github.com/nanovms/ops/types"
 )
 
@@ -41,11 +42,21 @@ func prepareTestImage(finalImage string) {
 	}
 }
 
+func runAndWait(image string, t *testing.T) qemu.Hypervisor {
+	rconfig := types.RunConfig{
+		ImageName: image,
+		Ports: []string{"8080"},
+		Verbose: true,
+		Memory: "2G",
+		Accel: true,
+	}
+	return runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
+}
+
 func TestArgsAndEnv(t *testing.T) {
 	const finalImage = "image"
 	prepareTestImage(finalImage)
-	rconfig := types.RuntimeConfig(finalImage, []string{"8080"}, true)
-	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
+	hypervisor := runAndWait(finalImage, t)
 	defer hypervisor.Stop()
 
 	resp, err := http.Get("http://127.0.0.1:8080/args")
@@ -79,8 +90,7 @@ func TestArgsAndEnv(t *testing.T) {
 func TestFileSystem(t *testing.T) {
 	const finalImage = "image"
 	prepareTestImage(finalImage)
-	rconfig := types.RuntimeConfig(finalImage, []string{"8080"}, true)
-	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
+	hypervisor := runAndWait(finalImage, t)
 	defer hypervisor.Stop()
 
 	resp, err := http.Get("http://127.0.0.1:8080")
@@ -98,8 +108,7 @@ func TestFileSystem(t *testing.T) {
 }
 
 func validateResponse(t *testing.T, finalImage string, expected string) {
-	rconfig := types.RuntimeConfig(finalImage, []string{"8080"}, true)
-	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
+	hypervisor := runAndWait(finalImage, t)
 	defer hypervisor.Stop()
 
 	resp, err := http.Get("http://127.0.0.1:8080/file")
@@ -126,8 +135,7 @@ func TestInstancePersistence(t *testing.T) {
 func TestHTTP(t *testing.T) {
 	const finalImage = "image"
 	prepareTestImage(finalImage)
-	rconfig := types.RuntimeConfig(finalImage, []string{"8080"}, true)
-	hypervisor := runAndWaitForString(&rconfig, START_WAIT_TIMEOUT, "Server started", t)
+	hypervisor := runAndWait(finalImage, t)
 	defer hypervisor.Stop()
 
 	resp, err := http.Get("http://127.0.0.1:8080/req")


### PR DESCRIPTION
The types.RuntimeConfig() function no longer exists in the Ops code base.