### PR TITLE
Enable JVM ZGC Uncommit - kernel: do not wait for the vmap lock deaf to the flush that needs an answer

### DIFF
--- a/src/kernel/flush.c
+++ b/src/kernel/flush.c
@@ -75,9 +75,14 @@ static boolean flush_gen_rlocked(word gen, cpuinfo ci, boolean full_flush)
 static void _flush_handler(void)
 {
     cpuinfo ci = current_cpu();
+    word gen_diff = inval_gen - ci->inval_gen;
+
+    if (!gen_diff)
+        return;
+
     /* Each generation has at least one page, so if the gen difference is
      * greater than FLUSH_THRESHOLD, just do a full tlb flush */
-    boolean full_flush = inval_gen - ci->inval_gen > FLUSH_THRESHOLD;
+    boolean full_flush = gen_diff > FLUSH_THRESHOLD;
 
     spin_rlock(&flush_lock);
     while (ci->inval_gen != inval_gen)

--- a/src/kernel/kernel.h
+++ b/src/kernel/kernel.h
@@ -179,6 +179,29 @@ static inline void spin_unlock_irq(spinlock l, u64 flags)
     irq_restore(flags);
 }
 
+/* For a lock whose holder can end up parked in a TLB flush rendezvous. Waiting for one of those
+ * with interrupts off is a deadlock: the flush IPI never arrives, so this processor never joins,
+ * so the rendezvous never ends, so its holder never lets go. The wait does the flush work itself. */
+static inline u64 spin_lock_irq_flush(spinlock l)
+{
+    u64 flags = irq_disable_save();
+    volatile u64 *p = (volatile u64 *)&l->w;
+#ifdef LOCK_STATS
+    u64 spins = 0;
+#endif
+    while (*p || !compare_and_swap_64(&l->w, 0, 1)) {
+#ifdef LOCK_STATS
+        spins++;
+#endif
+        page_invalidate_flush();
+        kern_pause();
+    }
+#ifdef LOCK_STATS
+    LOCKSTATS_RECORD_LOCK(l->s, true, spins, 0);
+#endif
+    return flags;
+}
+
 static inline u64 spin_wlock_irq(rw_spinlock l)
 {
     u64 flags = irq_disable_save();

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -828,7 +828,7 @@ boolean unix_timers_init(unix_heaps uh);
 
 #define sysreturn_from_pointer(__x) ((s64)u64_from_pointer(__x));
 
-#define vmap_lock(p) u64 _savedflags = spin_lock_irq(&(p)->vmap_lock)
+#define vmap_lock(p) u64 _savedflags = spin_lock_irq_flush(&(p)->vmap_lock)
 #define vmap_unlock(p) spin_unlock_irq(&(p)->vmap_lock, _savedflags)
 
 extern sysreturn syscall_ignore();

--- a/test/runtime/Makefile
+++ b/test/runtime/Makefile
@@ -140,6 +140,7 @@ LDFLAGS-ktest=		-static
 
 SRCS-mmap= \
 	$(CURDIR)/mmap.c \
+	$(CURDIR)/vmap_flush.c \
 	$(SRCDIR)/unix_process/unix_process_runtime.c \
 	$(RUNTIME)
 LDFLAGS-mmap=		-static

--- a/test/runtime/filesystem.c
+++ b/test/runtime/filesystem.c
@@ -1,11 +1,5 @@
 #include "../test_utils.h"
 
-#define TEST_FUNC(name) {                               \
-    extern void test_##name(int argc, char *argv[]);    \
-    test_##name(argc, argv);                            \
-    printf(#name " test:\tOK\n");                     \
-}
-
 int main(int argc, char **argv)
 {
     TEST_FUNC(creat);

--- a/test/runtime/mmap.c
+++ b/test/runtime/mmap.c
@@ -1683,6 +1683,7 @@ int main(int argc, char * argv[])
     filebacked_sigbus_test();
     madvise_test();
     check_fault_in_user_memory();
+    TEST_FUNC(vmap_flush);
 
     printf("\n**** all tests passed ****\n");
 

--- a/test/runtime/mmap.manifest
+++ b/test/runtime/mmap.manifest
@@ -1,4 +1,12 @@
 (
+    boot:(
+        children:(
+            klib:(children:(
+                tmpfs:(contents:(host:ARCH_DIR/bin/tmpfs))
+                shmem:(contents:(host:ARCH_DIR/bin/shmem))
+            ))
+        )
+    )
     children:(
         mmap:(contents:(host:output/test/runtime/bin/mmap))
 	infile:(contents:(host:test/runtime/read_contents/hello))
@@ -8,6 +16,7 @@
 	unmapme:(contents:(host:test/runtime/read_contents/unmapme))
         testpath:(contents:(host:test/runtime/read_contents/testpath))
     )
+    klibs:bootfs
     # filesystem path to elf for kernel to run
     program:/mmap
 #    trace:t

--- a/test/runtime/vmap_flush.c
+++ b/test/runtime/vmap_flush.c
@@ -1,0 +1,128 @@
+/* More than one thread giving pages back at the same time, while others fault
+   on them and the file they came from is synced.
+
+   tlbshootdown covers the neighbouring case: one thread unmaps while the others
+   read, and each of them takes the fault it should. What it never has is two
+   threads returning pages at once, and that is what closes a cycle -- madvise
+   takes the process's vmap lock with interrupts disabled and then unmaps, which
+   opens a shootdown every processor may have to join synchronously; a second
+   thread waiting for that same lock with interrupts disabled never services the
+   shootdown, so it never joins, so the first never finishes and never lets the
+   lock go.
+
+   Two processors are enough. */
+
+#define _GNU_SOURCE
+#include <pthread.h>
+#include <sched.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/sysinfo.h>
+#include <unistd.h>
+
+#include "../test_utils.h"
+
+#define MAX_CPUS    16
+#define PAGESIZE    4096
+#define MAP_PAGES   2048
+#define MAP_BYTES   (MAP_PAGES * PAGESIZE)
+#define ROUNDS      64
+
+static pthread_t threads[MAX_CPUS];
+static volatile uint8_t *m;
+static volatile int done;
+static int np;
+
+static int kidcnt;
+static pthread_cond_t kid_cv;
+static pthread_cond_t sync_cv;
+static pthread_mutex_t sync_mut;
+
+static void wait_for_sync(void)
+{
+    pthread_mutex_lock(&sync_mut);
+    kidcnt++;
+    pthread_cond_signal(&kid_cv);
+    pthread_cond_wait(&sync_cv, &sync_mut);
+    pthread_mutex_unlock(&sync_mut);
+}
+
+static void wait_for_children(void)
+{
+    pthread_mutex_lock(&sync_mut);
+    while (kidcnt < np)
+        pthread_cond_wait(&kid_cv, &sync_mut);
+    kidcnt = 0;
+    pthread_mutex_unlock(&sync_mut);
+}
+
+static void wake_children(void)
+{
+    pthread_mutex_lock(&sync_mut);
+    pthread_cond_broadcast(&sync_cv);
+    pthread_mutex_unlock(&sync_mut);
+}
+
+/* Bring a chunk of the mapping in, then give it back: it takes both, because a
+   range that is already gone is unmapped without a shootdown. */
+static void *cpu_thread(void *v)
+{
+    int id = (int)((uintptr_t)v);
+    size_t share = MAP_BYTES / np;
+    size_t base = share * id;
+
+    while (!done) {
+        wait_for_sync();
+        if (done)
+            break;
+        for (size_t off = base; off < base + share; off += PAGESIZE)
+            m[off] = (uint8_t)(id + 1);
+        test_assert(madvise((void *)(m + base), share, MADV_DONTNEED) == 0);
+    }
+    return NULL;
+}
+
+void test_vmap_flush(int argc, char *argv[])
+{
+    np = get_nprocs();
+    if (np > MAX_CPUS)
+        np = MAX_CPUS;
+    if (np < 2)
+        /* With one processor there is nobody to wait for the lock, and the
+           cycle cannot exist. */
+        return;
+
+    pthread_cond_init(&kid_cv, NULL);
+    pthread_cond_init(&sync_cv, NULL);
+    pthread_mutex_init(&sync_mut, NULL);
+
+    int fd = memfd_create("vmap_flush", 0);
+    test_assert(fd >= 0);
+    test_assert(ftruncate(fd, MAP_BYTES) == 0);
+    m = mmap(NULL, MAP_BYTES, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    test_assert(m != MAP_FAILED);
+
+    for (long i = 0; i < np; i++)
+        test_assert(pthread_create(&threads[i], NULL, cpu_thread, (void *)i) == 0);
+
+    for (int round = 0; round < ROUNDS; round++) {
+        wait_for_children();
+        wake_children();
+        /* The other way into the shootdown, from this thread, while they are in
+           the middle of theirs. */
+        test_assert(msync((void *)m, MAP_BYTES, MS_SYNC) == 0);
+        test_assert(fsync(fd) == 0);
+    }
+
+    wait_for_children();
+    done = 1;
+    wake_children();
+    for (int i = 0; i < np; i++)
+        test_assert(pthread_join(threads[i], NULL) == 0);
+
+    test_assert(munmap((void *)m, MAP_BYTES) == 0);
+    test_assert(close(fd) == 0);
+}

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -19,6 +19,12 @@
     exit(EXIT_FAILURE);                                                                 \
 } while (0)
 
+#define TEST_FUNC(name) {                               \
+    extern void test_##name(int argc, char *argv[]);    \
+    test_##name(argc, argv);                            \
+    printf(#name " test:\tOK\n");                     \
+}
+
 #define test_perror(msg, ...) do {                                                      \
     fprintf(stderr, "Error at %s:%d: " msg ": " , __FILE__, __LINE__, ##__VA_ARGS__);   \
     perror(NULL);                                                                       \


### PR DESCRIPTION
Why this is here. This is one of two changes that together let a JVM heap
shrink on nanos. ZGC keeps its heap in a memfd, maps it, and has a thread that
punches holes in it to return memory to the system; the companion pull request
makes fallocate(FALLOC_FL_PUNCH_HOLE) on a memory filesystem give the pages
back, which is what makes the collector's uncommit do anything at all. This
patch is what makes that survivable: with the punch returning memory and the
collector faulting the same file back in, the deadlock below fires within
seconds, every time.

The defect. Servicing a TLB shootdown in nanos is not an acknowledgement, it
is a join and a wait: page_invalidate_sync(..., rendezvous) spins until
joined == total_processors because the initiator runs the completion with every
other processor stopped. A processor that is spinning for a lock with interrupts
disabled never takes the flush interrupt, never joins, and the initiator waits
for it forever.

That is what spin_lock_irq(&p->vmap_lock) does in the fault path. Caught with
the stub on four processors, on the binary nanos ships today:

    CPU1  page_invalidate_sync(rendezvous=1)   flush.c:196, waiting for every
          processor to join
          <- pagecache_node_unmap_pages_sync <- vmap_unmap <- munmap,
          holding the process's vmap lock
    CPU2, CPU3  parked in flush_gen_rlocked, flush.c:65 -- they joined
    CPU0  unix_fault_handler, unix.c:320, spinning on that same vmap lock with
          interrupts off -- it can never join

So the wait for the vmap lock is made to service a pending flush while it spins,
which is what the flush machinery already expects of anyone holding a lock it
has to reach. Nothing else changes: the lock is acquired and released exactly
where it was.

This is not a defect of the new work. The unmapping side is plain munmap
and madvise of a shared file mapping, and the faulting side is any thread
touching the same file. It predates all of it and reproduces on an unmodified
tree.

Evidence. The test added here, vmap_flush_race, stops the machine in its
first round without the change and runs its sixty-four rounds with it, at
VCPUS=2, which is what the CI runs. Under the workload it was found in -- a
JVM with ZGC and an elastic heap, four processors, hardware virtualisation --
the guest wedged in between eight and thirty-three seconds on four attempts out
of four without this change, and ran a full thirty minutes with it: 1802
seconds, 738 uncommits, 21190 MB returned, 1.96 billion pages written and read
back through mappings of the file, nothing read back wrong and no fault or
assertion in the kernel. A second run of the same shape returned 50404 MB.