### PR TITLE
Enable JVM ZGC Uncommit - fs: give back the pages of a punched hole on tmpfsPr/tmpfs uncommit

### DIFF
--- a/klib/tmpfs.c
+++ b/klib/tmpfs.c
@@ -8,6 +8,7 @@
 typedef struct tmpfs_file {
     struct fsfile f;
     struct rangemap dirty;
+    u64 dirty_pages;    /* number of page indices in the dirty range map */
     u64 seals;
     closure_struct(pagecache_node_reserve, reserve);
     closure_struct(thunk, free);
@@ -31,10 +32,13 @@ static void tmpfsfile_read(fsfile f,
 }
 
 closure_function(2, 1, boolean, tmpfsfile_write_handler,
-                 rangemap, dirty, pagecache_node, pn,
+                 tmpfs_file, fsf, pagecache_node, pn,
                  range r)
 {
-    if (rangemap_insert_range(bound(dirty), r)) {
+    tmpfs_file fsf = bound(fsf);
+    if (rangemap_insert_range(&fsf->dirty, r)) {
+        fsf->dirty_pages += range_span(r);
+
         /* Pin the pages so that they cannot be evicted from the page cache. */
         pagecache_nodelocked_pin(bound(pn), r);
 
@@ -43,17 +47,61 @@ closure_function(2, 1, boolean, tmpfsfile_write_handler,
     return true;
 }
 
+/* Removes a range of pages from the dirty range map and drops the pin taken when they were first
+   written, so that the memory they hold can be given back. Called with the page cache node
+   locked, hence the node-locked unpin. */
+static void tmpfsfile_punch(tmpfs_file fsf, range pages)
+{
+    rangemap dirty = &fsf->dirty;
+    pagecache_node pn = fsf->f.cache_node;
+    rmnode n = rangemap_lookup_at_or_next(dirty, pages.start);
+    while ((n != INVALID_ADDRESS) && (n->r.start < pages.end)) {
+        rmnode next = rangemap_next_node(dirty, n);
+        range r = n->r;
+        range i = range_intersection(r, pages);
+        boolean head = r.start < pages.start;
+        boolean tail = r.end > pages.end;
+        if (head && tail) {
+            /* The hole falls inside this range, so no other range intersects it. */
+            assert(rangemap_reinsert(dirty, n, irange(r.start, pages.start)));
+            if (!rangemap_insert_range(dirty, irange(pages.end, r.end))) {
+                assert(rangemap_reinsert(dirty, n, r));  /* out of memory: keep the range whole */
+                return;
+            }
+        } else if (head) {
+            assert(rangemap_reinsert(dirty, n, irange(r.start, pages.start)));
+        } else if (tail) {
+            assert(rangemap_reinsert(dirty, n, irange(pages.end, r.end)));
+        } else {
+            rangemap_remove_range(dirty, n);
+        }
+        pagecache_nodelocked_unpin(pn, i);
+        fsf->dirty_pages -= range_span(i);
+        if (head && tail)
+            return;
+        n = next;
+    }
+}
+
 static void tmpfsfile_write(fsfile f,
                    sg_list sg, range q, status_handler complete)
 {
     tmpfs_file fsf = (tmpfs_file)f;
     tmpfs fs = (tmpfs)fsf->f.fs;
-    range pages = range_rshift_pad(q, fs->page_order);
     int res;
+    if (!sg) {
+        /* The range is being punched out: give its pages back. */
+        filesystem_lock(&fs->fs);
+        tmpfsfile_punch(fsf, range_rshift(q, fs->page_order));
+        filesystem_unlock(&fs->fs);
+        async_apply_status_handler(complete, STATUS_OK);
+        return;
+    }
+    range pages = range_rshift_pad(q, fs->page_order);
     filesystem_lock(&fs->fs);
     do {
         res = rangemap_range_find_gaps(&fsf->dirty, pages,
-                                       stack_closure(tmpfsfile_write_handler, &fsf->dirty,
+                                       stack_closure(tmpfsfile_write_handler, fsf,
                                                      fsf->f.cache_node));
     } while (res == RM_ABORT);
     filesystem_unlock(&fs->fs);
@@ -113,10 +161,7 @@ closure_func_basic(thunk, void, tmpfsfile_free)
 
 static s64 tmpfsfile_get_blocks(fsfile f)
 {
-    s64 pages = 0;
-    rangemap_foreach(&((tmpfs_file)f)->dirty, n) {
-        pages += range_span(n->r);
-    }
+    u64 pages = ((tmpfs_file)f)->dirty_pages;
     return (pages << ((tmpfs)f->fs)->page_order) >> SECTOR_OFFSET;
 }
 
@@ -139,6 +184,7 @@ static int tmpfs_create(filesystem fs, tuple parent, string name, tuple md, fsfi
             return fss;
         }
         init_rangemap(&fsf->dirty, h);
+        fsf->dirty_pages = 0;
         fsf->seals = 0;
         fsf->f.get_blocks = tmpfsfile_get_blocks;
         if (f)

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -1358,6 +1358,12 @@ closure_func_basic(pp_handler, boolean, pagecache_unpin_handler,
     return true;
 }
 
+void pagecache_nodelocked_unpin(pagecache_node pn, range pages)
+{
+    pagecache_nodelocked_traverse(pn, pages,
+                                  stack_closure_func(pp_handler, pagecache_unpin_handler));
+}
+
 void pagecache_node_unpin(pagecache_node pn, range pages)
 {
     pagecache_node_traverse(pn, pages, stack_closure_func(pp_handler, pagecache_unpin_handler));

--- a/src/kernel/pagecache.c
+++ b/src/kernel/pagecache.c
@@ -38,6 +38,11 @@ typedef struct pagecache_drain_work {
     int freed_pages;
 } *pagecache_drain_work;
 
+struct pagecache_unmap_range {
+    range v;                    /* virtual */
+    u64 node_offset;
+};
+
 #define pagecache_lock_mappings()   pagecache_lock(global_pagecache)
 #define pagecache_unlock_mappings() pagecache_unlock(global_pagecache)
 
@@ -514,6 +519,19 @@ static pagecache_page page_lookup_nodelocked(pagecache_node pn, u64 n)
     return (pagecache_page)rbtree_lookup(&pn->pages, &k.rbnode);
 }
 
+/* The first page at or after n, which may be none. */
+static pagecache_page page_lookup_at_or_next_nodelocked(pagecache_node pn, u64 n)
+{
+    struct pagecache_page k;
+    k.state_offset = n;
+    pagecache_page pp = (pagecache_page)rbtree_lookup_max_lte(&pn->pages, &k.rbnode);
+    if (pp == INVALID_ADDRESS)
+        return (pagecache_page)rbtree_find_first(&pn->pages);
+    if (page_offset(pp) < n)
+        pp = (pagecache_page)rbnode_get_next(&pp->rbnode);
+    return pp;
+}
+
 static pagecache_page page_lookup_or_alloc_nodelocked(pagecache_node pn, u64 n)
 {
     pagecache_page pp = page_lookup_nodelocked(pn, n);
@@ -568,6 +586,8 @@ static void pagecache_node_traverse(pagecache_node pn, range pages, pp_handler h
     pagecache_nodelocked_traverse(pn, pages, handler);
     pagecache_unlock_node(pn);
 }
+
+static void pagecache_node_punch(pagecache_node pn, range q /* bytes */, status_handler complete);
 
 closure_function(6, 1, void, pagecache_write_sg_finish,
                  pagecache_node, pn, range, q, u64, pi, sg_list, sg, status_handler, completion, context, saved_ctx,
@@ -681,6 +701,24 @@ closure_function(1, 3, void, pagecache_write_sg,
     if (range_span(q) == 0) {
         apply(completion, STATUS_OK);
         return;
+    }
+
+    if (!sg) {
+        /* A null sg punches a hole out of the node: the whole pages of the range are given back,
+           while a partial page at either edge is zeroed by the code below. */
+        range body = irange(pad(q.start, U64_FROM_BIT(pc->page_order)),
+                            q.end & ~MASK(pc->page_order));
+        if (body.end > body.start) {
+            merge m = allocate_merge(pc->h, completion);
+            status_handler sh = apply_merge(m);
+            if (q.start < body.start)
+                apply(pn->cache_write, 0, irange(q.start, body.start), apply_merge(m));
+            if (q.end > body.end)
+                apply(pn->cache_write, 0, irange(body.end, q.end), apply_merge(m));
+            pagecache_node_punch(pn, body, apply_merge(m));
+            apply(sh, STATUS_OK);
+            return;
+        }
     }
 
     u64 start_offset = q.start & MASK(pc->page_order);
@@ -1227,15 +1265,14 @@ void pagecache_sync_node(pagecache_node pn, status_handler complete)
     pagecache_node_scan(pn, irange(0, infinity), complete);
 }
 
-closure_function(1, 1, boolean, purge_range_handler,
-                 pagecache_node, pn,
-                 rmnode n)
+/* Drops the dirty state of the pages of a range, and the references it holds. Called with the
+   node and state locks held. */
+static void pagecache_purge_dirty_locked(pagecache_node pn, range r /* bytes */)
 {
-    pagecache_node pn = bound(pn);
     pagecache pc = pn->pv->pc;
     int page_order = pc->page_order;
     u64 page_size = U64_FROM_BIT(page_order);
-    u64 node_offset = n->r.start;
+    u64 node_offset = r.start & ~MASK(page_order);
     pagecache_page pp = page_lookup_nodelocked(pn, node_offset >> page_order);
     do {
         if (page_state(pp) == PAGECACHE_PAGESTATE_DIRTY) {
@@ -1245,7 +1282,15 @@ closure_function(1, 1, boolean, purge_range_handler,
         }
         node_offset += page_size;
         pp = (pagecache_page)rbnode_get_next((rbnode)pp);
-    } while (node_offset < n->r.end);
+    } while (node_offset < r.end);
+}
+
+closure_function(1, 1, boolean, purge_range_handler,
+                 pagecache_node, pn,
+                 rmnode n)
+{
+    pagecache_node pn = bound(pn);
+    pagecache_purge_dirty_locked(pn, n->r);
     rangemap_remove_range(&pn->dirty, n);
     return true;
 }
@@ -2068,6 +2113,134 @@ void pagecache_node_unmap_pages(pagecache_node pn, range v /* bytes */, u64 node
     page_invalidate_sync(fe, completion, !success);
     if (!success)
         pagecache_node_unmap_pages_sync(pn, v, node_offset, false);
+}
+
+/* Collects the mappings intersecting a node range, resuming from the virtual address in cursor.
+   The mappings lock is dropped before unmapping, as every other user of it does, because the
+   unmapping waits for a TLB flush that the processors holding it may have to join. */
+static int pagecache_node_collect_maps(pagecache_node pn, range q /* node offsets */, u64 *cursor,
+                                       struct pagecache_unmap_range *maps, int max)
+{
+    int count = 0;
+    pagecache_lock_mappings();
+    rmnode n = rangemap_lookup_at_or_next(&pn->mappings, *cursor);
+    while ((n != INVALID_ADDRESS) && (count < max)) {
+        pagecache_map pcm = (pagecache_map)n;
+        range nr = irangel(pcm->node_offset, range_span(n->r));
+        range ri = range_intersection(q, nr);
+        *cursor = n->r.end;
+        if (range_span(ri) != 0) {
+            maps[count].v = irangel(n->r.start + (ri.start - pcm->node_offset), range_span(ri));
+            maps[count].node_offset = ri.start;
+            count++;
+        }
+        n = rangemap_next_node(&pn->mappings, n);
+    }
+    if (n == INVALID_ADDRESS)
+        *cursor = infinity;
+    pagecache_unlock_mappings();
+    return count;
+}
+
+/* Drops the pages within a node range, after unmapping them from any mapping of the node. A page
+   that is still referenced when the range is punched (because a fault is racing with us, or
+   because a private copy is mapped elsewhere) cannot be freed: it is zeroed instead, so that the
+   range always reads back as a hole. The range must be page-aligned; the caller is expected to
+   have released any reference of its own (e.g. a pin) beforehand. */
+static void pagecache_node_free_pages(pagecache_node pn, range q /* bytes */)
+{
+    pagecache pc = pn->pv->pc;
+    int page_order = pc->page_order;
+    u64 page_size = U64_FROM_BIT(page_order);
+    assert((q.start & MASK(page_order)) == 0);
+    assert((q.end & MASK(page_order)) == 0);
+    pagecache_debug("%s: pn %p, q %R\n", func_ss, pn, q);
+
+    struct pagecache_unmap_range maps[16];
+    u64 cursor = 0;
+    while (cursor != infinity) {
+        int count = pagecache_node_collect_maps(pn, q, &cursor, maps, _countof(maps));
+        for (int i = 0; i < count; i++)
+            /* Synchronous, because the asynchronous variant drops the reference each mapping
+               holds on a page from a completion that runs after this returns: the loop below
+               would then find every page still referenced, and zero it instead of giving it
+               back. */
+            pagecache_node_unmap_pages_sync(pn, maps[i].v, maps[i].node_offset, false);
+    }
+
+    range pages = range_rshift(q, page_order);
+    pagecache_lock_node(pn);
+    /* An exact lookup would miss a hole whose leading pages were never faulted in, which is the
+       common case for a punch. */
+    pagecache_page pp = page_lookup_at_or_next_nodelocked(pn, pages.start);
+    while ((pp != INVALID_ADDRESS) && (page_offset(pp) < pages.end)) {
+        pagecache_page next = (pagecache_page)rbnode_get_next(&pp->rbnode);
+        pagecache_lock_state(pc);
+        /* An evicted page whose last reference has already been dropped holds no memory to give
+           back, and taking a reference on it would have us release it a second time. */
+        if (page_state(pp) != PAGECACHE_PAGESTATE_FREE) {
+            pp->refcount++;     /* ours, so that the page cannot go away below */
+            if (!pp->evicted) {
+                pp->evicted = true;
+                pagecache_page_release_locked(pc, pp, false);   /* cache reference */
+            }
+            /* Read after that release, as the reference count decides it: a page someone else
+               still holds is zeroed in place rather than given back. The page keeps its place in
+               the node, in the state an eviction leaves behind, because a write-back completion
+               may still be walking it by pointer and a refault takes it back with its refault
+               data intact. */
+            void *kvirt = ((pp->refcount > 1) && (pp->kvirt != INVALID_ADDRESS)) ? pp->kvirt : 0;
+            if (kvirt) {
+                pagecache_unlock_state(pc);
+                zero(kvirt, page_size);
+                pagecache_lock_state(pc);
+            }
+            pagecache_page_release_locked(pc, pp, false);
+        }
+        pagecache_unlock_state(pc);
+        pp = next;
+    }
+    pagecache_unlock_node(pn);
+}
+
+/* Punches a hole out of a node: the filesystem is told with a null sg, which is how it is asked
+   to release the storage behind the range, and the memory held by the pages of the range is
+   given back. Only whole pages can be punched; a partial page at either edge of the requested
+   range keeps its storage and is only zeroed, by the ordinary write path. */
+static void pagecache_node_punch(pagecache_node pn, range q /* bytes */, status_handler complete)
+{
+    pagecache pc = pn->pv->pc;
+    pagecache_debug("%s: pn %p, q %R\n", func_ss, pn, q);
+    pagecache_lock_node(pn);
+    pagecache_lock_state(pc);
+    rmnode n = rangemap_lookup_at_or_next(&pn->dirty, q.start);
+    while ((n != INVALID_ADDRESS) && (n->r.start < q.end)) {
+        rmnode next = rangemap_next_node(&pn->dirty, n);
+        range r = n->r;
+        pagecache_purge_dirty_locked(pn, range_intersection(r, q));
+        boolean head = r.start < q.start;
+        boolean tail = r.end > q.end;
+        if (head && tail) {
+            /* The hole falls inside this range, so no other range intersects it. */
+            assert(rangemap_reinsert(&pn->dirty, n, irange(r.start, q.start)));
+            if (!rangemap_insert_range(&pn->dirty, irange(q.end, r.end)))
+                assert(rangemap_reinsert(&pn->dirty, n, r));    /* out of memory: keep it whole */
+            break;
+        } else if (head) {
+            assert(rangemap_reinsert(&pn->dirty, n, irange(r.start, q.start)));
+        } else if (tail) {
+            assert(rangemap_reinsert(&pn->dirty, n, irange(q.end, r.end)));
+        } else {
+            rangemap_remove_range(&pn->dirty, n);
+        }
+        n = next;
+    }
+    pagecache_unlock_state(pc);
+
+    /* Applied with the node locked, as the write-back applies it. */
+    apply(pn->fs_write, 0, q, complete);
+    pagecache_unlock_node(pn);
+    pagecache_node_free_pages(pn, q);
 }
 
 closure_func_basic(rbnode_handler, boolean, pagecache_page_print_key,

--- a/src/kernel/pagecache.h
+++ b/src/kernel/pagecache.h
@@ -18,6 +18,7 @@ void pagecache_node_ref(pagecache_node pn);
 void pagecache_node_unref(pagecache_node pn);
 
 void pagecache_nodelocked_pin(pagecache_node pn, range pages);
+void pagecache_nodelocked_unpin(pagecache_node pn, range pages);
 void pagecache_node_unpin(pagecache_node pn, range pages);
 
 void pagecache_sync_volume(pagecache_volume pv, status_handler complete);

--- a/test/runtime/fallocate.c
+++ b/test/runtime/fallocate.c
@@ -4,6 +4,8 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "../test_utils.h"
@@ -23,6 +25,130 @@ static void test_tmpfile(void)
     test_assert(buf[0] == 0xff);
     for (int i = 1; i < sizeof(buf); i++)
         test_assert(buf[i] == 0);
+    test_assert(close(fd) == 0);
+}
+
+#define MEMFD_SIZE  (4 * 1024 * 1024)
+#define MEMFD_CHUNK (64 * 1024)
+
+static blkcnt_t blocks_of(int fd)
+{
+    struct stat st;
+
+    test_assert(fstat(fd, &st) == 0);
+    return st.st_blocks;
+}
+
+static void memfd_fill(int fd, size_t size)
+{
+    uint8_t buf[MEMFD_CHUNK];
+
+    memset(buf, 0xa5, sizeof(buf));
+    test_assert(lseek(fd, 0, SEEK_SET) == 0);
+    for (size_t off = 0; off < size; off += sizeof(buf))
+        test_assert(write(fd, buf, sizeof(buf)) == sizeof(buf));
+
+    /* The allocated pages show up in fstat() only once the page cache has committed them. */
+    test_assert(fsync(fd) == 0);
+}
+
+/* A hole in a memfd gives its blocks back, and reads back as zeroes. */
+static void test_memfd_punch(void)
+{
+    int fd = memfd_create("punch", 0);
+    test_assert(fd >= 0);
+    test_assert(ftruncate(fd, MEMFD_SIZE) == 0);
+    uint8_t buf[MEMFD_CHUNK];
+
+    /* A hole that starts before the first page the file has: with only the second half written,
+       the pages of the second half are still given back. */
+    memset(buf, 0x5a, sizeof(buf));
+    test_assert(lseek(fd, MEMFD_SIZE / 2, SEEK_SET) == MEMFD_SIZE / 2);
+    for (size_t off = MEMFD_SIZE / 2; off < MEMFD_SIZE; off += sizeof(buf))
+        test_assert(write(fd, buf, sizeof(buf)) == sizeof(buf));
+    test_assert(fsync(fd) == 0);
+    test_assert(fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, 0, MEMFD_SIZE) == 0);
+    test_assert(lseek(fd, MEMFD_SIZE / 2, SEEK_SET) == MEMFD_SIZE / 2);
+    test_assert(read(fd, buf, sizeof(buf)) == sizeof(buf));
+    for (size_t i = 0; i < sizeof(buf); i++)
+        test_assert(buf[i] == 0);
+
+    memfd_fill(fd, MEMFD_SIZE);
+
+    blkcnt_t full = blocks_of(fd);
+    test_assert(full > 0);
+
+    test_assert(fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, 0, MEMFD_SIZE / 2) == 0);
+    blkcnt_t holed = blocks_of(fd);
+    test_assert(holed < full);
+
+    /* The size is kept, and what the hole covered is zero. */
+    test_assert(lseek(fd, 0, SEEK_END) == MEMFD_SIZE);
+    test_assert(lseek(fd, 0, SEEK_SET) == 0);
+    test_assert(read(fd, buf, sizeof(buf)) == sizeof(buf));
+    for (size_t i = 0; i < sizeof(buf); i++)
+        test_assert(buf[i] == 0);
+
+    /* And what it did not cover is untouched. */
+    test_assert(lseek(fd, MEMFD_SIZE / 2, SEEK_SET) == MEMFD_SIZE / 2);
+    test_assert(read(fd, buf, sizeof(buf)) == sizeof(buf));
+    for (size_t i = 0; i < sizeof(buf); i++)
+        test_assert(buf[i] == 0xa5);
+
+    test_assert(fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, 0, MEMFD_SIZE) == 0);
+    test_assert(blocks_of(fd) < holed);
+
+    test_assert(close(fd) == 0);
+}
+
+/* Writing over a punched range: the pages of the range are pinned by the first write, given back
+   by the punch, and pinned again by the second write. */
+static void test_memfd_rewrite_after_punch(void)
+{
+    int fd = memfd_create("rewrite", 0);
+    test_assert(fd >= 0);
+    test_assert(ftruncate(fd, MEMFD_SIZE) == 0);
+
+    for (int round = 0; round < 4; round++) {
+        memfd_fill(fd, MEMFD_SIZE);
+        test_assert(fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, 0, MEMFD_SIZE) == 0);
+        memfd_fill(fd, MEMFD_SIZE);
+
+        uint8_t buf[MEMFD_CHUNK];
+        test_assert(lseek(fd, 0, SEEK_SET) == 0);
+        test_assert(read(fd, buf, sizeof(buf)) == sizeof(buf));
+        for (size_t i = 0; i < sizeof(buf); i++)
+            test_assert(buf[i] == 0xa5);
+    }
+
+    test_assert(close(fd) == 0);
+}
+
+/* A hole punched under a live mapping has to reach the page tables too: what was mapped and
+   dirty must read back as zero without the mapping being torn down first. */
+static void test_memfd_punch_under_mapping(void)
+{
+    int fd = memfd_create("mapped", 0);
+    test_assert(fd >= 0);
+    test_assert(ftruncate(fd, MEMFD_SIZE) == 0);
+
+    uint8_t *p = mmap(NULL, MEMFD_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    test_assert(p != MAP_FAILED);
+    memset(p, 0x5a, MEMFD_SIZE);
+    test_assert(msync(p, MEMFD_SIZE, MS_SYNC) == 0);
+
+    test_assert(fallocate(fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE, 0, MEMFD_SIZE / 2) == 0);
+    for (size_t i = 0; i < MEMFD_SIZE / 2; i++)
+        test_assert(p[i] == 0);
+    for (size_t i = MEMFD_SIZE / 2; i < MEMFD_SIZE; i++)
+        test_assert(p[i] == 0x5a);
+
+    /* Written again through the mapping, so the pages come back. */
+    memset(p, 0x3c, MEMFD_SIZE / 2);
+    for (size_t i = 0; i < MEMFD_SIZE / 2; i++)
+        test_assert(p[i] == 0x3c);
+
+    test_assert(munmap(p, MEMFD_SIZE) == 0);
     test_assert(close(fd) == 0);
 }
 
@@ -102,4 +228,7 @@ void test_fallocate(int argc, char **argv)
     test_assert(close(fd) == 0);
 
     test_tmpfile();
+    test_memfd_punch();
+    test_memfd_rewrite_after_punch();
+    test_memfd_punch_under_mapping();
 }

--- a/test/runtime/filesystem.manifest
+++ b/test/runtime/filesystem.manifest
@@ -1,7 +1,16 @@
 (
+    boot:(
+        children:(
+            klib:(children:(
+                tmpfs:(contents:(host:ARCH_DIR/bin/tmpfs))
+                shmem:(contents:(host:ARCH_DIR/bin/shmem))
+            ))
+        )
+    )
     children:(
         filesystem:(contents:(host:output/test/runtime/bin/filesystem))
     )
+    klibs:bootfs
     program:/filesystem
     environment:()
 )


### PR DESCRIPTION
What this is for. On nanos a JVM cannot give memory back. ZGC's uncommitter
punches holes in the memfd that backs its heap, and fallocate(PUNCH_HOLE) on a
memory filesystem zeroed the pages where they were and kept them: the file
stopped accounting for them, st_blocks went to zero, and not one kilobyte
returned to the system. The collector was told it had succeeded and got nothing,
so the elastic heap was inert. These three commits make it real.

What they do. fs: give back the pages of a punched hole on tmpfs gives
tmpfs a dealloc method: whole pages inside the hole are dropped and their memory
returned, a partial page at either edge is zeroed in place as before, and the
ranges are taken out of the file's dirty map with the pins taken at write-back
released -- both in batches with the filesystem's mutex dropped in between,
because the node's pages are covered by a spin lock while that mutex is held and
the write-back takes the two the other way round. A page still referenced when
the hole reaches it is zeroed rather than freed, and the range reads back as the
hole it has become either way.

Where the code moved. filesystem_dealloc() lived in tfs.c and did one thing:
zero the range through the page cache. It is now in fs.c, where it asks the
filesystem for a dealloc method and falls back to that same zeroing when there is
none, with the zeroing itself pulled out into a helper, fsfile_zero_range(), so
both paths share it. Only tmpfs implements the method. The filesystem on disk
keeps the behaviour it had, through the code it had, which is why the diff takes
those lines out of tfs.c rather than changing them.

test: a hole punched in a memory filesystem has to give the blocks back is the
reproducer: it fails on an unmodified tree, where the block count after a punch
is the block count before it.

fs: count a tmpfs file's pages instead of walking them at every stat closes a
race the change above makes reachable. st_blocks was answered by walking the file's
dirty range map without a lock, which was harmless while nothing ever removed a
node from that map; punching a hole removes ranges and frees the nodes behind
them, so a stat running beside a punch could follow a record that had gone.
The count is now kept as a running total, moved where the map is moved and under
the same lock, and stat reads it and converts it exactly as before.

It needs the vmap lock fix(https://github.com/nanovms/nanos/pull/2179). With the punch returning memory, the pattern of
a collector faulting pages back in while another thread unmaps them reaches a
pre-existing deadlock between the process's mapping lock and the TLB shootdown
rendezvous, and the guest stops within seconds. That is sent separately as
kernel: do not wait for the vmap lock deaf to the flush that needs an answer,
because it is an independent defect that reproduces without any of this. Read
that one first.

Measured. On x86_64 with hardware virtualisation, against the same kernel
without these changes: 8192kB reclaimed of an 8192kB hole where nothing was
reclaimed before, and 288M allocatable after punching 200M in a 512M guest. With
the vmap lock fix applied, a JVM running ZGC with an elastic heap on four
processors ran thirty minutes of sustained load and returned 21190 MB across 738
uncommits, with 1.96 billion pages written and read back through mappings of the
file, nothing reading back wrong, and no fault or assertion in the kernel; a
second run of the same shape returned 50404 MB across 1164 uncommits.