### PR TITLE
Read-only filesystem fixes

### DIFF
--- a/src/fs/fs.c
+++ b/src/fs/fs.c
@@ -106,32 +106,36 @@ timestamp filesystem_get_mtime(filesystem fs, tuple t)
     return filesystem_get_time(fs, t, sym(mtime));
 }
 
-static inline void filesystem_set_time(filesystem fs, tuple t, symbol s,
+static inline int filesystem_set_time(filesystem fs, tuple t, symbol s,
         timestamp tim)
 {
+    if (fs->ro)
+        return -EROFS;
     timestamp cur_time = 0;
     value time_val = get(t, s);
     if (time_val) {
         u64_from_value(time_val, &cur_time);
     }
     if (tim != cur_time) {
+        value new_time_val = value_from_u64(tim);
+        if (new_time_val == INVALID_ADDRESS)
+            return -ENOMEM;
+        set(t, s, new_time_val);
         if (time_val) {
             deallocate_value(time_val);
         }
-        time_val = value_from_u64(tim);
-        assert(time_val);
-        set(t, s, time_val);
     }
+    return 0;
 }
 
-void filesystem_set_atime(filesystem fs, tuple t, timestamp tim)
+int filesystem_set_atime(filesystem fs, tuple t, timestamp tim)
 {
-    filesystem_set_time(fs, t, sym(atime), tim);
+    return filesystem_set_time(fs, t, sym(atime), tim);
 }
 
-void filesystem_set_mtime(filesystem fs, tuple t, timestamp tim)
+int filesystem_set_mtime(filesystem fs, tuple t, timestamp tim)
 {
-    filesystem_set_time(fs, t, sym(mtime), tim);
+    return filesystem_set_time(fs, t, sym(mtime), tim);
 }
 
 u64 filesystem_get_rdev(filesystem fs, tuple t)

--- a/src/fs/fs.h
+++ b/src/fs/fs.h
@@ -30,8 +30,8 @@ void filesystem_release(filesystem fs);
 
 timestamp filesystem_get_atime(filesystem fs, tuple t);
 timestamp filesystem_get_mtime(filesystem fs, tuple t);
-void filesystem_set_atime(filesystem fs, tuple t, timestamp tim);
-void filesystem_set_mtime(filesystem fs, tuple t, timestamp tim);
+int filesystem_set_atime(filesystem fs, tuple t, timestamp tim);
+int filesystem_set_mtime(filesystem fs, tuple t, timestamp tim);
 
 #define filesystem_update_atime(fs, t) \
     filesystem_set_atime(fs, t, now(CLOCK_ID_REALTIME))

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -655,6 +655,8 @@ static sysreturn xattr_check(filesystem fs, const char *name, sstring *name_ss)
 static sysreturn setxattr_internal(filesystem fs, tuple n, const char *name,
                                    const void *val, u64 size, int flags)
 {
+    if (fs->ro)
+        return -EROFS;
     sstring attr_name;
     sysreturn rv = xattr_check(fs, name, &attr_name);
     if (rv)

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -326,8 +326,9 @@ static sysreturn utime_internal(const char *filename, timestamp actime,
     filesystem cwd_fs = fs;
     sysreturn rv = filesystem_get_node(&fs, cwd, filename_ss, FS_NODE_FOLLOW, &t, 0, 0);
     if (rv == 0) {
-        filesystem_set_atime(fs, t, actime);
-        filesystem_set_mtime(fs, t, modtime);
+        rv = filesystem_set_atime(fs, t, actime);
+        if (rv == 0)
+            rv = filesystem_set_mtime(fs, t, modtime);
         filesystem_put_node(fs, t);
     }
     filesystem_release(cwd_fs);
@@ -428,9 +429,9 @@ sysreturn utimensat(int dirfd, const char *filename, const struct timespec times
     }
     if (rv == 0) {
         if (atime != infinity)
-            filesystem_set_atime(fs, t, atime);
-        if (mtime != infinity)
-            filesystem_set_mtime(fs, t, mtime);
+            rv = filesystem_set_atime(fs, t, atime);
+        if ((rv == 0) && (mtime != infinity))
+            rv = filesystem_set_mtime(fs, t, mtime);
         if (filename) {
             filesystem_put_node(fs, t);
             filesystem_release(cwd_fs);


### PR DESCRIPTION
This change set makes the utime and setxattr families of syscalls (which modify file metadata) fail when invoked on a read-only filesystem.

Issue reported by Niklas Femerstrand (@niklasfemerstrand).