### PR TITLE
jvm aarch64: synthesize /proc/cpuinfo with the real core identity enable internal jvm tuning

### DIFF
--- a/src/aarch64/kernel_machine.h
+++ b/src/aarch64/kernel_machine.h
@@ -191,6 +191,16 @@
 #define ID_AA64PFR0_EL1_GIC_GICC_SYSREG_3_0_4_0 1
 #define ID_AA64PFR0_EL1_GIC_GICC_SYSREG_4_1     3
 
+/* MIDR_EL1 identity fields. */
+#define MIDR_EL1_REVISION_BITS      4
+#define MIDR_EL1_REVISION_SHIFT     0
+#define MIDR_EL1_PARTNUM_BITS       12
+#define MIDR_EL1_PARTNUM_SHIFT      4
+#define MIDR_EL1_VARIANT_BITS       4
+#define MIDR_EL1_VARIANT_SHIFT      20
+#define MIDR_EL1_IMPLEMENTER_BITS   8
+#define MIDR_EL1_IMPLEMENTER_SHIFT  24
+
 #define MPIDR_AFF3(mpidr)   (((mpidr) >> 32) & 0xff)
 #define MPIDR_AFF2(mpidr)   (((mpidr) >> 16) & 0xff)
 #define MPIDR_AFF1(mpidr)   (((mpidr) >> 8) & 0xff)

--- a/src/unix/special.c
+++ b/src/unix/special.c
@@ -207,10 +207,48 @@ static u32 cpu_online_events(file f)
     return (EPOLLIN | EPOLLOUT);
 }
 
