### PR TITLE
firewall: Add support for retrieving blacklisted IP addresses from Radar

### DIFF
--- a/klib/firewall.c
+++ b/klib/firewall.c
@@ -596,6 +596,20 @@ static void firewall_destroy_rule(heap h, firewall_rule rule)
     deallocate(h, rule, sizeof(*rule));
 }
 
+static boolean firewall_rules_init(heap h, value rules)
+{
+    if (!is_composite(rules)) {
+        msg_err("firewall: invalid rules");
+        return false;
+    }
+    value rule_spec;
+    for (int i = 0; (rule_spec = get(rules, integer_key(i))); i++) {
+        if (!firewall_create_rule(h, rule_spec))
+            return false;
+    }
+    return true;
+}
+
 int init(status_handler complete)
 {
     tuple config = get(get_root_tuple(), sym(firewall));
@@ -605,20 +619,11 @@ int init(status_handler complete)
         msg_err("firewall: invalid configuration");
         return KLIB_INIT_FAILED;
     }
-    value rules = get(config, sym(rules));
-    if (!rules)
-        return KLIB_INIT_OK;
-    if (!is_composite(rules)) {
-        msg_err("firewall: invalid rules");
-        return KLIB_INIT_FAILED;
-    }
     list_init(&firewall.rules);
-    value rule_spec;
     heap h = heap_locked(get_kernel_heaps());
-    for (int i = 0; (rule_spec = get(rules, integer_key(i))); i++) {
-        if (!firewall_create_rule(h, rule_spec))
-            goto err_dealloc_rules;
-    }
+    value rules = get(config, sym_this("rules"));
+    if (rules && !firewall_rules_init(h, rules))
+        goto err_dealloc_rules;
     if (!list_empty(&firewall.rules))
         net_ip_input_filter = firewall_filter;
     return KLIB_INIT_OK;

--- a/klib/firewall.c
+++ b/klib/firewall.c
@@ -1,6 +1,7 @@
 #include <kernel.h>
 #include <lwip.h>
 #include <lwip/prot/tcp.h>
