### PR TITLE
Exception handlers: Fix context refcount leak when handling a syscall

### DIFF
--- a/src/aarch64/interrupt.c
+++ b/src/aarch64/interrupt.c
@@ -211,8 +211,6 @@ void synchronous_handler(void)
 
     if (f[FRAME_FULL])
         halt("\nframe %p already full\n", f);
-    f[FRAME_FULL] = true;
-    context_reserve_refcount(ctx);
 
     int ec = field_from_u64(esr, ESR_EC);
     if (ec == ESR_EC_SVC_AARCH64 && (esr & ESR_IL) &&
@@ -234,6 +232,8 @@ void synchronous_handler(void)
         }
     }
 
+    f[FRAME_FULL] = true;
+    context_reserve_refcount(ctx);
     fault_handler fh = ctx->fault_handler;
     if (fh) {
         context retctx = apply(fh, ctx);

--- a/src/riscv64/interrupt.c
+++ b/src/riscv64/interrupt.c
@@ -313,9 +313,6 @@ void trap_exception(void)
         goto exit_fault;
     }
 
-    f[FRAME_FULL] = true;
-    context_reserve_refcount(ctx);
-
     if (f[FRAME_CAUSE] == TRAP_E_ECALL_UMODE) {
         f[FRAME_PC] += 4;   /* must advance pc, hw does not do it */
         context ctx = ci->m.syscall_context;
@@ -324,6 +321,8 @@ void trap_exception(void)
         console("\nsyscall returned to trap handler\n");
         goto exit_fault;
     }
+    f[FRAME_FULL] = true;
+    context_reserve_refcount(ctx);
     fault_handler fh = ctx->fault_handler;
     if (fh) {
 #ifdef INT_DEBUG


### PR DESCRIPTION
The ARM and RISC-V exception handlers acquire a refcount of the current context, but only release it on the fault path, leaking one reference per syscall.
Since the syscall handler takes its own refcount, the exception handlers can avoid acquiring a refcount on the syscall path, and acquire it only on the fault path.