### PR TITLE
JVM ZGC GC fail to start on Nanos: dispatch fallocate() through the filesystem

### DIFF
--- a/klib/tmpfs.c
+++ b/klib/tmpfs.c
@@ -179,6 +179,18 @@ static int tmpfs_truncate(filesystem fs, fsfile f, u64 len)
     return 0;
 }
 
+static void tmpfs_alloc(filesystem fs, fsfile f, long offset, long len, boolean keep_size,
+                        fs_status_handler completion)
+{
+    /* Pages are allocated on demand and unwritten ones are read as zeroes, so
+       there is no storage to reserve: only the file length may need to grow. */
+    int fss = 0;
+    u64 end = offset + len;
+    if (!keep_size && (fsfile_get_length(f) < end))
+        fss = filesystem_truncate(fs, f, end);
+    apply(completion, fss);
+}
+
 static int tmpfs_set_seals(filesystem fs, fsfile f, u64 seals)
 {
     tmpfs_file fsf = (tmpfs_file)f;
@@ -236,6 +248,7 @@ filesystem tmpfs_new(void)
     fs->fs.unlink = tmpfs_unlink;
     fs->fs.rename = tmpfs_rename;
     fs->fs.truncate = tmpfs_truncate;
+    fs->fs.alloc = tmpfs_alloc;
     fs->fs.get_freeblocks = tmpfs_freeblocks;
     fs->fs.get_sync_handler = tmpfs_get_sync_handler;
     return &fs->fs;

--- a/src/fs/fs.c
+++ b/src/fs/fs.c
@@ -382,6 +382,16 @@ void filesystem_write_linear(fsfile f, void *src, range q, io_status_handler io_
                                           fs, sg, length, tail_buf, io_complete));
 }
 
+void filesystem_alloc(fsfile f, long offset, long len, boolean keep_size,
+                      fs_status_handler completion)
+{
+    filesystem fs = f->fs;
+    if (fs->alloc)
+        fs->alloc(fs, f, offset, len, keep_size, completion);
+    else
+        apply(completion, -EOPNOTSUPP);
+}
+
 int filesystem_truncate(filesystem fs, fsfile f, u64 len)
 {
     filesystem_lock(fs);

--- a/src/fs/fs.h
+++ b/src/fs/fs.h
@@ -79,6 +79,8 @@ struct filesystem {
                         boolean *destruct_md);
     int (*write_attr)(filesystem fs, tuple md, sstring name, buffer value);
     int (*truncate)(filesystem fs, fsfile f, u64 len);
+    void (*alloc)(filesystem fs, fsfile f, long offset, long len, boolean keep_size,
+                  fs_status_handler completion);
     int (*get_fsfile)(filesystem fs, tuple md, fsfile *f);
     fs_io file_read;
     fs_io file_write;

--- a/src/fs/tfs.c
+++ b/src/fs/tfs.c
@@ -908,16 +908,9 @@ static int add_extents_to_file(tfsfile f, rangemap rm)
 }
 
 /* no longer async, but keep completion to match dealloc... */
