### PR TITLE
JVM aarch64: advertise the full safe HWCAP feature set via AT_HWCAP

### DIFF
--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -130,14 +130,61 @@
 #define ESR_ISS_SERROR_INT_DFSC_UNCAT 0
 #define ESR_ISS_SERROR_INT_DFSC_ASYNC 0x11
 
+/* ID_AA64ISAR0_EL1 feature fields (each 4 bits; 0 = absent, >=1 = present). */
+#define ID_AA64ISAR0_EL1_AES_BITS           4
+#define ID_AA64ISAR0_EL1_AES_SHIFT          4
+#define ID_AA64ISAR0_EL1_AES_PMULL          2   /* >= this also has PMULL/PMULL2 */
+#define ID_AA64ISAR0_EL1_SHA1_BITS          4
+#define ID_AA64ISAR0_EL1_SHA1_SHIFT         8
+#define ID_AA64ISAR0_EL1_SHA2_BITS          4
+#define ID_AA64ISAR0_EL1_SHA2_SHIFT         12
+#define ID_AA64ISAR0_EL1_SHA2_SHA512        2   /* >= this also has SHA512H/H2/SU0/SU1 */
+#define ID_AA64ISAR0_EL1_CRC32_BITS         4
+#define ID_AA64ISAR0_EL1_CRC32_SHIFT        16
 #define ID_AA64ISAR0_EL1_ATOMIC_BITS        4
 #define ID_AA64ISAR0_EL1_ATOMIC_SHIFT       20
 #define ID_AA64ISAR0_EL1_ATOMIC_IMPLEMENTED 2
+#define ID_AA64ISAR0_EL1_RDM_BITS           4
+#define ID_AA64ISAR0_EL1_RDM_SHIFT          28
+#define ID_AA64ISAR0_EL1_SHA3_BITS          4
+#define ID_AA64ISAR0_EL1_SHA3_SHIFT         32
+#define ID_AA64ISAR0_EL1_SM3_BITS           4
+#define ID_AA64ISAR0_EL1_SM3_SHIFT          36
+#define ID_AA64ISAR0_EL1_SM4_BITS           4
+#define ID_AA64ISAR0_EL1_SM4_SHIFT          40
+#define ID_AA64ISAR0_EL1_DP_BITS            4
+#define ID_AA64ISAR0_EL1_DP_SHIFT           44
+#define ID_AA64ISAR0_EL1_FHM_BITS           4
+#define ID_AA64ISAR0_EL1_FHM_SHIFT          48
+#define ID_AA64ISAR0_EL1_TS_BITS            4
+#define ID_AA64ISAR0_EL1_TS_SHIFT           52
+#define ID_AA64ISAR0_EL1_RNDR_BITS          4
+#define ID_AA64ISAR0_EL1_RNDR_SHIFT         60
+#define ID_AA64ISAR0_EL1_RNDR_IMPLEMENTED   1 /* RNDR, RNDRRS MSRs */
 
-#define ID_AA64ISAR0_EL1_RNDR_BITS        4
-#define ID_AA64ISAR0_EL1_RNDR_SHIFT       60
-#define ID_AA64ISAR0_EL1_RNDR_IMPLEMENTED 1 /* RNDR, RNDRRS MSRs */
+/* ID_AA64ISAR1_EL1 feature fields (each 4 bits; 0 = absent, >=1 = present). */
+#define ID_AA64ISAR1_EL1_DPB_BITS       4
+#define ID_AA64ISAR1_EL1_DPB_SHIFT      0
+#define ID_AA64ISAR1_EL1_JSCVT_BITS     4
+#define ID_AA64ISAR1_EL1_JSCVT_SHIFT    12
+#define ID_AA64ISAR1_EL1_FCMA_BITS      4
+#define ID_AA64ISAR1_EL1_FCMA_SHIFT     16
+#define ID_AA64ISAR1_EL1_LRCPC_BITS     4
+#define ID_AA64ISAR1_EL1_LRCPC_SHIFT    20
+#define ID_AA64ISAR1_EL1_LRCPC_ILRCPC   2   /* >= this also has LDAPR immediate offset */
+#define ID_AA64ISAR1_EL1_SB_BITS        4
+#define ID_AA64ISAR1_EL1_SB_SHIFT       36
 
