### PR TITLE
netsock getsockopt: implement TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT, SO_INCOMING_NAPI_ID

### DIFF
--- a/klib/tun.c
+++ b/klib/tun.c
@@ -222,6 +222,7 @@ closure_func_basic(file_io, sysreturn, tun_write,
     } while (q);
     context_clear_err(ctx);
     struct netif *n = &tun->ndev.n;
+    p->napi_id = net_get_napi_id(n->num, 0);
     n->input(p, n);
     if (!(tun->flags & IFF_NO_PI))
         len += sizeof(struct tun_pi);

--- a/platform/pc/linker_script
+++ b/platform/pc/linker_script
@@ -48,6 +48,8 @@ SECTIONS
     {
         ro_after_init_start = .;
         *(.ro_after_init)
+        *(.got.plt)
+        *(.got)
         . = ALIGN(4096);
         ro_after_init_end = .;
         *(.data)

--- a/src/aws/ena/ena_datapath.c
+++ b/src/aws/ena/ena_datapath.c
@@ -30,6 +30,7 @@
 
 #include <kernel.h>
 #include <lwip.h>
+#include <net/net.h>
 #include <pci.h>
 
 #include "ena.h"
@@ -420,6 +421,7 @@ static int ena_rx_cleanup(struct ena_ring *rx_ring)
 
         rx_ring->rx_stats.bytes += mbuf->tot_len;
         adapter->hw_stats.rx_bytes += mbuf->tot_len;
+        mbuf->napi_id = net_get_napi_id(ifp->num, qid);
 
         ena_trace(NULL, ENA_DBG | ENA_RXPTH, "calling if_input() with mbuf %p\n", mbuf);
         (*ifp->input)(mbuf, ifp);

--- a/src/drivers/gve.c
+++ b/src/drivers/gve.c
@@ -1,6 +1,7 @@
 #include <kernel.h>
 #include <lwip.h>
 #include <lwip/prot/tcp.h>
+#include <net/net.h>
 #include <netif/ethernet.h>
 #include <pci.h>
 
@@ -569,6 +570,7 @@ closure_func_basic(thunk, void, gve_rx_service)
                 continue;
             }
         }
+        p->napi_id = net_get_napi_id(net_if->num, 0);
         err_t err = net_if->input(p, net_if);
         if (err != ERR_OK)
             pbuf_free(p);

--- a/src/hyperv/netvsc/netvsc.c
+++ b/src/hyperv/netvsc/netvsc.c
@@ -8,6 +8,7 @@
 #include <lwip/stats.h>
 #include <lwip/snmp.h>
 #include <lwip/etharp.h>
+#include <net/net.h>
 #include <netif/ethernet.h>
 #include "hv_net_vsc.h"
 #include "hv_rndis.h"
@@ -402,6 +403,7 @@ netvsc_recv(struct hv_device *device_ctx, netvsc_packet *packet)
             vaddr + packet->page_buffers[i].gpa_ofs);
     }
 