-void filesystem_alloc(fsfile f, long offset, long len,
+static void tfs_alloc(filesystem fs, fsfile f, long offset, long len,
                       boolean keep_size, fs_status_handler completion)
 {
-    assert(f);
-    filesystem fs = f->fs;
-    if (!fs_is_tfs(fs)) {
-        apply(completion, -EINVAL);
-        return;
-    }
-
     range blocks = range_rshift_pad(irangel(offset, len), fs->blocksize_order);
     tfs_debug("%s: blocks %R%s\n", func_ss, blocks,
               keep_size ? ss(" (keep size)") : sstring_empty());
@@ -1424,6 +1417,7 @@ void create_filesystem(heap h,
     fs->storage = allocate_rangemap(h);
     assert(fs->storage != INVALID_ADDRESS);
 #ifdef KERNEL
+    fs->fs.alloc = tfs_alloc;
     spin_lock_init(&fs->storage_lock);
     fs->page_order = pagecache_get_page_order();
     fs->zero_page = pagecache_get_zero_page();

--- a/src/unix/filesystem.c
+++ b/src/unix/filesystem.c
@@ -857,19 +857,40 @@ sysreturn fallocate(int fd, int mode, long offset, long len)
     } else if (!fdesc_is_writable(desc)) {
         rv = -EBADF;
         goto out;
+    } else if ((offset < 0) || (len <= 0)) {
+        rv = -EINVAL;
+        goto out;
     }
 
     heap h = heap_locked(get_kernel_heaps());
     file f = (file) desc;
+    fsfile fsf = f->fsf;
+    filesystem fs = f->fs;
+    if (fs->get_seals) {
+        u64 seals;
+        if (fs->get_seals(fs, fsf, &seals) == 0) {
+            /* Allocating does not change what the file reads as, so a write
+               seal forbids punching holes only, while a grow seal forbids
+               allocating past the end of the file. */
+            boolean forbidden;
+            if (mode & FALLOC_FL_PUNCH_HOLE)
+                forbidden = !!(seals & (F_SEAL_WRITE | F_SEAL_FUTURE_WRITE));
+            else
+                forbidden = (seals & F_SEAL_GROW) && (offset + len > fsfile_get_length(fsf));
+            if (forbidden) {
+                rv = -EPERM;
+                goto out;
+            }
+        }
+    }
     switch (mode) {
     case 0:
     case FALLOC_FL_KEEP_SIZE:
-        filesystem_alloc(f->fsf, offset, len,
-                         mode == FALLOC_FL_KEEP_SIZE,
+        filesystem_alloc(fsf, offset, len, mode == FALLOC_FL_KEEP_SIZE,
                          closure(h, fs_op_complete, current, f));
         break;
     case FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE:
-        filesystem_dealloc(f->fsf, offset, len,
+        filesystem_dealloc(fsf, offset, len,
                            closure(h, fs_op_complete, current, f));
         break;
     default:

--- a/test/runtime/shmem.c
+++ b/test/runtime/shmem.c
@@ -1,4 +1,6 @@
+#define _GNU_SOURCE
 #include <errno.h>
+#include <fcntl.h>
 #include <linux/memfd.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -57,9 +59,73 @@ static void test_memfd(void)
     close(fd);
 }
 
+static void test_memfd_fallocate(void)
+{
+    const size_t capacity = 8192;
+    char buf[64];
+    struct stat s;
+    int fd;
+
+    fd = syscall(__NR_memfd_create, "test", 0);
+    test_assert(fd >= 0);
+
+    /* Allocating past the end of the file extends it, unless the size is kept. */
+    test_assert(fallocate(fd, 0, 0, capacity) == 0);
+    test_assert(fstat(fd, &s) == 0);
+    test_assert(s.st_size == capacity);
+    test_assert(fallocate(fd, FALLOC_FL_KEEP_SIZE, capacity, capacity) == 0);
+    test_assert(fstat(fd, &s) == 0);
+    test_assert(s.st_size == capacity);
+
+    /* A punched hole reads as zeroes. */
+    memset(buf, 'a', sizeof(buf));
+    test_assert(pwrite(fd, buf, sizeof(buf), 0) == sizeof(buf));
+    test_assert(fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, 0, capacity) == 0);
+    test_assert(pread(fd, buf, sizeof(buf), 0) == sizeof(buf));
+    for (int i = 0; i < sizeof(buf); i++)
+        test_assert(buf[i] == '\0');
+
+    /* A negative offset, or a length that allocates nothing, is rejected. */
+    test_assert((fallocate(fd, 0, -1, capacity) == -1) && (errno == EINVAL));
+    test_assert((fallocate(fd, 0, 0, 0) == -1) && (errno == EINVAL));
+
+    test_assert(close(fd) == 0);
+}
+
+static void test_memfd_fallocate_seals(void)
+{
+    const size_t capacity = 4096;
+    int fd;
+
+    fd = syscall(__NR_memfd_create, "test", MFD_ALLOW_SEALING);
+    test_assert(fd >= 0);
+    test_assert(ftruncate(fd, capacity) == 0);
+
+    /* A grow seal forbids allocating past the end of the file, whether or not
+     * the file size is to be updated, and allows everything else. */
+    test_assert(fcntl(fd, F_ADD_SEALS, F_SEAL_GROW) == 0);
+    test_assert((fallocate(fd, 0, 0, capacity + 1) == -1) && (errno == EPERM));
+    test_assert((fallocate(fd, FALLOC_FL_KEEP_SIZE, capacity, capacity) == -1) &&
+                (errno == EPERM));
+    test_assert(fallocate(fd, 0, 0, capacity) == 0);
+    test_assert(fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, capacity) == 0);
+    test_assert(fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, 0, capacity) == 0);
+
+    /* A write seal forbids punching holes, which changes the file contents,
+     * but not allocation, which does not. */
+    test_assert(fcntl(fd, F_ADD_SEALS, F_SEAL_WRITE) == 0);
+    test_assert((fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, 0, capacity) == -1) &&
+                (errno == EPERM));
+    test_assert(fallocate(fd, 0, 0, capacity) == 0);
+
+    test_assert(close(fd) == 0);
+}
+
 int main(int argc, char *argv[])
 {
     test_memfd();
+    test_memfd_fallocate();
+    test_memfd_fallocate_seals();
     printf("Shared memory tests OK\n");
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
ZGC Garbage Collector does not start on nanos: the JVM cannot commit its Java heap because `fallocate()` works on tfs files only.

`filesystem_alloc()` is defined in `src/fs/tfs.c` and starts with

```c
if (!fs_is_tfs(fs)) {
    apply(completion, -EINVAL);
    return;
}
```

so on any other filesystem the allocate and keep-size modes fail, while the punch-hole mode succeeds, since `filesystem_dealloc()` goes through the page cache and does not care which filesystem the file belongs to.

The filesystem this rules out in practice is tmpfs, and therefore every descriptor returned by `memfd_create()`.

This change adds an `alloc` method to the filesystem vtable, lets tfs register the implementation it already had, and makes `fallocate()` call the method of the filesystem the file belongs to, returning `EOPNOTSUPP` when there is none. The tmpfs implementation has no storage to reserve, because its pages are allocated on demand and read as zeroes while unwritten, so it only grows the file length when the requested range extends past it.

Since `fallocate()` can now reach a filesystem that supports file sealing, it also has to honour the seals, the way `write()` and `ftruncate()` already do, and it does so along the same line Linux draws: allocating does not change what the file reads as, so a write seal rejects hole punching alone, while a grow seal rejects allocating past the end of the file, with or without the keep-size mode. Without this, sealing could be bypassed through `fallocate()` on the very filesystem the feature was added for.

The offset and length are validated as Linux validates them, since a filesystem that does not turn them into block allocations would otherwise accept a negative length and quietly do nothing.

What it unblocks

ZGC, the JDK's low-latency garbage collector, does not start on nanos. It backs the Java heap with a `memfd_create()` file and commits memory into it with `fallocate(fd, 0, offset, length)`, which returned `EINVAL`:

```
[gc,init] Heap Backing File: /memfd:java_heap
[gc     ] Failed to commit memory (Invalid argument)
[gc     ] Failed to allocate initial Java heap (192M)
Error occurred during initialization of VM
```

With this change the same image runs it:

```
[gc,init] Heap Backing File: /memfd:java_heap
[gc,init] Reserved Space Type: Contiguous/Unrestricted/Complete
GC OK collector=ZGC_Minor_Cycles(10)+ZGC_Minor_Pauses(31)+ZGC_Major_Cycles(15)+ZGC_Major_Pauses(110)
```

 Testing

`test/runtime/shmem.c` gains the cases the change makes reachable: allocating on a memfd with and without keeping the size, hole punching, and the seals each of them has to honour. The test passes under nanos through the usual `make run-noaccel TARGET=shmem`, and also passes when built and run on Linux, so the sealing behaviour it asserts is the one Linux implements rather than the one this patch happens to produce.

Booted Temurin 25 (aarch64) inside nanos under QEMU TCG, with the `tmpfs` and `shmem` klibs loaded, running a workload that allocates several times the heap so the collector has to run, and that verifies its live set with a checksum at the end so a collector that dropped or corrupted an object would be caught rather than silently pass.

Before the change: `Failed to commit memory (Invalid argument)`, JVM does not start.
After: ZGC completes 10 minor and 15 major collections with the live set intact.

Two further configurations cover the paths a larger heap would not have reached: objects of 32 MB, which are above `ZObjectSizeLimitMedium` and are therefore committed as ZGC large pages, and an elastic heap (`-Xms64m -Xmx512m`), the only case in which the collector punches holes in its memfd instead of only committing into it. Both complete the workload, and the uncommitter reports having given memory back.

The same workload was run under G1, Serial, Parallel and Shenandoah, before and after, to check nothing regressed for tfs-backed images; all four complete it unchanged.

A separate C program run inside the guest checks the primitives around the change directly: `memfd_create`, `ftruncate`, two `MAP_SHARED` mappings of one memfd and their coherency, `MAP_FIXED` commit into a `PROT_NONE` reservation, and punch-hole followed by a read-back. All pass on the patched image.

 Note, not addressed here

Punching a hole zeroes the range and subsequent reads return zeroes, but the pages are not released, and they are not reclaimed under memory pressure either. Filling 200M of a memfd in a 512M guest, punching all of it out and then allocating anonymous memory without releasing it gives:

```
PRESSURE punched+unmapped   MemFree=272748kB Cached=205356kB (punch rv=0)
PRESSURE touched 240M       MemFree= 23136kB Cached=205108kB
page fill failed with (result:out of memory)
```

`Cached` gives back 248kB out of 200M, and the process is killed for lack of memory that it had already released. ZGC uncommits by punching holes, so it hits this whenever the heap shrinks; any other user of sparse files or memfds does too.

This is pre-existing behaviour: hole punching goes through `filesystem_dealloc()` and the page cache, neither of which this change touches, and fixing it means letting a filesystem release those pages rather than only zeroing them. It is left for a separate change so that this one stays reviewable.