+#ifdef __aarch64__
+static sysreturn cpuinfo_read(file f, void *dest, u64 length, u64 offset)
+{
+    /* The processors are homogeneous, so the identity read from MIDR_EL1 on the
+       current CPU applies to every online CPU. The architecture field is
+       reported as 8 like Linux does (the MIDR field holds the 0xf "refer to ID
+       registers" sentinel rather than an architecture version). */
+    u64 midr = read_psr(MIDR_EL1);
+    u64 implementer = field_from_u64(midr, MIDR_EL1_IMPLEMENTER);
+    u64 variant = field_from_u64(midr, MIDR_EL1_VARIANT);
+    u64 partnum = field_from_u64(midr, MIDR_EL1_PARTNUM);
+    u64 revision = field_from_u64(midr, MIDR_EL1_REVISION);
+    heap h = heap_locked(get_kernel_heaps());
+    buffer b = allocate_buffer(h, 128 * total_processors);
+    if (b == INVALID_ADDRESS) {
+        return -ENOMEM;
+    }
+    for (u64 cpu = 0; cpu < total_processors; cpu++)
+        bprintf(b, "processor\t: %ld\n"
+                   "CPU implementer\t: 0x%02lx\n"
+                   "CPU architecture: 8\n"
+                   "CPU variant\t: 0x%lx\n"
+                   "CPU part\t: 0x%03lx\n"
+                   "CPU revision\t: %ld\n\n",
+                cpu, implementer, variant, partnum, revision);
+    context ctx = get_current_context(current_cpu());
+    if (!context_set_err(ctx))
+        length = buffer_read_at(b, offset, dest, length);
+    else
+        length = -EFAULT;
+    deallocate_buffer(b);
+    return length;
+}
+#endif
+
 static const special_file special_files[] = {
     { ss_static_init("/dev/urandom"), .read = urandom_read, .write = 0, .events = urandom_events },
     { ss_static_init("/dev/null"), .read = null_read, .write = null_write, .events = null_events },
     { ss_static_init("/proc/meminfo"), .read = meminfo_read},
+#ifdef __aarch64__
+    { ss_static_init("/proc/cpuinfo"), .read = cpuinfo_read },
+#endif
     { ss_static_init("/proc/mounts"), .open = mounts_open, .close = mounts_close,
       .read = mounts_read, .events = mounts_events,
       .alloc_size = sizeof(struct mounts_notify_data)},


### PR DESCRIPTION
## Summary

Expose `/proc/cpuinfo` on aarch64 so the JVM can identify the CPU core and
**unlock the model-specific tunings it otherwise leaves disabled**.

On arm64 HotSpot has no way to read the CPU identity directly from userspace —
`MIDR_EL1` is EL1-only and there is no `CPUID` instruction as on x86 — so it
relies **solely** on `/proc/cpuinfo`:

- `VM_Version::get_os_cpu_info()` (`os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp`)
  opens the file and reads the `CPU implementer/variant/part/revision` lines into
  `_cpu/_model/_variant/_revision`.
- `VM_Version::initialize()` (`cpu/aarch64/vm_version_aarch64.cpp`) then **gates
  its model-specific tunings on those fields**.

That is the only channel the JVM has. With the file absent (nanos today) every
field reads back as zero — the `0x00:0x0:0x000:0` "unknown core" line in
`-Xlog:os+cpu` — so HotSpot treats the CPU as an unknown vendor and every
model-specific tuning stays at its generic default, even when the underlying
silicon is a well-known core.

## What this does

Synthesize `/proc/cpuinfo` on aarch64, one block per online CPU, with the
identity decoded from `MIDR_EL1` (read at EL1, no trap): implementer, variant,
part number, revision. The instance is homogeneous, so the current-CPU MIDR
applies to all. Format matches Linux — numeric codes, `CPU architecture: 8`
hardcoded (arm64 exposes no vendor/model *name*; that lookup lives in userspace,
e.g. `lscpu`).

## Reading it unlocks the JVM tunings

Once the core is identified, HotSpot applies the tunings it keys off the CPU
implementer/part — the same optimisations the JVM already selects when run on
Linux on that silicon. Measured inside nanos under QEMU, before/after:

| flag | stock (no cpuinfo) | `-cpu max` (unknown) | `neoverse-n1` | AmpereOne |
|---|---|---|---|---|
| identity | `0x00:0x0:0x000:0` | `0x00:0x0:0x051:0` | `0x41:0x4:0xd0c:1` | `0xc0:0x0:0xac3:0` |
| `UseSIMDForMemoryOps` | — | false | **true** | **true** |
| `OnSpinWaitInst` | — | yield | **isb** | **isb** |
| `OnSpinWaitInstCount` | — | 1 | 1 | **2** |
| `AlwaysMergeDMB` | — | true | **false** | **false** |

What each unlocks:

- **`UseSIMDForMemoryOps` → true**: the aarch64 bulk copy/fill routine
  (`MacroAssembler::copy_memory`, shared by the arraycopy/fill stubs) uses
  32-byte Q-register `ldp/stp` instead of 16-byte GPR pairs. The same path
  serves both on-heap copies/fills (`System.arraycopy`, `Arrays.copyOf`/`fill`)
  and off-heap/native ones (`Unsafe.copyMemory`, direct/mapped `ByteBuffer`s).
  It widens the bulk transfer; it does not gate arraycopy on/off.
- **`OnSpinWaitInst=isb`** (with a per-model `OnSpinWaitInstCount`): a cheaper
  `Thread.onSpinWait()` than the default `yield`.
- **`AlwaysMergeDMB=false`**: fewer memory barriers emitted in generated code.
- **`CodeEntryAlignment=32`** and, together with the `AT_HWCAP` crypto bits,
  **`UseCryptoPmullForCRC32`** on Neoverse V-series.

(`OnSpinWaitInstCount=2` on AmpereOne confirms HotSpot took the Ampere-specific
path, not a generic one — i.e. the exact `_cpu`/`_model` branch fired.)

Without `/proc/cpuinfo` the core is "unknown" and all of the above stay off, so
the JVM runs unoptimised for the very CPU it is on.

## Safety / scope

- Reads `MIDR_EL1` at EL1 — no new trap, no new save/restore.
- No CPU feature is advertised here; this reports only the core's identity. The
  crypto/SIMD feature bits come from `AT_HWCAP` (#2174); SVE etc. are unaffected.
- No `Features` line: HotSpot's arm64 parser does not read it, and omitting it
  keeps `AT_HWCAP` the single source of truth for features (no second list to
  drift).
- arm64 only: on x86 the JVM gets the core identity from `CPUID` directly.