### PR TITLE
Implement MADV_DONTNEED

### DIFF
--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -1449,6 +1449,15 @@ sysreturn madvise(void *addr, s64 length, int advice)
     case MADV_NOHUGEPAGE:
         clear_mask = VMAP_FLAG_THP;
         break;
+    case MADV_DONTNEED:
+        zero(addr, pad(length, PAGESIZE));
+        return 0;
+    case MADV_FREE:
+    case MADV_NORMAL:
+    case MADV_RANDOM:
+    case MADV_SEQUENTIAL:
+    case MADV_WILLNEED:
+        return 0;   /* advisory only, safe to ignore */
     default:
         return 0;   /* ignore non-supported advice values */
     }

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -192,6 +192,12 @@ struct flock {
 #define MS_SYNC       4
 
 /* madvise */
+#define MADV_NORMAL          0
+#define MADV_RANDOM          1
+#define MADV_SEQUENTIAL      2
+#define MADV_WILLNEED        3
+#define MADV_DONTNEED        4
+#define MADV_FREE            8
 #define MADV_HUGEPAGE       14
 #define MADV_NOHUGEPAGE     15
 


### PR DESCRIPTION
### Summary

We were seeing consistent crashes in a Go/Fiber service running on Nanos (Azure VMSS) under moderate load (~200–500 requests). The failures showed up across different parts of the runtime and app stack, but all pointed to corrupted heap state.

Current hypothesis: interaction between Go’s GC scavenging behavior and how `madvise(MADV_DONTNEED)` is handled in Nanos leads to reused memory not being zeroed.

---

### Symptoms

Observed four general crash patterns:

- Slice growth failures (`runtime.growslice`)
- GC inconsistencies (`found pointer to free object`)
- Nil / near-nil derefs in fasthttp
- Nil derefs during JSON / reflect decode

The common thread is reads from memory that should have been zeroed but appears to contain stale data.

---

### What we checked

We tried to eliminate the usual sources of corruption:

- **Hardware / DMA**: Canary + guard pages stayed intact  
- **Page aliasing**: No duplicate physical mappings observed  
- **Kernel writing into user memory**: Sentinel pages remained unchanged  

One useful signal: corruption only showed up in **recycled heap spans** (i.e. after GC scavenging), not in freshly allocated or actively referenced memory.

---

### Current understanding

Go’s default behavior on Linux:

1. GC releases memory → calls `madvise(..., MADV_DONTNEED)`
2. OS is expected to discard and zero pages
3. When reused, Go skips zeroing and assumes pages are clean

In Nanos today, `MADV_DONTNEED` appears to return success but does not zero or discard the pages:

```c
default:
    return 0;
```

If that assumption holds, then:

- Pages retain previous contents  
- Go reuses them without zeroing  
- Stale data is interpreted as valid heap objects  

This lines up with the crash patterns we observed.

---

### Mitigation + change

Two things we tried:

- **Application-side toggle**  
  Set:
  ```
  GODEBUG=madvdontneed=0
  ```
  This switches Go to `MADV_FREE`, which makes the runtime zero memory on reuse.

- **Kernel-side change**  
  Added handling for `MADV_DONTNEED` that zeros the affected range to align with expected behavior.

---

### Results

- Before: crashes consistently within ~200–500 requests  
- After: ran ~14k requests without reproducing the issue  

---

### Impact

This likely affects any Go workload on Nanos that:

- Triggers GC scavenging
- Relies on `MADV_DONTNEED` semantics (default since Go 1.16)

We initially hit it on Azure, likely due to higher memory pressure, but nothing here appears provider-specific.

---

### Open questions / feedback

- Does the interpretation of `MADV_DONTNEED` behavior here match expectations?  
- Any concerns with zeroing on the kernel side vs relying on Go runtime behavior?  
- Are there cases where ignoring `MADV_DONTNEED` is intentional and we should handle this differently?  

Looking for confirmation that this explanation and direction make sense.