### PR TITLE
FUTEX_WAKE_OP: use atomic read-modify-write memory access

### DIFF
--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -252,14 +252,13 @@ sysreturn futex(int *uaddr, int futex_op, int val,
             ret = -EFAULT;
             goto wake_op_done;
         }
-        oldval = *(int *) uaddr2;
         
         switch (op) {
-        case FUTEX_OP_SET:   *uaddr2 = oparg; break;
-        case FUTEX_OP_ADD:   *uaddr2 += oparg; break;
-        case FUTEX_OP_OR:    *uaddr2 |= oparg; break;
-        case FUTEX_OP_ANDN:  *uaddr2 &= ~oparg; break;
-        case FUTEX_OP_XOR:   *uaddr2 ^= oparg; break;
+        case FUTEX_OP_SET:   oldval = __atomic_exchange_n(uaddr2, oparg, __ATOMIC_RELAXED); break;
+        case FUTEX_OP_ADD:   oldval = __atomic_fetch_add(uaddr2, oparg, __ATOMIC_RELAXED); break;
+        case FUTEX_OP_OR:    oldval = __atomic_fetch_or(uaddr2, oparg, __ATOMIC_RELAXED); break;
+        case FUTEX_OP_ANDN:  oldval = __atomic_fetch_and(uaddr2, ~oparg, __ATOMIC_RELAXED); break;
+        case FUTEX_OP_XOR:   oldval = __atomic_fetch_xor(uaddr2, oparg, __ATOMIC_RELAXED); break;
         default:             ret = -ENOSYS; break;
         }
         context_clear_err(ctx);

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -247,10 +247,9 @@ sysreturn futex(int *uaddr, int futex_op, int val,
         struct futex *f2 = soft_create_futex(current->p, u64_from_pointer(uaddr2));
         if (f2 == INVALID_ADDRESS)
             return -ENOMEM;
-        boolean fault = false;
         spin_lock_2(&f->lock, &f2->lock);
         if (context_set_err(ctx)) {
-            fault = true;
+            ret = -EFAULT;
             goto wake_op_done;
         }
         oldval = *(int *) uaddr2;
@@ -261,8 +260,11 @@ sysreturn futex(int *uaddr, int futex_op, int val,
         case FUTEX_OP_OR:    *uaddr2 |= oparg; break;
         case FUTEX_OP_ANDN:  *uaddr2 &= ~oparg; break;
         case FUTEX_OP_XOR:   *uaddr2 ^= oparg; break;
+        default:             ret = -ENOSYS; break;
         }
         context_clear_err(ctx);
+        if (ret)
+            goto wake_op_done;
 
         wake1 = futex_wake_many(f, val);
         
@@ -284,7 +286,7 @@ sysreturn futex(int *uaddr, int futex_op, int val,
       wake_op_done:
         futex_unlock(f2);
         futex_unlock(f);
-        return fault ? -EFAULT : wake1 + wake2;
+        return ret ? ret : wake1 + wake2;
     }
 
     case FUTEX_WAIT_BITSET: {


### PR DESCRIPTION
In a FUTEX_WAKE_OP futex operation, the kernel modifies the memory pointed to by the 'uaddr2' argument; according to the Linux ABI, this modification must be done using atomic machine instructions.
In addition, the syscall should return an error if the op value extracted from the val3 argument is not a known value.

Thanks to Niklas Femerstrand (@niklasfemerstrand) for reporting the race condition caused by non-atomic memory accesses.