+    x->p.pbuf.napi_id = net_get_napi_id(n->num, 0);
     err_enum_t err = n->input((struct pbuf *)x, n);
     if (err != ERR_OK) {
         msg_err("netvsc: rx drop by stack, err %d", err);

--- a/src/net/lwipopts.h
+++ b/src/net/lwipopts.h
@@ -56,6 +56,9 @@
 /* Must be a type on which atomic operations are supported by the CPU. */
 #define LWIP_PBUF_REF_T u32_t
 
+#define LWIP_PBUF_CUSTOM_DATA   \
+    int napi_id;    \
+
 #define LWIP_CHKSUM_ALGORITHM   3
 
 #define LWIP_WND_SCALE 1

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -1,6 +1,15 @@
 #define NET 1
 #define NET_SYSCALLS 1
 
+#define NET_NAPI_ID_MAGIC       0xAD000000
+#define NET_NAPI_ID_MAGIC_MASK  0xFF000000
+#define NET_NAPI_ID_IFACE_SHIFT 16
+
 void init_net(kernel_heaps kh);
 void init_network_iface(tuple root, merge m);
 status listen_port(heap h, u16 port, connection_handler c);
+
+static inline int net_get_napi_id(u8 iface_id, u16 queue_id)
+{
+    return (NET_NAPI_ID_MAGIC | ((u32)iface_id << NET_NAPI_ID_IFACE_SHIFT) | queue_id);
+}

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -85,6 +85,7 @@ typedef struct netsock {
     struct sock sock;             /* must be first */
     process p;
     queue incoming;
+    int napi_id;
     err_t lwip_error;             /* lwIP error code; ERR_OK if normal */
     u8 ipv6only:1;
     union {
@@ -430,6 +431,14 @@ static void netsock_tcp_close(netsock s, struct tcp_pcb *tcp_lw)
         s->info.tcp.state = TCP_SOCK_UNDEFINED;
     }
     netsock_unlock(s);
+}
+
+static void netsock_set_napi_id(netsock s, struct pbuf *p)
+{
+    int id = p->napi_id;
+
+    if ((id & NET_NAPI_ID_MAGIC_MASK) == NET_NAPI_ID_MAGIC)
+        s->napi_id = id;
 }
 
 static inline s64 lwip_to_errno(s8 err)
@@ -1368,6 +1377,7 @@ static void udp_input_lower(void *z, struct udp_pcb *pcb, struct pbuf *p,
 	e->rport = port;
 	assert(enqueue(s->incoming, e));
 	s->sock.rx_len += p->tot_len;
+	netsock_set_napi_id(s, p);
 	wakeup_sock(s, WAKEUP_SOCK_RX);
     } else {
 	msg_err("%s error: null pbuf", func_ss);
@@ -1395,6 +1405,7 @@ static int allocate_sock(process p, int af, int type, u32 flags, boolean alloc_f
     s->sock.f.events = init_closure_func(&s->events, fdesc_events, socket_events);
     s->sock.f.ioctl = init_closure_func(&s->ioctl, fdesc_ioctl, netsock_ioctl);
     s->p = p;
+    s->napi_id = 0;
 
     s->incoming = allocate_queue(h, SOCK_QUEUE_LEN);
     if (s->incoming == INVALID_ADDRESS) {
@@ -1545,6 +1556,7 @@ static err_t tcp_input_lower(void *z, struct tcp_pcb *pcb, struct pbuf *p, err_t
             return ERR_BUF;     /* XXX verify */
         }
         s->sock.rx_len += p->tot_len;
+        netsock_set_napi_id(s, p);
     }
     wakeup_sock(s, WAKEUP_SOCK_RX);
 
@@ -2739,6 +2751,9 @@ static sysreturn netsock_getsockopt(struct sock *sock, int level,
             break;
         case SO_DOMAIN:
             ret_optval.val = s->sock.domain;
+            break;
+        case SO_INCOMING_NAPI_ID:
+            ret_optval.val = s->napi_id;
             break;
         default:
             goto unimplemented;

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -2784,6 +2784,15 @@ static sysreturn netsock_getsockopt(struct sock *sock, int level,
             runtime_memcpy(ret_optval.str, TCP_CONG_CTRL_ALGO, sizeof(TCP_CONG_CTRL_ALGO));
             ret_optlen = sizeof(ret_optval.str);
             break;
+        case TCP_KEEPIDLE:
+            ret_optval.val = TCP_KEEPIDLE_DEFAULT / THOUSAND;
+            break;
+        case TCP_KEEPINTVL:
+            ret_optval.val = TCP_KEEPINTVL_DEFAULT / THOUSAND;
+            break;
+        case TCP_KEEPCNT:
+            ret_optval.val = TCP_KEEPCNT_DEFAULT;
+            break;
         case TCP_CORK:
         case TCP_DEFER_ACCEPT:
         case TCP_QUICKACK:

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -865,6 +865,7 @@ struct io_uring_params {
 #define SO_ACCEPTCONN   30
 #define SO_PROTOCOL     38
 #define SO_DOMAIN       39
+#define SO_INCOMING_NAPI_ID 56
 
 #define IP_TOS              1
 #define IP_TTL              2

--- a/src/virtio/virtio_net.c
+++ b/src/virtio/virtio_net.c
@@ -43,6 +43,7 @@
 #include "lwip/dhcp.h"
 #include "lwip/inet_chksum.h"
 #include "lwip/timeouts.h"
+#include "net/net.h"
 #include "netif/ethernet.h"
 #include "virtio_internal.h"
 #include "virtio_mmio.h"
@@ -64,6 +65,7 @@
 typedef struct vnet_rx {
     virtqueue q;
     u32 seqno;
+    u16 idx;
     struct virtio_net_hdr_mrg_rxbuf *hdr;
 } *vnet_rx;
 
@@ -279,8 +281,10 @@ closure_func_basic(vqfinish, void, vnet_input,
             err = true;
         }
     }
-    if (!err)
+    if (!err) {
+        x->p.pbuf.napi_id = net_get_napi_id(vn->ndev.n.num, rx->idx);
         err = (vn->ndev.n.input(&x->p.pbuf, &vn->ndev.n) != ERR_OK);
+    }
   out:
     if (err)
         receive_buffer_release(&x->p.pbuf);
@@ -466,6 +470,7 @@ closure_func_basic(netif_dev_setup, boolean, virtio_net_setup,
         rx[i].q = vq;
         rx[i].seqno = 0;
         rx[i].hdr = 0;
+        rx[i].idx = i;
         rxq_entries += virtqueue_entries(vq);
         vq_index++;
         s = virtio_alloc_vq_aff(dev, ss("virtio net tx"), vq_index, cpu_affinity, &vq);

--- a/src/vmware/vmxnet3_net.c
+++ b/src/vmware/vmxnet3_net.c
@@ -9,6 +9,7 @@
 #include "lwip/ethip6.h"
 #include "lwip/etharp.h"
 #include "lwip/dhcp.h"
+#include <net/net.h>
 #include <pci.h>
 #include "netif/ethernet.h"
 #include "vmware.h"
@@ -251,6 +252,7 @@ closure_function(1, 0, void, vmxnet3_rx_service_bh,
             xpbuf rxb = struct_from_list(i, xpbuf, l);
             list_delete(i);
             struct netif *n = &vn->ndev.n;
+            rxb->p.pbuf.napi_id = net_get_napi_id(n->num, 0);
             err_enum_t err = n->input((struct pbuf *)rxb, n);
             if (err != ERR_OK) {
                 msg_err("vmxnet3: rx drop by stack, err %d", err);

--- a/src/xen/xennet.c
+++ b/src/xen/xennet.c
@@ -16,6 +16,7 @@
 #include "lwip/pbuf.h"
 #include "lwip/etharp.h"
 #include "lwip/snmp.h"
+#include "net/net.h"
 #include "netif/ethernet.h"
 
 #undef memset                   /* ugh, lwIP */
@@ -634,6 +635,7 @@ closure_function(1, 0, void, xennet_rx_service_bh,
             xennet_rx_buf rxb = struct_from_list(i, xennet_rx_buf, l);
             list_delete(i);
             struct netif *n = &xd->ndev.n;
+            rxb->p.pbuf.napi_id = net_get_napi_id(n->num, 0);
             err_enum_t err = n->input((struct pbuf *)&rxb->p, n);
             if (err != ERR_OK) {
                 msg_err("xennet: rx drop by stack, err %d", err);

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -136,6 +136,7 @@ func testPackages(t *testing.T) {
 		{name: "go", dir: "go", request: "http://0.0.0.0:8080", elf: "main", prebuild: goPrebuild},
 		{name: "rust", dir: "rust", request: "http://0.0.0.0:8080", elf: "main", prebuild: rustPrebuild, nocross: true},
 	}
+	numCPU := runtime.GOMAXPROCS(0)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.skip {
@@ -163,9 +164,9 @@ func testPackages(t *testing.T) {
 				tt.prebuild(t)
 			}
 			if tt.elf != "" {
-				execcmd = fmt.Sprintf("ops run %s -c config.json --smp %d", tt.elf, runtime.NumCPU())
+				execcmd = fmt.Sprintf("ops run %s -c config.json --smp %d", tt.elf, numCPU)
 			} else {
-				execcmd = fmt.Sprintf("ops pkg load %s -c config.json --smp %d", tt.pkg, runtime.NumCPU())
+				execcmd = fmt.Sprintf("ops pkg load %s -c config.json --smp %d", tt.pkg, numCPU)
 			}
 			timeout := 120 * time.Second
 			if tt.request != "" {

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,3 +1,3 @@
 module e2e
 
-go 1.13
+go 1.25

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -70,6 +70,8 @@ static void *netsock_test_basic_thread(void *arg)
     struct sockaddr_in addr;
     uint8_t rx_buf[8 * KB];
     int rx;
+    int val;
+    socklen_t len = sizeof(val);
 
     fd = socket(AF_INET, sock_type, 0);
     test_assert(fd > 0);
@@ -81,6 +83,9 @@ static void *netsock_test_basic_thread(void *arg)
         rx = read(fd, rx_buf, sizeof(rx_buf));
         test_assert(rx >= 0);
     } while (rx > 0);
+    /* packets received from the loopback interface have a NAPI ID set to 0 */
+    test_assert(getsockopt(fd, SOL_SOCKET, SO_INCOMING_NAPI_ID, &val, &len) == 0);
+    test_assert((len == sizeof(val)) && (val == 0));
     test_assert(close(fd) == 0);
     if (sock_type == SOCK_STREAM) {
         /* Create a new connection to the server, to test resource deallocation for the new

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -156,6 +156,9 @@ static void netsock_test_basic(int sock_type)
 
         test_assert(getsockopt(tx_fd, SOL_SOCKET, SO_ACCEPTCONN, &val, &len) == 0 && val == 0);
         test_assert(getsockopt(tx_fd, IPPROTO_TCP, TCP_MAXSEG, &val, &len) == 0 && val > 0);
+        test_assert(getsockopt(tx_fd, IPPROTO_TCP, TCP_KEEPIDLE, &val, &len) == 0 && val > 0);
+        test_assert(getsockopt(tx_fd, IPPROTO_TCP, TCP_KEEPINTVL, &val, &len) == 0 && val > 0);
+        test_assert(getsockopt(tx_fd, IPPROTO_TCP, TCP_KEEPCNT, &val, &len) == 0 && val > 0);
     } else {
         netsock_toggle_and_check_sockopt(fd, SOL_SOCKET, SO_BROADCAST, 1);
         netsock_toggle_and_check_sockopt(fd, SOL_SOCKET, SO_BROADCAST, 0);


### PR DESCRIPTION
The TCP_KEEP* socket options allow retrieving the parameters used by the TCP/IP stack to implement TCP keepalive.
The value of the SO_INCOMING_NAPI_ID option is a system-level unique ID called NAPI ID that is associated with a RX queue on which the last packet associated with a socket has been received. This feature is useful for performance tuning and workload steering.
Closes #2130.

The first 2 commits are fixes for unrelated issues that have been observed when testing these new features.