### PR TITLE
ARM CPU IDs: prioritize info from ACPI over info from device tree

### DIFF
--- a/platform/virt/service.c
+++ b/platform/virt/service.c
@@ -410,7 +410,7 @@ static void platform_dtb_parse(kernel_heaps kh, vector cpu_ids)
                     break;
                 }
             }
-        } else if (!runtime_strcmp(name, ss("cpus"))) {
+        } else if (cpu_ids && !runtime_strcmp(name, ss("cpus"))) {
             u32 cpus_acells, cpus_scells;
             fdt_get_cells(&fdt, &cpus_acells, &cpus_scells);
             fdt_foreach_node(&fdt, node) {
@@ -460,12 +460,13 @@ closure_function(2, 2, void, plat_spcr_handler,
 void init_platform_devices(kernel_heaps kh)
 {
     vector cpu_ids = cpus_init_ids(heap_general(kh));
-    platform_dtb_parse(kh, cpu_ids);
+    /* Prefer retrieving CPU ID info from ACPI if present, because DT CPU nodes might have incorrect
+     * info (as seen on AWS c6g.8xlarge instances). */
+    platform_dtb_parse(kh, init_acpi_tables(kh) ? 0 : cpu_ids);
     /* the device tree blob is never accessed from now on: reclaim the memory where it is located */
     pageheap_add_range(DEVICETREE_BLOB_BASE + kernel_phys_offset,
                       INIT_PAGEMEM - DEVICETREE_BLOB_BASE);
     struct console_driver *console_driver = 0;
-    init_acpi_tables(kh);
     acpi_parse_spcr(stack_closure(plat_spcr_handler, kh, &console_driver));
     if (!console_driver) {
         console_driver = allocate_zero(heap_general(kh), sizeof(*console_driver));

--- a/src/drivers/acpi.c
+++ b/src/drivers/acpi.c
@@ -209,18 +209,19 @@ static ACPI_STATUS acpi_device_handler(ACPI_HANDLE object, u32 nesting_level, vo
     return rv;
 }
 
-void init_acpi_tables(kernel_heaps kh)
+boolean init_acpi_tables(kernel_heaps kh)
 {
     assert(ACPI_SUCCESS(AcpiInitializeSubsystem()));
     ACPI_STATUS rv = AcpiInitializeTables(NULL, 0, true);
     if (ACPI_FAILURE(rv)) {
         acpi_debug("AcpiInitializeTables returned %d", rv);
-        return;
+        return false;
     }
     rv = AcpiLoadTables();
     if (ACPI_FAILURE(rv))
         acpi_debug("AcpiLoadTables returned %d", rv);
     AcpiGetDevices(NULL, acpi_device_handler, NULL, NULL);
+    return !ACPI_FAILURE(rv);
 }
 
 static UINT32 acpi_sleep(void *context)

--- a/src/drivers/acpi.h
+++ b/src/drivers/acpi.h
@@ -158,7 +158,7 @@ closure_type(mcfg_handler, boolean, u64 addr, u16 segment, u8 bus_start, u8 bus_
 closure_type(spcr_handler, void, u8 type, u64 addr);
 
 void init_acpi(kernel_heaps kh);
-void init_acpi_tables(kernel_heaps kh);
+boolean init_acpi_tables(kernel_heaps kh);
 void acpi_save_rsdp(u64 rsdp);
 void acpi_register_irq_handler(int irq, thunk t, sstring name);
 boolean acpi_walk_madt(madt_handler mh);


### PR DESCRIPTION
On AWS c6g.8xlarge instances it has been observed that CPU ID info present in the device tree is inaccurate for 16 out of 32 vCPUs. This prevents proper bringup of secondary cores and results in a boot failure.
With this change, if ACPI is present, CPU info is retrieved from ACPI instead of from the device tree.