### PR TITLE
madvise(): Add support for MADV_DONTNEED

### DIFF
--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1945,9 +1945,10 @@ closure_function(6, 3, boolean, pagecache_unmap_page_nodelocked,
     return true;
 }
 
-closure_function(4, 0, void, pagecache_node_unmap_pages_complete,
-                 buffer, unmap_entries, boolean, shared_mappings, boolean, on_stack, bytes *, remaining)
+closure_function(5, 0, void, pagecache_node_unmap_pages_complete,
+                 pagecache_node, pn, buffer, unmap_entries, boolean, shared_mappings, boolean, on_stack, bytes *, remaining)
 {
+    pagecache_node pn = bound(pn);
     buffer unmap_entries = bound(unmap_entries);
     boolean check_dirty = bound(shared_mappings);
     pagecache_page_entry e;
@@ -1963,7 +1964,6 @@ closure_function(4, 0, void, pagecache_node_unmap_pages_complete,
         pagecache pc = global_pagecache;
         pagecache_page pp = e->pp;
         if (check_dirty && pte_is_dirty(old_pte)) {
-            pagecache_node pn = pp->node;
             pagecache_lock_node(pn);
             boolean success = pagecache_set_dirty(pn, range_lshift(irangel(page_offset(pp), 1),
                                                                    pc->page_order));
@@ -2001,6 +2001,7 @@ closure_function(4, 0, void, pagecache_node_unmap_pages_complete,
         buffer_clear(unmap_entries);
     } else {
         deallocate_buffer(unmap_entries);
+        pagecache_node_unref(pn);
         closure_finish();
     }
 }
@@ -2010,7 +2011,7 @@ static void pagecache_node_unmap_pages_sync(pagecache_node pn, range v, u64 node
 {
     buffer unmap_entries = little_stack_buffer(context_stack_space() / 2);
     bytes remaining;
-    thunk completion = stack_closure(pagecache_node_unmap_pages_complete, unmap_entries,
+    thunk completion = stack_closure(pagecache_node_unmap_pages_complete, pn, unmap_entries,
                                      shared_mappings, true, &remaining);
     boolean done, progress;
     do {
@@ -2050,7 +2051,8 @@ void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node
     buffer unmap_entries = allocate_buffer(h, 512);
     if (unmap_entries == INVALID_ADDRESS)
         return pagecache_node_unmap_pages_sync(pn, v, node_offset, false);
-    thunk completion = closure(h, pagecache_node_unmap_pages_complete, unmap_entries, false, false,
+    thunk completion = closure(h, pagecache_node_unmap_pages_complete, pn, unmap_entries,
+                               false, false,
                                0);
     if (completion == INVALID_ADDRESS) {
         deallocate_buffer(unmap_entries);
@@ -2062,6 +2064,7 @@ void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node
                                     stack_closure(pagecache_unmap_page_nodelocked, pn, v.start,
                                                   node_offset, fe, true, unmap_entries));
     pagecache_unlock_node(pn);
+    pagecache_node_ref(pn); /* reference to be released on completion */
     page_invalidate_sync(fe, completion, !success);
     if (!success)
         pagecache_node_unmap_pages_sync(pn, v, node_offset, false);

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -2032,17 +2032,20 @@ static void pagecache_node_unmap_pages_sync(pagecache_node pn, range v, u64 node
                 node_offset, shared_mappings ? ss("") : ss("no "));
 }
 
-void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node_offset)
+void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node_offset,
+                                boolean del_mappings)
 {
     pagecache_debug("%s: pn %p, v %R, node_offset 0x%lx\n", func_ss, pn, v, node_offset);
-    boolean shared_mappings = false;
-    pagecache_lock_mappings();
-    rangemap_range_lookup(&pn->mappings, v,
-                          stack_closure(pagecache_node_unmap_intersection, pn, v,
-                                        &shared_mappings));
-    pagecache_unlock_mappings();
-    if (shared_mappings)
-        return pagecache_node_unmap_pages_sync(pn, v, node_offset, true);
+    if (del_mappings) {
+        boolean shared_mappings = false;
+        pagecache_lock_mappings();
+        rangemap_range_lookup(&pn->mappings, v,
+                              stack_closure(pagecache_node_unmap_intersection, pn, v,
+                                            &shared_mappings));
+        pagecache_unlock_mappings();
+        if (shared_mappings)
+            return pagecache_node_unmap_pages_sync(pn, v, node_offset, true);
+    }
     heap h = global_pagecache->h;
     buffer unmap_entries = allocate_buffer(h, 512);
     if (unmap_entries == INVALID_ADDRESS)

--- a/src/kernel/pagecache.h
+++ b/src/kernel/pagecache.h
@@ -53,7 +53,8 @@ void pagecache_get_page(pagecache_node pn, u64 node_offset, boolean private,
 void *pagecache_get_page_if_filled(pagecache_node pn, u64 node_offset, boolean private);
 void pagecache_release_page(pagecache_node pn, u64 node_offset);
 
-void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node_offset);
+void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node_offset,
+                                boolean del_mappings);
 
 pagecache_volume pagecache_allocate_volume(u64 length, int block_order);
 void pagecache_dealloc_volume(pagecache_volume pv);

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -1129,7 +1129,7 @@ closure_function(3, 1, boolean, vmap_remove_intersection,
     return true;
 }
 
-static void vmap_unmap_page_range(process p, vmap k)
+static void vmap_unmap_page_range(process p, vmap k, boolean del_mappings)
 {
     range r = k->node.r;
     int type = k->flags & VMAP_MMAP_TYPE_MASK;
@@ -1139,7 +1139,7 @@ static void vmap_unmap_page_range(process p, vmap k)
         unmap_and_free_phys(r.start, len);
         break;
     case VMAP_MMAP_TYPE_FILEBACKED:
-        pagecache_node_unmap_pages(k->cache_node, r, k->node_offset);
+        pagecache_node_unmap_pages(k->cache_node, r, k->node_offset, del_mappings);
         break;
     case VMAP_MMAP_TYPE_CUSTOM:
         unmap(r.start, len);
@@ -1151,7 +1151,7 @@ closure_function(1, 1, boolean, vmap_unmap,
                  process, p,
                  vmap v)
 {
-    vmap_unmap_page_range(bound(p), v);
+    vmap_unmap_page_range(bound(p), v, true);
     return true;
 }
 
@@ -1183,7 +1183,7 @@ void truncate_file_maps(process p, fsfile f, u64 new_length)
         u64 node_offset = vm->node_offset + (v.start - n->r.start);
         pf_debug("%s: vmap %p, %R, delta 0x%lx, remove v %R, node_offset 0x%lx\n",
                  func_ss, vm, n->r, delta, v, node_offset);
-        pagecache_node_unmap_pages(pn, v, node_offset);
+        pagecache_node_unmap_pages(pn, v, node_offset, false);
     }
     vmap_unlock(p);
 }

--- a/src/unix/mmap.c
+++ b/src/unix/mmap.c
@@ -361,6 +361,9 @@ static status demand_page_internal(process p, context ctx, u64 vaddr, vmap vm, p
             anonymous = false;
             break;
         default:
+            if (!vm->fault)
+                return timm("result", "no fault handler for vaddr 0x%lx, flags 0x%x",
+                            vaddr, vm->flags);
             return vm->fault(p, ctx, vaddr, vm, pf);
         }
     } else if (vm->flags & VMAP_FLAG_PROG) {
@@ -1443,6 +1446,8 @@ sysreturn madvise(void *addr, s64 length, int advice)
         return -EINVAL;
     u32 clear_mask = 0, set_mask = 0;
     switch (advice) {
+    case MADV_DONTNEED:
+        break;
     case MADV_HUGEPAGE:
         set_mask = VMAP_FLAG_THP;
         break;
@@ -1463,7 +1468,15 @@ sysreturn madvise(void *addr, s64 length, int advice)
     if (res == RM_MATCH) {
         while (range_span(q)) {
             vmap vm = (vmap)rangemap_lookup(vmaps, q.start);
-            vmap_update_flags_intersection(vmaps, q, clear_mask, set_mask, vm);
+            if (advice == MADV_DONTNEED) {
+                range ri = range_intersection(q, vm->node.r);
+                struct vmap k;
+                alter_vmap_key(&k, vm, vm->flags, ri.start - vm->node.r.start);
+                k.node.r = ri;
+                vmap_unmap_page_range(p, &k, false);
+            } else {
+                vmap_update_flags_intersection(vmaps, q, clear_mask, set_mask, vm);
+            }
             q.start = MIN(q.end, vm->node.r.end);
         }
         rv = 0;

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -192,6 +192,7 @@ struct flock {
 #define MS_SYNC       4
 
 /* madvise */
+#define MADV_DONTNEED       4
 #define MADV_HUGEPAGE       14
 #define MADV_NOHUGEPAGE     15
 

--- a/test/runtime/mmap.c
+++ b/test/runtime/mmap.c
@@ -1603,6 +1603,42 @@ static void thp_test(void)
            elapsed.tv_sec, elapsed.tv_nsec, (1000000000ull / MB) * map_len / ns);
 }
 
+static void madv_dontneed_test(void)
+{
+    size_t map_len = 4 * KB;
+
+    /* anonymous mapping */
+    u8 *addr = mmap(NULL, map_len, PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    test_assert(addr != MAP_FAILED);
+    addr[0] = 1;                                                /* fault in page */
+    test_assert(madvise(addr, map_len, MADV_DONTNEED) == 0);    /* discard page */
+    test_assert(addr[0] == 0);                                  /* fault back in page */
+    munmap(addr, map_len);
+
+    /* file-backed mapping */
+    int fd = open("madv_test", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    test_assert(fd >= 0);
+    test_assert(ftruncate(fd, map_len) == 0);
+
+    addr = mmap(NULL, map_len, PROT_WRITE, MAP_SHARED, fd, 0);
+    test_assert(addr != MAP_FAILED);
+    addr[0] = 1;                                                /* fault in page */
+    test_assert(fsync(fd) == 0);                                /* save page to file */
+    test_assert(madvise(addr, map_len, MADV_DONTNEED) == 0);    /* discard page */
+    test_assert(addr[0] == 1);                                  /* fault back in page */
+    munmap(addr, map_len);
+
+    addr = mmap(NULL, map_len, PROT_WRITE, MAP_PRIVATE, fd, 0);
+    test_assert(addr != MAP_FAILED);
+    addr[0] = 0;                                                /* fault in page */
+    test_assert(madvise(addr, map_len, MADV_DONTNEED) == 0);    /* discard page */
+    test_assert(addr[0] == 1);                                  /* fault back in page */
+    munmap(addr, map_len);
+
+    close(fd);
+    test_assert(unlink("madv_test") == 0);
+}
+
 static void madvise_test(void)
 {
     size_t map_len = 2 * PAGESIZE;
@@ -1616,6 +1652,7 @@ static void madvise_test(void)
     munmap(addr + map_len / 2, map_len / 2);
 
     thp_test();
+    madv_dontneed_test();
 }
 
 int main(int argc, char * argv[])


### PR DESCRIPTION
The MADV_DONTNEED argument to madvise() instructs the kernel to discard the specified pages, i.e. on next access the kernel should provide fresh zero-filled pages (for anonymous mappings).
The current madvise() implementation silently ignores MADV_DONTNEED (returns 0 without acting), which means that the pages retain their old contents. This can cause heap corruption and crashes in Go programs running under default settings (since Go 1.16), because Go's runtime depends on MADV_DONTNEED to zero pages.
To fix this issue, properly implement MADV_DONTNEED; for completeness, implement it for all mapping types (anonymous, file-backed, and custom). Since this functionality allows the user program to remove pages from custom mappings for which there may not be a custom fault handler (such as io_uring mappings), add a check for a non-NULL fault handler in order to properly handle (with SIGBUS) any subsequent access to removed pages.