### PR TITLE
boot: uefi: base the kernel on reported memory, not on the boot image

### DIFF
--- a/src/boot/uefi.c
+++ b/src/boot/uefi.c
@@ -9,7 +9,7 @@
  * inserted in the memory map between a get_memory_map() call and a exit_boot_services() call. */
 #define UEFI_MEMDESC_SPARE_COUNT    8
 
-//#define UEFI_DEBUG
+#define UEFI_DEBUG
 #ifdef UEFI_DEBUG
 # define uefi_debug(x, ...) rprintf("UEFI: " x "\n", ##__VA_ARGS__)
 #else
@@ -190,6 +190,38 @@ closure_function(2, 1, void, uefi_blkdev_read,
           EFI_ERROR(status) ? timm("result", "read_blocks status %d", status) : STATUS_OK);
 }
 
+/* Report the lowest conventional memory region in the firmware's map, which is where memory
+   actually begins. The address the firmware chose for this boot image says nothing about that, and
+   a kernel based on it is moved for no reason whenever the two lie in different regions. */
+static void uefi_report_phys_memory(void)
+{
+    u64 map_size = 0, map_key, desc_size;
+    u32 desc_version;
+    void *map = 0;
+
+    efi_status status = UBS->get_memory_map(&map_size, 0, &map_key, &desc_size, &desc_version);
+    if (status != EFI_BUFFER_TOO_SMALL)
+        return;
+    map_size += UEFI_MEMDESC_SPARE_COUNT * desc_size;
+    status = UBS->allocate_pool(efi_loader_data, map_size, &map);
+    if (EFI_ERROR(status) || !map)
+        return;
+    status = UBS->get_memory_map(&map_size, map, &map_key, &desc_size, &desc_version);
+    if (!EFI_ERROR(status)) {
+        u64 num_desc = map_size / desc_size;
+        for (u64 i = 0; i < num_desc; i++) {
+            efi_memory_desc d = map + i * desc_size;
+            if (d->type != efi_conventional_memory)
+                continue;
+            if ((elf_physmem_base == 0) || (d->physical_start < elf_physmem_base)) {
+                elf_physmem_base = d->physical_start;
+                elf_physmem_size = d->number_of_pages * PAGESIZE;
+            }
+        }
+    }
+    UBS->free_pool(map);
+}
+
 closure_function(3, 2, void, uefi_bootfs_complete,
                  heap, general, heap, aligned, uefi_arch_options, options,
                  filesystem fs, status s)
