### PR TITLE
fix(linker): make virt linker script compatible with LLD

### DIFF
--- a/platform/virt/linker_script
+++ b/platform/virt/linker_script
@@ -4,6 +4,14 @@ ENTRY(_start)
 
 INCLUDE klib-syms.lds
 
+PHDRS
+{
+        text PT_LOAD FLAGS(5);          /* R E */
+        rodata PT_LOAD FLAGS(4);        /* R   */
+        data PT_LOAD FLAGS(6);          /* RW  */
+        dynamic PT_DYNAMIC FLAGS(4);    /* R   */
+}
+
 SECTIONS
 {
         /* 0x40000000 - 0x401fffff: dtb
@@ -14,22 +22,14 @@ SECTIONS
         START = .;
 
         text_start = .;
-	.text :
-	{
-       	    *(.text)
-            *(.text.*)
-            . = ALIGN(4096);
-	}
+	.text : { *(.text) *(.text.*) . = ALIGN(4096); } :text
 	text_end = .;
 
-        .rodata :
-        {
-            *(.rodata)
-            *(.rodata.*)
-            *(.dynamic)
-            _DYNSYM = .;
-            *(.dynsym)
-        }
+        .rodata : { *(.rodata) *(.rodata.*) } :rodata
+
+        .dynamic : { *(.dynamic) } :rodata :dynamic
+
+        .dynsym : { _DYNSYM = .; *(.dynsym) } :rodata
 
         . = ALIGN(4096);
         READONLY_END = .;
@@ -42,7 +42,7 @@ SECTIONS
             ro_after_init_end = .;
             *(.data)
             *(.data.*)
-        }
+        } :data
 
         .bss ALIGN(4096):
         {
@@ -54,7 +54,7 @@ SECTIONS
             *(.bss)
             *(.bss.*)
             *(COMMON)
-        }
+        } :data
         . = ALIGN(4096);
         PROVIDE(bss_end = .);
 


### PR DESCRIPTION
## Summary

- Split `.dynamic` and `.dynsym` out of `.rodata` into their own output sections to fix section type mismatch errors with LLD
- Add explicit `PHDRS` with correct permissions (R+E for text, R for rodata, RW for data)
- Assign sections to segments to eliminate RWX permission warnings

## Problem

The original linker script merged `SHT_DYNAMIC` and `SHT_DYNSYM` sections into the `SHT_PROGBITS` `.rodata` output section. GNU ld silently accepts this type mismatch, but LLD (used by Zig, Rust, and modern LLVM toolchains) rejects it:

```
ld.lld: error: section type mismatch for .dynamic
>>> <internal>:(.dynamic): SHT_DYNAMIC
>>> output section .rodata: SHT_PROGBITS
```

## Solution

Give `.dynamic` and `.dynsym` their own output sections while keeping them in the read-only segment. The kernel only reads these at early init for PIE relocation (`elf_dyn_relocate` in `init.c`), so they don't need write permissions.

## Test plan

- [x] GNU ld (`aarch64-elf-ld`): links with zero warnings
- [x] LLD (`zig ld.lld`): links with zero warnings, no `--noinhibit-exec` needed
- [x] GNU ld kernel boots, runs Python hello world on QEMU aarch64
- [x] LLD kernel boots, runs Python hello world on QEMU aarch64
- [x] `make kernel` succeeds with no changes to Makefile

🤖 Generated with [Claude Code](https://claude.com/claude-code)