+/* ID_AA64PFR0_EL1 FP / AdvSIMD fields (signed): 0 = implemented, 1 = also
+   half-precision, 0xf = not implemented. */
+#define ID_AA64PFR0_EL1_FP_BITS         4
+#define ID_AA64PFR0_EL1_FP_SHIFT        16
+#define ID_AA64PFR0_EL1_FP_NI           0xf
+#define ID_AA64PFR0_EL1_FP_FP16         1
+#define ID_AA64PFR0_EL1_ADVSIMD_BITS    4
+#define ID_AA64PFR0_EL1_ADVSIMD_SHIFT   20
+#define ID_AA64PFR0_EL1_ADVSIMD_NI      0xf
+#define ID_AA64PFR0_EL1_ADVSIMD_FP16    1
 #define ID_AA64PFR0_EL1_GIC_BITS                4
 #define ID_AA64PFR0_EL1_GIC_SHIFT               24
 #define ID_AA64PFR0_EL1_GIC_GICC_SYSREG_NONE    0

--- a/src/aarch64/unix_machine.h
+++ b/src/aarch64/unix_machine.h
@@ -162,13 +162,98 @@ static inline void thread_frame_restore_tls(context_frame f)
     }
 }
 
-/* We currently only check for the atomic feature as it is the only one used
-   to generate the necessary dynamic library search paths */
+/* AT_HWCAP bit positions (Linux arm64 ABI).  We advertise only EL0-safe
+   features whose register state survives a context switch; SVE is excluded as
+   its state is not saved. */
+#define HWCAP_FP        (1 << 0)
+#define HWCAP_ASIMD     (1 << 1)
+#define HWCAP_AES       (1 << 3)
+#define HWCAP_PMULL     (1 << 4)
+#define HWCAP_SHA1      (1 << 5)
+#define HWCAP_SHA2      (1 << 6)
+#define HWCAP_CRC32     (1 << 7)
 #define HWCAP_ATOMICS   (1 << 8)