@@ -207,6 +239,9 @@ closure_function(3, 2, void, uefi_bootfs_complete,
         if (!fsf)
             halt("UEFI: invalid kernel file\n");
         u64 kernel_entry;
+        uefi_report_phys_memory();
+        uefi_debug("conventional memory begins at %p, size 0x%lx, boot image at %p",
+                   elf_physmem_base, elf_physmem_size, uefi_report_phys_memory);
         load_elf_to_physical(general, stack_closure(uefi_kernel_load, fsf), &kernel_entry,
                              stack_closure(uefi_kernel_loaded, &kernel_entry));
     } else {

--- a/src/kernel/elf.c
+++ b/src/kernel/elf.c
@@ -451,7 +451,16 @@ closure_function(5, 1, void, elf_load_phdr,
     if (is_ok(s)) {
         /* Calculate an offset so that the ELF is loaded at addresses corresponding to actual memory
          * (the addresses in the ELF file may not correspond to valid memory locations). */
-        u64 physmem_base = u64_from_pointer(closure_self()) & ~PHYSMEM_BASE_MASK;
+        u64 base = u64_from_pointer(closure_self());
+#ifdef INIT_IDENTITY_SIZE
+        /* Prefer the reported start of memory, but only if the kernel can be based there: it must
+           begin where a base is allowed to fall, and hold the span that is mapped there before any
+           memory manager exists. */
+        if (elf_physmem_base && !(elf_physmem_base & PHYSMEM_BASE_MASK) &&
+            (elf_physmem_size >= INIT_IDENTITY_SIZE))
+            base = elf_physmem_base;
+#endif
+        u64 physmem_base = base & ~PHYSMEM_BASE_MASK;
         u64 physmem_offset = physmem_base - (e->e_entry & ~PHYSMEM_BASE_MASK);
 
         elf_debug("  %d program headers, entry %p, physmem offset 0x%lx\n", e->e_phnum, e->e_entry,
@@ -469,6 +478,13 @@ closure_function(5, 1, void, elf_load_phdr,
     closure_finish();
 }
 
+
+/* Physical address the kernel is based at, or zero to derive it from where the loader itself was
+   placed. Where the boot environment can tell which memory is usable, it sets this: the address the
+   firmware happened to load the boot code at says nothing about where memory begins, and a kernel
+   based on it is moved for no reason whenever the two lie in different regions. */
+u64 elf_physmem_base;
+u64 elf_physmem_size;
 
 void load_elf_to_physical(heap h, elf_loader loader, u64 *entry, status_handler sh)
 {

--- a/src/kernel/elf64.h
+++ b/src/kernel/elf64.h
@@ -270,6 +270,9 @@ void elf_dyn_relocate(u64 base, u64 offset, Elf64_Dyn *dyn, Elf64_Sym *syms);
 boolean elf_plt_get(buffer elf, u64 *addr, u64 *offset, u64 *size);
 void walk_elf(buffer elf, range_handler rh);
 void *load_elf(buffer elf, u64 load_offset, elf_map_handler mapper);
+extern u64 elf_physmem_base;
+extern u64 elf_physmem_size;
+
 void load_elf_to_physical(heap h, elf_loader loader, u64 *entry, status_handler sh);
 
 /* Architecture-specific */


### PR DESCRIPTION
load_elf_to_physical() bases the kernel at the address of the loader itself,
rounded down by PHYSMEM_BASE_MASK. Where the firmware places the boot image says
nothing about where memory begins, so whenever the two fall in different regions
the kernel is moved for no reason.

The early boot path does not survive being moved. It reads extern symbols
through a global offset table that elf_dyn_relocate() only fixes up later, from
kaslr(), so the offset computed in platform/virt/service.c comes out as zero
however far the kernel was moved, and init_mmu() then maps a region that does
not hold the running kernel. The result is a silent hang immediately after
ExitBootServices, with no exception and no output.

Measured on a VM.Standard.A1.Flex instance in eu-milan-1 with two gigabytes of
memory:

    UEFI: conventional memory begins at 0x0000000040000000, boot image at 0x00000000be3584e0
    UEFI: starting kernel at 0x0000000080400024

The link address is 0x40400024 and the region at 0x40000000 is free, so nothing
required the move. With one gigabyte the rounding lands on the same address
either way, which is why this is invisible below two.

The loader now reports the lowest conventional memory region and its size, and
elf.c bases the kernel there when the region qualifies: it must begin where a
base is allowed to fall, and hold the span that is mapped there before any
memory manager exists. Otherwise the previous behaviour stands. Platforms that
do not define INIT_IDENTITY_SIZE are excluded by the preprocessor, and any
platform whose PHYSMEM_BASE_MASK leaves the offset at zero is unaffected in any
case.

The arm64 EFI stub in Linux makes the same choice for the same reason:
efi_kaslr_relocate_kernel() in drivers/firmware/efi/libstub/kaslr.c checks the
placement against the memory map and, when it is suitable, runs from where the
loader left the image rather than moving it.

After the change the kernel starts at 0x40400024 and the same image serves
requests on 1 OCPU / 2 GB and on 2 OCPU / 4 GB, neither of which completed boot
before.

Console of the instance, captured with oci compute console-history. Before the
change, with the loader built to report what it decides:

    UEFI: conventional memory begins at 0x0000000040000000
    UEFI: starting kernel at 0x0000000080400024
    EFI ExitBootServices: Called.
    [nothing further: no exception, no output, the instance stays up and answers nothing]

The memory map in the same capture shows the link address is free memory:

    UEFI:   type 7, start 0x40000000, size 0x4000000, attributes 0x8

After the change, same image, same shape:

    UEFI: conventional memory begins at 0x0000000040000000, size 0x4000000, boot image at 0x00000000be3584e0
    UEFI: starting kernel at 0x0000000040400024
    [4.070072] en1: assigned 10.0.0.231

The boot image sits at 0xbe3584e0, near the top of memory, which is what made
the old rounding pick 0x80000000. The kernel now stays at its link address.

Shapes tried with the same image, before and after:

    1 OCPU / 1 GB    boots        boots
    1 OCPU / 2 GB    silent hang  boots, serves in about 45 seconds
    1 OCPU / 4 GB    silent hang  boots
    2 OCPU / 2 GB    silent hang  boots, serves in about 23 seconds
    2 OCPU / 4 GB    silent hang  boots

An Ubuntu image on the same tenancy runs on 2 OCPU / 12 GB, so the platform and
the hardware are not a factor.
