### PR TITLE
iovec structures: Fix TOCTOU vulnerabilities

### DIFF
--- a/klib/pledge.c
+++ b/klib/pledge.c
@@ -289,7 +289,7 @@ static boolean pledge_sendmsg(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, 
         return true;
     const struct msghdr *msg = (const struct msghdr *)arg1;
     if (!(pldg.abilities & (PLEDGE_INET | PLEDGE_UNIX | PLEDGE_DNS)) &&
-        validate_user_memory(msg, sizeof(*msg), false) && msg->msg_name) {
+        memory_is_user(msg, sizeof(*msg)) && msg->msg_name) {
         *rv = pledge_fail(sc->t);
         return true;
     }
@@ -644,7 +644,7 @@ static boolean pledge_sendmmsg(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4,
     struct mmsghdr *msgvec = (struct mmsghdr *)arg1;
     unsigned int vlen = arg2;
     if (!(pldg.abilities & (PLEDGE_INET | PLEDGE_UNIX)) &&
-        validate_user_memory(msgvec, vlen * sizeof(struct mmsghdr), false))
+        memory_is_user(msgvec, vlen * sizeof(struct mmsghdr)))
         for (unsigned int i = 0; i < vlen; i++)
             if (msgvec[i].msg_hdr.msg_name) {
                 *rv = pledge_fail(sc->t);

--- a/klib/tun.c
+++ b/klib/tun.c
@@ -341,7 +341,7 @@ closure_func_basic(fdesc_ioctl, sysreturn, tun_ioctl,
             return -EBADFD;
         struct ifreq *ifreq = varg(ap, struct ifreq *);
         context ctx = get_current_context(current_cpu());
-        if (!validate_user_memory(ifreq, sizeof(struct ifreq), true) || context_set_err(ctx))
+        if (!memory_is_user(ifreq, sizeof(struct ifreq)) || context_set_err(ctx))
             return -EFAULT;
         netif_name_cpy(ifreq->ifr_name, &tun->ndev.n);
         ifreq->ifr.ifr_flags = tun->flags;

--- a/klib/unveil.c
+++ b/klib/unveil.c
@@ -356,7 +356,7 @@ static boolean unveil_bind(u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64
     socklen_t addrlen = arg2;
     if ((f->type == FDESC_TYPE_SOCKET) && (((struct sock *)f)->domain == AF_UNIX) &&
         (addrlen > offsetof(struct sockaddr_un *, sun_path)) &&
-        validate_user_memory(addr, addrlen, false))
+        memory_is_user(addr, addrlen))
         result = unveil_check_path(addr->sun_path, false, UNVEIL_CREATE, rv);
     fdesc_put(f);
     return result;

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -460,6 +460,11 @@ static inline void context_clear_err(context ctx)
     ((kernel_context)ctx)->err_frame[ERR_FRAME_FULL] = 0;
 }
 
+static inline void page_fault(void)
+{
+    *((u64 *)0xfffffffffffffff8ull) = 0;
+}
+
 static inline void use_fault_handler(fault_handler h)
 {
     context ctx = get_current_context(current_cpu());

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -469,17 +469,25 @@ struct udp_entry {
     u16 rport;
 };
 
-static sysreturn sock_read_bh_internal(netsock s, struct msghdr *msg, int flags,
+static sysreturn sock_read_bh_internal(netsock s, struct msghdr *msg, boolean user_hdr, int flags,
                                        io_completion completion, u64 bqflags, context ctx)
 {
     sysreturn rv = 0;
-    if (context_set_err(ctx)) {
+    if (user_hdr && context_set_err(ctx)) {
         rv = -EFAULT;
         goto out;
     }
     iovec iov = msg->msg_iov;
     u64 length = msg->msg_iovlen;
-    context_clear_err(ctx);
+    sockaddr src_addr = msg->msg_name;
+    if (user_hdr) {
+        context_clear_err(ctx);
+        if ((src_addr && !memory_is_user(src_addr, sizeof(struct sockaddr_in6))) ||
+            (length && !memory_is_user(iov, length * sizeof(*iov)))) {
+            rv = -EFAULT;
+            goto out;
+        }
+    }
 
     netsock_lock(s);
     err_t err = get_lwip_error(s);
@@ -529,7 +537,6 @@ static sysreturn sock_read_bh_internal(netsock s, struct msghdr *msg, int flags,
     }
     msg->msg_controllen = 0;
     msg->msg_flags = 0;
-    sockaddr src_addr = msg->msg_name;
     if (src_addr) {
         socklen_t *addrlen = &msg->msg_namelen;
         if (s->sock.type == SOCK_STREAM) {
@@ -541,6 +548,9 @@ static sysreturn sock_read_bh_internal(netsock s, struct msghdr *msg, int flags,
         }
     }
 
+    void *iov_base = iov->iov_base;
+    u64 iov_len = iov->iov_len;
+    boolean iov_validated = false;
     u64 iov_offset = 0;
     u32 pbuf_idx = 0;
     if ((s->sock.type == SOCK_STREAM) && !(flags & MSG_PEEK)) {
@@ -556,8 +566,11 @@ static sysreturn sock_read_bh_internal(netsock s, struct msghdr *msg, int flags,
 
         while ((length > 0) && cur_buf) {
             if (cur_buf->len > 0) {
-                u64 xfer = MIN(iov->iov_len - iov_offset, cur_buf->len);
-                runtime_memcpy(iov->iov_base + iov_offset, cur_buf->payload, xfer);
+                if (!iov_validated && !memory_is_user(iov_base, iov_len))
+                    page_fault();
+                iov_validated = true;
+                u64 xfer = MIN(iov_len - iov_offset, cur_buf->len);
+                runtime_memcpy(iov_base + iov_offset, cur_buf->payload, xfer);
                 if (!(flags & MSG_PEEK)) {
                     pbuf_consume(cur_buf, xfer);
                     if (s->sock.type == SOCK_STREAM)
@@ -565,10 +578,15 @@ static sysreturn sock_read_bh_internal(netsock s, struct msghdr *msg, int flags,
                 }
                 xfer_total += xfer;
                 iov_offset += xfer;
-                if (iov_offset == iov->iov_len) {
+                if (iov_offset == iov_len) {
                     length--;
-                    iov++;
-                    iov_offset = 0;
+                    if (length) {
+                        iov++;
+                        iov_base = iov->iov_base;
+                        iov_len = iov->iov_len;
+                        iov_validated = false;
+                        iov_offset = 0;
+                    }
                 }
             }
             if ((cur_buf->len == 0) || (flags & MSG_PEEK))
@@ -647,7 +665,8 @@ closure_function(7, 1, sysreturn, sock_read_bh,
         }
     }
     if (!rv)
-        rv = sock_read_bh_internal(bound(s), &msg, bound(flags), bound(completion), flags, ctx);
+        rv = sock_read_bh_internal(bound(s), &msg, false, bound(flags), bound(completion), flags,
+                                   ctx);
     else
         apply(bound(completion), rv);
     if (rv != BLOCKQ_BLOCK_REQUIRED) {
@@ -666,7 +685,8 @@ closure_function(4, 1, sysreturn, recvmsg_bh,
                  netsock, s, struct msghdr *, msg, int, flags, io_completion, completion,
                  u64 flags)
 {
-    sysreturn rv = sock_read_bh_internal(bound(s), bound(msg), bound(flags), bound(completion),
+    sysreturn rv = sock_read_bh_internal(bound(s), bound(msg), true, bound(flags),
+                                         bound(completion),
                                          flags, context_from_closure(closure_self()));
     if (rv != BLOCKQ_BLOCK_REQUIRED)
         closure_finish();
@@ -775,6 +795,8 @@ closure_function(6, 1, sysreturn, socket_write_tcp_bh,
             if (!remain)
                 break;
             buf = iov->iov_base;
+            if (!memory_is_user(buf + buf_offset, n))
+                page_fault();
             if (remain)
                 apiflags |= TCP_WRITE_FLAG_MORE;
         } else {
@@ -840,12 +862,15 @@ static sysreturn socket_write_udp(netsock s, void *source, struct iovec *iov, u6
     ip_addr_t ipaddr;
     u16 port = 0;
     context ctx = get_current_context(current_cpu());
-    if (dest_addr) {
+    u64 xfer_len;
+    if (!source || dest_addr) {
         if (context_set_err(ctx))
             return -EFAULT;
-        sysreturn ret = sockaddr_to_addrport(s, dest_addr, addrlen,
-                                             true,
-            &ipaddr, &port);
+        if (!source)
+            xfer_len = iov_total_len(iov, length);
+        sysreturn ret = 0;
+        if (dest_addr)
+            ret = sockaddr_to_addrport(s, dest_addr, addrlen, true, &ipaddr, &port);
         context_clear_err(ctx);
         if (ret)
             return ret;
@@ -859,7 +884,8 @@ static sysreturn socket_write_udp(netsock s, void *source, struct iovec *iov, u6
         return -EDESTADDRREQ;
     }
 
-    u64 xfer_len = source ? length : iov_total_len(iov, length);
+    if (source)
+        xfer_len = length;
     struct pbuf *pbuf = pbuf_alloc(PBUF_TRANSPORT, xfer_len, PBUF_RAM);
     if (!pbuf) {
         netsock_unlock(s);
@@ -874,7 +900,7 @@ static sysreturn socket_write_udp(netsock s, void *source, struct iovec *iov, u6
     if (source)
         runtime_memcpy(pbuf->payload, source, length);
     else
-        iov_to_buf(pbuf->payload, iov, length);
+        iov_to_buf(pbuf->payload, xfer_len, iov, length);
     context_clear_err(ctx);
     if (dest_addr)
         err = udp_sendto(s->info.udp.lw, pbuf, &ipaddr, port);
@@ -977,10 +1003,10 @@ static boolean siocgifconf_populate(struct netif *n, void *priv)
 
 typedef sysreturn (*socket_ifreq_handler)(struct ifreq *ifreq, struct netif *netif);
 
-static sysreturn socket_ifreq(struct ifreq *ifreq, boolean set, socket_ifreq_handler handler)
+static sysreturn socket_ifreq(struct ifreq *ifreq, socket_ifreq_handler handler)
 {
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(ifreq, sizeof(struct ifreq), !set) || context_set_err(ctx))
+    if (!memory_is_user(ifreq, sizeof(struct ifreq)) || context_set_err(ctx))
         return -EFAULT;
     struct netif *netif = netif_find(sstring_from_cstring(ifreq->ifr_name, IFNAMSIZ));
     context_clear_err(ctx);
@@ -1085,7 +1111,7 @@ sysreturn socket_ioctl(struct sock *s, unsigned long request, vlist ap)
     case SIOCGIFNAME: {
         struct ifreq *ifreq = varg(ap, struct ifreq *);
         context ctx = get_current_context(current_cpu());
-        if (!validate_user_memory(ifreq, sizeof(struct ifreq), true) || context_set_err(ctx))
+        if (!memory_is_user(ifreq, sizeof(struct ifreq)) || context_set_err(ctx))
             return -EFAULT;
         struct netif *netif = netif_get_by_index(ifreq->ifr.ifr_ivalue);
         context_clear_err(ctx);
@@ -1105,7 +1131,7 @@ sysreturn socket_ioctl(struct sock *s, unsigned long request, vlist ap)
     case SIOCGIFCONF: {
         struct ifconf *ifconf = varg(ap, struct ifconf *);
         context ctx = get_current_context(current_cpu());
-        if (!validate_user_memory(ifconf, sizeof(struct ifconf), true) || context_set_err(ctx))
+        if (!memory_is_user(ifconf, sizeof(struct ifconf)) || context_set_err(ctx))
             return -EFAULT;
         ifconf->ifc_len = 0;
         boolean get_len = (ifconf->ifc.ifc_req == NULL);
@@ -1123,25 +1149,25 @@ sysreturn socket_ioctl(struct sock *s, unsigned long request, vlist ap)
         }
     }
     case SIOCGIFFLAGS:
-        return socket_ifreq(varg(ap, struct ifreq *), false, socket_get_flags);
+        return socket_ifreq(varg(ap, struct ifreq *), socket_get_flags);
     case SIOCSIFFLAGS:
-        return socket_ifreq(varg(ap, struct ifreq *), true, socket_set_flags);
+        return socket_ifreq(varg(ap, struct ifreq *), socket_set_flags);
     case SIOCGIFADDR:
-        return socket_ifreq(varg(ap, struct ifreq *), false, socket_get_addr);
+        return socket_ifreq(varg(ap, struct ifreq *), socket_get_addr);
     case SIOCSIFADDR:
-        return socket_ifreq(varg(ap, struct ifreq *), true, socket_set_addr);
+        return socket_ifreq(varg(ap, struct ifreq *), socket_set_addr);
     case SIOCGIFNETMASK:
-        return socket_ifreq(varg(ap, struct ifreq *), false, socket_get_netmask);
+        return socket_ifreq(varg(ap, struct ifreq *), socket_get_netmask);
     case SIOCSIFNETMASK:
-        return socket_ifreq(varg(ap, struct ifreq *), true, socket_set_netmask);
+        return socket_ifreq(varg(ap, struct ifreq *), socket_set_netmask);
     case SIOCGIFMTU:
-        return socket_ifreq(varg(ap, struct ifreq *), false, socket_get_mtu);
+        return socket_ifreq(varg(ap, struct ifreq *), socket_get_mtu);
     case SIOCSIFMTU:
-        return socket_ifreq(varg(ap, struct ifreq *), true, socket_set_mtu);
+        return socket_ifreq(varg(ap, struct ifreq *), socket_set_mtu);
     case SIOCGIFHWADDR:
-        return socket_ifreq(varg(ap, struct ifreq *), false, socket_get_hwaddr);
+        return socket_ifreq(varg(ap, struct ifreq *), socket_get_hwaddr);
     case SIOCGIFINDEX:
-        return socket_ifreq(varg(ap, struct ifreq *), false, socket_get_index);
+        return socket_ifreq(varg(ap, struct ifreq *), socket_get_index);
     default:
         return ioctl_generic(&s->f, request, ap);
     }
@@ -1570,7 +1596,7 @@ static sysreturn netsock_bind(struct sock *sock, struct sockaddr *addr,
 
 sysreturn bind(int sockfd, struct sockaddr *addr, socklen_t addrlen)
 {
-    if (!validate_user_memory(addr, addrlen, false))
+    if (!memory_is_user(addr, addrlen))
         return -EFAULT;
     struct sock *s = resolve_socket(current->p, sockfd);
     net_debug("sock %d, type %d\n", sockfd, s->type);
@@ -1764,7 +1790,7 @@ static sysreturn netsock_connect(struct sock *sock, struct sockaddr *addr,
 
 sysreturn connect(int sockfd, struct sockaddr *addr, socklen_t addrlen)
 {
-    if (!validate_user_memory(addr, addrlen, false))
+    if (!memory_is_user(addr, addrlen))
         return -EFAULT;
     struct sock *sock = resolve_socket(current->p, sockfd);
     if (!sock->connect) {
@@ -1815,8 +1841,7 @@ static sysreturn netsock_sendto(struct sock *sock, void *buf, u64 len,
 sysreturn sendto(int sockfd, void *buf, u64 len, int flags,
 		 struct sockaddr *dest_addr, socklen_t addrlen)
 {
-    if (!validate_user_memory(buf, len, false) ||
-            (dest_addr && !validate_user_memory(dest_addr, addrlen, false)))
+    if (!memory_is_user(buf, len) || (dest_addr && !memory_is_user(dest_addr, addrlen)))
         return -EFAULT;
     struct sock *sock = resolve_socket(current->p, sockfd);
     net_debug("sendto %d, buf %p, len %ld, flags %x, dest_addr %p, addrlen %d\n",
@@ -1836,7 +1861,7 @@ sysreturn socket_send(fdesc f, void *buf, u64 len, context ctx, boolean in_bh,
 {
     if (f->type != FDESC_TYPE_SOCKET)
         return io_complete(completion, -ENOTSOCK);
-    if (!validate_user_memory(buf, len, false))
+    if (!memory_is_user(buf, len))
         return io_complete(completion, -EFAULT);
     struct sock *sock = struct_from_field(f, struct sock *, f);
     return sock->sendto(sock, buf, len, 0, 0, 0, ctx, in_bh, completion);
@@ -1848,16 +1873,24 @@ static sysreturn netsock_sendmsg(struct sock *s, const struct msghdr *msg, int f
     sysreturn rv = sendto_prepare(s, flags);
     if (rv < 0)
         goto out;
-    return socket_write_internal(s, 0, msg->msg_iov, msg->msg_iovlen, flags,
-                                 msg->msg_name, msg->msg_namelen,
-                                 get_current_context(current_cpu()), in_bh, completion);
+    context ctx = get_current_context(current_cpu());
+    if (context_set_err(ctx)) {
+        rv = -EFAULT;
+        goto out;
+    }
+    struct iovec *iov = msg->msg_iov;
+    u64 iov_len = msg->msg_iovlen;
+    struct sockaddr *addr = msg->msg_name;
+    socklen_t addr_len = msg->msg_namelen;
+    context_clear_err(ctx);
+    return socket_write_internal(s, 0, iov, iov_len, flags, addr, addr_len, ctx, in_bh, completion);
   out:
     return io_complete(completion, rv);
 }
 
 sysreturn sendmsg(int sockfd, const struct msghdr *msg, int flags)
 {
-    if (!validate_msghdr(msg, false))
+    if (!memory_is_user(msg, sizeof(struct msghdr)))
         return -EFAULT;
     struct sock *s = resolve_socket(current->p, sockfd);
     net_debug("sock %d, type %d, msg %p, flags 0x%x\n", s->fd, s->type, msg, flags);
@@ -1910,12 +1943,8 @@ sysreturn sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
 {
     if (vlen == 0)
         return 0;
-    if (!validate_user_memory(msgvec, vlen * sizeof(struct mmsghdr), true))
+    if (!memory_is_user(msgvec, vlen * sizeof(struct mmsghdr)))
         return -EFAULT;
-    for (int i = 0; i < vlen; i++) {
-        if (!validate_msghdr(&msgvec[i].msg_hdr, false))
-            return -EFAULT;
-    }
     thread t = current;
     struct sock *s = resolve_socket(t->p, sockfd);
 
@@ -1964,8 +1993,8 @@ sysreturn recvfrom(int sockfd, void * buf, u64 len, int flags,
 {
     /* Use a dummy value for the address length, instead of reading it from addrlen (the value
      * pointed to by addrlen might change before this syscall completes). */
-    if (src_addr && (!validate_user_memory(addrlen, sizeof(socklen_t), true) ||
-                     !validate_user_memory(src_addr, PAGESIZE, true)))
+    if (src_addr && (!memory_is_user(addrlen, sizeof(socklen_t)) ||
+                     !memory_is_user(src_addr, PAGESIZE)))
         return -EFAULT;
 
     struct sock *sock = resolve_socket(current->p, sockfd);
@@ -1986,7 +2015,7 @@ sysreturn socket_recv(fdesc f, void *buf, u64 len, context ctx, boolean in_bh,
 {
     if (f->type != FDESC_TYPE_SOCKET)
         return io_complete(completion, -ENOTSOCK);
-    if (!validate_user_memory(buf, len, true))
+    if (!memory_is_user(buf, len))
         return io_complete(completion, -EFAULT);
     struct sock *sock = struct_from_field(f, struct sock *, f);
     return sock->recvfrom(sock, buf, len, 0, 0, 0, ctx, in_bh, completion);
@@ -2010,7 +2039,7 @@ static sysreturn netsock_recvmsg(struct sock *sock, struct msghdr *msg,
 
 sysreturn recvmsg(int sockfd, struct msghdr *msg, int flags)
 {
-    if (!validate_msghdr(msg, true))
+    if (!memory_is_user(msg, sizeof(*msg)))
         return -EFAULT;
     struct sock *s = resolve_socket(current->p, sockfd);
     net_debug("sock %d, type %d, thread %ld\n", s->fd, s->type, current->tid);
@@ -2064,12 +2093,8 @@ define_closure_function(0, 0, void, recvmmsg_next)
 sysreturn recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags,
                    struct timespec *timeout)
 {
-    if (!validate_user_memory(msgvec, vlen * sizeof(struct mmsghdr), true))
+    if (!memory_is_user(msgvec, vlen * sizeof(struct mmsghdr)))
         return -EFAULT;
-    for (int i = 0; i < vlen; i++) {
-        if (!validate_msghdr(&msgvec[i].msg_hdr, true))
-            return -EFAULT;
-    }
     if (vlen == 0)
         return 0;
     if (timeout)
@@ -2322,8 +2347,7 @@ sysreturn socket_accept4(fdesc f, struct sockaddr *addr, socklen_t *addrlen, int
 
     /* Use a dummy value for the address length, instead of reading it from addrlen (the value
      * pointed to by addrlen might change before this syscall completes). */
-    if (addr && (!validate_user_memory(addrlen, sizeof(socklen_t), true) ||
-                 !validate_user_memory(addr, PAGESIZE, true)))
+    if (addr && (!memory_is_user(addrlen, sizeof(socklen_t)) || !memory_is_user(addr, PAGESIZE)))
         return io_complete(completion, -EFAULT);
 
     struct sock *sock = struct_from_field(f, struct sock *, f);

--- a/src/unix/aio.c
+++ b/src/unix/aio.c
@@ -199,7 +199,7 @@ static unsigned int aio_avail_events(struct aio *aio)
 
 static sysreturn iocb_enqueue(struct aio *aio, struct iocb *iocb, context ctx)
 {
-    if (!validate_user_memory(iocb, sizeof(struct iocb), false) || context_set_err(ctx))
+    if (!memory_is_user(iocb, sizeof(struct iocb)) || context_set_err(ctx))
         return -EFAULT;
 
     if (iocb->aio_reserved1 || iocb->aio_reserved2 || !iocb->aio_buf ||
@@ -294,8 +294,8 @@ sysreturn io_submit(aio_context_t ctx_id, long nr, struct iocb **iocbpp)
 {
     struct aio *aio;
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(ctx_id, sizeof(struct aio_ring), false) ||
-        !validate_user_memory(iocbpp, sizeof(struct iocb *) * nr, false) ||
+    if (!memory_is_user(ctx_id, sizeof(struct aio_ring)) ||
+        !memory_is_user(iocbpp, sizeof(struct iocb *) * nr) ||
         context_set_err(ctx))
         return -EFAULT;
     aio = aio_from_ring_id(current->p, ctx_id->id);
@@ -389,9 +389,9 @@ sysreturn io_getevents(aio_context_t ctx_id, long min_nr, long nr,
         struct io_event *events, struct timespec *timeout)
 {
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(ctx_id, sizeof(struct aio_ring), false) ||
-        !validate_user_memory(events, sizeof(struct io_event) * nr, true) ||
-        (timeout && !validate_user_memory(timeout, sizeof(struct timespec), false)) ||
+    if (!memory_is_user(ctx_id, sizeof(struct aio_ring)) ||
+        !memory_is_user(events, sizeof(struct io_event) * nr) ||
+        (timeout && !memory_is_user(timeout, sizeof(struct timespec))) ||
         context_set_err(ctx))
         return -EFAULT;
     struct aio *aio = aio_from_ring_id(current->p, ctx_id->id);

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -92,10 +92,32 @@ void file_readahead(file f, u64 offset, u64 len)
     }
 }
 
-static sysreturn file_io_init_internal(file f, u64 offset, struct iovec *iov, int count, sg_list sg)
+static sysreturn file_io_init_internal(file f, u64 offset, boolean direct_io,
+                                       struct iovec *iov, int count, boolean user_iov, sg_list sg)
 {
-    if (!(f->f.flags & O_DIRECT)) {
-        return iov_to_sg(sg, iov, count) ? 0 : -ENOMEM;
+    if (!direct_io) {
+        for (int i = 0; i < count; i++) {
+            void *base = iov[i].iov_base;
+            u64 len = iov[i].iov_len;
+            u64 offset = 0;
+            boolean validated = false;
+            while (len > 0) {
+                if (user_iov && !validated && !memory_is_user(base, len))
+                    return -EFAULT;
+                validated = true;
+                u64 buf_len = MIN(len, U32_MAX & ~PAGEMASK);
+                sg_buf sgb = sg_list_tail_add(sg, buf_len);
+                if (sgb == INVALID_ADDRESS)
+                    return -ENOMEM;
+                sgb->buf = base + offset;
+                sgb->size = buf_len;
+                sgb->offset = 0;
+                sgb->refcount = 0;
+                len -= buf_len;
+                offset += buf_len;
+            }
+        }
+        return 0;
     }
     u64 block_mask = fs_blocksize(f->fs) - 1;
     if (offset & block_mask)
@@ -105,6 +127,8 @@ static sysreturn file_io_init_internal(file f, u64 offset, struct iovec *iov, in
         if (len == 0)
             continue;
         void *ptr = iov[i].iov_base;
+        if (user_iov && !memory_is_user(ptr, len))
+            return -EFAULT;
         if ((u64_from_pointer(ptr) & block_mask) || (len & block_mask))
             return -EINVAL;
         touch_memory(ptr, len);
@@ -151,23 +175,28 @@ static sysreturn file_io_init_internal(file f, u64 offset, struct iovec *iov, in
     return 0;
 }
 
-sysreturn file_io_init_sg(file f, u64 offset, struct iovec *iov, int count, sg_list *sgp)
+sysreturn file_io_init_sg(file f, u64 offset, struct iovec *iov, int count, boolean user_iov,
+                          sg_list *sgp)
 {
     sg_list sg = sg_new(count);
     if (sg == INVALID_ADDRESS)
         return -ENOMEM;
+    boolean direct_io = !!(f->f.flags & O_DIRECT);
     sysreturn rv;
-    context ctx = get_current_context(current_cpu());
-    if (context_set_err(ctx)) {
-        rv = -EFAULT;
-        goto out;
+    context ctx;
+    if (user_iov || direct_io) {
+        ctx = get_current_context(current_cpu());
+        if (context_set_err(ctx)) {
+            rv = -EFAULT;
+            goto out;
+        }
     }
-    rv = file_io_init_internal(f, offset, iov, count, sg);
+    rv = file_io_init_internal(f, offset, direct_io, iov, count, user_iov, sg);
     if (!rv)
         *sgp = sg;
-  out:
-    if (rv != -EFAULT)
+    if (user_iov || direct_io)
         context_clear_err(ctx);
+  out:
     if (rv < 0)
         deallocate_sg_list(sg);
     return rv;
@@ -310,7 +339,7 @@ sysreturn utime(const char *filename, const struct utimbuf *times)
     context ctx;
     if (times) {
         ctx = get_current_context(current_cpu());
-        if (!validate_user_memory(times, sizeof(struct utimbuf), false) || context_set_err(ctx))
+        if (!memory_is_user(times, sizeof(struct utimbuf)) || context_set_err(ctx))
             return -EFAULT;
     }
     timestamp atime = times ? seconds(times->actime) : now(CLOCK_ID_REALTIME);
@@ -325,7 +354,7 @@ sysreturn utimes(const char *filename, const struct timeval times[2])
     context ctx;
     if (times) {
         ctx = get_current_context(current_cpu());
-        if (!validate_user_memory(times, 2 * sizeof(struct timeval), false) || context_set_err(ctx))
+        if (!memory_is_user(times, 2 * sizeof(struct timeval)) || context_set_err(ctx))
             return -EFAULT;
     }
     /* Sub-second precision is not supported. */
@@ -357,7 +386,7 @@ sysreturn utimensat(int dirfd, const char *filename, const struct timespec times
     timestamp atime, mtime;
     if (times) {
         context ctx = get_current_context(current_cpu());
-        if (!validate_user_memory(times, 2 * sizeof(struct timespec), false) ||
+        if (!memory_is_user(times, 2 * sizeof(struct timespec)) ||
             context_set_err(ctx))
             return -EFAULT;
         if (!utimens_is_valid(&times[0]) || !utimens_is_valid(&times[1]))
@@ -415,7 +444,7 @@ sysreturn utimensat(int dirfd, const char *filename, const struct timespec times
 static sysreturn statx_internal(filesystem fs, int type, tuple n, fsfile f, struct statx *statxbuf)
 {
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(statxbuf, sizeof(struct rlimit), true) || context_set_err(ctx))
+    if (!memory_is_user(statxbuf, sizeof(struct rlimit)) || context_set_err(ctx))
         return -EFAULT;
     zero(statxbuf, sizeof(*statxbuf));
     statxbuf->stx_mode = stat_mode(current->p, type, n);

--- a/src/unix/filesystem.h
+++ b/src/unix/filesystem.h
@@ -31,7 +31,8 @@ u16 stat_mode(process p, int type, tuple meta);
  * not to the range to be read ahead. */
 void file_readahead(file f, u64 offset, u64 len);
 
-sysreturn file_io_init_sg(file f, u64 offset, struct iovec *iov, int count, sg_list *sgp);
+sysreturn file_io_init_sg(file f, u64 offset, struct iovec *iov, int count, boolean user_iov,
+                          sg_list *sgp);
 
 int filesystem_chdir(process p, sstring path);
 

--- a/src/unix/futex.c
+++ b/src/unix/futex.c
@@ -157,7 +157,7 @@ sysreturn futex(int *uaddr, int futex_op, int val,
     timestamp ts;
     int op;
 
-    if (!validate_user_memory(uaddr, sizeof(int), false))
+    if (!memory_is_user(uaddr, sizeof(int)))
         return set_syscall_error(current, EFAULT);
 
     f = soft_create_futex(current->p, u64_from_pointer(uaddr));
@@ -200,7 +200,7 @@ sysreturn futex(int *uaddr, int futex_op, int val,
     case FUTEX_CMP_REQUEUE: {
         int woken, requeued;
 
-        if (!validate_user_memory(uaddr2, sizeof(int), false))
+        if (!memory_is_user(uaddr2, sizeof(int)))
             return set_syscall_error(current, EFAULT);
 
         sysreturn rv;
@@ -241,7 +241,7 @@ sysreturn futex(int *uaddr, int futex_op, int val,
         unsigned int op = (val3 >> 28) & MASK(4);
         int oldval, wake1, wake2, c;
 
-        if (!validate_user_memory(uaddr2, sizeof(int), true))
+        if (!memory_is_user(uaddr2, sizeof(int)))
             return set_syscall_error(current, EFAULT);
 
         struct futex *f2 = soft_create_futex(current->p, u64_from_pointer(uaddr2));
@@ -357,14 +357,14 @@ void wake_robust_list(process p, void *head)
         l = l->next;
         if (uaddr == pending)   /* don't process it twice */
             continue;
-        if (!validate_user_memory(l, sizeof(*l), false))
+        if (!memory_is_user(l, sizeof(*l)))
             break;
-        if (!validate_user_memory(uaddr, sizeof(*uaddr), true))
+        if (!memory_is_user(uaddr, sizeof(*uaddr)))
             break;
         *uaddr |= FUTEX_OWNER_DIED;
         futex_wake_many_by_uaddr(p, uaddr, 1);
     }
-    if (pending && validate_user_memory(pending, sizeof(*pending), true)) {
+    if (pending && memory_is_user(pending, sizeof(*pending))) {
         *pending |= FUTEX_OWNER_DIED;
         futex_wake_one_by_uaddr(p, pending);
     }
@@ -374,8 +374,8 @@ void wake_robust_list(process p, void *head)
 sysreturn get_robust_list(int pid, void *head, u64 *len)
 {
     struct robust_list_head **hp = head;
-    if (!validate_user_memory(hp, sizeof(*hp), true) ||
-        !validate_user_memory(len, sizeof(*len), true))
+    if (!memory_is_user(hp, sizeof(*hp)) ||
+        !memory_is_user(len, sizeof(*len)))
         return -EFAULT;
 
     thread t = 0;

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -960,7 +960,7 @@ static boolean iour_submit(io_uring iour, struct io_uring_sqe *sqe)
         struct iovec *iov = pointer_from_u64(sqe->addr);
         u32 len = sqe->len;
         boolean write = (opcode == IORING_OP_WRITEV);
-        if (!validate_iovec(iov, len, !write)) {
+        if (!memory_is_user(iov, len * sizeof(*iov))) {
             res = -EFAULT;
             goto complete;
         }
@@ -1120,7 +1120,7 @@ static boolean iour_submit(io_uring iour, struct io_uring_sqe *sqe)
             switch (opcode) {
             case IORING_OP_READ:
             case IORING_OP_WRITE:
-                if (!validate_user_memory(buf, len, !write)) {
+                if (!memory_is_user(buf, len)) {
                     res = -EFAULT;
                     goto complete;
                 }
@@ -1281,9 +1281,22 @@ static sysreturn iour_register_buffers(io_uring iour, struct iovec *bufs,
         if (iour->bufs == INVALID_ADDRESS) {
             ret = -ENOMEM;
         } else {
-            runtime_memcpy(iour->bufs, bufs, sizeof(struct iovec) * count);
-            iour->buf_count = count;
-            ret = 0;
+            if (copy_from_user(bufs, iour->bufs, sizeof(struct iovec) * count)) {
+                ret = 0;
+                for (unsigned int i = 0; i < count; i++) {
+                    struct iovec *iov = &iour->bufs[i];
+                    if (!memory_is_user(iov->iov_base, iov->iov_len)) {
+                        ret = -EFAULT;
+                        break;
+                    }
+                }
+                if (!ret)
+                    iour->buf_count = count;
+            } else {
+                ret = -EFAULT;
+            }
+            if (ret)
+                deallocate(iour->h, iour->bufs, sizeof(struct iovec) * count);
         }
     }
     iour_unlock(iour);
@@ -1442,10 +1455,7 @@ sysreturn io_uring_register(int fd, unsigned int opcode, void *arg,
     sysreturn rv;
     switch (opcode) {
     case IORING_REGISTER_BUFFERS:
-        if (!validate_iovec((struct iovec *)arg, nr_args, true))
-            rv = -EFAULT;
-        else
-            rv = iour_register_buffers(iour, (struct iovec *)arg, nr_args);
+        rv = iour_register_buffers(iour, (struct iovec *)arg, nr_args);
         break;
     case IORING_UNREGISTER_BUFFERS:
         if (arg || nr_args)
@@ -1495,8 +1505,7 @@ sysreturn io_uring_register(int fd, unsigned int opcode, void *arg,
         break;
     case IORING_REGISTER_PROBE: {
         struct io_uring_probe *probe = (struct io_uring_probe *)arg;
-        if (!validate_user_memory(probe,
-                sizeof(*probe) + sizeof(probe->ops[0]) * nr_args, true))
+        if (!memory_is_user(probe, sizeof(*probe) + sizeof(probe->ops[0]) * nr_args))
             rv = -EFAULT;
         else
             rv = iour_register_probe(probe, nr_args);

--- a/src/unix/io_uring.c
+++ b/src/unix/io_uring.c
@@ -916,7 +916,8 @@ static boolean iour_submit(io_uring iour, struct io_uring_sqe *sqe)
         res = -EINVAL;
         goto complete;
     }
-    switch(sqe->opcode) {
+    u8 opcode = sqe->opcode;
+    switch (opcode) {
     case IORING_OP_READV:
     case IORING_OP_WRITEV:
     case IORING_OP_READ_FIXED:
@@ -946,7 +947,7 @@ static boolean iour_submit(io_uring iour, struct io_uring_sqe *sqe)
     default:
         break;
     }
-    switch (sqe->opcode) {
+    switch (opcode) {
     case IORING_OP_NOP:
         res = 0;
         goto complete;
@@ -958,7 +959,7 @@ static boolean iour_submit(io_uring iour, struct io_uring_sqe *sqe)
         }
         struct iovec *iov = pointer_from_u64(sqe->addr);
         u32 len = sqe->len;
-        boolean write = (sqe->opcode == IORING_OP_WRITEV);
+        boolean write = (opcode == IORING_OP_WRITEV);
         if (!validate_iovec(iov, len, !write)) {
             res = -EFAULT;
             goto complete;
@@ -980,7 +981,7 @@ static boolean iour_submit(io_uring iour, struct io_uring_sqe *sqe)
             struct iovec *iov = &iour->bufs[buf_index];
             void *buf = pointer_from_u64(sqe->addr);
             u32 len = sqe->len;
-            boolean write = sqe->opcode == IORING_OP_WRITE_FIXED;
+            boolean write = opcode == IORING_OP_WRITE_FIXED;
             if ((buf < iov->iov_base) || (u64_from_pointer(buf) + len >
                     u64_from_pointer(iov->iov_base) + iov->iov_len)) {
                 res = -EFAULT;
@@ -1115,7 +1116,6 @@ static boolean iour_submit(io_uring iour, struct io_uring_sqe *sqe)
         } else {
             void *buf = pointer_from_u64(sqe->addr);
             u32 len = sqe->len;
-            u8 opcode = sqe->opcode;
             boolean write = ((opcode == IORING_OP_WRITE) || (opcode == IORING_OP_SEND));
             switch (opcode) {
             case IORING_OP_READ:

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -1028,7 +1028,7 @@ static sysreturn vmap_update_protections_locked(heap h, rangemap pvmap, range q,
     assert(range_span(q) > 0);
 
     vmap_debug("%s: q %R newflags 0x%x\n", func_ss, q, newflags);
-    if (!validate_user_memory(pointer_from_u64(q.start), range_span(q), false) ||
+    if (!memory_is_user(pointer_from_u64(q.start), range_span(q)) ||
         (rangemap_range_find_gaps(pvmap, q,
                                   stack_closure_func(range_handler, vmap_update_protections_gap))
          == RM_ABORT))
@@ -1555,7 +1555,7 @@ boolean fault_in_user_memory(const void *buf, bytes length, boolean writable)
         if (!validate_user_memory_permissions(current->p, buf, length, VMAP_FLAG_WRITABLE, 0))
             return false;
     } else {
-        if (!validate_user_memory(buf, length, false))
+        if (!memory_is_user(buf, length))
             return false;
     }
 

--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -708,7 +708,7 @@ static sysreturn nl_check_dest(struct sockaddr *addr, socklen_t addrlen)
     return 0;
 }
 
-static sysreturn nl_write_internal(nlsock s, void * src, u64 len)
+static sysreturn nl_write_internal(nlsock s, void *src, u64 len, context ctx)
 {
     nl_debug("write_internal: len %ld", len);
     struct nlmsghdr *hdr;
@@ -716,7 +716,6 @@ static sysreturn nl_write_internal(nlsock s, void * src, u64 len)
     buffer kbuf = allocate_buffer(s->sock.h, sizeof(struct nlmsghdr));
     if (kbuf == INVALID_ADDRESS)
         return -ENOMEM;
-    context ctx = get_current_context(current_cpu());
     if (context_set_err(ctx)) {
         if (offset == 0)
             offset = -EFAULT;
@@ -801,6 +800,7 @@ closure_function(8, 1, sysreturn, nl_read_bh,
         }
         *from_len = sizeof(struct sockaddr_nl);
     }
+    boolean iov_validated = false;
     u64 dest_len;
     do {
         nl_debug("read_bh: msg len %d, type %d, flags 0x%x, seq %d, pid %d", hdr->nlmsg_len,
@@ -820,9 +820,13 @@ closure_function(8, 1, sysreturn, nl_read_bh,
                     iov_buf = iov->iov_base;
                     iov++;
                     length--;
+                    iov_validated = false;
                 }
                 if (iov_len == 0)
                     break;
+                if (!iov_validated && !memory_is_user(iov_buf, iov_len))
+                    page_fault();
+                iov_validated = true;
                 u64 xfer = MIN(hdr->nlmsg_len - msg_offset, iov_len);
                 runtime_memcpy(iov_buf, hdr + msg_offset, xfer);
                 iov_buf += xfer;
@@ -873,7 +877,7 @@ closure_func_basic(file_io, sysreturn, nl_write,
     nl_debug("write len %ld", length);
     nlsock s = struct_from_closure(nlsock, write);
     nl_lock(s);
-    sysreturn rv = nl_write_internal(s, src, length);
+    sysreturn rv = nl_write_internal(s, src, length, ctx);
     nl_unlock(s);
     return io_complete(completion, rv);
 }
@@ -1017,12 +1021,14 @@ static sysreturn nl_sendmsg(struct sock *sock, const struct msghdr *msg, int fla
                             io_completion completion)
 {
     context ctx = get_current_context(current_cpu());
+    u64 iov_len;
     sysreturn rv;
     if (context_set_err(ctx)) {
         rv = -EFAULT;
     } else {
         nl_debug("sendmsg: iovlen %ld, flags 0x%x", msg->msg_iovlen, flags);
         rv = nl_check_dest(msg->msg_name, msg->msg_namelen);
+        iov_len = msg->msg_iovlen;
         context_clear_err(ctx);
     }
     nlsock s = (nlsock)sock;
@@ -1030,8 +1036,18 @@ static sysreturn nl_sendmsg(struct sock *sock, const struct msghdr *msg, int fla
         goto out;
     u64 written = 0;
     nl_lock(s);
-    for (u64 i = 0; i < msg->msg_iovlen; i++) {
-        rv = nl_write_internal(s, msg->msg_iov[i].iov_base, msg->msg_iov[i].iov_len);
+    for (u64 i = 0; i < iov_len; i++) {
+        if (context_set_err(ctx)) {
+            rv = -EFAULT;
+        } else {
+            struct iovec *iov = &msg->msg_iov[i];
+            void *src = iov->iov_base;
+            u64 len = iov->iov_len;
+            if (!memory_is_user(src, len))
+                page_fault();
+            context_clear_err(ctx);
+            rv = nl_write_internal(s, src, len, ctx);
+        }
         if (rv > 0)
             written += rv;
         else
@@ -1046,10 +1062,18 @@ static sysreturn nl_sendmsg(struct sock *sock, const struct msghdr *msg, int fla
 static sysreturn nl_recvmsg(struct sock *sock, struct msghdr *msg, int flags, boolean in_bh,
                             io_completion completion)
 {
+    context ctx = get_current_context(current_cpu());
+    if (context_set_err(ctx)) {
+        return io_complete(completion, -EFAULT);
+    }
     nl_debug("recvmsg: iovlen %ld, flags 0x%x", msg->msg_iovlen, flags);
     nlsock s = (nlsock)sock;
-    blockq_action ba = contextual_closure(nl_read_bh, s, 0, 0, msg, flags,
-                                          msg->msg_name, &msg->msg_namelen, completion);
+    struct sockaddr *addr = msg->msg_name;
+    if (!memory_is_user(addr, sizeof(struct sockaddr_nl)))
+        page_fault();
+    context_clear_err(ctx);
+    blockq_action ba = closure_from_context(ctx, nl_read_bh, s, 0, 0, msg, flags,
+                                            addr, &msg->msg_namelen, completion);
     if (ba == INVALID_ADDRESS)
         return io_complete(completion, -ENOMEM);
     return blockq_check(s->sock.rxbq, ba, in_bh);

--- a/src/unix/netlink.c
+++ b/src/unix/netlink.c
@@ -702,10 +702,7 @@ static sysreturn nl_check_dest(struct sockaddr *addr, socklen_t addrlen)
 
         if (addrlen < sizeof(*nl_addr))
             return -EINVAL;
-        u32 pid;
-        if (!get_user_value(&nl_addr->nl_pid, &pid))
-            return -EFAULT;
-        if (pid != NL_PID_KERNEL)
+        if (nl_addr->nl_pid != NL_PID_KERNEL)
             return -EPERM;
     }
     return 0;
@@ -989,7 +986,13 @@ static sysreturn nl_sendto(struct sock *sock, void *buf, u64 len, int flags,
                            boolean in_bh, io_completion completion)
 {
     nl_debug("sendto: len %ld, flags 0x%x", len, flags);
-    sysreturn rv = nl_check_dest(dest_addr, addrlen);
+    sysreturn rv;
+    if (context_set_err(ctx)) {
+        rv = -EFAULT;
+    } else {
+        rv = nl_check_dest(dest_addr, addrlen);
+        context_clear_err(ctx);
+    }
     if (rv) {
         return io_complete(completion, rv);
     }
@@ -1013,9 +1016,16 @@ static sysreturn nl_recvfrom(struct sock *sock, void *buf, u64 len, int flags,
 static sysreturn nl_sendmsg(struct sock *sock, const struct msghdr *msg, int flags, boolean in_bh,
                             io_completion completion)
 {
-    nl_debug("sendmsg: iovlen %ld, flags 0x%x", msg->msg_iovlen, flags);
+    context ctx = get_current_context(current_cpu());
+    sysreturn rv;
+    if (context_set_err(ctx)) {
+        rv = -EFAULT;
+    } else {
+        nl_debug("sendmsg: iovlen %ld, flags 0x%x", msg->msg_iovlen, flags);
+        rv = nl_check_dest(msg->msg_name, msg->msg_namelen);
+        context_clear_err(ctx);
+    }
     nlsock s = (nlsock)sock;
-    sysreturn rv = nl_check_dest(msg->msg_name, msg->msg_namelen);
     if (rv)
         goto out;
     u64 written = 0;

--- a/src/unix/poll.c
+++ b/src/unix/poll.c
@@ -553,7 +553,7 @@ sysreturn epoll_wait(int epfd,
                      int maxevents,
                      int timeout)
 {
-    if (!validate_user_memory(events, sizeof(struct epoll_event) * maxevents, true))
+    if (!memory_is_user(events, sizeof(struct epoll_event) * maxevents))
         return -EFAULT;
 
     epoll e = resolve_fd(current->p, epfd);
@@ -1015,7 +1015,7 @@ static sysreturn poll_internal(struct pollfd *fds, nfds_t nfds,
                                timestamp timeout,
                                const sigset_t * sigmask)
 {
-    if (nfds && !validate_user_memory(fds, sizeof(struct pollfd) * nfds, true))
+    if (nfds && !memory_is_user(fds, sizeof(struct pollfd) * nfds))
         return -EFAULT;
     epoll e = thread_get_epoll(EPOLL_TYPE_POLL);
     if (e == INVALID_ADDRESS)

--- a/src/unix/signal.c
+++ b/src/unix/signal.c
@@ -539,7 +539,7 @@ sysreturn sigaltstack(const stack_t *ss, stack_t *oss)
     thread t = current;
     context ctx = get_current_context(current_cpu());
     if (oss) {
-        if (!validate_user_memory(oss, sizeof(stack_t), true) || context_set_err(ctx))
+        if (!memory_is_user(oss, sizeof(stack_t)) || context_set_err(ctx))
             return -EFAULT;
         if (t->signal_stack) {
             oss->ss_sp = t->signal_stack;
@@ -556,13 +556,13 @@ sysreturn sigaltstack(const stack_t *ss, stack_t *oss)
         if (thread_is_on_altsigstack(t)) {
             return -EPERM;
         }
-        if (!validate_user_memory(ss, sizeof(stack_t), false) || context_set_err(ctx))
+        if (!memory_is_user(ss, sizeof(stack_t)) || context_set_err(ctx))
             return -EFAULT;
         sysreturn rv;
         if (ss->ss_flags & SS_DISABLE) {
             t->signal_stack = 0;
             rv = 0;
-        } else if (!validate_user_memory(ss->ss_sp, ss->ss_size, true)) {
+        } else if (!memory_is_user(ss->ss_sp, ss->ss_size)) {
             rv = -EFAULT;
         } else {
             if (ss->ss_flags) { /* unknown flags */
@@ -640,7 +640,7 @@ static inline sysreturn sigqueueinfo_sanitize_args(int tgid, int sig, siginfo_t 
         return -EINVAL;
 
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(uinfo, sizeof(siginfo_t), true) || context_set_err(ctx))
+    if (!memory_is_user(uinfo, sizeof(siginfo_t)) || context_set_err(ctx))
         return -EFAULT;
     touch_memory(uinfo, sizeof(siginfo_t));
     uinfo->si_signo = sig;
@@ -742,8 +742,8 @@ sysreturn rt_sigtimedwait(const u64 * set, siginfo_t * info, const struct timesp
 {
     if (sigsetsize != (NSIG / 8))
         return -EINVAL;
-    if (!validate_user_memory(set, sigsetsize, false) ||
-        (timeout && !validate_user_memory(timeout, sizeof(struct timespec), false)))
+    if (!memory_is_user(set, sigsetsize) ||
+        (timeout && !memory_is_user(timeout, sizeof(struct timespec))))
         return -EFAULT;
     context ctx = get_current_context(current_cpu());
     if (context_set_err(ctx))

--- a/src/unix/socket.c
+++ b/src/unix/socket.c
@@ -198,6 +198,14 @@ closure_function(7, 1, sysreturn, unixsock_read_bh,
             read_done = true;
         goto out;
     }
+    void *iov_base;
+    u64 iov_len;
+    boolean iov_validated;
+    if (!dest) {
+        iov_base = iov->iov_base;
+        iov_len = iov->iov_len;
+        iov_validated = false;
+    }
     u64 buf_offset = 0;
     do {
         buffer b = shb->b;
@@ -212,16 +220,24 @@ closure_function(7, 1, sysreturn, unixsock_read_bh,
             do {
                 u64 partial_xfer;
                 do {
-                    partial_xfer = MIN(buffer_length(b), iov->iov_len - buf_offset);
+                    partial_xfer = MIN(buffer_length(b), iov_len - buf_offset);
                     if (partial_xfer == 0) {
                         iov++;
                         length--;
+                        if (length) {
+                            iov_base = iov->iov_base;
+                            iov_len = iov->iov_len;
+                            iov_validated = false;
+                        }
                         buf_offset = 0;
                     }
                 } while ((partial_xfer == 0) && length);
                 if (!length)
                     break;
-                buffer_read(b, iov->iov_base + buf_offset, partial_xfer);
+                if (!iov_validated && !memory_is_user(iov_base, iov_len))
+                    page_fault();
+                iov_validated = true;
+                buffer_read(b, iov_base + buf_offset, partial_xfer);
                 buf_offset += partial_xfer;
                 xfer += partial_xfer;
             } while (buffer_length(b));
@@ -294,8 +310,28 @@ static sysreturn unixsock_write_to(void *src, struct iovec *iov, u64 length,
     context ctx = get_current_context(current_cpu());
     u64 buf_offset = 0;
     sysreturn rv = 0;
+    unixsock_msg shb = INVALID_ADDRESS;
+    if (context_set_err(ctx)) {
+        if (shb != INVALID_ADDRESS)
+            unixsock_msg_dealloc(shb);
+        return (rv == 0) ? -EFAULT : rv;
+    }
+    void *iov_base;
+    u64 iov_len;
+    boolean iov_validated;
+    if (!src) {
+        iov_base = iov->iov_base;
+        iov_len = iov->iov_len;
+        iov_validated = false;
+    }
     do {
         u64 xfer = src ? length : iov_total_len(iov, length);
+        sysreturn check_rv = unixsock_write_check(from, xfer);
+        if (check_rv <= 0) {
+            if (rv == 0)
+                rv = check_rv;
+            break;
+        }
         xfer = MIN(UNIXSOCK_BUF_MAX_SIZE, xfer);
         if (from->sock.type == SOCK_STREAM)
             xfer = MIN(xfer, so_rcvbuf - dest->sock.rx_len);
@@ -308,12 +344,6 @@ static sysreturn unixsock_write_to(void *src, struct iovec *iov, u64 length,
         }
         if (from && from->sock.type == SOCK_DGRAM)
             runtime_memcpy(&shb->from_addr, &from->local_addr, sizeof(struct sockaddr_un));
-        if (context_set_err(ctx)) {
-            unixsock_msg_dealloc(shb);
-            if (rv == 0)
-                rv = -EFAULT;
-            break;
-        }
         if (src) {
             assert(buffer_write(shb->b, src + buf_offset, xfer));
             buf_offset += xfer;
@@ -323,28 +353,43 @@ static sysreturn unixsock_write_to(void *src, struct iovec *iov, u64 length,
             do {
                 u64 partial_xfer;
                 do {
-                    partial_xfer = MIN(xfer_limit, iov->iov_len - buf_offset);
+                    partial_xfer = MIN(xfer_limit, iov_len - buf_offset);
                     if (partial_xfer == 0) {
-                        iov++;
                         length--;
+                        if (length == 0)
+                            break;
+                        iov++;
+                        iov_base = iov->iov_base;
+                        iov_len = iov->iov_len;
+                        iov_validated = false;
                         buf_offset = 0;
                     }
                 } while (partial_xfer == 0);
-                buffer_write(shb->b, iov->iov_base + buf_offset, partial_xfer);
+                if (partial_xfer == 0)
+                    break;
+                if (!iov_validated && !memory_is_user(iov_base, iov_len))
+                    page_fault();
+                iov_validated = true;
+                buffer_write(shb->b, iov_base + buf_offset, partial_xfer);
                 buf_offset += partial_xfer;
                 xfer_limit -= partial_xfer;
             } while (xfer_limit);
-            if (buf_offset == iov->iov_len) {
-                iov++;
+            if (buf_offset == iov_len) {
                 length--;
-                buf_offset = 0;
+                if (length > 0) {
+                    iov++;
+                    iov_base = iov->iov_base;
+                    iov_len = iov->iov_len;
+                    iov_validated = false;
+                    buf_offset = 0;
+                }
             }
         }
-        context_clear_err(ctx);
         assert(enqueue(dest->data, shb));
         dest->sock.rx_len += xfer;
         rv += xfer;
     } while ((length > 0) && (dest->sock.rx_len < so_rcvbuf) && !queue_full(dest->data));
+    context_clear_err(ctx);
     return rv;
 }
 
@@ -425,12 +470,6 @@ out:
 static sysreturn unixsock_write_with_addr(unixsock s, void *src, u64 length, u64 offset, context ctx,
                                           boolean bh, io_completion completion, unixsock addr)
 {
-    sysreturn rv = unixsock_write_check(s, length);
-    if (rv <= 0) {
-        refcount_release(&addr->refcount);
-        return io_complete(completion, rv);
-    }
-
     blockq_action ba = closure_from_context(ctx, unixsock_write_bh, s, src, 0, length,
                                             completion, addr);
     return blockq_check(addr->sock.txbq, ba, bh);
@@ -465,9 +504,6 @@ closure_func_basic(file_iov, sysreturn, unixsock_writev,
                    struct iovec *iov, int count, u64 offset, context ctx, boolean bh, io_completion completion)
 {
     unixsock s = struct_from_field(closure_self(), unixsock, writev);
-    sysreturn rv = unixsock_write_check(s, iov_total_len(iov, count));
-    if (rv <= 0)
-        return io_complete(completion, rv);
     unixsock_lock(s);
     unixsock dest = s->peer;
     if (dest)
@@ -892,15 +928,32 @@ sysreturn unixsock_sendmsg(struct sock *sock, const struct msghdr *msg,
                            int flags, boolean in_bh, io_completion completion)
 {
     context ctx = get_current_context(current_cpu());
-    return apply(sock->f.writev, msg->msg_iov, msg->msg_iovlen, 0, ctx, in_bh, completion);
+    if (context_set_err(ctx)) {
+        return io_complete(completion, -EFAULT);
+    }
+    struct iovec *iov = msg->msg_iov;
+    u64 len = msg->msg_iovlen;
+    if (!memory_is_user(iov, len * sizeof(*iov)))
+        page_fault();
+    context_clear_err(ctx);
+    return apply(sock->f.writev, iov, len, 0, ctx, in_bh, completion);
 }
 
 sysreturn unixsock_recvmsg(struct sock *sock, struct msghdr *msg, int flags, boolean in_bh,
                            io_completion completion)
 {
-    blockq_action ba = contextual_closure(unixsock_read_bh, (unixsock)sock,
-                                          0, msg->msg_iov, msg->msg_iovlen,
-                                          completion, msg->msg_name, &msg->msg_namelen);
+    context ctx = get_current_context(current_cpu());
+    if (context_set_err(ctx)) {
+        return io_complete(completion, -EFAULT);
+    }
+    struct iovec *iov = msg->msg_iov;
+    u64 len = msg->msg_iovlen;
+    struct sockaddr_un *addr = msg->msg_name;
+    if (!memory_is_user(iov, len * sizeof(*iov)) || (addr && !memory_is_user(addr, sizeof(*addr))))
+        page_fault();
+    context_clear_err(ctx);
+    blockq_action ba = closure_from_context(ctx, unixsock_read_bh, (unixsock)sock, 0, iov, len,
+                                            completion, addr, &msg->msg_namelen);
     if (ba == INVALID_ADDRESS) {
         return io_complete(completion, -ENOMEM);
     }

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -160,24 +160,6 @@ sysreturn socket_send(fdesc f, void *buf, u64 len, context ctx, boolean in_bh,
 sysreturn socket_recv(fdesc f, void *buf, u64 len, context ctx, boolean in_bh,
                       io_completion completion);
 
-static inline boolean validate_msghdr(const struct msghdr *mh, boolean write)
-{
-    if (!validate_user_memory(mh, sizeof(struct msghdr), false))
-        return false;
-    context ctx = get_current_context(current_cpu());
-    if (!context_set_err(ctx)) {
-        boolean ok;
-        ok = (!mh->msg_name || validate_user_memory(mh->msg_name, mh->msg_namelen, false)) &&
-             (!mh->msg_control || validate_user_memory(mh->msg_control, mh->msg_controllen, write));
-        context_clear_err(ctx);
-        if (!ok)
-            return false;
-    } else {
-        return false;
-    }
-    return validate_iovec(mh->msg_iov, mh->msg_iovlen, write);
-}
-
 static inline sysreturn sockopt_copy_from_user(void *uval, socklen_t ulen, void *val, socklen_t len)
 {
     if (ulen != len)
@@ -192,11 +174,11 @@ static inline sysreturn sockopt_copy_to_user(void *uval, socklen_t *ulen, void *
     if (!uval || !ulen)
         return 0;
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(ulen, sizeof(socklen_t), true) || context_set_err(ctx))
+    if (!memory_is_user(ulen, sizeof(socklen_t)) || context_set_err(ctx))
         return -EFAULT;
     len = MIN(*ulen, len);
     sysreturn rv;
-    if (validate_user_memory(uval, len, true)) {
+    if (memory_is_user(uval, len)) {
         runtime_memcpy(uval, val, len);
         *ulen = len;
         rv = 0;

--- a/src/unix/syscall.c
+++ b/src/unix/syscall.c
@@ -13,22 +13,6 @@ sysreturn close(int fd);
 BSS_RO_AFTER_INIT io_completion syscall_io_complete;
 BSS_RO_AFTER_INIT io_completion io_completion_ignore;
 
-boolean validate_iovec(struct iovec *iov, u64 len, boolean write)
-{
-    if (!validate_user_memory(iov, sizeof(struct iovec) * len, false))
-        return false;
-    context ctx = get_current_context(current_cpu());
-    if (context_set_err(ctx))
-        return false;
-    for (u64 i = 0; i < len; i++) {
-        if ((iov[i].iov_len != 0) &&
-                !validate_user_memory(iov[i].iov_base, iov[i].iov_len, write))
-            return false;
-    }
-    context_clear_err(ctx);
-    return true;
-}
-
 struct iov_progress {
     heap h;
     fdesc f;
@@ -39,7 +23,8 @@ struct iov_progress {
     boolean blocking;
     u64 file_offset;
     int curr;
-    u64 curr_offset;
+    void *curr_base;
+    u64 curr_len;
     u64 total_len;
     context ctx;
     io_completion completion;
@@ -49,17 +34,14 @@ struct iov_progress {
 
 static void iov_op_each(struct iov_progress *p)
 {
-    struct iovec *iov = p->iov;
     file_io op = p->write ? p->f->write : p->f->read;
     boolean blocking = p->blocking;
     p->blocking = false;
 
     /* Issue the next request. */
-    thread_log(current, "   op: curr %d, offset %ld, @ %p, len %ld, blocking %d",
-               p->curr, p->curr_offset, iov[p->curr].iov_base + p->curr_offset,
-               iov[p->curr].iov_len - p->curr_offset, blocking);
-    apply(op, iov[p->curr].iov_base + p->curr_offset,
-          iov[p->curr].iov_len - p->curr_offset, p->file_offset, p->ctx, !blocking,
+    thread_log(current, "   op: curr %d, @ %p, len %ld, blocking %d",
+               p->curr, p->curr_base, p->curr_len, blocking);
+    apply(op, p->curr_base, p->curr_len, p->file_offset, p->ctx, !blocking,
           (io_completion)&p->each_complete);
 }
 
@@ -88,14 +70,25 @@ closure_func_basic(io_completion, void, iov_op_each_complete,
        (non-zero-len) buffer if needed. */
     struct iovec *iov = p->iov;
     p->total_len += rv;
-    p->curr_offset += rv;
-    if (p->curr_offset == iov[p->curr].iov_len) {
-        p->curr_offset = 0;
+    p->curr_base += rv;
+    p->curr_len -= rv;
+    if (p->curr_len == 0) {
+        context ctx = p->ctx;
+        if (context_set_err(ctx)) {
+            rv = p->total_len;
+            if (rv == 0)
+                rv = -EFAULT;
+            goto out_complete;
+        }
         do {
             p->curr++;
-        } while (p->curr < iovcnt && iov[p->curr].iov_len == 0);
-    } else {
-        assert(p->curr_offset < iov[p->curr].iov_len);
+        } while (p->curr < iovcnt && (p->curr_len = iov[p->curr].iov_len) == 0);
+        if (p->curr < iovcnt) {
+            p->curr_base = iov[p->curr].iov_base;
+            if (!memory_is_user(p->curr_base, p->curr_len))
+                page_fault();
+        }
+        context_clear_err(ctx);
     }
 
     /* If we're done, return the total length... */
@@ -162,7 +155,7 @@ void iov_op(fdesc f, boolean write, struct iovec *iov, int iovcnt, u64 offset,
     p->blocking = blocking;
     p->file_offset = offset;
     p->curr = 0;
-    p->curr_offset = 0;
+    p->curr_len = 0;
     p->total_len = 0;
     p->ctx = ctx;
     p->completion = completion;
@@ -178,7 +171,7 @@ out:
 
 static sysreturn iov_internal(int fd, boolean write, struct iovec *iov, int iovcnt, u64 offset)
 {
-    if (!validate_iovec(iov, iovcnt, !write))
+    if (!memory_is_user(iov, iovcnt * sizeof(*iov)))
         return -EFAULT;
     fdesc f = resolve_fd(current->p, fd);
     context ctx = get_current_context(current_cpu());
@@ -188,7 +181,7 @@ static sysreturn iov_internal(int fd, boolean write, struct iovec *iov, int iovc
 
 sysreturn read(int fd, u8 *dest, bytes length)
 {
-    if (!validate_user_memory(dest, length, true))
+    if (!memory_is_user(dest, length))
         return -EFAULT;
     fdesc f = resolve_fd(current->p, fd);
     sysreturn rv;
@@ -212,7 +205,7 @@ sysreturn read(int fd, u8 *dest, bytes length)
 
 sysreturn pread(int fd, u8 *dest, bytes length, s64 offset)
 {
-    if (!validate_user_memory(dest, length, true))
+    if (!memory_is_user(dest, length))
         return -EFAULT;
     fdesc f = resolve_fd(current->p, fd);
     sysreturn rv;
@@ -248,7 +241,7 @@ sysreturn preadv(int fd, struct iovec *iov, int iovcnt, s64 offset)
 
 sysreturn write(int fd, u8 *body, bytes length)
 {
-    if (!validate_user_memory(body, length, false))
+    if (!memory_is_user(body, length))
         return -EFAULT;
     fdesc f = resolve_fd(current->p, fd);
     sysreturn rv;
@@ -272,7 +265,7 @@ sysreturn write(int fd, u8 *body, bytes length)
 
 sysreturn pwrite(int fd, u8 *body, bytes length, s64 offset)
 {
-    if (!validate_user_memory(body, length, false))
+    if (!memory_is_user(body, length))
         return -EFAULT;
     fdesc f = resolve_fd(current->p, fd);
     sysreturn rv;
@@ -500,13 +493,14 @@ static void file_io_complete(file f, range r, boolean is_file_offset, sg_list sg
     apply(completion, rv);
 }
 
-static sysreturn file_read_check(file f, u64 offset, struct iovec *iov, int count, sg_list *sgp)
+static sysreturn file_read_check(file f, u64 offset, struct iovec *iov, int count, boolean user_iov,
+                                 sg_list *sgp)
 {
     if (fdesc_type(&f->f) == FDESC_TYPE_DIRECTORY)
         return -EISDIR;
     else if (!f->fsf)
         return -EBADF;
-    return file_io_init_sg(f, offset, iov, count, sgp);
+    return file_io_init_sg(f, offset, iov, count, user_iov, sgp);
 }
 
 static void begin_file_read(file f, u64 length)
@@ -560,7 +554,7 @@ closure_func_basic(file_io, sysreturn, file_read,
         .iov_len = length,
     };
     sg_list sg;
-    sysreturn rv = file_read_check(f, offset, &iov, 1, &sg);
+    sysreturn rv = file_read_check(f, offset, &iov, 1, false, &sg);
     if (rv < 0)
         return io_complete(completion, rv);
     range r = irangel(offset, length);
@@ -588,7 +582,7 @@ closure_func_basic(file_iov, sysreturn, file_readv,
                f->fsf ? fsfile_get_length(f->fsf) : 0);
 
     sg_list sg;
-    sysreturn rv = file_read_check(f, offset, iov, count, &sg);
+    sysreturn rv = file_read_check(f, offset, iov, count, true, &sg);
     if (rv < 0)
         return io_complete(completion, rv);
     range r = irangel(offset, sg->count);
@@ -604,14 +598,18 @@ closure_func_basic(file_iov, sysreturn, file_readv,
     return bh ? SYSRETURN_CONTINUE_BLOCKING : thread_maybe_sleep_uninterruptible(t);
 }
 
-static sysreturn file_write_check(file f, u64 offset, struct iovec *iov, int count, sg_list *sgp)
+static sysreturn file_write_check(file f, u64 offset, struct iovec *iov, int count,
+                                  boolean user_iov, sg_list *sgp)
 {
     fsfile fsf = f->fsf;
     if (!fsf)
         return -EBADF;
+    sysreturn rv = file_io_init_sg(f, offset, iov, count, user_iov, sgp);
+    if (rv < 0)
+        return rv;
     filesystem fs = f->fs;
     if (fs->get_seals) {
-        u64 len = iov_total_len(iov, count);
+        u64 len = (*sgp)->count;
         u64 seals;
         if ((len > 0) && (fs->get_seals(fs, fsf, &seals) == 0)) {
             if ((seals & (F_SEAL_WRITE | F_SEAL_FUTURE_WRITE)) ||
@@ -619,7 +617,7 @@ static sysreturn file_write_check(file f, u64 offset, struct iovec *iov, int cou
                 return -EPERM;
         }
     }
-    return file_io_init_sg(f, offset, iov, count, sgp);
+    return 0;
 }
 
 static void begin_file_write(file f, u64 len)
@@ -672,7 +670,7 @@ closure_func_basic(file_io, sysreturn, file_write,
         .iov_len = length,
     };
     sg_list sg;
-    sysreturn rv = file_write_check(f, offset, &iov, 1, &sg);
+    sysreturn rv = file_write_check(f, offset, &iov, 1, false, &sg);
     if (rv < 0)
         return io_complete(completion, rv);
 
@@ -703,7 +701,7 @@ closure_func_basic(file_iov, sysreturn, file_writev,
                func_ss, f, iov, count, offset, is_file_offset ? ss("file") : ss("specified"),
                f->fsf ? fsfile_get_length(f->fsf) : 0);
     sg_list sg;
-    rv = file_write_check(f, offset, iov, count, &sg);
+    rv = file_write_check(f, offset, iov, count, true, &sg);
     if (rv < 0)
         goto out;
     u64 len = sg->count;
@@ -1121,7 +1119,7 @@ sysreturn getrandom(void *buf, u64 buflen, unsigned int flags)
         return set_syscall_error(current, EINVAL);
 
     u64 n = MIN(GETRANDOM_MAX_BUFLEN, buflen);
-    if (!validate_user_memory(buf, buflen, true) || !fill_random(buf, n))
+    if (!memory_is_user(buf, buflen) || !fill_random(buf, n))
         return -EFAULT;
 
     if (n < buflen) {
@@ -1729,7 +1727,7 @@ sysreturn uname(struct utsname *v)
 sysreturn setrlimit(int resource, const struct rlimit *rlim)
 {
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(rlim, sizeof(struct rlimit), false) || context_set_err(ctx))
+    if (!memory_is_user(rlim, sizeof(struct rlimit)) || context_set_err(ctx))
         return -EFAULT;
     switch (resource) {
     case RLIMIT_STACK:
@@ -1743,7 +1741,7 @@ sysreturn setrlimit(int resource, const struct rlimit *rlim)
 sysreturn getrlimit(int resource, struct rlimit *rlim)
 {
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(rlim, sizeof(struct rlimit), true) || context_set_err(ctx))
+    if (!memory_is_user(rlim, sizeof(struct rlimit)) || context_set_err(ctx))
         return -EFAULT;
 
     sysreturn rv = 0;
@@ -1792,7 +1790,7 @@ sysreturn prlimit64(int pid, int resource, const struct rlimit *new_limit, struc
 static sysreturn getrusage(int who, struct rusage *usage)
 {
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(usage, sizeof(*usage), true) || context_set_err(ctx))
+    if (!memory_is_user(usage, sizeof(*usage)) || context_set_err(ctx))
         return -EFAULT;
     zero(usage, sizeof(*usage));
     sysreturn rv = 0;
@@ -1847,7 +1845,7 @@ static sysreturn brk(void *addr)
         unmap_and_free_phys(new_end, old_end - new_end);
     } else if (new_end > old_end) {
         u64 alloc = new_end - old_end;
-        if (!validate_user_memory(pointer_from_u64(old_end), alloc, true) ||
+        if (!memory_is_user(pointer_from_u64(old_end), alloc) ||
             !adjust_process_heap(p, irange(p->heap_base, new_end)))
             goto out;
     }
@@ -2220,7 +2218,7 @@ sysreturn sched_setaffinity(int pid, u64 cpusetsize, u64 *mask)
     context ctx = get_current_context(current_cpu());
     u64 first_cpu = -1ull;
     u64 i;
-    if (!validate_user_memory(mask, cpusetsize, false) || context_set_err(ctx))
+    if (!memory_is_user(mask, cpusetsize) || context_set_err(ctx))
         return -EFAULT;
     for (i = 0; (first_cpu == -1ull) && (i + sizeof(u64) <= cpusetsize); i += sizeof(u64))
         first_cpu = i * 8 + lsb(mask[i / sizeof(u64)]);
@@ -2283,7 +2281,7 @@ sysreturn capget(cap_user_header_t hdrp, cap_user_data_t datap)
 {
     if (datap) {
         context ctx = get_current_context(current_cpu());
-        if (!validate_user_memory(datap, sizeof(struct user_cap_data), true) ||
+        if (!memory_is_user(datap, sizeof(struct user_cap_data)) ||
             context_set_err(ctx))
             return -EFAULT;
         zero(datap, sizeof(*datap));
@@ -2312,7 +2310,7 @@ sysreturn prctl(int option, u64 arg2, u64 arg3, u64 arg4, u64 arg5)
 sysreturn sysinfo(struct sysinfo *info)
 {
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(info, sizeof(struct sysinfo), true) || context_set_err(ctx))
+    if (!memory_is_user(info, sizeof(struct sysinfo)) || context_set_err(ctx))
         return set_syscall_error(current, EFAULT);
 
     kernel_heaps kh = get_kernel_heaps();
@@ -2336,8 +2334,8 @@ sysreturn getcpu(unsigned int *cpu, unsigned int *node, void *tcache)
 {
     cpuinfo ci = current_cpu();
     context ctx = get_current_context(ci);
-    if ((cpu != 0 && !validate_user_memory(cpu, sizeof *cpu, true)) ||
-        (node != 0 && !validate_user_memory(node, sizeof *node, true)) ||
+    if ((cpu != 0 && !memory_is_user(cpu, sizeof(*cpu))) ||
+        (node != 0 && !memory_is_user(node, sizeof(*node))) ||
         context_set_err(ctx))
         return -EFAULT;
     if (cpu)

--- a/src/unix/thread.c
+++ b/src/unix/thread.c
@@ -20,7 +20,7 @@ sysreturn arch_prctl(int code, unsigned long addr)
 {
     /* just validate the word at base */
     if ((code == ARCH_SET_FS || code == ARCH_SET_GS) &&
-        !validate_user_memory((void *)addr, sizeof(u64), false))
+        !memory_is_user((void *)addr, sizeof(u64)))
         return set_syscall_error(current, EFAULT);
 
     switch (code) {
@@ -59,13 +59,13 @@ static sysreturn clone_internal(struct clone_args_internal *args)
           return -ENOSYS;
      }
 
-     if (!validate_user_memory(stack, stack_size, true))
+     if (!memory_is_user(stack, stack_size))
           return -EFAULT;
 
      if (((flags & CLONE_PARENT_SETTID) &&
-          !validate_user_memory(args->parent_tid, sizeof(u64), true)) ||
+          !memory_is_user(args->parent_tid, sizeof(u64))) ||
          ((flags & CLONE_CHILD_CLEARTID) &&
-          !validate_user_memory(args->child_tid, sizeof(u64), true)))
+          !memory_is_user(args->child_tid, sizeof(u64))))
           return -EFAULT;
 
      thread t = create_thread(current->p, INVALID_PHYSICAL);
@@ -121,7 +121,7 @@ sysreturn clone3(struct clone_args *args, bytes size)
      if (size < sizeof(*args))
           return -EINVAL;
 
-     if (!validate_user_memory(args, size, false))
+     if (!memory_is_user(args, size))
           return -EFAULT;
 
      context ctx = get_current_context(current_cpu());

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -433,7 +433,7 @@ sysreturn timer_settime(u32 timerid, int flags,
                         struct itimerspec *old_value) {
     /* Linux doesn't validate flags? */
     if (!validate_user_memory(new_value, sizeof(struct itimerspec), false))
-        return -EINVAL;         /* usually EFAULT, but linux gives EINVAL */
+        return -EFAULT;
 
     context ctx = get_current_context(current_cpu());
     if (context_set_err(ctx))

--- a/src/unix/timer.c
+++ b/src/unix/timer.c
@@ -108,7 +108,7 @@ static boolean itimerspec_from_timer(unix_timer ut, struct itimerspec *i)
     if (timer_is_active(&ut->t))
         timer_get_remaining(ut->tq, &ut->t, &remain, &interval);
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(i, sizeof(struct itimerspec), true) || context_set_err(ctx))
+    if (!memory_is_user(i, sizeof(struct itimerspec)) || context_set_err(ctx))
         return false;
     timespec_from_time(&i->it_value, remain);
     timespec_from_time(&i->it_interval, interval);
@@ -176,7 +176,7 @@ sysreturn timerfd_settime(int fd, int flags,
         return -EINVAL;
 
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(new_value, sizeof(struct itimerspec), false) || context_set_err(ctx))
+    if (!memory_is_user(new_value, sizeof(struct itimerspec)) || context_set_err(ctx))
         return -EFAULT;
     timestamp tinit = time_from_timespec(&new_value->it_value);
     timestamp interval = time_from_timespec(&new_value->it_interval);
@@ -432,7 +432,7 @@ sysreturn timer_settime(u32 timerid, int flags,
                         const struct itimerspec *new_value,
                         struct itimerspec *old_value) {
     /* Linux doesn't validate flags? */
-    if (!validate_user_memory(new_value, sizeof(struct itimerspec), false))
+    if (!memory_is_user(new_value, sizeof(struct itimerspec)))
         return -EFAULT;
 
     context ctx = get_current_context(current_cpu());
@@ -640,7 +640,7 @@ sysreturn getitimer(int which, struct itimerval *curr_value)
         return -EINVAL;
     }
 
-    if (!validate_user_memory(curr_value, sizeof(struct itimerval), true))
+    if (!memory_is_user(curr_value, sizeof(struct itimerval)))
         return -EFAULT;
 
     unix_timer ut = vector_get(current->p->itimers, which);

--- a/src/unix/unix.c
+++ b/src/unix/unix.c
@@ -93,7 +93,7 @@ void release_fdesc(fdesc f)
 
 sysreturn user_timeval_get(const struct timeval *tv, timestamp *t)
 {
-    if (!validate_user_memory(tv, sizeof(*tv), false))
+    if (!memory_is_user(tv, sizeof(*tv)))
         return -EFAULT;
     context ctx = get_current_context(current_cpu());
     if (context_set_err(ctx)) {
@@ -106,7 +106,7 @@ sysreturn user_timeval_get(const struct timeval *tv, timestamp *t)
 
 sysreturn user_timespec_get(const struct timespec *ts, timestamp *t)
 {
-    if (!validate_user_memory(ts, sizeof(*ts), false))
+    if (!memory_is_user(ts, sizeof(*ts)))
         return -EFAULT;
     context ctx = get_current_context(current_cpu());
     if (context_set_err(ctx)) {
@@ -119,7 +119,7 @@ sysreturn user_timespec_get(const struct timespec *ts, timestamp *t)
 
 boolean copy_from_user(const void *uaddr, void *kaddr, u64 len)
 {
-    if (!validate_user_memory(uaddr, len, false))
+    if (!memory_is_user(uaddr, len))
         return false;
     context ctx = get_current_context(current_cpu());
     if (!context_set_err(ctx)) {
@@ -132,7 +132,7 @@ boolean copy_from_user(const void *uaddr, void *kaddr, u64 len)
 
 boolean copy_to_user(void *uaddr, const void *kaddr, u64 len)
 {
-    if (!validate_user_memory(uaddr, len, true))
+    if (!memory_is_user(uaddr, len))
         return false;
     context ctx = get_current_context(current_cpu());
     if (!context_set_err(ctx)) {

--- a/src/unix/unix_clock.c
+++ b/src/unix/unix_clock.c
@@ -60,7 +60,7 @@ boolean clockid_get(process p, clockid_t id, boolean timer, clock_id *res, threa
 sysreturn gettimeofday(struct timeval *tv, void *tz)
 {
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(tv, sizeof(struct timeval), true) || context_set_err(ctx))
+    if (!memory_is_user(tv, sizeof(struct timeval)) || context_set_err(ctx))
         return -EFAULT;
     timeval_from_time(tv, now(CLOCK_ID_REALTIME));
     context_clear_err(ctx);
@@ -110,7 +110,7 @@ closure_function(5, 1, sysreturn, nanosleep_bh,
 
 sysreturn nanosleep(const struct timespec *req, struct timespec *rem)
 {
-    if (rem && !validate_user_memory(rem, sizeof(struct timespec), true))
+    if (rem && !memory_is_user(rem, sizeof(struct timespec)))
         return -EFAULT;
 
     timestamp interval;
@@ -127,7 +127,7 @@ sysreturn nanosleep(const struct timespec *req, struct timespec *rem)
 sysreturn clock_nanosleep(clockid_t _clock_id, int flags, const struct timespec *req,
                           struct timespec *rem)
 {
-    if (rem && !validate_user_memory(rem, sizeof(struct timespec), true))
+    if (rem && !memory_is_user(rem, sizeof(struct timespec)))
         return -EFAULT;
 
     /* Report any attempted use of CLOCK_PROCESS_CPUTIME_ID */
@@ -164,7 +164,7 @@ sysreturn sys_time(time_t *tloc)
 sysreturn times(struct tms *buf)
 {
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(buf, sizeof(struct tms), true) || context_set_err(ctx))
+    if (!memory_is_user(buf, sizeof(struct tms)) || context_set_err(ctx))
         return -EFAULT;
     buf->tms_utime = CLOCKS_PER_SEC * proc_utime(current->p) / TIMESTAMP_SECOND;
     buf->tms_stime = CLOCKS_PER_SEC * proc_stime(current->p) / TIMESTAMP_SECOND;
@@ -196,7 +196,7 @@ sysreturn clock_gettime(clockid_t clk_id, struct timespec *tp)
         break;
     }
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(tp, sizeof(struct timespec), true) || context_set_err(ctx))
+    if (!memory_is_user(tp, sizeof(struct timespec)) || context_set_err(ctx))
         return -EFAULT;
     timespec_from_time(tp, t);
     context_clear_err(ctx);
@@ -226,7 +226,7 @@ sysreturn clock_getres(clockid_t clk_id, struct timespec *res)
     if (clockid_get(current->p, clk_id, false, &cid, 0)) {
         if (res) {
             context ctx = get_current_context(current_cpu());
-            if (!validate_user_memory(res, sizeof(*res), true) || context_set_err(ctx))
+            if (!memory_is_user(res, sizeof(*res)) || context_set_err(ctx))
                 return -EFAULT;
             res->tv_sec = 0;
             res->tv_nsec = 1;
@@ -287,7 +287,7 @@ static void adjtime_set_freq(s64 freq)
 static sysreturn adjtimex(struct timex *buf)
 {
     context ctx = get_current_context(current_cpu());
-    if (!validate_user_memory(buf, sizeof(struct timex), true) || context_set_err(ctx))
+    if (!memory_is_user(buf, sizeof(struct timex)) || context_set_err(ctx))
         return -EFAULT;
     int modes = buf->modes;
     boolean nano = !(modes & ADJ_MICRO);

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -741,23 +741,11 @@ boolean fault_in_user_memory(const void *buf, bytes length, boolean writable);
 
 void mmap_process_init(process p, tuple root);
 
-/* This "validation" is just a simple limit check right now, but this
-   could optionally expand to do more rigorous validation (e.g. vmap
-   lookup or page table walk). We may also want to place attributes on
-   user pointer arguments for use with a static analysis tool like
-   Sparse. */
-
-static inline boolean validate_user_memory(const void *p, bytes length, boolean write)
+static inline boolean memory_is_user(const void *p, bytes length)
 {
     u64 v = u64_from_pointer(p);
 
-    if (v < MIN(PAGESIZE, current->p->mmap_min_addr))
-        return false;
-
-    if (length >= USER_LIMIT)
-        return false;
-
-    return v < USER_LIMIT - length;
+    return (v < USER_LIMIT) && (length <= USER_LIMIT) && (v + length <= USER_LIMIT);
 }
 
 static inline u64 grow_and_validate_stack(thread t, u64 sp, u64 size)
@@ -1045,13 +1033,10 @@ void fpreg_copy_out(void *b, thread t);
 
 void syscall_debug(context f);
 
-boolean validate_iovec(struct iovec *iov, u64 len, boolean write);
-
 static inline boolean validate_user_string(const char *name)
 {
     u64 a = u64_from_pointer(name);
-    while (validate_user_memory(pointer_from_u64(a & ~PAGEMASK),
-                                PAGESIZE, false)) {
+    while (memory_is_user(pointer_from_u64(a & ~PAGEMASK), PAGESIZE)) {
         u64 lim = (a & ~PAGEMASK) + PAGESIZE;
         while (a < lim) {
             if (*(u8*)pointer_from_u64(a++) == '\0')
@@ -1079,35 +1064,19 @@ static inline boolean fault_in_user_string(const char *name, sstring *res)
     return false;
 }
 
-static inline boolean iov_to_sg(sg_list sg, struct iovec *iov, int iovlen)
+static inline void iov_to_buf(void *buf, u64 buflen, struct iovec *iov, int iovlen)
 {
     for (int i = 0; i < iovlen; i++) {
-        u64 len = iov[i].iov_len;
-        u64 offset = 0;
-        while (len > 0) {
-            u64 buf_len = MIN(len, U32_MAX & ~PAGEMASK);
-            sg_buf sgb = sg_list_tail_add(sg, buf_len);
-            if (sgb == INVALID_ADDRESS)
-                return false;
-            sgb->buf = iov[i].iov_base + offset;
-            sgb->size = buf_len;
-            sgb->offset = 0;
-            sgb->refcount = 0;
-            len -= buf_len;
-            offset += buf_len;
-        }
-    }
-    return true;
-}
-
-static inline void iov_to_buf(void *buf, struct iovec *iov, int iovlen)
-{
-    for (int i = 0; i < iovlen; i++) {
+        void *base = iov[i].iov_base;
         u64 len = iov[i].iov_len;
         if (len == 0)
             continue;
-        runtime_memcpy(buf, iov[i].iov_base, len);
+        if (!memory_is_user(base, len))
+            page_fault();
+        len = MIN(len, buflen);
+        runtime_memcpy(buf, base, len);
         buf += len;
+        buflen -= len;
     }
 }
 

--- a/src/x86_64/unix_machine.c
+++ b/src/x86_64/unix_machine.c
@@ -202,7 +202,7 @@ void restore_ucontext(struct ucontext * uctx, thread t)
     else
         f[FRAME_CS] &= ~1;
     t->signal_mask = normalize_signal_mask(mcontext->oldmask);
-    if (validate_user_memory(mcontext->fpstate, extended_frame_size, false)) {
+    if (memory_is_user(mcontext->fpstate, extended_frame_size)) {
         context ctx = get_current_context(current_cpu());
         if (context_set_err(ctx))
             return;

--- a/test/runtime/netlink.c
+++ b/test/runtime/netlink.c
@@ -113,6 +113,8 @@ static void test_fault(void)
     socklen_t len;
     struct nlmsghdr nlh;
     uint8_t buf[512];
+    struct msghdr msg;
+    struct iovec iov;
     void *fault_addr = FAULT_ADDR;
 
     fd = socket(PF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
@@ -139,6 +141,21 @@ static void test_fault(void)
     test_assert(write(fd, &nlh, sizeof(nlh)) == sizeof(nlh));
     test_assert(recvfrom(fd, buf, sizeof(buf), 0, (struct sockaddr *)&nladdr, fault_addr) == -1);
     test_assert(errno == EFAULT);
+
+    test_assert(write(fd, &nlh, sizeof(nlh)) == sizeof(nlh));
+    test_assert((recvmsg(fd, fault_addr, 0) == -1) && (errno == EFAULT));
+
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_iov = fault_addr;
+    msg.msg_iovlen = 1;
+    test_assert(write(fd, &nlh, sizeof(nlh)) == sizeof(nlh));
+    test_assert((recvmsg(fd, &msg, 0) == -1) && (errno == EFAULT));
+
+    iov.iov_base = fault_addr;
+    iov.iov_len = sizeof(nlh);
+    msg.msg_iov = &iov;
+    test_assert(write(fd, &nlh, sizeof(nlh)) == sizeof(nlh));
+    test_assert((recvmsg(fd, &msg, 0) == -1) && (errno == EFAULT));
 
     test_assert(close(fd) == 0);
 }

--- a/test/runtime/time.c
+++ b/test/runtime/time.c
@@ -596,10 +596,10 @@ void test_posix_timers(void)
         test_error("timer_gettime with null curr_value should have failed with "
                    "EFAULT (rv %d, errno %d)", rv, errno);
 
-    rv = syscall(SYS_timer_settime, dummy_id, 0, 0, 0);
-    if (rv >= 0 || errno != EINVAL)
-        test_error("timer_settime with null new_value should have failed with "
-                   "EINVAL (rv %d, errno %d)", rv, errno);
+    rv = syscall(SYS_timer_settime, dummy_id, 0, FAULT_ADDR, 0);
+    if (rv >= 0 || errno != EFAULT)
+        test_error("timer_settime with invalid new_value pointer should have failed with "
+                   "EFAULT (rv %d, errno %d)", rv, errno);
 
     if (syscall(SYS_timer_delete, dummy_id) < 0)
         test_perror("timer_delete");

--- a/test/runtime/unixsocket.c
+++ b/test/runtime/unixsocket.c
@@ -42,7 +42,7 @@ static void *uds_stream_server(void *arg)
     ssize_t nbytes, total;
 
     /* on linux, generates SIGPIPE */
-    test_assert(accept(fd, (struct sockaddr *) &addr, NULL) == -1);
+    test_assert(accept(fd, (struct sockaddr *)&addr, FAULT_ADDR1) == -1);
     test_assert(errno == EFAULT);
     client_fd = accept(fd, (struct sockaddr *) &addr, &addr_len);
     test_assert(client_fd >= 0);

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 
 #define FAULT_ADDR  ((void *)0xBADF0000)
+#define FAULT_ADDR1 ((void *)0xFFFFFFFFFFFF0000ull)
 
 #define test_assert(expr) do {                                                          \
     if (!(expr)) {                                                                      \


### PR DESCRIPTION
This change set fixes some TOCTOU vulnerabilities present in code that handles syscalls involving struct iovec arrays.
User memory validation via validate_iovec() and validate_msghdr() is being replaced with validation at the time of use.
In addition, this fixes a double read of the SQE opcode from user memory when handling the io_uring_enter syscall.
To minimize runtime overhead, validate_user_memory() is being replaced with a more lightweight memory_is_user() function
whose only purpose is to ensure that a memory range will fault when accessed if it is not a userspace address range.

Security issues reported by Niklas Femerstrand (@niklasfemerstrand).