+#define HWCAP_FPHP      (1 << 9)
+#define HWCAP_ASIMDHP   (1 << 10)
+#define HWCAP_ASIMDRDM  (1 << 12)
+#define HWCAP_JSCVT     (1 << 13)
+#define HWCAP_FCMA      (1 << 14)
+#define HWCAP_LRCPC     (1 << 15)
+#define HWCAP_DCPOP     (1 << 16)
+#define HWCAP_SHA3      (1 << 17)
+#define HWCAP_SM3       (1 << 18)
+#define HWCAP_SM4       (1 << 19)
+#define HWCAP_ASIMDDP   (1 << 20)
+#define HWCAP_SHA512    (1 << 21)
+#define HWCAP_ASIMDFHM  (1 << 23)
+#define HWCAP_ILRCPC    (1 << 26)
+#define HWCAP_FLAGM     (1 << 27)
+#define HWCAP_SB        (1 << 29)
+
 static inline u64 get_cpu_capabilities(void)
 {
-    if (field_from_u64(read_psr(ID_AA64ISAR0_EL1), ID_AA64ISAR0_EL1_ATOMIC)
-        == ID_AA64ISAR0_EL1_ATOMIC_IMPLEMENTED)
-        return HWCAP_ATOMICS;
-    return 0;
+    u64 isar0 = read_psr(ID_AA64ISAR0_EL1);
+    u64 isar1 = read_psr(ID_AA64ISAR1_EL1);
+    u64 pfr0 = read_psr(ID_AA64PFR0_EL1);
+    u64 caps = 0;
+
+    u64 fp = field_from_u64(pfr0, ID_AA64PFR0_EL1_FP);
+    if (fp != ID_AA64PFR0_EL1_FP_NI) {
+        caps |= HWCAP_FP;
+        if (fp == ID_AA64PFR0_EL1_FP_FP16)
+            caps |= HWCAP_FPHP;
+    }
+    u64 simd = field_from_u64(pfr0, ID_AA64PFR0_EL1_ADVSIMD);
+    if (simd != ID_AA64PFR0_EL1_ADVSIMD_NI) {
+        caps |= HWCAP_ASIMD;
+        if (simd == ID_AA64PFR0_EL1_ADVSIMD_FP16)
+            caps |= HWCAP_ASIMDHP;
+    }
+
+    u64 aes = field_from_u64(isar0, ID_AA64ISAR0_EL1_AES);
+    if (aes != 0)
+        caps |= HWCAP_AES;
+    if (aes >= ID_AA64ISAR0_EL1_AES_PMULL)
+        caps |= HWCAP_PMULL;
+    if (field_from_u64(isar0, ID_AA64ISAR0_EL1_SHA1) != 0)
+        caps |= HWCAP_SHA1;
+    u64 sha2 = field_from_u64(isar0, ID_AA64ISAR0_EL1_SHA2);
+    if (sha2 != 0)
+        caps |= HWCAP_SHA2;
+    if (sha2 >= ID_AA64ISAR0_EL1_SHA2_SHA512)
+        caps |= HWCAP_SHA512;
+    if (field_from_u64(isar0, ID_AA64ISAR0_EL1_CRC32) != 0)
+        caps |= HWCAP_CRC32;
+    if (field_from_u64(isar0, ID_AA64ISAR0_EL1_ATOMIC) >= ID_AA64ISAR0_EL1_ATOMIC_IMPLEMENTED)
+        caps |= HWCAP_ATOMICS;
+    if (field_from_u64(isar0, ID_AA64ISAR0_EL1_RDM) != 0)
+        caps |= HWCAP_ASIMDRDM;
+    if (field_from_u64(isar0, ID_AA64ISAR0_EL1_SHA3) != 0)
+        caps |= HWCAP_SHA3;
+    if (field_from_u64(isar0, ID_AA64ISAR0_EL1_SM3) != 0)
+        caps |= HWCAP_SM3;
+    if (field_from_u64(isar0, ID_AA64ISAR0_EL1_SM4) != 0)
+        caps |= HWCAP_SM4;
+    if (field_from_u64(isar0, ID_AA64ISAR0_EL1_DP) != 0)
+        caps |= HWCAP_ASIMDDP;
+    if (field_from_u64(isar0, ID_AA64ISAR0_EL1_FHM) != 0)
+        caps |= HWCAP_ASIMDFHM;
+    if (field_from_u64(isar0, ID_AA64ISAR0_EL1_TS) != 0)
+        caps |= HWCAP_FLAGM;
+
+    if (field_from_u64(isar1, ID_AA64ISAR1_EL1_DPB) != 0)
+        caps |= HWCAP_DCPOP;
+    if (field_from_u64(isar1, ID_AA64ISAR1_EL1_JSCVT) != 0)
+        caps |= HWCAP_JSCVT;
+    if (field_from_u64(isar1, ID_AA64ISAR1_EL1_FCMA) != 0)
+        caps |= HWCAP_FCMA;
+    u64 lrcpc = field_from_u64(isar1, ID_AA64ISAR1_EL1_LRCPC);
+    if (lrcpc != 0)
+        caps |= HWCAP_LRCPC;
+    if (lrcpc >= ID_AA64ISAR1_EL1_LRCPC_ILRCPC)
+        caps |= HWCAP_ILRCPC;
+    if (field_from_u64(isar1, ID_AA64ISAR1_EL1_SB) != 0)
+        caps |= HWCAP_SB;
+
+    return caps;
 }


### PR DESCRIPTION
# aarch64: advertise the full safe HWCAP feature set via AT_HWCAP

Hi maintainers,

this change came out of run a JVM on arm64 under nanos. Running a
Temurin workload I noticed HotSpot was leaving *all* of its hardware crypto
(AES-GCM, SHA, CRC32) disabled even on a core that clearly supports it; tracing
why led straight to `AT_HWCAP` carrying a single bit. Since on arm64 that vector
is where a runtime reads the CPU's feature set, it seemed worth exposing the
full safe set — so the idea and the patch both grew directly out of that JVM
experiment. Happy to adjust anything to your taste.

