### PR TITLE
AWS S3 filesystem

### DIFF
--- a/klib/aws.c
+++ b/klib/aws.c
@@ -1,7 +1,7 @@
 #include <kernel.h>
 #include <aws.h>
-#include <http.h>
 #include <lwip.h>
+#include <net_utils.h>
 
 #define _RUNTIME_H_ /* guard against double inclusion of runtime.h */
 #include <mbedtls/md.h>
@@ -288,6 +288,25 @@ static boolean aws_headers_sort(heap h, tuple req, binding_handler handler)
     return result;
 }
 
+static boolean aws_query_encode(buffer dest, char *src, bytes len)
+{
+    bytes start = 0;
+    for (bytes i = 0; i <= len; i++) {
+        if (i == len || src[i] == '&' || src[i] == '=') {
+            if (i > start) {
+                if (!net_uri_encode(dest, src + start, i - start))
+                    return false;
+            }
+            if (i < len) {
+                if (!buffer_write_byte(dest, src[i]))
+                    return false;
+            }
+            start = i + 1;
+        }
+    }
+    return true;
+}
+
 /* creates a canonical request */
 static buffer aws_create_can_req(heap h, sstring method, tuple req, buffer body)
 {
@@ -307,7 +326,7 @@ static buffer aws_create_can_req(heap h, sstring method, tuple req, buffer body)
         goto error;
     push_u8(can_req, '\n');
     if ((uri_end < buffer_length(url)) &&
-        !buffer_write(can_req, buffer_ref(url, uri_end + 1), buffer_length(url) - uri_end - 1))
+        !aws_query_encode(can_req, buffer_ref(url, uri_end + 1), buffer_length(url) - uri_end - 1))
         goto error;
     push_u8(can_req, '\n');
     if (!aws_headers_sort(h, req, stack_closure(aws_header_add, can_req, false)))

--- a/klib/aws.c
+++ b/klib/aws.c
@@ -45,7 +45,7 @@ closure_function(5, 1, boolean, aws_metadata_in,
                 msg_err("%s: failed to allocate value handler", func_ss);
                 goto error;
             }
-            bound(parser) = allocate_http_parser(h, vh);
+            bound(parser) = allocate_http_parser(h, false, vh);
             if (bound(parser) == INVALID_ADDRESS) {
                 msg_err("%s: failed to allocate HTTP parser", func_ss);
                 deallocate_closure(vh);

--- a/klib/aws.c
+++ b/klib/aws.c
@@ -413,6 +413,11 @@ void aws_req_set_date(tuple req, buffer b)
     set(req, sym(x-amz-date), b);
 }
 
