### PR TITLE
aarch64: page-align the UEFI loader image

### DIFF
--- a/src/aarch64/uefi-crt0.s
+++ b/src/aarch64/uefi-crt0.s
@@ -75,7 +75,14 @@ section_table:
     .short 0                 // NumberOfLineNumbers
     .long 0xc0000040         // Characteristics
 
-    .align 8
+    /* The PE header declares SectionAlignment and FileAlignment of 0x1000 above, and every field
+       that locates .text - SizeOfHeaders, AddressOfEntryPoint, BaseOfCode, and the section's
+       VirtualAddress and PointerToRawData - is _start - IMAGE_BASE. Aligning _start to a page is
+       therefore what makes those fields agree with the declared alignment, as the PE/COFF format
+       requires of both a section's virtual address and SizeOfHeaders. Firmware that enforces it
+       when it applies memory attributes to a loaded image - OCI's edk2 does, as of the 2026-05-22
+       build - rejects the image and asserts in DxeCore before the loader ever runs. */
+    .align 12
 _start:
     stp x29, x30, [sp, #-32]!
     stp x0, x1, [sp, #16]


### PR DESCRIPTION
The PE header of the aarch64 UEFI loader declares a SectionAlignment and a
FileAlignment of 0x1000, but _start is aligned to 8, so SizeOfHeaders and the
virtual address of .text both come out as 0x200. The format does not allow
either of them to be unaligned with respect to the values declared above.

Firmware that enforces this when it applies memory attributes to a loaded image
rejects the loader before it runs. The edk2 build that Oracle Cloud
Infrastructure ships as of 2026-05-22 asserts in DxeCore:

    UpdateRegionMapping RegionStart: 0x33E357000 or RegionLength: 0x200 are not page aligned
    SetUefiImageMemoryAttributes failed on 33E357000 of length 200 - Invalid Parameter
    ASSERT [DxeCore] MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c(281)

Aligning _start to a page makes the declared and the actual layout agree. Every
field that locates .text derives from _start - IMAGE_BASE, so they all move
together, and the header grows into the space .text no longer occupies: the
loader does not get any larger, 128112 bytes before and after.

Tested on a VM.Standard.A1.Flex instance in eu-milan-1. Before the change the
firmware asserts as above; after it, the loader runs and reaches
ExitBootServices.

Console of the instance, captured with oci compute console-history, before the
change:

    Loading Boot0002 "UEFI ORACLE BlockVolume " from PciRoot(0x0)/Pci(0x5,0x7)/Pci(0x0,0x0)/Scsi(0x0,0x1)
    UpdateRegionMapping RegionStart: 0x33E357000 or RegionLength: 0x200 are not page aligned!
    SetUefiImageMemoryAttributes failed on 33E357000 of length 200 with attributes 4008 - Invalid Parameter

    ASSERT_EFI_ERROR (Status = Invalid Parameter)
    ASSERT [DxeCore] /builddir/build/BUILD/edk2-20260522/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c(281)

The same image on a 1 OCPU / 1 GB shape fails identically, only the address
differs (0x7E358000), so the shape of the instance is not a factor.

After the change, on the same shape, the firmware starts the image and the
loader reaches the end of its work:

    Loading Boot0002 "UEFI ORACLE BlockVolume " from PciRoot(0x0)/Pci(0x5,0x7)/Pci(0x0,0x0)/Scsi(0x0,0x1)
    Starting Boot0002 "UEFI ORACLE BlockVolume " from PciRoot(0x0)/Pci(0x5,0x7)/Pci(0x0,0x0)/Scsi(0x0,0x1)
    EFI ExitBootServices: Called.

Header fields before and after, read from the built binary:

    SizeOfHeaders   0x200    ->  0x1000
    .text VirtualAddress and PointerToRawData   0x200  ->  0x1000
    file size       128112 bytes  ->  128112 bytes