## Summary

The JVM in particular reads its arm64 crypto/SIMD capability bits from
`getauxval(AT_HWCAP)`/`HWCAP2`. nanos currently advertises a single bit there
(`HWCAP_ATOMICS`, `src/aarch64/unix_machine.h`), so as things stand many of the
core's units — AES, SHA, CRC32, the AdvSIMD-gated crypto paths — simply go
unused by Java workloads, even on hardware that has them.

This PR lets nanos light up the rest of the CPU: `get_cpu_capabilities()` now
derives the full **safe** HWCAP mask from the real ID registers, so a guest can
actually use the hardware it is running on.

## How arm64 feature detection works, and where nanos sits

On x86 the JVM  read `CPUID`/`XGETBV` directly and never rely on the
kernel for feature detection. arm64 is different by design: the discovery
registers live at EL1, and the kernel projects them to userspace through
`AT_HWCAP`. So on arm64 the JVM has no way of its own to find out what the CPU
supports — it takes whatever `getauxval(AT_HWCAP)` returns and enables its
hardware code paths from that alone. That makes nanos the one component
positioned to expose the CPU's capabilities, and a natural place to do it, since
the values come straight from the ID registers nanos already reads.

See https://github.com/openjdk/jdk/blob/master/src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp#L140

The JVM (HotSpot) is the clearest example: its arm64 crypto/SIMD capability bits
come from `getauxval(AT_HWCAP)`/`HWCAP2` (`vm_version_linux_aarch64.cpp`) — it
consults `/proc/cpuinfo` only for core identity — and OpenJ9's OMR reads the same
vector. Whatever the vector omits, the JVM treats as absent and never uses — so
today, with one bit, all of its crypto/CRC/post-quantum intrinsics stay off. The
richer the HWCAP, the more of those hardware paths it turns on.
It is not JVM-specific: other runtimes and crypto libraries key their hardware
paths off the same vector (see below).

## What the patch does

`get_cpu_capabilities()` reads `ID_AA64ISAR0_EL1`, `ID_AA64ISAR1_EL1` and
`ID_AA64PFR0_EL1` and sets each HWCAP bit **from the real field value** — never
hardcoded, so a core that lacks a feature never sees it advertised. The shape
mirrors the existing x86 `get_hwcap2()` (`src/x86_64/unix_machine.h`): an
accumulator plus one `if (field) caps |= HWCAP_x`. Field values that carry
sub-levels (AES→PMULL, SHA2→SHA512, LRCPC→LRCPC2, FP/AdvSIMD sentinel + fp16)
use named constants added next to their `_SHIFT`/`_BITS` in
`src/aarch64/kernel_machine.h`.

## Safety: we advertise only what nanos truly supports

The single rule: **advertise a feature only if (a) its instructions run at EL0
without trapping and (b) any register state it touches is preserved across a
context switch.** Every bit set here satisfies both.

- **FP / AdvSIMD execute at EL0.** `CPACR_EL1.FPEN = NO_TRAP` is set in
  `crt0.S`, so V0–V31 / FPSR / FPCR are directly usable by userspace. The
  crypto/CRC/dotprod/fp16 instructions all operate on these same V registers.
- **That state is saved and restored on context switch.**
  `frame_save_fpsimd` / `frame_restore_fpsimd` (`src/aarch64/crt0.S:248,274`)
  `stp`/`ldp` **q0–q31** plus `fpsr`/`fpcr` into the extended frame
  (`FRAME_Q0..Q31`, `FRAME_FPSR`, `FRAME_FPCR` in `src/aarch64/frame.h`), driven
  by `thread_frame_save/restore_fpsimd` (`src/aarch64/unix_machine.h`). A thread
  that uses AES/SHA/NEON therefore cannot corrupt another thread's V registers.
