### PR TITLE
CircleCI: Replace google-cloud-sdk package with google-cloud-cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build-pc:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             fi
       - run: echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
       - run: curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-      - run: sudo apt-get update && sudo apt-get install google-cloud-sdk
+      - run: sudo apt-get update && sudo apt-get install google-cloud-cli
       - run: echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
       - run: gcloud config set project ${GOOGLE_PROJECT_ID}
       - run: gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
@@ -75,7 +75,7 @@ jobs:
 
       - run: echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
       - run: curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-      - run: sudo apt-get update && sudo apt-get install google-cloud-sdk
+      - run: sudo apt-get update && sudo apt-get install google-cloud-cli
 
       - run: echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
       - run: gcloud config set project ${GOOGLE_PROJECT_ID}
@@ -116,7 +116,7 @@ jobs:
 
       - run: echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
       - run: curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-      - run: sudo apt-get update && sudo apt-get install google-cloud-sdk
+      - run: sudo apt-get update && sudo apt-get install google-cloud-cli
 
       - run: echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
       - run: gcloud config set project ${GOOGLE_PROJECT_ID}
@@ -152,7 +152,7 @@ jobs:
 
       - run: echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
       - run: curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-      - run: sudo apt-get update && sudo apt-get install google-cloud-sdk
+      - run: sudo apt-get update && sudo apt-get install google-cloud-cli
 
       - run: echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
       - run: gcloud config set project ${GOOGLE_PROJECT_ID}


### PR DESCRIPTION
The google-cloud-sdk package has been obsoleted by google-cloud-cli and is no longer available.

While at it, upgrade the config version from 2 to 2.1 (config version 2 has reached end of life).