### PR TITLE
runtime: aarch64: do not use DC ZVA while the MMU is off

### DIFF
--- a/src/runtime/memops.c
+++ b/src/runtime/memops.c
@@ -125,13 +125,22 @@ void runtime_memcpy(void *a, const void *b, bytes len)
 }
 
 #if defined(__aarch64__)
+
+#define SCTLR_EL1_M 0x1     /* MMU enable */
+
 void zero(void *x, bytes length)
 {
     u8 *a = x;
     bytes len = length;
-    u64 dczid;
+    u64 dczid, sctlr;
     asm volatile("mrs %0, DCZID_EL0" : "=r"(dczid));
-    if (!(dczid & (1u << 4))) {         /* DZP clear: DC ZVA not prohibited */
+
+    /* DC ZVA requires Normal memory, and every access is Device memory while the MMU is off, so the
+       instruction faults there however DZP reads. The kernel runs in that state from the moment the
+       UEFI loader clears SCTLR_EL1 until enable_mmu() turns translation back on. */
+    asm volatile("mrs %0, SCTLR_EL1" : "=r"(sctlr));
+    if ((sctlr & SCTLR_EL1_M) &&
+        !(dczid & (1u << 4))) {         /* MMU on, and DZP clear: DC ZVA not prohibited */
         bytes block_size = 4ull << (dczid & 0xf); /* 64 B on Graviton2/Cortex-A72 */
         bytes misalign = (u64)a & (block_size - 1);
         bytes head = MIN(block_size - misalign, len);


### PR DESCRIPTION
DC ZVA requires Normal memory. While the MMU is off every access is Device
memory, where the instruction faults whatever DCZID_EL0.DZP reports.

The kernel runs in exactly that state between the UEFI loader clearing
SCTLR_EL1 and enable_mmu() turning translation back on, so any zero() call in
that window takes a synchronous exception on real hardware. QEMU does not
enforce the restriction, so the same image boots there either way.

Observed on a VM.Standard.A1.Flex instance in eu-milan-1:

    Synchronous Exception at 0x0000000040488E54

which the disassembly of the running kernel resolves to the dc zva instruction
in zero(). With the check added, the same image boots and serves requests.

The change adds SCTLR_EL1.M to the condition that already tests DZP, and leaves
the body of the fast path untouched.

Console of the instance, captured with oci compute console-history, before the
change:

    Starting Boot0002 "UEFI ORACLE BlockVolume " from PciRoot(0x0)/Pci(0x5,0x7)/Pci(0x0,0x0)/Scsi(0x0,0x1)
    EFI ExitBootServices: Called.

    Synchronous Exception at 0x0000000040488E54
    PC 0x000040488E54

    Recursive exception occurred while dumping the CPU state

Disassembly of the kernel that produced it, at that address:

    40488e54:  d50b7424   dc   zva, x4
    40488e58:  8b070084   add  x4, x4, x7
    40488e5c:  b5ffffa0   cbnz x0, 40488e50

addr2line places it in zero() at src/runtime/memops.c.

After the change, the same image on the same shape reaches userspace:

    EFI ExitBootServices: Called.
    [4.179006] en1: assigned 10.0.0.113

and an application server on top of it starts and serves requests.
