### PR TITLE
Fix/setsockopt enoprotoopt

### DIFF
--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1896,14 +1896,26 @@ static sysreturn netsock_sendmsg(struct sock *s, const struct msghdr *msg, int f
     u64 iov_len = msg->msg_iovlen;
     struct sockaddr *addr = msg->msg_name;
     socklen_t addr_len = msg->msg_namelen;
+    void *control = msg->msg_control;
     socklen_t control_len = msg->msg_controllen;
     context_clear_err(ctx);
     if (control_len != 0) {
-        /* No cmsg types are supported on send (e.g. UDP_SEGMENT for GSO).
-           Reject explicitly rather than silently sending the iovec as a
-           single unsegmented datagram, which would corrupt anything relying
-           on the cmsg having been honored. */
-        rv = -EINVAL;
+        struct cmsghdr cmsg;
+
+        /* No cmsg types are supported on send. In particular, a UDP_SEGMENT
+           cmsg (used by e.g. curl and quic-go to request UDP GSO) must be
+           rejected with EIO, the same errno Linux itself returns when GSO
+           can't be performed - callers such as curl's vquic layer already
+           handle that specific errno by retrying without GSO, so this stays
+           correct instead of just failing the transfer outright. Anything
+           else is rejected with EINVAL rather than silently ignored, which
+           would otherwise send the iovec as a single unsegmented datagram. */
+        if ((control_len < sizeof(cmsg)) || !copy_from_user(control, &cmsg, sizeof(cmsg))) {
+            rv = -EINVAL;
+            goto out;
+        }
+        rv = ((cmsg.cmsg_level == SOL_UDP) && (cmsg.cmsg_type == UDP_SEGMENT)) ?
+            -EIO : -EINVAL;
         goto out;
     }
     return socket_write_internal(s, 0, iov, iov_len, flags, addr, addr_len, ctx, in_bh, completion);

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -2772,6 +2772,15 @@ static sysreturn netsock_getsockopt(struct sock *sock, int level,
             goto unimplemented;
         }
         break;
+    case SOL_UDP:
+        switch (optname) {
+        case UDP_SEGMENT:
+        case UDP_GRO:
+            goto unimplemented;
+        default:
+            goto unimplemented;
+        }
+        break;
     case SOL_TCP:
         if (s->sock.type != SOCK_STREAM) {
             rv = -EOPNOTSUPP;

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -2536,6 +2536,19 @@ static sysreturn netsock_setsockopt(struct sock *sock, int level,
             goto unimplemented;
         }
         break;
+    case SOL_UDP:
+        switch (optname) {
+        case UDP_SEGMENT:
+        case UDP_GRO:
+            /* UDP GSO/GRO are not implemented. Reject explicitly rather than
+               relying on the generic unimplemented path, so a sender can't
+               mistake success here for segmentation offload actually being
+               applied to its sendmsg() calls. */
+            goto unimplemented;
+        default:
+            goto unimplemented;
+        }
+        break;
     case SOL_TCP:
         switch (optname) {
         case TCP_NODELAY:

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -1896,7 +1896,16 @@ static sysreturn netsock_sendmsg(struct sock *s, const struct msghdr *msg, int f
     u64 iov_len = msg->msg_iovlen;
     struct sockaddr *addr = msg->msg_name;
     socklen_t addr_len = msg->msg_namelen;
+    socklen_t control_len = msg->msg_controllen;
     context_clear_err(ctx);
+    if (control_len != 0) {
+        /* No cmsg types are supported on send (e.g. UDP_SEGMENT for GSO).
+           Reject explicitly rather than silently sending the iovec as a
+           single unsegmented datagram, which would corrupt anything relying
+           on the cmsg having been honored. */
+        rv = -EINVAL;
+        goto out;
+    }
     return socket_write_internal(s, 0, iov, iov_len, flags, addr, addr_len, ctx, in_bh, completion);
   out:
     return io_complete(completion, rv);

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -2578,7 +2578,7 @@ static sysreturn netsock_setsockopt(struct sock *sock, int level,
 unimplemented:
     msg_warn("setsockopt unimplemented: fd %d, level %d, optname %d",
              sock->fd, level, optname);
-    rv = 0;
+    rv = -ENOPROTOOPT;
 out:
     socket_release(sock);
     return rv;

--- a/src/unix/socket.h
+++ b/src/unix/socket.h
@@ -44,6 +44,12 @@ struct mmsghdr {
     unsigned int msg_len;
 };
 
+struct cmsghdr {
+    u64 cmsg_len;
+    int cmsg_level;
+    int cmsg_type;
+};
+
 #define IFNAMSIZ    16
 
 struct ifmap {

--- a/src/unix/system_structs.h
+++ b/src/unix/system_structs.h
@@ -845,6 +845,7 @@ struct io_uring_params {
 #define IPPROTO_IP      0
 #define SOL_SOCKET      1
 #define SOL_TCP         6
+#define SOL_UDP         17
 #define IPPROTO_IPV6    41
 
 /* set/getsockopt optnames */
@@ -877,6 +878,9 @@ struct io_uring_params {
 #define IP_MULTICAST_LOOP   34
 #define IP_ADD_MEMBERSHIP   35
 #define IP_DROP_MEMBERSHIP  36
+
+#define UDP_SEGMENT     103
+#define UDP_GRO         104
 
 #define IPV6_UNICAST_HOPS   16
 #define IPV6_MULTICAST_IF   17

--- a/test/runtime/netsock.c
+++ b/test/runtime/netsock.c
@@ -17,6 +17,14 @@
 
 #include "../test_utils.h"
 
+/* Not defined by every libc's <linux/udp.h>. */
+#ifndef UDP_SEGMENT
+#define UDP_SEGMENT 103
+#endif
+#ifndef UDP_GRO
+#define UDP_GRO     104
+#endif
+
 #define NETSOCK_TEST_BASIC_PORT 1233
 #define NETSOCK_TEST_FAULT_PORT 1237
 #define NETSOCK_TEST_TIMEO_PORT 1238
@@ -172,6 +180,27 @@ static void netsock_test_basic(int sock_type)
         test_assert(write(tx_fd, &ret, sizeof(ret)) < 0 && errno == EDESTADDRREQ);
         test_assert(connect(tx_fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
     }
+    /* setsockopt()/getsockopt() must not silently succeed for options they don't implement. */
+    {
+        int val = 0;
+        socklen_t len = sizeof(val);
+
+        test_assert((setsockopt(tx_fd, SOL_SOCKET, SO_REUSEPORT, &val, len) == -1) &&
+                     (errno == ENOPROTOOPT));
+
+        /* UDP_SEGMENT/UDP_GRO (UDP GSO/GRO) are not implemented and must be rejected
+         * explicitly rather than silently accepted (setsockopt) or misreported
+         * (getsockopt). */
+        test_assert((setsockopt(tx_fd, IPPROTO_UDP, UDP_SEGMENT, &val, len) == -1) &&
+                     (errno == ENOPROTOOPT));
+        test_assert((setsockopt(tx_fd, IPPROTO_UDP, UDP_GRO, &val, len) == -1) &&
+                     (errno == ENOPROTOOPT));
+        test_assert((getsockopt(tx_fd, IPPROTO_UDP, UDP_SEGMENT, &val, &len) == -1) &&
+                     (errno == ENOPROTOOPT));
+        test_assert((getsockopt(tx_fd, IPPROTO_UDP, UDP_GRO, &val, &len) == -1) &&
+                     (errno == ENOPROTOOPT));
+    }
+
     addr_len = sizeof(addr);
     test_assert((getpeername(tx_fd, FAULT_ADDR, &addr_len) == -1) && (errno == EFAULT));
     test_assert((getpeername(tx_fd, &addr, FAULT_ADDR) == -1) && (errno == EFAULT));
@@ -670,6 +699,34 @@ static void netsock_test_msg(int sock_type)
         test_assert(msg2.msg_flags == MSG_TRUNC);
         test_assert(recvmsg(rx_fd, &msg2, MSG_TRUNC) == total_len);
         test_assert(msg2.msg_flags == MSG_TRUNC);
+    }
+
+    /* sendmsg() must reject ancillary data it doesn't implement, rather than
+     * silently sending the iovec unsegmented. A UDP_SEGMENT cmsg (used for
+     * GSO) must fail with EIO specifically - the same errno Linux itself
+     * returns when GSO can't be done, which is what real callers (e.g.
+     * curl) already handle by retrying without it. Anything else fails
+     * with EINVAL. */
+    {
+        union {
+            struct cmsghdr hdr;
+            uint8_t buf[CMSG_SPACE(sizeof(int))];
+        } cmsg;
+
+        memset(&cmsg, 0, sizeof(cmsg));
+        cmsg.hdr.cmsg_len = CMSG_LEN(sizeof(int));
+        cmsg.hdr.cmsg_level = IPPROTO_UDP;
+        cmsg.hdr.cmsg_type = UDP_SEGMENT;
+        msg1.msg_control = &cmsg;
+        msg1.msg_controllen = sizeof(cmsg);
+        test_assert((sendmsg(tx_fd, &msg1, 0) == -1) && (errno == EIO));
+
+        cmsg.hdr.cmsg_level = SOL_SOCKET;
+        cmsg.hdr.cmsg_type = SCM_RIGHTS;
+        test_assert((sendmsg(tx_fd, &msg1, 0) == -1) && (errno == EINVAL));
+
+        msg1.msg_control = NULL;
+        msg1.msg_controllen = 0;
     }
 
     memset(&mmsg1, 0, sizeof(mmsg1));


### PR DESCRIPTION
netsock: fail unimplemented setsockopt/sendmsg cmsg options instead of silently succeeding

Summary
-------

While looking into what it would take for QUIC-capable binaries (e.g. `curl`
built with ngtcp2/nghttp3) to run correctly under Nanos, two related bugs
in `src/net/netsyscall.c` turned out to actively break real-world QUIC
clients rather than just being a missing feature:

1. `setsockopt()` returned 0 (success) for any option it didn't recognize,
   instead of an error. In particular, there was no case at all for
   `SOL_UDP`, so `setsockopt(fd, SOL_UDP, UDP_SEGMENT, ...)`, the call curl,
   quic-go, msquic and others use to opportunistically enable UDP GSO,
   appeared to succeed while doing nothing.

2. `sendmsg()` never looked at msg->msg_control at all. So once a caller
   believed GSO was enabled (because of bug # 1) and attached a
   `UDP_SEGMENT` cmsg to `sendmsg()` to batch several QUIC packets into one
   send call, Nanos silently ignored the cmsg and handed the whole,
   oversized buffer to the network stack as a single unsegmented
   datagram.

Neither failure was visible to the caller: no error was returned, so a
QUIC stack had no signal that its GSO request had not been honored.

`curl`'s vquic layer (`lib/vquic/vquic.c`) enables UDP GSO purely at compile
time on Linux (`#if defined(__linux__) && defined(UDP_SEGMENT) && ...`),
with no runtime capability probe. Whenever it has more than one QUIC
packet queued for the same destination, it concatenates them into one
buffer and calls `sendmsg()` with a `UDP_SEGMENT` cmsg, expecting the kernel
to split that buffer into individually-sized datagrams.

Under unpatched Nanos, that call still "succeeds" but the data is sent as
one oversized datagram. lwIP's IP layer then refuses to transmit it
(exceeds the interface MTU with the DF bit set, which `curl` sets via
IP_MTU_DISCOVER) and the packet never reaches the network at all.
`curl`'s own PMTUD handling treats this as an expected, silent packet loss
and just retries the same oversized send, so the QUIC handshake times out
after ~10s with no error ever surfacing to the user.

Proposed patch
-------

- `setsockopt()` now returns -ENOPROTOOPT for any option it doesn't
  implement, instead of silently returning 0. This is a correctness fix
  independent of QUIC: a caller checking the return value can no longer
  be lied to about an option having taken effect.

- SOL_UDP / UDP_SEGMENT / UDP_GRO get an explicit case in both
  `setsockopt()` and `getsockopt()`, documenting that UDP GSO/GRO are
  intentionally unimplemented, rather than falling through a generic
  "unknown level" path.

- `sendmsg()` now inspects msg_control. A UDP_SEGMENT cmsg is rejected with
  -EIO specifically. This is the same errno Linux returns when UDP GSO
  can't be performed. `curl` (and other GSO-aware stacks)
  only treats EIO as "GSO isn't available here" and transparently
  retries the same data without segmentation; any other errno is treated
  as a fatal send error and aborts the whole transfer. Any other,
  unrecognized cmsg is rejected with -EINVAL.

- struct cmsghdr didn't exist anywhere in the tree (nothing had ever
  needed to parse a cmsg); added to `src/unix/socket.h`.

Testing
-------

`test/runtime/netsock.c` gained coverage for all of the above:
`setsockopt(SO_REUSEPORT)` and `setsockopt/getsockopt(SOL_UDP,
UDP_SEGMENT/UDP_GRO)` now assert -ENOPROTOOPT instead of success;
`sendmsg()` with a UDP_SEGMENT cmsg asserts -EIO, and `sendmsg()` with any
other cmsg (SCM_RIGHTS) asserts -EINVAL.

Proof of concept: `curl`, before and after
----------------------------------------------
[poc-after.pcap.txt](https://github.com/user-attachments/files/31680530/poc-after.pcap.txt)
[poc-before.pcap.txt](https://github.com/user-attachments/files/31680531/poc-before.pcap.txt)

(`txt` extension was added to upload the files and needs to be removed, these are PCAP files)

To confirm this is a real, observable difference (not just a change in
returned errno), `curl` 8.21.0 (static, glibc, built with ngtcp2/nghttp3)
was run inside Nanos with `--http3-only` against a local HTTP/3 test server,
once on a kernel built from master (poc-before.pcap) and once on
a kernel built from this branch (poc-after.pcap). Both captures were
taken directly on the guest's virtio-net device (via QEMU's
`-object filter-dump`), so they show exactly what Nanos itself put on
the wire.

Before (poc-before.pcap):
  * `curl` builds its Initial-flight buffer, attaches a UDP_SEGMENT cmsg,
    and calls `sendmsg()`.
  * Nanos's lwIP layer logs `udp_send: sending datagram of length 2408`
    (the whole batched buffer, unsegmented) and then silently drops it
    for exceeding the interface MTU with DF set.
  * The capture shows zero packets ever leaving the guest's NIC for this
    connection attempt.
  * `curl` prints nothing (EMSGSIZE is treated as ordinary, silent PMTUD
    loss) and the connection eventually fails:
      * ngtcp2_conn_handle_expiry returned error: ERR_HANDSHAKE_TIMEOUT
      curl: (55) Failed to connect ... after 10037 ms: Failed sending
      data to the peer

After (poc-after.pcap):
  * The identical `sendmsg()` call now fails immediately with the expected
    errno, and curl's own log line proves it recognized it correctly:
      * sendmsg() returned -1 (errno 5); disable GSO
  * `curl` transparently retries without GSO. The capture shows clean,
    correctly-sized (1242 bytes, under MTU) QUIC Initial packets actually
    leaving the guest, each fully parseable by Wireshark as a valid QUIC
    packet (DCID/SCID/PKN/CRYPTO frames).

The remaining round trip (getting a full HTTP/3 response back) is
blocked by a QEMU/slirp limitation unrelated to Nanos: slirp reliably
relays guest-initiated UDP to real external destinations, but not to a
service listening on the host itself via the 10.0.2.2 host alias. The
client-side behavior change (which is what this PR fixes) is fully
demonstrated by the two captures regardless.

Commits on this branch
-----------------------

- netsock setsockopt: return -ENOPROTOOPT for unimplemented options
- Socket options: add SOL_UDP, UDP_SEGMENT and UDP_GRO definitions
- netsock setsockopt: explicitly reject UDP_SEGMENT and UDP_GRO
- netsock getsockopt: mirror the explicit SOL_UDP rejection
- netsock sendmsg: reject non-empty ancillary data
- netsock sendmsg: return EIO for a UDP_SEGMENT cmsg, not EINVAL
- test/runtime/netsock: cover the setsockopt/sendmsg fixes