- **DC CVAP (DCPOP)** is permitted at EL0 (`SCTLR_EL1.UCI`, `src/kernel/page.c`)
  — advertised.

**Deliberately NOT advertised**, precisely because they would break the rule:

- **SVE / SVE2.** The Z/P/FFR registers are *not* in the exception frame (it
  holds only q0–q31), so advertising SVE would let two threads silently corrupt
  each other's vector state. Left off until that state is saved (out of scope).
  This is the direct arm64 analogue of leaving AVX-512 out of XCR0 on x86.
- **Pointer authentication** (needs key setup), **EL0 access to ID registers**
  (traps here), **RNDR** (`MRS` may trap). Same "only what we support" rule.

Because the safe set is exactly the V0-31 / FPSR / FPCR block the frame already
saves, this needs no new save/restore logic and no new trap handling — it just
reports state nanos was already preserving.

## What this lets the JVM exploit

With only `HWCAP_ATOMICS`, HotSpot cannot see these units and leaves the
corresponding intrinsics off. Each is gated on a specific HWCAP bit this patch
now advertises, so all of them become available (measured with
`-XX:+PrintFlagsFinal` on Temurin 25 inside nanos). The mapping is one-to-one —
every flag traces back to a bit derived from a real ID-register field:

**AES / GCM (SIMD crypto unit) — `HWCAP_AES`, `HWCAP_PMULL`**
- `UseAES`, `UseAESIntrinsics`, `UseAESCTRIntrinsics`
- `UseGHASHIntrinsics` (PMULL/PMULL2, GCM authentication)

**SHA (SIMD crypto unit) — `HWCAP_SHA1`, `HWCAP_SHA2`, `HWCAP_SHA512`**
- `UseSHA`, `UseSHA1Intrinsics`, `UseSHA256Intrinsics`, `UseSHA512Intrinsics`

**CRC32 (scalar CRC unit, non-SIMD) — `HWCAP_CRC32`**
- `UseCRC32` — the hardware `crc32*` instructions; without the bit it is
  software-only
- `UseCRC32CIntrinsics`

**AdvSIMD-gated, JDK 21+ post-quantum & stream ciphers — `HWCAP_ASIMD`**
- `UseChaCha20Intrinsics`
- `UseKyberIntrinsics` (ML-KEM), `UseDilithiumIntrinsics` (ML-DSA)

For accuracy: the general auto-vectorizer (`UseSuperWord`,
`UseSIMDForArrayEquals`, vectorized `hashCode`, `MaxVectorSize=16`) is already
enabled on stock nanos and is unchanged — NEON codegen is gated on
`MaxVectorSize`, not on these HWCAP bits. Two further crypto flags
(`UseSHA3Intrinsics`, `UseCryptoPmullForCRC32`) still stay off because they are
gated on CPU *identity* rather than HWCAP (HotSpot enables them only for
specific cores); exposing that is a separate `/proc/cpuinfo` follow-up.

## What every arm64 guest gains

The capability is process-wide, so the upside is broad rather than niche:

- **TLS / crypto throughput** — AES-GCM and SHA use the dedicated crypto units
  instead of scalar code: HTTPS servers, gRPC, message brokers, anything doing
  TLS.
- **Checksums** — hardware CRC32/CRC32C: Kafka, Cassandra, Hadoop, zlib/gzip
  paths, any framed protocol.
- **Post-quantum & stream ciphers** (JDK 21+) — ChaCha20-Poly1305, ML-KEM,
  ML-DSA come on.

The JVM is  the consumer that makes the capability most visible; the
kernel-side change is language-agnostic and benefits any of the above running
as a nanos unikernel.

## Notes for reviewers

- arm64-only; no behavioural change on x86_64 or riscv64.
- Vector width is unaffected: `MaxVectorSize` stays 16 (128-bit NEON). This
  patch does not touch SVE, so the JVM's Vector API stays at 128-bit exactly as
  before.
- The `0x00:0x0:0x000:0` core identity seen in `-Xlog:os+cpu` is a separate
  matter (no synthesized `/proc/cpuinfo`), orthogonal to feature advertisement.