### PR TITLE
aarch64: enable DC ZVA from EL0 (set SCTLR_EL1.DZE)

### DIFF
--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -161,6 +161,7 @@
 #define SCTLR_EL1_nTWE    U64_FROM_BIT(18) /* no trap on WFE */
 #define SCTLR_EL1_nTWI    U64_FROM_BIT(16) /* no trap on WFI */
 #define SCTLR_EL1_UCT     U64_FROM_BIT(15) /* no trap on CTR_EL0 access */
+#define SCTLR_EL1_DZE     U64_FROM_BIT(14) /* no trap on DC ZVA / DC GVA / DC GZVA from EL0 */
 #define SCTLR_EL1_I       U64_FROM_BIT(12) /* instruction cacheability (no effect) */
 #define SCTLR_EL1_CP15BEN U64_FROM_BIT(5) /* memory barrier enable from EL0 */
 #define SCTLR_EL1_SA0     U64_FROM_BIT(4) /* SP alignment fault enable for EL0 */

--- a/src/aarch64/page.c
+++ b/src/aarch64/page.c
@@ -119,6 +119,7 @@ void enable_mmu(u64 vtarget)
                  SCTLR_EL1_nTWI |
                  SCTLR_EL1_UCI |
                  SCTLR_EL1_UCT |
+                 SCTLR_EL1_DZE |
                  SCTLR_EL1_I |
                  SCTLR_EL1_C |
                  SCTLR_EL1_M);


### PR DESCRIPTION
The DC ZVA / DC GVA / DC GZVA instructions are used by JIT/GC runtimes (e.g. HotSpot's block zeroing with -XX:+UseBlockZeroing) to clear memory blocks efficiently. With SCTLR_EL1.DZE = 0 (the architectural reset value), any attempt to execute these from EL0 traps to EL1 with ESR_EL1.EC = 0x18 (System instruction trap), which the kernel delivers to user space as SIGILL.

Additionally, with DZE = 0, a read of DCZID_EL0.DZP from EL0 returns 1, indicating to user space that the instructions are prohibited.

This breaks applications such as Eclipse Temurin JRE on arm64, which use these instructions in their GC fast path.

Set SCTLR_EL1.DZE during kernel bring-up so these instructions are permitted at EL0 and DCZID_EL0.DZP reads as 0, matching the Linux behaviour on arm64.

Reference: ARM ARM, SCTLR_EL1.DZE (bit 14); DC ZVA pseudocode.

Fixes: #2126