+buffer aws_req_get_date(tuple req)
+{
+    return get_string(req, sym(x-amz-date));
+}
+
 buffer aws_req_sign(heap h, sstring region, sstring service, sstring method,
                     tuple req, buffer body, sstring access_key, sstring secret)
 {

--- a/klib/aws.c
+++ b/klib/aws.c
@@ -338,12 +338,18 @@ static buffer aws_create_can_req(heap h, sstring method, tuple req, buffer body)
     /* Replace the last ';' character from the signed header list with a newline. */
     *(char *)buffer_ref(can_req, buffer_length(can_req) - 1) = '\n';
 
-    u8 sha[32];
-    if (mbedtls_sha256_ret(body ? buffer_ref(body, 0) : 0, body ? buffer_length(body) : 0,
-                           sha, 0) < 0)
-        goto error;
-    for (int i = 0; i < sizeof(sha); i++)
-        print_byte(can_req, sha[i]);
+    buffer content_hash = get(req, sym(x-amz-content-sha256));
+    if (content_hash) {
+        if (!push_buffer(can_req, content_hash))
+            goto error;
+    } else {
+        u8 sha[32];
+        if (mbedtls_sha256_ret(body ? buffer_ref(body, 0) : 0, body ? buffer_length(body) : 0,
+                               sha, 0) < 0)
+            goto error;
+        for (int i = 0; i < sizeof(sha); i++)
+            print_byte(can_req, sha[i]);
+    }
     return can_req;
   error:
     deallocate_buffer(can_req);

--- a/klib/aws.h
+++ b/klib/aws.h
@@ -22,6 +22,7 @@ closure_type(aws_cred_handler, void, aws_cred cred);
 void aws_cred_get(heap h, aws_cred_handler handler);
 
 void aws_req_set_date(tuple req, buffer b);
+buffer aws_req_get_date(tuple req);
 
 buffer aws_req_sign(heap h, sstring region, sstring service, sstring method,
                     tuple req, buffer body, sstring access_key, sstring secret);

--- a/klib/azure_diagnostics.c
+++ b/klib/azure_diagnostics.c
@@ -513,7 +513,7 @@ int azure_diag_init(tuple cfg)
         init_closure_func(&diag->metrics.ibh, input_buffer_handler, azure_metrics_in_handler);
         value_handler vh = init_closure_func(&diag->metrics.vh, value_handler,
                                              azure_metrics_value_handler);
-        diag->metrics.resp_parser = allocate_http_parser(h, vh);
+        diag->metrics.resp_parser = allocate_http_parser(h, false, vh);
         assert(diag->metrics.resp_parser != INVALID_ADDRESS);
         diag->metrics.pending = false;
         config_empty = false;

--- a/klib/cloud_init.c
+++ b/klib/cloud_init.c
@@ -250,7 +250,7 @@ define_closure_function(4, 2, boolean, cloud_download_file_recv,
                 fsfile_release(f);
                 goto error;
             }
-            bound(parser) = allocate_http_parser(cloud_heap, vh);
+            bound(parser) = allocate_http_parser(cloud_heap, false, vh);
             if (bound(parser) == INVALID_ADDRESS) {
                 s = timm("result", "%s: failed to allocate HTTP parser", func_ss);
                 deallocate_closure(vh);
@@ -598,7 +598,7 @@ define_closure_function(2, 2, boolean, cloud_download_env_recv,
     cloud_download_env cfg = struct_from_field(closure_self(), cloud_download_env, recv);
     if (data && (bound(parser) == INVALID_ADDRESS)) {
         value_handler vh = init_closure(&cfg->setenv, cloud_download_setenv, &bound(s));
-        bound(parser) = allocate_http_parser(cloud_heap, vh);
+        bound(parser) = allocate_http_parser(cloud_heap, false, vh);
         if (bound(parser) == INVALID_ADDRESS) {
             bound(s) = timm("result", "%s: failed to allocate HTTP parser", func_ss);
             goto close_conn;

--- a/klib/cloudwatch.c
+++ b/klib/cloudwatch.c
@@ -292,7 +292,7 @@ static void cw_logstream_create(const ip_addr_t *server)
         msg_err("%s: failed to allocate value handler", func_ss);
         return;
     }
-    buffer_handler parser = allocate_http_parser(cw.h, vh);
+    buffer_handler parser = allocate_http_parser(cw.h, false, vh);
     if (parser == INVALID_ADDRESS) {
         msg_err("%s: failed to allocate HTTP parser", func_ss);
         deallocate_closure(vh);
@@ -392,7 +392,7 @@ static void cw_loggroup_create(const ip_addr_t *server)
         msg_err("%s: failed to allocate value handler", func_ss);
         return;
     }
-    buffer_handler parser = allocate_http_parser(cw.h, vh);
+    buffer_handler parser = allocate_http_parser(cw.h, false, vh);
     if (parser == INVALID_ADDRESS) {
         msg_err("%s: failed to allocate HTTP parser", func_ss);
         deallocate_closure(vh);
@@ -864,7 +864,8 @@ int init(status_handler complete)
         assert(cw.log_entries != INVALID_ADDRESS);
         init_closure_func(&cw.log_conn_handler, connection_handler, cw_log_conn_handler);
         init_closure_func(&cw.log_in_handler, input_buffer_handler, cw_log_in_handler);
-        cw.log_resp_parser = allocate_http_parser(cw.h, init_closure_func(&cw.log_vh, value_handler,
+        cw.log_resp_parser = allocate_http_parser(cw.h, false,
+                                                  init_closure_func(&cw.log_vh, value_handler,
                                                                           cw_log_vh));
         assert(cw.log_resp_parser != INVALID_ADDRESS);
         init_closure_func(&cw.log_timer_handler, timer_handler, cw_log_timer_handler);

--- a/klib/digitalocean.c
+++ b/klib/digitalocean.c
@@ -64,7 +64,7 @@ closure_function(4, 1, boolean, do_instance_md_in,
     if (data) {
         if (bound(parser) == INVALID_ADDRESS) {
             value_handler vh = bound(vh);
-            bound(parser) = allocate_http_parser(digitalocean.h, vh);
+            bound(parser) = allocate_http_parser(digitalocean.h, false, vh);
             if (bound(parser) == INVALID_ADDRESS) {
                 s = timm_oom;
                 deallocate_closure(vh);
@@ -492,7 +492,7 @@ int init(status_handler complete)
         init_closure_func(&digitalocean.metrics.ibh, input_buffer_handler, do_metrics_in_handler);
         value_handler vh = init_closure_func(&digitalocean.metrics.vh, value_handler,
                                              do_metrics_value_handler);
-        digitalocean.metrics.resp_parser = allocate_http_parser(digitalocean.h, vh);
+        digitalocean.metrics.resp_parser = allocate_http_parser(digitalocean.h, false, vh);
         assert(digitalocean.metrics.resp_parser != INVALID_ADDRESS);
         config_empty = false;
     }

--- a/klib/gcp.c
+++ b/klib/gcp.c
@@ -213,7 +213,7 @@ closure_function(4, 1, boolean, gcp_instance_md_in,
     if (data) {
         if (bound(parser) == INVALID_ADDRESS) {
             value_handler vh = bound(vh);
-            bound(parser) = allocate_http_parser(gcp.h, vh);
+            bound(parser) = allocate_http_parser(gcp.h, false, vh);
             if (bound(parser) == INVALID_ADDRESS) {
                 s = timm("result", "failed to allocate HTTP parser");
                 deallocate_closure(vh);
@@ -871,7 +871,7 @@ int init(status_handler complete)
         assert(gcp.log_entries != INVALID_ADDRESS);
         init_closure_func(&gcp.log_conn_handler, connection_handler, gcp_log_conn_handler);
         init_closure_func(&gcp.log_in_handler, input_buffer_handler, gcp_log_in_handler);
-        gcp.log_resp_parser = allocate_http_parser(gcp.h,
+        gcp.log_resp_parser = allocate_http_parser(gcp.h, false,
                                                    init_closure_func(&gcp.log_vh, value_handler,
                                                                      gcp_log_vh));
         assert(gcp.log_resp_parser != INVALID_ADDRESS);
@@ -905,7 +905,7 @@ int init(status_handler complete)
         init_closure_func(&gcp.metrics_timer_handler, timer_handler, gcp_metrics_timer_handler);
         init_closure_func(&gcp.metrics_conn_handler, connection_handler, gcp_metrics_conn_handler);
         init_closure_func(&gcp.metrics_in_handler, input_buffer_handler, gcp_metrics_in_handler);
-        gcp.metrics_resp_parser = allocate_http_parser(gcp.h,
+        gcp.metrics_resp_parser = allocate_http_parser(gcp.h, false,
                                                        init_closure_func(&gcp.metrics_value_handler,
                                                            value_handler,
                                                            gcp_metrics_value_handler));

--- a/klib/klib.mk
+++ b/klib/klib.mk
@@ -34,6 +34,7 @@ SRCS-cloud_init= \
 SRCS-cloudwatch= \
 	$(KLIB_DIR)/aws.c \
 	$(KLIB_DIR)/cloudwatch.c \
+	$(KLIB_DIR)/net_utils.c \
 
 SRCS-digitalocean= \
 	$(KLIB_DIR)/crc32.c \

--- a/klib/klib.mk
+++ b/klib/klib.mk
@@ -11,6 +11,7 @@ KLIBS= \
 	gcp \
 	ntp \
 	radar \
+	s3fs \
 	sandbox \
 	shmem \
 	special_files \
@@ -52,6 +53,12 @@ SRCS-ntp= \
 SRCS-radar= \
 	$(KLIB_DIR)/net_utils.c \
 	$(KLIB_DIR)/radar.c \
+
+SRCS-s3fs= \
+	$(KLIB_DIR)/aws.c \
+	$(KLIB_DIR)/net_utils.c \
+	$(KLIB_DIR)/s3fs.c \
+	$(KLIB_DIR)/xml.c \
 
 SRCS-sandbox= \
 	$(KLIB_DIR)/pledge.c \

--- a/klib/net_utils.c
+++ b/klib/net_utils.c
@@ -68,7 +68,8 @@ closure_func_basic(connection_handler, input_buffer_handler, net_http_ch,
         req_data->out = out;
         net_http_req_params params = &req_data->params;
         tuple req = params->req;
-        set(req, sym(Host), alloca_wrap_sstring(params->host));
+        /* Use lowercase host header in order to be compatible with AWS SigV4 protocol. */
+        set(req, sym(host), alloca_wrap_sstring(params->host));
         set(req, sym(Connection), alloca_wrap_cstring("close"));
         status s = http_request(req_data->h, out, params->method, req, params->body);
         if (is_ok(s)) {

--- a/klib/net_utils.c
+++ b/klib/net_utils.c
@@ -134,6 +134,25 @@ void net_resolve(sstring host, void (*cb)(sstring host, const ip_addr_t *addr, v
     }
 }
 
+boolean net_uri_encode(buffer dest, char *src, bytes len)
+{
+    const char *hex = "0123456789ABCDEF";
+    for (bytes i = 0; i < len; i++) {
+        char c = src[i];
+        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+            c == '_' || c == '-' || c == '.' || c == '~') {
+            if (!buffer_write_byte(dest, c))
+                return false;
+        } else {
+            if (!buffer_write_byte(dest, '%') ||
+                !buffer_write_byte(dest, hex[(c >> 4) & 0xf]) ||
+                !buffer_write_byte(dest, hex[c & 0xf]))
+                return false;
+        }
+    }
+    return true;
+}
+
 status net_http_req(net_http_req_params params)
 {
     heap h = heap_locked(get_kernel_heaps());

--- a/klib/net_utils.c
+++ b/klib/net_utils.c
@@ -140,7 +140,8 @@ status net_http_req(net_http_req_params params)
     net_http_req_data req_data = allocate(h, sizeof(*req_data));
     if (req_data == INVALID_ADDRESS)
         return timm_oom;
-    req_data->parser = allocate_http_parser(h, init_closure_func(&req_data->vh, value_handler,
+    req_data->parser = allocate_http_parser(h, params->method == HTTP_REQUEST_METHOD_HEAD,
+                                            init_closure_func(&req_data->vh, value_handler,
                                                                  net_http_vh));
     if (req_data->parser == INVALID_ADDRESS) {
         deallocate(h, req_data, sizeof(*req_data));

--- a/klib/net_utils.h
+++ b/klib/net_utils.h
@@ -2,6 +2,7 @@
 #define NET_UTILS_H_
 
 #include <http.h>
+#include <lwip/ip_addr.h>
 
 typedef struct net_http_req_params {
     sstring host;
@@ -15,6 +16,8 @@ typedef struct net_http_req_params {
 
 void net_resolve(sstring host, void (*cb)(sstring host, const ip_addr_t *addr, void *cb_arg),
                  void *cb_arg);
+
+boolean net_uri_encode(buffer dest, char *src, bytes len);
 
 status net_http_req(net_http_req_params params);
 

--- a/klib/radar.c
+++ b/klib/radar.c
@@ -139,7 +139,7 @@ closure_function(2, 1, boolean, telemetry_recv,
     if (data) {
         value_handler vh = bound(vh);
         if (vh) {
-            buffer_handler parser = allocate_http_parser(telemetry.h, vh);
+            buffer_handler parser = allocate_http_parser(telemetry.h, false, vh);
             if (parser != INVALID_ADDRESS) {
                 status s = apply(parser, data);
                 if (!is_ok(s)) {

--- a/klib/s3fs.c
+++ b/klib/s3fs.c
@@ -1,0 +1,1011 @@
+#include <errno.h>
+#include <kernel.h>
+#include <pagecache.h>
+#include <fs.h>
+#include <storage.h>
+#include <net_utils.h>
+#include <xml.h>
+#include <aws.h>
+
+#define S3FS_VOL_PREFIX ss("s3:")
+
+#if S3FS_DEBUG
+#define s3fs_debug(x, ...) do {tprintf(sym(s3fs), 0, ss(x"\n"), ##__VA_ARGS__);} while(0)
+#else
+#define s3fs_debug(x, ...)
+#endif
+
+static struct {
+    heap h;
+    sstring region;
+    sstring access_key;
+    sstring secret;
+    struct buffer sha_empty;
+    struct buffer sha_payload;
+} s3fs;
+
+typedef struct s3fs_volume {
+    struct filesystem fs;
+    sstring bucket;
+    struct buffer hostname;
+    closure_struct(fs_init_handler, fs_init);
+    struct list objs;
+} *s3fs_volume;
+
+typedef struct s3fs_object {
+    struct list l;
+    tuple md;
+    /* The key stored here is prepended with a leading slash, to make it easier to build an S3 query
+     * string. */
+    sstring key;
+    boolean stale;
+    struct s3fs_file *f;
+} *s3fs_object;
+
+typedef struct s3fs_file {
+    struct fsfile f;
+    s3fs_object obj;
+    closure_struct(pagecache_node_reserve, reserve);
+    closure_struct(thunk, free);
+} *s3fs_file;
+
+typedef struct s3fs_read_ctx {
+    sg_list sg;
+    status_handler completion;
+    closure_struct(value_handler, handler);
+} *s3fs_read_ctx;
+
+typedef struct s3fs_write_ctx {
+    fsfile f;
+    u64 write_end;
+    sg_buf sgb;
+    status_handler completion;
+    closure_struct(value_handler, handler);
+} *s3fs_write_ctx;
+
+/* Helper to dispatch an HTTP request to the S3 REST API */
+static void s3fs_request(s3fs_volume vol, buffer query, http_method method, tuple req, buffer body,
+                         value_handler resp_handler)
+{
+    sstring m = http_request_methods[method];
+    s3fs_debug("S3 request: %s %b", m, query);
+    set(req, sym(url), query);
+    buffer datetime = allocate_buffer(s3fs.h, 16);
+    if (datetime == INVALID_ADDRESS) {
+        msg_err("s3fs request: cannot allocate memory");
+        goto err;
+    }
+    aws_req_set_date(req, datetime);
+    /* The host header must be inserted now (even though the net_utils code inserts it internally)
+     * because it needs to be included in the signature. */
+    set(req, sym(host), &vol->hostname);
+    buffer content_hash = (body && buffer_length(body)) ? &s3fs.sha_payload : &s3fs.sha_empty;
+    set(req, sym(x-amz-content-sha256), content_hash);
+    buffer auth = aws_req_sign(s3fs.h, s3fs.region, ss("s3"), m, req, body,
+                               s3fs.access_key, s3fs.secret);
+    if (!auth) {
+        msg_err("s3fs request: cannot allocate memory");
+        goto err;
+    }
+    set(req, sym(Authorization), auth);
+    struct net_http_req_params params;
+    params.host = isstring(vol->hostname.contents, vol->hostname.length);
+    params.req = req;
+    params.body = body;
+    params.resp_handler = resp_handler;
+    params.method = method;
+    params.port = 443;
+    params.tls = true;
+    status s = net_http_req(&params);
+    if (is_ok(s))
+        return;
+    msg_err("S3 request error: %v", s);
+    timm_dealloc(s);
+  err:
+    apply(resp_handler, 0);
+}
+
+static void s3fs_req_cleanup(tuple req)
+{
+    buffer auth = get_string(req, sym(Authorization));
+    if (auth)
+        deallocate_buffer(auth);
+    buffer datetime = aws_req_get_date(req);
+    if (datetime)
+        deallocate_buffer(datetime);
+    deallocate_value(req);
+}
+
+static s3fs_object s3fs_obj_new_from_md(s3fs_volume vol, bytes key_len, tuple md)
+{
+    heap h = vol->fs.h;
+    s3fs_object obj = allocate(h, sizeof(*obj));
+    if (obj == INVALID_ADDRESS)
+        return 0;
+    if (!sstring_allocate(h, key_len, &obj->key))
+        goto err_dealloc_obj;
+    obj->md = md;
+    obj->f = 0;
+    list_push(&vol->objs, &obj->l);
+    return obj;
+  err_dealloc_obj:
+    deallocate(h, obj, sizeof(*obj));
+    return 0;
+}
+
+static s3fs_object s3fs_obj_new(s3fs_volume vol, bytes key_len, tuple parent, boolean directory)
+{
+    tuple md = allocate_tuple();
+    if (md == INVALID_ADDRESS)
+        return 0;
+    if (directory) {
+        tuple c = allocate_tuple();
+        if (c == INVALID_ADDRESS)
+            goto err_dealloc_md;
+        set(md, sym(children), c);
+    }
+    s3fs_object obj = s3fs_obj_new_from_md(vol, key_len, md);
+    if (!obj)
+        goto err_dealloc_md;
+    set(md, sym(..), parent);
+    return obj;
+  err_dealloc_md:
+    destruct_value(md, true);
+    return 0;
+}
+
+static void s3fs_obj_delete(s3fs_volume fs, s3fs_object obj)
+{
+    s3fs_debug("deleting object %p, md %p", obj, obj->md);
+    if (list_inserted(&obj->l))
+        list_delete(&obj->l);
+    heap h = fs->fs.h;
+    sstring_deallocate(h, obj->key);
+    if (obj->md)
+        fs_cleanup_dir_entry(obj->md);
+    if (obj->f)
+        fsfile_release(&obj->f->f);
+    deallocate(h, obj, sizeof(*obj));
+}
+
+static void s3fs_obj_cache_hit(s3fs_volume fs, s3fs_object obj)
+{
+    if (&obj->l != list_begin(&fs->objs)) {
+        list_delete(&obj->l);
+        list_push(&fs->objs, &obj->l);
+    }
+}
+
+static s3fs_object s3fs_obj_get(s3fs_volume fs, tuple md)
+{
+    list_foreach(&fs->objs, e) {
+        s3fs_object obj = struct_from_list(e, s3fs_object, l);
+         if (obj->md == md) {
+             s3fs_obj_cache_hit(fs, obj);
+             return obj;
+         }
+    }
+    return 0;
+}
+
+static s64 s3fs_get_blocks(fsfile f)
+{
+    u64 len = fsfile_get_length(f);
+    return pad(len, SECTOR_SIZE) >> SECTOR_OFFSET;
+}
+
+closure_func_basic(pagecache_node_reserve, status, s3fs_f_reserve,
+                   range q)
+{
+    s3fs_debug("reserve range %R", q);
+    s3fs_file fsf = struct_from_closure(s3fs_file, reserve);
+    fsfile f = &fsf->f;
+    if (f->length < q.end)
+        f->length = q.end;
+    return STATUS_OK;
+}
+
+static void s3fs_file_delete(s3fs_volume fs, s3fs_file fsf)
+{
+    s3fs_debug("deallocating file %p", fsf);
+    pagecache_deallocate_node(fsf->f.cache_node);
+    deallocate(fs->fs.h, fsf, sizeof(*fsf));
+}
+
+closure_func_basic(status_handler, void, s3fs_f_sync_complete,
+                   status s)
+{
+    s3fs_debug("file sync complete: %v", s);
+    if (!is_ok(s)) {
+        msg_err("s3fs: failed to sync page cache node: %v", s);
+        timm_dealloc(s);
+    }
+    fsfile f = struct_from_closure(fsfile, sync_complete);
+    s3fs_file fsf = (s3fs_file)f;
+    s3fs_volume s3fs = (s3fs_volume)(f->fs);
+    s3fs_file_delete(s3fs, fsf);
+}
+
+closure_func_basic(thunk, void, s3fs_f_free)
+{
+    s3fs_debug("file free");
+    s3fs_file fsf = struct_from_closure(s3fs_file, free);
+    fsfile f = &fsf->f;
+    pagecache_purge_node(f->cache_node, init_closure_func(&f->sync_complete, status_handler,
+                                                          s3fs_f_sync_complete));
+}
+
+static s3fs_file s3fs_file_new(s3fs_volume fs, s3fs_object obj)
+{
+    heap h = fs->fs.h;
+    s3fs_file fsf = allocate(h, sizeof(*fsf));
+    if (fsf == INVALID_ADDRESS)
+        return 0;
+    int ret = fsfile_init(&fs->fs, &fsf->f, obj->md,
+                          init_closure_func(&fsf->reserve, pagecache_node_reserve, s3fs_f_reserve),
+                          init_closure_func(&fsf->free, thunk, s3fs_f_free));
+    if (ret < 0) {
+        deallocate(h, fsf, sizeof(*fsf));
+        return 0;
+    }
+    obj->f = fsf;
+    fsf->obj = obj;
+    fsf->f.get_blocks = s3fs_get_blocks;
+    return fsf;
+}
+
+closure_function(3, 1, void, s3fs_io_handler,
+                 tuple, req, buffer, query, value_handler, handler,
+                 value resp)
+{
+    buffer query = bound(query);
+    unwrap_buffer(query->h, query);
+    s3fs_req_cleanup(bound(req));
+    value_handler handler = bound(handler);
+    apply(handler, resp);
+    closure_finish();
+}
+
+static void s3fs_io_req(fsfile f, boolean write, range q, buffer body, value_handler handler)
+{
+    s3fs_file s3f = (s3fs_file)f;
+    s3fs_volume vol = (s3fs_volume)f->fs;
+    tuple req = allocate_tuple();
+    if (req == INVALID_ADDRESS)
+        goto err;
+    heap h = s3fs.h;
+    buffer query = wrap_buffer(h, s3f->obj->key.ptr, s3f->obj->key.len);
+    if (query == INVALID_ADDRESS)
+        goto err_dealloc_req;
+    buffer r = 0;
+    if (!range_empty(q)) {
+        buffer r = allocate_buffer(h, 32);
+        if (r == INVALID_ADDRESS)
+            goto err_dealloc_query;
+        bprintf(r, "bytes=%ld-%ld", q.start, q.end - 1);
+        set(req, sym(range), r);
+    }
+    value_handler resp_handler = closure(h, s3fs_io_handler, req, query, handler);
+    if (resp_handler == INVALID_ADDRESS)
+        goto err_dealloc_range;
+    s3fs_request(vol, query, write ? HTTP_REQUEST_METHOD_PUT : HTTP_REQUEST_METHOD_GET, req, body,
+                 resp_handler);
+    return;
+  err_dealloc_range:
+    if (r)
+        deallocate_buffer(r);
+  err_dealloc_query:
+    unwrap_buffer(h, query);
+  err_dealloc_req:
+    deallocate_value(req);
+  err:
+    apply(handler, 0);
+}
+
+closure_func_basic(value_handler, void, s3fs_read_handler,
+                   value resp)
+{
+    s3fs_read_ctx ctx = struct_from_closure(s3fs_read_ctx, handler);
+    status s;
+    sg_list sg = ctx->sg;
+    if (http_resp_is_ok(resp)) {
+        buffer body = get(resp, sym(content));
+        if (body)
+            sg_copy_from_buf(buffer_ref(body, 0), sg, buffer_length(body));
+        s = STATUS_OK;
+    } else {
+        s = timm("result", "fserror");
+        timm_append(s, "fsstatus", "%d", -EIO);
+    }
+    async_apply_1(ctx->completion, s);
+    deallocate(s3fs.h, ctx, sizeof(*ctx));
+}
+
+static void s3fs_fsf_read(fsfile f, sg_list sg, range q, status_handler completion)
+{
+    s3fs_debug("read r %R, sh %F", q, completion);
+    status s;
+    int fsstatus;
+    s3fs_read_ctx read_ctx = allocate(s3fs.h, sizeof(*read_ctx));
+    if (read_ctx == INVALID_ADDRESS) {
+        fsstatus = -ENOMEM;
+        goto out;
+    }
+    read_ctx->sg = sg;
+    read_ctx->completion = completion;
+    s3fs_io_req(f, false, q, 0,
+                init_closure_func(&read_ctx->handler, value_handler, s3fs_read_handler));
+    return;
+  out:
+    s = timm("result", "fserror");
+    apply(completion, timm_append(s, "fsstatus", "%d", fsstatus));
+}
+
+closure_func_basic(value_handler, void, s3fs_write_handler,
+                   value resp)
+{
+    s3fs_write_ctx ctx = struct_from_closure(s3fs_write_ctx, handler);
+    status s;
+    sg_buf sgb = ctx->sgb;
+    if (http_resp_is_ok(resp)) {
+        fsfile_set_length(ctx->f, ctx->write_end);
+        s = STATUS_OK;
+    } else {
+        s = timm("result", "fserror");
+        timm_append(s, "fsstatus", "%d", -EIO);
+    }
+    if (sgb != INVALID_ADDRESS)
+        sg_buf_release(sgb);
+    async_apply_1(ctx->completion, s);
+    deallocate(s3fs.h, ctx, sizeof(*ctx));
+}
+
+static void s3fs_fsf_write(fsfile f, sg_list sg, range q, status_handler completion)
+{
+    s3fs_debug("write r %R, sh %F", q, completion);
+    status s;
+    int fsstatus;
+    if ((sg_list_length(sg) > 1) || (q.start != 0)) {
+        fsstatus = -EOPNOTSUPP;
+        goto out;
+    }
+    s3fs_write_ctx write_ctx = allocate(s3fs.h, sizeof(*write_ctx));
+    if (write_ctx == INVALID_ADDRESS) {
+        fsstatus = -ENOMEM;
+        goto out;
+    }
+    sg_buf sgb = sg_list_head_remove(sg);
+    buffer body;
+    if (sgb != INVALID_ADDRESS) {
+        body = wrap_buffer(s3fs.h, sgb->buf + sgb->offset, range_span(q));
+        if (body == INVALID_ADDRESS) {
+            sg_buf_release(sgb);
+            fsstatus = -ENOMEM;
+            goto err_dealloc_ctx;
+        }
+    } else {
+        body = 0;
+    }
+    write_ctx->f = f;
+    write_ctx->write_end = q.end;
+    write_ctx->sgb = sgb;
+    write_ctx->completion = completion;
+    s3fs_io_req(f, true, irange(0, 0), body,
+                init_closure_func(&write_ctx->handler, value_handler, s3fs_write_handler));
+    return;
+  err_dealloc_ctx:
+    deallocate(s3fs.h, write_ctx, sizeof(*write_ctx));
+  out:
+    s = timm("result", "fserror");
+    async_apply_1(completion, timm_append(s, "fsstatus", "%d", fsstatus));
+}
+
+static boolean is_leap_year(int year) {
+    if ((year & 3) != 0) {
+        return false;
+    }
+    if ((year % 100) != 0) {
+        return true;
+    }
+    return (year % 400) == 0;
+}
+
+static boolean parse_last_modified(buffer b, timestamp *ts)
+{
+    /* timestamp example: Sat, 25 Jul 2026 09:15:30 GMT */
+    if (buffer_length(b) < 29)
+        return false;
+    char *p = buffer_ref(b, 0);
+    u64 day = (p[5] - '0') * 10 + (p[6] - '0');
+    u64 month = -1ull;
+    sstring mon = isstring(p + 8, 3);
+    const char *months[] = {
+            "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    };
+    for (int i = 0; i < 12; i++) {
+        if (!runtime_memcmp(mon.ptr, months[i], 3)) {
+            month = i;
+            break;
+        }
+    }
+    if (month == -1ull)
+        return false;
+    u64 year = 0;
+    for (int i = 0; i < 4; i++) {
+        year = year * 10 + (p[12 + i] - '0');
+    }
+    u64 hour = (p[17] - '0') * 10 + (p[18] - '0');
+    u64 min = (p[20] - '0') * 10 + (p[21] - '0');
+    u64 sec = (p[23] - '0') * 10 + (p[24] - '0');
+    s3fs_debug("last modified '%b', %d-%02d-%02d %02d:%02d:%02d", b,
+               year, month + 1, day, hour, min, sec);
+    u64 days = 0;
+    for (u64 y = 1970; y < year; y++)
+        days += is_leap_year(y) ? 366 : 365;
+    int month_days[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    for (u64 m = 0; m < month; m++) {
+        if (m == 1 && is_leap_year(year))
+            days += 29;
+        else
+            days += month_days[m];
+    }
+    days += day - 1;
+    u64 total_secs = days * 86400 + hour * 3600 + min * 60 + sec;
+    *ts = seconds(total_secs);
+    return true;
+}
+
+closure_function(4, 1, void, s3fs_head_resp,
+                 u64 *, plen, timestamp *, pmtime, boolean *, success, context, ctx,
+                 value resp)
+{
+    if (http_resp_is_ok(resp)) {
+        *bound(success) = true;
+        buffer cl = get(resp, sym(Content-Length));
+        if (!cl || !parse_int(cl, 10, bound(plen)))
+            *bound(plen) = 0;
+        buffer lm = get(resp, sym(Last-Modified));
+        if (!lm || !parse_last_modified(lm, bound(pmtime)))
+            *bound(pmtime) = 0;
+    }
+    context_schedule_return(bound(ctx));
+}
+
+static int s3fs_head_object(s3fs_volume s3fs, s3fs_object obj, u64 *plen, timestamp *pmtime)
+{
+    tuple req = allocate_tuple();
+    if (req == INVALID_ADDRESS)
+        return -ENOMEM;
+    buffer query = alloca_wrap_sstring(obj->key);
+    boolean success = false;
+    context ctx = current_context();
+    value_handler resp_handler = stack_closure(s3fs_head_resp, plen, pmtime, &success, ctx);
+    context_pre_suspend(ctx);
+    s3fs_request(s3fs, query, HTTP_REQUEST_METHOD_HEAD, req, 0, resp_handler);
+    context_suspend();
+    s3fs_req_cleanup(req);
+    return success ? 0 : -EIO;
+}
+
+static int s3fs_get_fsfile(filesystem fs, tuple md, fsfile *f)
+{
+    s3fs_volume vol = (s3fs_volume)fs;
+    s3fs_object obj = s3fs_obj_get(vol, md);
+    s3fs_debug("get fsfile, md %p, obj %p", md, obj);
+    if (!obj)
+        return -ENOENT;
+    s3fs_file fsf = obj->f;
+    if (!fsf) {
+        u64 len;
+        timestamp mtime;
+        int ret = s3fs_head_object(vol, obj, &len, &mtime);
+        if (ret < 0)
+            return ret;
+        fsf = s3fs_file_new(vol, obj);
+        if (!fsf)
+            return -ENOMEM;
+        fsfile_set_length(&fsf->f, len);
+        filesystem_set_mtime(fs, md, mtime);
+        obj->f = fsf;
+    }
+    fsfile_reserve(&fsf->f);
+    *f = &fsf->f;
+    return 0;
+}
+
+static tuple s3fs_get_meta(filesystem fs, inode n)
+{
+    s3fs_volume vol = (s3fs_volume)fs;
+    s3fs_object obj = s3fs_obj_get(vol, pointer_from_u64(n));
+    return obj ? obj->md : 0;
+}
+
+closure_function(1, 2, boolean, s3fs_dir_set_stale,
+                 s3fs_volume, vol,
+                 value k, value v)
+{
+    s3fs_volume vol = bound(vol);
+    s3fs_object obj = s3fs_obj_get(vol, v);
+    if (obj)
+        obj->stale = true;
+    return true;
+}
+
+closure_function(1, 2, boolean, s3fs_dir_del_stale,
+                 s3fs_volume, vol,
+                 value k, value v)
+{
+    s3fs_volume vol = bound(vol);
+    s3fs_object obj = s3fs_obj_get(vol, v);
+    if (obj && obj->stale) {
+        s3fs_debug("deleting stale object %s", obj->key);
+        fs_notify_release(obj->md, false);
+        s3fs_obj_delete(vol, obj);
+    }
+    return true;
+}
+
+static boolean s3fs_readdir_entry(s3fs_volume vol, tuple parent, bytes dir_path_len, buffer body,
+                                  xml_elem elem, boolean dir)
+{
+    if (elem->data_len <= dir_path_len)
+        return true;
+    s3fs_object obj = 0;
+    sstring base_name = isstring(buffer_ref(body, elem->data_start + dir_path_len),
+                                 elem->data_len - dir_path_len);
+    if (dir)
+        /* The trailing slash must not be included in the children tuple attribute. */
+        base_name.len -= 1;
+    symbol base_name_s = sym_sstring(base_name);
+    tuple c = children(parent);
+    tuple md = get(c, base_name_s);
+    if (md)
+        obj = s3fs_obj_get(vol, md);
+    s3fs_debug("readdir '%s%s' (%s)", base_name, dir ? ss("/") : sstring_empty(),
+               obj ? ss("cached") : ss("new"));
+    if (obj) {
+        obj->stale = false;
+    } else {
+        obj = s3fs_obj_new(vol, 1 + elem->data_len, parent, dir);   /* +1 for the leading slash */
+        if (!obj) {
+            msg_err("s3fs: readdir allocation failure");
+            return false;
+        }
+        obj->key.ptr[0] = '/';
+        runtime_memcpy(obj->key.ptr + 1, buffer_ref(body, elem->data_start), elem->data_len);
+        obj->stale = false;
+        set(c, base_name_s, obj->md);
+    }
+    return true;
+}
+
+closure_function(4, 1, void, s3fs_readdir_resp,
+                 s3fs_volume, vol, s3fs_object, dir, boolean *, success, context, ctx,
+                 value resp)
+{
+    s3fs_volume vol = bound(vol);
+    if (!http_resp_is_ok(resp)) {
+        *bound(success) = false;
+        goto out;
+    }
+    buffer body = get(resp, sym(content));
+    if (!body) {
+        *bound(success) = false;
+        goto out;
+    }
+    *bound(success) = true;
+    s3fs_object dir = bound(dir);
+    tuple dir_md = dir->md;
+    bytes dir_path_len = dir->key.len - 1;
+    struct xml_elem elem;
+    while (xml_get_elem(body, ss("Key"), &elem)) {
+        if (!s3fs_readdir_entry(vol, dir_md, dir_path_len, body, &elem, false)) {
+            *bound(success) = false;
+            goto out;
+        }
+        buffer_consume(body, elem.start + elem.len);
+    }
+    while (xml_get_elem(body, ss("Prefix"), &elem)) {
+        if (!s3fs_readdir_entry(vol, dir_md, dir_path_len, body, &elem, true)) {
+            *bound(success) = false;
+            goto out;
+        }
+        buffer_consume(body, elem.start + elem.len);
+    }
+  out:
+    context_schedule_return(bound(ctx));
+}
+
+static int s3fs_readdir(s3fs_volume fs, s3fs_object dir)
+{
+    tuple req = allocate_tuple();
+    if (req == INVALID_ADDRESS) {
+        msg_err("s3fs: readdir allocation failure");
+        return -ENOMEM;
+    }
+
+    /* Request list of objects with prefix */
+    buffer query = little_stack_buffer(dir->key.len + 32);
+    /* Remove the leading slash from the key string. */
+    sstring prefix = isstring(dir->key.ptr + 1, dir->key.len - 1);
+    bprintf(query, "/?delimiter=/&list-type=2&prefix=%s", prefix);
+    tuple c = children(dir->md);
+    iterate(c, stack_closure(s3fs_dir_set_stale, fs));
+    boolean success;
+    context ctx = current_context();
+    value_handler resp_handler = stack_closure(s3fs_readdir_resp, fs, dir, &success, ctx);
+    context_pre_suspend(ctx);
+    s3fs_request(fs, query, HTTP_REQUEST_METHOD_GET, req, 0, resp_handler);
+    context_suspend();
+    s3fs_req_cleanup(req);
+    if (success) {
+        iterate(c, stack_closure(s3fs_dir_del_stale, fs));
+        return 0;
+    }
+    return -EIO;
+}
+
+closure_function(2, 1, void, s3fs_mkobj_resp,
+                 boolean *, success, context, ctx,
+                 value resp)
+{
+    if (http_resp_is_ok(resp))
+        *bound(success) = true;
+    context_schedule_return(bound(ctx));
+}
+
+static int s3fs_mkobj(s3fs_volume s3fs, s3fs_object obj)
+{
+    tuple req = allocate_tuple();
+    if (req == INVALID_ADDRESS)
+        return -ENOMEM;
+    buffer query = alloca_wrap_sstring(obj->key);
+    boolean success = false;
+    context ctx = current_context();
+    value_handler resp_handler = stack_closure(s3fs_mkobj_resp, &success, ctx);
+    context_pre_suspend(ctx);
+    s3fs_request(s3fs, query, HTTP_REQUEST_METHOD_PUT, req, 0, resp_handler);
+    context_suspend();
+    s3fs_req_cleanup(req);
+    return success ? 0 : -EIO;
+}
+
+closure_function(2, 1, void, s3fs_delete_resp,
+                 boolean *, success, context, ctx,
+                 value resp)
+{
+    if (http_resp_is_ok(resp))
+        *bound(success) = true;
+    context_schedule_return(bound(ctx));
+}
+
+static int s3fs_delete_key(s3fs_volume s3fs, sstring key)
+{
+    tuple req = allocate_tuple();
+    if (req == INVALID_ADDRESS)
+        return -ENOMEM;
+    buffer query = alloca_wrap_sstring(key);
+    boolean success = false;
+    context ctx = current_context();
+    value_handler resp_handler = stack_closure(s3fs_delete_resp, &success, ctx);
+    context_pre_suspend(ctx);
+    s3fs_request(s3fs, query, HTTP_REQUEST_METHOD_DELETE, req, 0, resp_handler);
+    context_suspend();
+    s3fs_req_cleanup(req);
+    return success ? 0 : -EIO;
+}
+
+static tuple s3fs_lookup(filesystem fs, tuple parent, string name)
+{
+    s3fs_debug("lookup '%b'", name);
+    s3fs_volume s3fs = (s3fs_volume)fs;
+    tuple md;
+    s3fs_object obj;
+    if (!buffer_strcmp(name, "."))
+        md = parent;
+    else if (!buffer_strcmp(name, ".."))
+        md = get(parent, sym(..));
+    else
+        md = get(children(parent), intern(name));
+    if (!md || !(obj = s3fs_obj_get(s3fs, md)))
+        return 0;
+    if (is_dir(md) && (s3fs_readdir(s3fs, obj) < 0))
+        return 0;
+    return md;
+}
+
+static int s3fs_create(filesystem fs, tuple parent, string name, tuple md, fsfile *f)
+{
+    if (!name || is_symlink(md) || is_socket(md))
+        return -EOPNOTSUPP;
+    s3fs_debug("create '%b'", name);
+    s3fs_volume s3fs = (s3fs_volume)fs;
+    s3fs_object parent_obj = s3fs_obj_get(s3fs, parent);
+    if (!parent_obj)
+        return -ENOENT;
+    boolean dir = is_dir(md);
+    bytes key_len = parent_obj->key.len + buffer_length(name);
+    if (dir)
+        key_len += 1;   /* for the trailing slash */
+    s3fs_object obj = s3fs_obj_new_from_md(s3fs, key_len, md);
+    if (!obj)
+        return -ENOMEM;
+    runtime_memcpy(obj->key.ptr, parent_obj->key.ptr, parent_obj->key.len);
+    runtime_memcpy(obj->key.ptr + parent_obj->key.len, buffer_ref(name, 0), buffer_length(name));
+    s3fs_file fsf = 0;
+    int ret;
+    if (dir)
+        obj->key.ptr[key_len - 1] = '/';
+    else {
+        fsf = s3fs_file_new(s3fs, obj);
+        if (!fsf) {
+            ret = -ENOMEM;
+            goto out;
+        }
+        if (f) {
+            fsfile_reserve(&fsf->f);
+            *f = &fsf->f;
+        }
+    }
+    ret = s3fs_mkobj(s3fs, obj);
+  out:
+    if (ret < 0) {
+        obj->md = 0;
+        s3fs_obj_delete(s3fs, obj);
+    }
+    return ret;
+}
+
+static int s3fs_unlink(filesystem fs, tuple parent, string name, tuple md, boolean *destruct_md)
+{
+    s3fs_volume s3fs = (s3fs_volume)fs;
+    s3fs_debug("unlink '%b'", name);
+    s3fs_object obj = s3fs_obj_get(s3fs, md);
+    if (!obj)
+        return -ENOENT;
+    int ret = s3fs_delete_key(s3fs, obj->key);
+    if (ret < 0)
+        return ret;
+    obj->md = 0;
+    s3fs_obj_delete(s3fs, obj);
+    if (destruct_md)
+        *destruct_md = true;
+    return 0;
+}
+
+closure_function(2, 1, void, s3fs_copy_resp,
+                 boolean *, success, context, ctx,
+                 value resp)
+{
+    if (http_resp_is_ok(resp))
+        *bound(success) = true;
+    context_schedule_return(bound(ctx));
+}
+
+static int s3fs_copy_object(s3fs_volume s3fs, sstring src_key, sstring dest_key)
+{
+    tuple req = allocate_tuple();
+    if (req == INVALID_ADDRESS)
+        return -ENOMEM;
+    buffer copy_source = little_stack_buffer(1 + s3fs->bucket.len + src_key.len);
+    bprintf(copy_source, "/%s%s", s3fs->bucket, src_key);
+    set(req, sym(x-amz-copy-source), copy_source);
+    buffer query = alloca_wrap_sstring(dest_key);
+    boolean success = false;
+    context ctx = current_context();
+    value_handler resp_handler = stack_closure(s3fs_copy_resp, &success, ctx);
+    context_pre_suspend(ctx);
+    s3fs_request(s3fs, query, HTTP_REQUEST_METHOD_PUT, req, 0, resp_handler);
+    context_suspend();
+    s3fs_req_cleanup(req);
+    return success ? 0 : -EIO;
+}
+
+static int s3fs_rename(filesystem fs, tuple old_parent, string old_name, tuple old_md,
+                       tuple new_parent, string new_name, tuple new_md, boolean exchange,
+                       boolean *destruct_md)
+{
+    s3fs_debug("rename old '%b' new '%b'%s", old_name, new_name,
+               exchange ? ss(" (exchange)") : sstring_empty());
+    if (exchange)
+        return -EOPNOTSUPP;
+    s3fs_volume s3fs = (s3fs_volume)fs;
+    s3fs_object old_obj = s3fs_obj_get(s3fs, old_md);
+    if (!old_obj)
+        return -ENOENT;
+    s3fs_object new_parent_obj = s3fs_obj_get(s3fs, new_parent);
+    if (!new_parent_obj)
+        return -ENOENT;
+    boolean dir = is_dir(old_md);
+    bytes key_len = new_parent_obj->key.len + buffer_length(new_name);
+    if (dir)
+        key_len += 1;
+    sstring new_key;
+    if (!sstring_allocate(s3fs->fs.h, key_len, &new_key))
+        return -ENOMEM;
+    runtime_memcpy(new_key.ptr, new_parent_obj->key.ptr, new_parent_obj->key.len);
+    runtime_memcpy(new_key.ptr + new_parent_obj->key.len, buffer_ref(new_name, 0),
+                   buffer_length(new_name));
+    if (dir)
+        new_key.ptr[key_len - 1] = '/';
+    int ret = s3fs_copy_object(s3fs, old_obj->key, new_key);
+    if (!ret) {
+        s3fs_delete_key(s3fs, old_obj->key);
+        sstring_deallocate(s3fs->fs.h, old_obj->key);
+        old_obj->key = new_key;
+    } else {
+        sstring_deallocate(s3fs->fs.h, new_key);
+    }
+    if (!ret && new_md) {
+        s3fs_object obj = s3fs_obj_get(s3fs, new_md);
+        if (obj) {
+            obj->md = 0;
+            s3fs_obj_delete(s3fs, obj);
+        }
+        *destruct_md = true;
+    }
+    return ret;
+}
+
+static int s3fs_truncate(filesystem fs, fsfile f, u64 len)
+{
+    if (len > 0)
+        return -EOPNOTSUPP;
+    s3fs_volume s3fs = (s3fs_volume)fs;
+    s3fs_file s3f = (s3fs_file)f;
+    return s3fs_mkobj(s3fs, s3f->obj);
+}
+
+closure_function(4, 1, void, s3fs_cache_sync_complete,
+                 filesystem, fs, fsfile, f, boolean, datasync, status_handler, completion,
+                 status s)
+{
+    s3fs_debug("cache sync complete, status %v", s);
+    async_apply_status_handler(bound(completion), s);
+    closure_finish();
+}
+
+static status_handler s3fs_get_sync_handler(filesystem fs, fsfile fsf, boolean datasync,
+                                            status_handler completion)
+{
+    return closure(fs->h, s3fs_cache_sync_complete, fs, fsf, datasync, completion);
+}
+
+closure_func_basic(fs_init_handler, void, s3fs_fs_init,
+                   boolean readonly, filesystem_complete complete)
+{
+    s3fs_debug("FS init read-%s (%F)", readonly ? ss("only") : ss("write"), complete);
+    s3fs_volume vol = struct_from_closure(s3fs_volume, fs_init);
+    filesystem fs = &vol->fs;
+
+    status s = filesystem_init(fs, s3fs.h, 1024ull * GB, 1, readonly);
+    if (!is_ok(s)) {
+        apply(complete, INVALID_ADDRESS, s);
+        return;
+    }
+    tuple root_md = allocate_tuple();
+    if (root_md == INVALID_ADDRESS)
+        goto err_fs_deinit;
+    tuple c = allocate_tuple();
+    if (c == INVALID_ADDRESS)
+        goto err_root_dealloc;
+    s3fs_object root = s3fs_obj_new_from_md(vol, 1, root_md);
+    if (!root)
+        goto err_c_dealloc;
+    set(root_md, sym_this("children"), c);
+    set(root_md, sym_this(".."), root_md);
+    root->key.ptr[0] = '/';
+    fs->root = root_md;
+    fs->lookup = s3fs_lookup;
+    fs->create = s3fs_create;
+    fs->unlink = s3fs_unlink;
+    fs->rename = s3fs_rename;
+    fs->truncate = s3fs_truncate;
+    fs->get_fsfile = s3fs_get_fsfile;
+    fs->get_inode = fs_get_inode;
+    fs->file_read = s3fs_fsf_read;
+    fs->file_write = s3fs_fsf_write;
+    fs->get_meta = s3fs_get_meta;
+    fs->get_sync_handler = s3fs_get_sync_handler;
+    apply(complete, fs, STATUS_OK);
+    return;
+  err_c_dealloc:
+    deallocate_value(c);
+  err_root_dealloc:
+    deallocate_value(root_md);
+  err_fs_deinit:
+    filesystem_deinit(fs);
+    apply(complete, INVALID_ADDRESS, timm_oom);
+}
+
+static boolean s3fs_volume_create(heap h, value spec)
+{
+    string bucket = get_string(spec, sym_this("name"));
+    if (!bucket) {
+        msg_err("s3fs: missing or invalid bucket name");
+        return false;
+    }
+    char label[VOLUME_LABEL_MAX_LEN];
+    if (rsnprintf(label, sizeof(label), "%s%b", S3FS_VOL_PREFIX, bucket) >= sizeof(label)) {
+        msg_err("s3fs: bucket name '%b' too long", bucket);
+        return false;
+    }
+    string mount_path = get_string(spec, sym(mount));
+    if (mount_path) {
+        if (!storage_add_mountpoint(sym_sstring(sstring_from_cstring(label, sizeof(label))),
+                                    mount_path)) {
+            msg_err("s3fs: failed to add mount point for bucket %b at %b", bucket, mount_path);
+            return false;
+        }
+    }
+    s3fs_volume vol = allocate(h, sizeof(*vol));
+    if (vol == INVALID_ADDRESS) {
+        msg_err("s3fs: cannot allocate volume");
+        return false;
+    }
+    vol->bucket = buffer_to_sstring(bucket);
+    const sstring host_prefix = ss(".s3.");
+    const sstring host_suffix = ss(".amazonaws.com");
+    bytes bucket_len = buffer_length(bucket);
+    bytes hostname_len = bucket_len + host_prefix.len + s3fs.region.len + host_suffix.len;
+    char *hostname = mem_alloc(h, hostname_len, MEM_NOFAIL);
+    init_buffer(&vol->hostname, hostname_len, false, h, hostname);
+    runtime_memcpy(hostname, buffer_ref(bucket, 0), bucket_len);
+    bytes offset = bucket_len;
+    runtime_memcpy(hostname + offset, host_prefix.ptr, host_prefix.len);
+    offset += host_prefix.len;
+    runtime_memcpy(hostname + offset, s3fs.region.ptr, s3fs.region.len);
+    offset += s3fs.region.len;
+    runtime_memcpy(hostname + offset, host_suffix.ptr, host_suffix.len);
+    buffer_produce(&vol->hostname, hostname_len);
+    list_init(&vol->objs);
+    u8 uuid[UUID_LEN];
+    if (!volume_add(uuid, label, vol,
+                    init_closure_func(&vol->fs_init, fs_init_handler, s3fs_fs_init), -1)) {
+        msg_err("s3fs: cannot add volume for bucket %b", bucket);
+        deallocate(h, vol, sizeof(*vol));
+        return false;
+    }
+    return true;
+}
+
+int init(status_handler complete)
+{
+    tuple config = get(get_root_tuple(), sym_this("s3fs"));
+    if (!config)
+        return KLIB_INIT_OK;
+    heap h = heap_locked(get_kernel_heaps());
+    s3fs.h = h;
+    string region = get_string(config, sym_this("region"));
+    if (!region) {
+        msg_err("s3fs: missing or invalid region");
+        return KLIB_INIT_FAILED;
+    }
+    s3fs.region = buffer_to_sstring(region);
+    string access_key = get_string(config, sym_this("access_key"));
+    if (!access_key) {
+        msg_err("s3fs: missing or invalid access key");
+        return KLIB_INIT_FAILED;
+    }
+    s3fs.access_key = buffer_to_sstring(access_key);
+    string secret = get_string(config, sym_this("secret"));
+    if (!secret) {
+        msg_err("s3fs: missing or invalid secret");
+        return KLIB_INIT_FAILED;
+    }
+    s3fs.secret = buffer_to_sstring(secret);
+    string buckets = get(config, sym_this("buckets"));
+    if (!is_composite(buckets)) {
+        msg_err("s3fs: invalid configuration");
+        return KLIB_INIT_FAILED;
+    }
+    buffer_init_from_string(&s3fs.sha_empty,
+                            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    buffer_init_from_string(&s3fs.sha_payload, "UNSIGNED-PAYLOAD");
+    value volume_spec;
+    for (int i = 0; (volume_spec = get(buckets, integer_key(i))); i++) {
+        if (!s3fs_volume_create(h, volume_spec))
+            return KLIB_INIT_FAILED;
+    }
+    return KLIB_INIT_OK;
+}

--- a/klib/tmpfs.c
+++ b/klib/tmpfs.c
@@ -166,12 +166,11 @@ static int tmpfs_rename(filesystem fs, tuple old_parent, string old_name, tuple 
                               tuple new_parent, string new_name, tuple new_md, boolean exchange,
                               boolean *destruct_md)
 {
-    int s = fs_check_rename(old_parent, old_md, new_parent, new_md, exchange);
-    if ((s == 0) && !exchange && new_md) {
+    if (!exchange && new_md) {
         fs_unlink(((tmpfs)fs)->files, new_md);
         *destruct_md = true;
     }
-    return s;
+    return 0;
 }
 
 static int tmpfs_truncate(filesystem fs, fsfile f, u64 len)

--- a/src/fs/9p.c
+++ b/src/fs/9p.c
@@ -47,22 +47,6 @@ static symbol p9_sym(struct p9_string *name)
     return intern(alloca_wrap_buffer(name->str, name->length));
 }
 
-static void p9_md_cleanup(tuple md)
-{
-    symbol parent_sym = sym_this("..");
-    tuple parent = get_tuple(md, parent_sym);
-    if (parent) {
-        tuple c = children(parent);
-        if (c) {
-            symbol name = tuple_get_symbol(c, md);
-            if (name)
-                set(c, name, 0);
-        }
-        set(md, parent_sym, 0);
-    }
-    destruct_value(md, true);
-}
-
 static u32 p9_fid_new(p9fs fs)
 {
     u32 fid;
@@ -108,7 +92,7 @@ static void p9_dentry_delete(p9fs fs, p9_dentry dentry)
     if (dentry->fid != P9_NOFID)
         p9_fid_release(fs, dentry->fid);
     if (dentry->md)
-        p9_md_cleanup(dentry->md);
+        fs_cleanup_dir_entry(dentry->md);
     deallocate(fs->fs.h, dentry, sizeof(*dentry));
 }
 
@@ -238,7 +222,7 @@ closure_func_basic(thunk, void, p9_fsf_free)
     if (md && !fs_file_is_busy(fs, md)) {
         /* dentry will be deallocated when the pagecache sync is done: delete its metadata tuple now
          * so that it cannot be looked up (e.g. via its parent tuple). */
-        p9_md_cleanup(md);
+        fs_cleanup_dir_entry(md);
         dentry->md = 0;
 
         f->md = 0;  /* so that it won't be accessed by the file write completion */
@@ -621,7 +605,7 @@ static tuple p9_lookup(filesystem fs, tuple parent, string name)
     return md;
   error:
     if (!dentry) {
-        p9_md_cleanup(md);
+        fs_cleanup_dir_entry(md);
         p9_fid_release(p9fs, fid);
         md = 0;
     }

--- a/src/fs/fs.c
+++ b/src/fs/fs.c
@@ -494,6 +494,22 @@ static int fs_create_dir_entry(filesystem fs, tuple parent, string name, tuple m
     return s;
 }
 
+void fs_cleanup_dir_entry(tuple md)
+{
+    symbol parent_sym = sym(..);
+    tuple parent = get_tuple(md, parent_sym);
+    if (parent) {
+        tuple c = children(parent);
+        if (c) {
+            symbol name = tuple_get_symbol(c, md);
+            if (name)
+                set(c, name, 0);
+        }
+        set(md, parent_sym, 0);
+    }
+    destruct_value(md, true);
+}
+
 closure_function(1, 2, boolean, file_unlink_each,
                  tuple, t,
                  value k, value v)

--- a/src/fs/fs.c
+++ b/src/fs/fs.c
@@ -858,6 +858,9 @@ int filesystem_rename(filesystem oldfs, inode oldwd, sstring oldpath,
     string newname = alloca_wrap_sstring(filename_from_path(newpath));
     symbol new_s = intern(newname);
     boolean destruct_md;
+    s = fs_check_rename(oldparent, old, newparent, new, false);
+    if (s != 0)
+        goto out;
     s = oldfs->rename(oldfs, oldparent, oldname, old, newparent, newname, new, false, &destruct_md);
     if (s == 0) {
         set(children(oldparent), old_s, 0);
@@ -931,6 +934,9 @@ int filesystem_exchange(filesystem fs1, inode wd1, sstring path1,
         goto out;
     string name1 = alloca_wrap_sstring(filename_from_path(path1));
     string name2 = alloca_wrap_sstring(filename_from_path(path2));
+    s = fs_check_rename(parent1, n1, parent2, n2, true);
+    if (s != 0)
+        goto out;
     s = fs1->rename(fs1, parent1, name1, n1, parent2, name2, n2, true, 0);
     if (s == 0) {
         set(children(parent1), intern(name1), n2);

--- a/src/fs/fs.h
+++ b/src/fs/fs.h
@@ -156,6 +156,7 @@ static inline u64 sector_from_offset(filesystem fs, bytes b)
 #endif
 
 tuple fs_new_entry(filesystem fs);
+void fs_cleanup_dir_entry(tuple md);
 
 boolean file_tuple_is_ancestor(tuple t1, tuple t2, tuple p2);
 int fs_check_rename(tuple old_parent, tuple old_md, tuple new_parent, tuple new_md,

--- a/src/fs/tfs.c
+++ b/src/fs/tfs.c
@@ -1187,9 +1187,7 @@ static int tfs_rename(filesystem fs, tuple old_parent, string old_name, tuple ol
                             tuple new_parent, string new_name, tuple new_md, boolean exchange,
                             boolean *destruct_md)
 {
-    int s = fs_check_rename(old_parent, old_md, new_parent, new_md, exchange);
-    if (s != 0)
-        return s;
+    int s;
     tfs tfs = (struct tfs *)fs;
     s = filesystem_write_eav(tfs, children(new_parent), intern(new_name), old_md, true);
     if (s == 0)

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -20,6 +20,7 @@ typedef struct http_parser {
     heap h;
     vector start_line;
     int state;
+    boolean headers_only;
     boolean chunked;
     buffer word;
     symbol s;
@@ -251,6 +252,8 @@ closure_function(1, 1, status, http_recv,
                 buffer_clear(p->word);
                 break;
             case '\n':
+                if (p->headers_only)
+                    goto content_finish;
                 if (p->chunked) {
                     p->state = STATE_CHUNK_SIZE;
                     p->body = allocate_buffer(p->h, KB);
@@ -358,12 +361,13 @@ closure_function(1, 1, status, http_recv,
     return STATUS_OK;
 }
 
-buffer_handler allocate_http_parser(heap h, value_handler each)
+buffer_handler allocate_http_parser(heap h, boolean headers_only, value_handler each)
 {
     http_parser p = allocate(h, sizeof(struct http_parser));
     if (p == INVALID_ADDRESS)
         return INVALID_ADDRESS;
     p->h = h;
+    p->headers_only = headers_only;
     p->each = each;
     reset_parser(p);
     return closure(h, http_recv, p);
@@ -548,7 +552,8 @@ closure_function(1, 1, input_buffer_handler, each_http_connection,
     hr.keepalive = true;
     hr.out = out;
     hr.http_version = HTTP_VER(1, 1);
-    buffer_handler parser = allocate_http_parser(hl->h, closure(hl->h, each_http_request, hl, hr));
+    buffer_handler parser = allocate_http_parser(hl->h, false,
+                                                 closure(hl->h, each_http_request, hl, hr));
     if (parser == INVALID_ADDRESS)
         return INVALID_ADDRESS;
     input_buffer_handler ibh = closure(hl->h, http_ibh, parser);

--- a/src/http/http.c
+++ b/src/http/http.c
@@ -81,6 +81,15 @@ status http_request(heap h, buffer_handler bh, http_method method, tuple headers
     return s;
 }
 
+boolean http_resp_is_ok(value v)
+{
+    if (!v)
+        return false;
+    value start_line = get(v, sym(start_line));
+    string status_code = get_string(start_line, integer_key(1));
+    return (status_code && (buffer_length(status_code) == 3) && (peek_char(status_code) == '2'));
+}
+
 static status send_http_headers(http_responder out, tuple t)
 {
     status s;

--- a/src/http/http.h
+++ b/src/http/http.h
@@ -17,6 +17,7 @@ buffer_handler allocate_http_parser(heap h, boolean headers_only, value_handler 
 // just format the buffer?
 status http_request(heap h, buffer_handler bh, http_method method,
                     tuple headers, buffer body);
+boolean http_resp_is_ok(value v);
 status send_http_response(http_responder out,
                           tuple t,
                           buffer c);

--- a/src/http/http.h
+++ b/src/http/http.h
@@ -13,7 +13,7 @@ typedef enum {
 
 typedef struct http_responder *http_responder;
 
-buffer_handler allocate_http_parser(heap h, value_handler each);
+buffer_handler allocate_http_parser(heap h, boolean headers_only, value_handler each);
 // just format the buffer?
 status http_request(heap h, buffer_handler bh, http_method method,
                     tuple headers, buffer body);

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -257,6 +257,11 @@ static inline __attribute__((always_inline)) void set_current_context(cpuinfo ci
     ci->m.current_context = c;
 }
 
+static inline context current_context(void)
+{
+    return get_current_context(current_cpu());
+}
+
 static inline boolean in_interrupt(void)
 {
     return current_cpu()->state == cpu_interrupt;

--- a/src/kernel/storage.c
+++ b/src/kernel/storage.c
@@ -256,6 +256,23 @@ void storage_set_mountpoints(tuple mounts)
     storage_check_if_ready();
 }
 
+boolean storage_add_mountpoint(symbol volume, string path)
+{
+    storage_lock();
+    tuple mounts = storage.mounts;
+    if (!mounts) {
+        mounts = allocate_tuple();
+        if (mounts == INVALID_ADDRESS) {
+            storage_unlock();
+            return false;
+        }
+        storage.mounts = mounts;
+    }
+    set(mounts, volume, path);
+    storage_unlock();
+    return true;
+}
+
 closure_function(1, 2, boolean, volume_add_mount_each,
                  volume, v,
                  value k, value path)

--- a/src/runtime/runtime_string.h
+++ b/src/runtime/runtime_string.h
@@ -24,3 +24,17 @@ static inline string wrap_string_sstring(sstring s)
 }
 
 #define wrap_string_cstring(x)  wrap_string_sstring(ss(x))
+
+static inline boolean sstring_allocate(heap h, bytes len, sstring *s)
+{
+    s->ptr = allocate(h, len);
+    if (s->ptr == INVALID_ADDRESS)
+        return false;
+    s->len = len;
+    return true;
+}
+
+static inline void sstring_deallocate(heap h, sstring s)
+{
+    deallocate(h, s.ptr, s.len);
+}

--- a/src/runtime/storage.h
+++ b/src/runtime/storage.h
@@ -98,6 +98,7 @@ closure_type(fs_init_handler, void, boolean readonly, fs_init_complete complete)
 void init_volumes(heap h);
 void storage_set_root_fs(struct filesystem *root_fs);
 void storage_set_mountpoints(tuple mounts);
+boolean storage_add_mountpoint(symbol volume, string path);
 boolean volume_add(u8 *uuid, char *label, void *priv, fs_init_handler init_handler, int attach_id);
 void storage_when_ready(status_handler complete);
 void storage_sync(status_handler sh);

--- a/test/unit/network_test.c
+++ b/test/unit/network_test.c
@@ -87,7 +87,9 @@ closure_function(5, 1, input_buffer_handler, newconn,
     send_request(c, s, out, t);
     send_request(c, s, out, t);
     send_request(c, s, out, t);
-    buffer_handler bh = allocate_http_parser(c, closure(c, value_in, c, out, count, bound(sth), bound(newconn), s, t));
+    buffer_handler bh = allocate_http_parser(c, false,
+                                             closure(c, value_in, c, out, count, bound(sth),
+                                                     bound(newconn), s, t));
     return closure(c, ibh_parser_wrap, bh);
 }
 


### PR DESCRIPTION
This change set adds support for a new filesystem type that allows accessing objects in an AWS S3 bucket as regular files.
This filesystem is implemented as a klib (with a dependency on the existing tls klib), and is configured as shown in the following Ops configuration snippet:
```
  "Klibs": ["s3fs", "tls"],
  "ManifestPassthrough": {
    "s3fs": {
      "region": "us-west-1",
      "access_key": "MY_ACCESS_KEY",
      "secret": "my_secret",
      "buckets": [
        {
          "name": "my-bucket",
          "mount": "/mnt"
        }
      ]
    }
  }
```

It is possible to specify multiple S3 buckets, each with its own mount point, as long as all buckets are registered in the same AWS region and accessible with the same credentials. All mount points must be existing directories.
This filesystem allows reading and writing existing S3 objects, as well as creating new objects, using the AWS S3 API over HTTPS. Directories are emulated as zero-length objects whose name ends with '/'.

The current implementation has the following limitations:
- writing to an object at a non-zero offset is not supported
- each write replaces the entire contents of an object, i.e. a write modifies the object size to match the length of the data being written
- it is not possible to write objects larger than 4 KB, unless direct I/O (O_DIRECT flag) is used
- it is not possible to use the writev and pwritev syscalls when using direct I/O
- symbolic links are not supported
- renaming objects using the RENAME_EXCHANGE flag is not supported
- it is not possible to truncate an object to a non-zero length