+#include <radar.h>
 
 typedef struct firewall_rule {
     struct list l;
@@ -36,6 +37,15 @@ typedef struct firewall_constraint_buf {
     u64 len;    /* expressed in number of bits */
     u8 buf[0];
 } *firewall_constraint_buf;
+
+typedef struct fw_radar {
+    heap h;
+    struct buffer url;
+    closure_struct(value_handler, resp_handler);
+    struct timer retry_timer;
+    closure_struct(timer_handler, retry_func);
+    timestamp retry_backoff;
+}*fw_radar;
 
 static struct firewall {
     struct list rules;
@@ -610,6 +620,165 @@ static boolean firewall_rules_init(heap h, value rules)
     return true;
 }
 
+static boolean firewall_block_ip(heap h, sstring ip)
+{
+    ip_addr_t addr;
+    boolean ipv6;
+    if (ip4addr_aton(ip, &addr.u_addr.ip4)) {
+        ipv6 = false;
+    } else if (ip6addr_aton(ip, &addr.u_addr.ip6)) {
+        ipv6 = true;
+    } else {
+        msg_err("firewall: invalid IP address '%s'", ip);
+        return false;
+    }
+    firewall_rule rule = allocate(h, sizeof(*rule));
+    if (rule == INVALID_ADDRESS) {
+        msg_err("firewall: cannot allocate rule");
+        return false;
+    }
+    rule->l3_match = allocate_vector(h, 1);
+    if (rule->l3_match == INVALID_ADDRESS) {
+        msg_err("firewall: cannot allocate rule");
+        deallocate(h, rule, sizeof(*rule));
+        return false;
+    }
+    u64 byte_count = (ipv6 ? sizeof(ip6_addr_t) : sizeof(ip4_addr_t));
+    firewall_constraint_buf c = allocate(h, sizeof(*c) + byte_count);
+    if (c == INVALID_ADDRESS) {
+        msg_err("firewall: cannot allocate rule");
+        deallocate_vector(rule->l3_match);
+        deallocate(h, rule, sizeof(*rule));
+        return false;
+    }
+    rule->ip_version = ipv6 ? 6 : 4;
+    rule->l4_proto = 0;
+    rule->l4_match = 0;
+    c->c.type = FW_L3_SRC;
+    c->c.equals = true;
+    c->len = byte_count * 8;
+    runtime_memcpy(&c->buf, &addr, byte_count);
+    vector_push(rule->l3_match, c);
+    rule->drop = true;
+    list_push_back(&firewall.rules, &rule->l);
+    return true;
+}
+
+static void fw_radar_retry(fw_radar fwr)
+{
+    register_timer(kernel_timers, &fwr->retry_timer, CLOCK_ID_MONOTONIC, fwr->retry_backoff, false,
+                   0, (timer_handler)&fwr->retry_func);
+    if (fwr->retry_backoff < seconds(600))
+        fwr->retry_backoff <<= 1;
+}
+
+closure_func_basic(value_handler, void, fw_radar_handler,
+                   value v)
+{
+    fw_radar fwr = struct_from_closure(fw_radar, resp_handler);
+    if (!v) {
+        if (fwr->retry_backoff > seconds(2))
+            msg_err("firewall: cannot get rules from radar");
+        fw_radar_retry(fwr);
+        return;
+    }
+    value status_line = get(v, sym_this("start_line"));
+    buffer body = get(v, sym_this("content"));
+    if (!status_line || !body) {
+        msg_err("firewall: invalid response from radar");
+        goto done;
+    }
+    buffer status_code = get(status_line, integer_key(1));
+    if (!status_code || buffer_strcmp(status_code, "200")) {
+        msg_err("firewall: unexpected response from radar: %v", status_line);
+        goto done;
+    }
+    heap h = fwr->h;
+    while (buffer_length(body) > 0) {
+        /* skip leading whitespace/newlines */
+        char c = peek_char(body);
+        if (c == ' ' || c == '\r' || c == '\n' || c == '\t') {
+            buffer_consume(body, 1);
+            continue;
+        }
+
+        char *ptr = buffer_ref(body, 0);
+        bytes len = 0;
+        while (len < buffer_length(body)) {
+            char next = ptr[len];
+            if (next == '\n' || next == '\r' || next == ' ' || next == '\t')
+                break;
+            len++;
+        }
+        if (len > 0) {
+            if (!firewall_block_ip(h, isstring(ptr, len)))
+                break;
+            buffer_consume(body, len);
+        }
+    }
+    if (!list_empty(&firewall.rules))
+        net_ip_input_filter = firewall_filter;
+  done:
+    deallocate(fwr->h, fwr, sizeof(*fwr));
+}
+
+closure_func_basic(timer_handler, void, fw_radar_get,
+                   timestamp expiry, u64 overruns)
+{
+    if (overruns == timer_disabled)
+        return;
+    fw_radar fwr = struct_from_closure(fw_radar, retry_func);
+    status s = radar_get(&fwr->url,
+                         init_closure_func(&fwr->resp_handler, value_handler, fw_radar_handler));
+    if (!is_ok(s)) {
+        if (fwr->retry_backoff > seconds(2))
+            msg_err("firewall: cannot get rules from radar: %v", s);
+        timm_dealloc(s);
+        fw_radar_retry(fwr);
+    }
+}
+
+static boolean firewall_radar_init(heap h)
+{
+    fw_radar fwr = allocate(h, sizeof(*fwr));
+    if (fwr == INVALID_ADDRESS) {
+        msg_err("firewall: cannot allocate radar struct");
+        return false;
+    }
+    fwr->h = h;
+    buffer_init_from_string(&fwr->url, "/api/v1/threats");
+    init_timer(&fwr->retry_timer);
+    fwr->retry_backoff = seconds(1);
+    apply(init_closure_func(&fwr->retry_func, timer_handler, fw_radar_get), 0, 0);
+    return true;
+}
+
+static boolean firewall_rule_src_init(heap h, value src)
+{
+    if (is_string(src)) {
+        if (!buffer_strcmp(src, "radar"))
+            return firewall_radar_init(h);
+    }
+    msg_err("firewall: invalid dynamic rule source %v", src);
+    return false;
+}
+
+static boolean firewall_dyn_rules_init(heap h, value dyn_rules)
+{
+    if (!is_composite(dyn_rules)) {
+        msg_err("firewall: invalid dynamic rules");
+        return false;
+    }
+    if (get(dyn_rules, integer_key(1))) {
+        msg_err("firewall: only a single source of dynamic rules is supported");
+        return false;
+    }
+    value rule_src = get(dyn_rules, integer_key(0));
+    if (!rule_src)
+        return true;
+    return firewall_rule_src_init(h, rule_src);
+}
+
 int init(status_handler complete)
 {
     tuple config = get(get_root_tuple(), sym(firewall));
@@ -623,6 +792,9 @@ int init(status_handler complete)
     heap h = heap_locked(get_kernel_heaps());
     value rules = get(config, sym_this("rules"));
     if (rules && !firewall_rules_init(h, rules))
+        goto err_dealloc_rules;
+    value dyn_rules = get(config, sym_this("dynamic_rules"));
+    if (dyn_rules && !firewall_dyn_rules_init(h, dyn_rules))
         goto err_dealloc_rules;
     if (!list_empty(&firewall.rules))
         net_ip_input_filter = firewall_filter;

--- a/klib/klib.mk
+++ b/klib/klib.mk
@@ -49,6 +49,7 @@ SRCS-ntp= \
 	$(KLIB_DIR)/ntp.c \
 
 SRCS-radar= \
+	$(KLIB_DIR)/net_utils.c \
 	$(KLIB_DIR)/radar.c \
 
 SRCS-sandbox= \

--- a/klib/net_utils.c
+++ b/klib/net_utils.c
@@ -53,7 +53,7 @@ static void net_http_dns_cb(sstring hostname, const ip_addr_t *addr, void *callb
         if (!success)
             timm_dealloc(s);
     } else {
-        success = true;
+        success = false;
     }
     if (!success)
         net_http_dealloc(req_data);

--- a/klib/radar.c
+++ b/klib/radar.c
@@ -1,9 +1,9 @@
 #include <kernel.h>
-#include <http.h>
 #include <lwip.h>
 #include <pagecache.h>
 #include <storage.h>
 #include <fs.h>
+#include <net_utils.h>
 #include <tls.h>
 
 #define RADAR_HOSTNAME  "radar.relayered.net"
@@ -431,6 +431,24 @@ closure_func_basic(status_handler, void, klog_dump_loaded,
     } else
         timm_dealloc(s);
     closure_finish();
+}
+
+status radar_get(string url, value_handler handler)
+{
+    struct net_http_req_params p;
+    p.host = ss(RADAR_HOSTNAME);
+    p.port = RADAR_PORT;
+    p.tls = true;
+    p.method = HTTP_REQUEST_METHOD_GET;
+    p.req = allocate_tuple();
+    if (p.req == INVALID_ADDRESS)
+        return timm_oom;
+    set(p.req, sym(url), url);
+    if (telemetry.auth_header)
+        set(p.req, sym(RADAR-KEY), telemetry.auth_header);
+    p.body = 0;
+    p.resp_handler = handler;
+    return net_http_req(&p);
 }
 
 int init(status_handler complete)

--- a/klib/radar.h
+++ b/klib/radar.h
@@ -1,0 +1,6 @@
+#ifndef RADAR_H_
+#define RADAR_H_
+
+status radar_get(string url, value_handler handler);
+
+#endif

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -10,16 +10,23 @@
 #define STATE_HEADER 2
 #define STATE_VALUE 3
 #define STATE_BODY 4
+#define STATE_CHUNK_SIZE        5
+#define STATE_CHUNK_EXTENSION   6
+#define STATE_CHUNK_DATA        7
+#define STATE_CHUNK_CRLF        8
+#define STATE_CHUNK_FINAL_CRLF  9
 
 typedef struct http_parser {
     heap h;
     vector start_line;
     int state;
+    boolean chunked;
     buffer word;
     symbol s;
     tuple header;
     value_handler each;
     u64 content_length;
+    buffer body;
 } *http_parser;
 
 struct http_responder {
@@ -171,16 +178,20 @@ status send_http_response(http_responder out, tuple t, buffer c)
 static void reset_parser(http_parser p)
 {
     p->state = STATE_INIT;
+    p->chunked = false;
     p->header = allocate_tuple();
     p->word = allocate_buffer(p->h, 10);
     p->start_line = allocate_tagged_vector(3);
     p->content_length = 0;
+    p->body = 0;
 }
 
 static void cleanup_parser(http_parser p)
 {
     if (p->word != INVALID_ADDRESS)
         deallocate_buffer(p->word);
+    if (p->body)
+        deallocate_buffer(p->body);
     destruct_value(p->header, true);
 }
 
@@ -240,7 +251,16 @@ closure_function(1, 1, status, http_recv,
                 buffer_clear(p->word);
                 break;
             case '\n':
-                p->state = STATE_BODY;
+                if (p->chunked) {
+                    p->state = STATE_CHUNK_SIZE;
+                    p->body = allocate_buffer(p->h, KB);
+                    if (p->body == INVALID_ADDRESS)
+                        return timm_oom;
+                } else {
+                    p->state = STATE_BODY;
+                    p->body = p->word;
+                    p->word = INVALID_ADDRESS;
+                }
                 break;
             case '\r':
             case ':':
@@ -258,6 +278,9 @@ closure_function(1, 1, status, http_recv,
 
                     /* unconsume the bytes consumed by parse_int() */
                     p->word->start = 0;
+                } else if (p->s == sym(Transfer-Encoding)) {
+                    if (!buffer_compare_with_sstring_ci(p->word, ss("chunked")))
+                        p->chunked = true;
                 }
                 set(p->header, p->s, p->word);
                 p->word = allocate_buffer(p->h, 0);                
@@ -269,21 +292,61 @@ closure_function(1, 1, status, http_recv,
             break;
             
         case STATE_BODY:
-            push_u8(p->word, x);            
+            push_u8(p->body, x);
             --p->content_length;
+            break;
+
+        case STATE_CHUNK_SIZE:
+            switch (x) {
+            case ';':
+            case '\r':
+                if (!parse_int(p->word, 16, &p->content_length))
+                    msg_err("%s: failed to parse chunk size", func_ss);
+                buffer_clear(p->word);
+                if (x == '\r')
+                    p->state = STATE_CHUNK_EXTENSION;
+                break;
+            case '\n':
+                p->state = (p->content_length > 0) ? STATE_CHUNK_DATA : STATE_CHUNK_FINAL_CRLF;
+                break;
+            default:
+                push_u8(p->word, x);
+            }
+            break;
+
+        case STATE_CHUNK_EXTENSION:
+            if (x == '\n')
+                p->state = (p->content_length > 0) ? STATE_CHUNK_DATA : STATE_CHUNK_FINAL_CRLF;
+            break;
+
+        case STATE_CHUNK_DATA:
+            push_u8(p->body, x);
+            if (--p->content_length == 0)
+                p->state = STATE_CHUNK_CRLF;
+            break;
+
+        case STATE_CHUNK_CRLF:
+            if (x == '\n')
+                p->state = STATE_CHUNK_SIZE;
+            break;
+
+        case STATE_CHUNK_FINAL_CRLF:
+            if (x == '\n')
+                goto content_finish;
+            break;
         }
 
         if ((p->state == STATE_BODY) && (p->content_length == 0))
             goto content_finish;
     }
-    if ((p->state != STATE_BODY) || (p->content_length != 0))
+    if ((p->state != STATE_BODY && p->state != STATE_CHUNK_FINAL_CRLF) || (p->content_length != 0))
         /* Incomplete HTTP message; parsing can continue when the next packet arrives. */
         return STATUS_OK;
 
   content_finish:
     set(p->header, sym(start_line), p->start_line);
-    set(p->header, sym(content), p->word);
-    p->word = INVALID_ADDRESS;
+    set(p->header, sym(content), p->body);
+    p->body = 0;
     apply(p->each, p->header);
     if (b) {
         cleanup_parser(p);

--- a/src/net/net.c
+++ b/src/net/net.c
@@ -11,7 +11,7 @@
 #define IFF_MULTICAST   (1 << 12)
 
 BSS_RO_AFTER_INIT static heap lwip_heap;
-BSS_RO_AFTER_INIT int (*net_ip_input_filter)(struct pbuf *pbuf, struct netif *input_netif);
+int (*net_ip_input_filter)(struct pbuf *pbuf, struct netif *input_netif);
 
 typedef struct net_complete {
     struct list l;


### PR DESCRIPTION
This change set adds support for a "dynamic_rules" attribute in the "firewall" configuration tuple: this attribute contains an array of sources for firewall rules that are retrieved dynamically (as opposed to hard-coding the rules in the configuration manifest).

The first type of dynamic rule sources being supported is "radar", which allows retrieving from the Radar server a list of IP addresses to be blocked (requires a Radar API key).

Example Ops configuration snippet that specifies the Radar source for
firewall rules:
```
  "ManifestPassthrough": {
    "firewall": {
      "dynamic_rules":["radar"]
    }
  },
  "Env": {
    "RADAR_KEY": "my_radar_api_key"
  }
```

As part of these changes, the internal HTTP client implementation has been enhanced to support receiving data with chunked transfer encoding. This removes a previous limitation on the ability of the cloud_init klib to download files from some servers.