### PR TITLE
Debug log macros: fix stale log_printf() call signature

### DIFF
--- a/src/net/direct.c
+++ b/src/net/direct.c
@@ -4,7 +4,7 @@
 
 //#define DIRECT_DEBUG
 #ifdef DIRECT_DEBUG
-#define direct_debug(x, ...) do {log_printf(ss("DNET"), ss("%s: " x), func_ss, ##__VA_ARGS__);} while(0)
+#define direct_debug(x, ...) do {log_printf(LOG_INFO, ss("DNET %s: " x), func_ss, ##__VA_ARGS__);} while(0)
 #else
 #define direct_debug(x, ...)
 #endif

--- a/src/net/netsyscall.c
+++ b/src/net/netsyscall.c
@@ -14,7 +14,7 @@
 
 //#define NETSYSCALL_DEBUG
 #ifdef NETSYSCALL_DEBUG
-#define net_debug(x, ...) do {log_printf(ss(" NET"), ss("%s: " x), func_ss, ##__VA_ARGS__);} while(0)
+#define net_debug(x, ...) do {log_printf(LOG_INFO, ss("NET %s: " x), func_ss, ##__VA_ARGS__);} while(0)
 #else
 #define net_debug(x, ...)
 #endif

--- a/src/riscv64/interrupt.c
+++ b/src/riscv64/interrupt.c
@@ -4,7 +4,7 @@
 
 //#define INT_DEBUG
 #ifdef INT_DEBUG
-#define int_debug(x, ...) do {log_printf(ss("  INT"), ss(x), ##__VA_ARGS__);} while(0)
+#define int_debug(x, ...) do {log_printf(LOG_INFO, ss("INT " x), ##__VA_ARGS__);} while(0)
 #else
 #define int_debug(x, ...)
 #endif

--- a/src/runtime/timer.c
+++ b/src/runtime/timer.c
@@ -10,7 +10,7 @@
 
 //#define TIMER_DEBUG
 #ifdef TIMER_DEBUG
-#define timer_debug(x, ...) do {log_printf(ss("TIMER"), ss(x), ##__VA_ARGS__);} while(0)
+#define timer_debug(x, ...) do {log_printf(LOG_INFO, ss("TIMER " x), ##__VA_ARGS__);} while(0)
 #else
 #define timer_debug(x, ...)
 #endif

--- a/src/unix/unix_internal.h
+++ b/src/unix/unix_internal.h
@@ -584,7 +584,7 @@ static inline thread _current(sstring caller) {
     thread t = get_current_thread();
     if (t == 0 && runtime_strcmp(ss("run_thread_frame"), caller) != 0 &&
         runtime_strcmp(ss("thread_wakeup"), caller) != 0) {
-        log_printf(ss("CURRENT"), ss("invalid address returned to caller '%s'\n"), caller);
+        log_printf(LOG_INFO, ss("CURRENT invalid address returned to caller '%s'"), caller);
         print_frame_trace_from_here();
     }
     return t;


### PR DESCRIPTION
Debug log macros: fix stale log_printf() call signature

Summary
-------

net_debug() (src/net/netsyscall.c), direct_debug() (src/net/direct.c),
timer_debug() (src/runtime/timer.c), int_debug() (src/riscv64/interrupt.c),
and the CURRENT_DEBUG logging path in unix_internal.h's current() macro
all still called log_printf() with its old signature:

    log_printf(<free-form tag sstring>, <format sstring>, ...)

f695ae1d ("Logging: add user-adjustable log levels (\"err\", \"warn\",
\"info\")") changed log_printf()'s first parameter to an enum log_level
and updated the call sites it could find, but missed these five. Each
one sits behind its own commented-out *_DEBUG define
(NETSYSCALL_DEBUG, DIRECT_DEBUG, TIMER_DEBUG, INT_DEBUG, CURRENT_DEBUG),
so none of them are compiled by default and the type mismatch never
surfaced as a build failure - it just sat there, broken, waiting for
anyone who uncommented one of those defines to actually use the
debugging aid.

Proposed patch
-------

Fold the old tag text (" NET", "DNET", "TIMER", "  INT", "CURRENT")
into the format string itself, since there's no dedicated debug level
to route it through - use LOG_INFO for all five, matching the only
level below LOG_WARN that exists. Also drop the trailing newline in
the CURRENT_DEBUG message, which is now redundant: log_printf() has
appended its own since f695ae1d.

No behavioral change under a default build; this only matters to
someone who enables one of these five debug switches.

Testing
-------

Compiled net/netsyscall.c, net/direct.c and runtime/timer.c with their
respective *_DEBUG defines enabled (NETSYSCALL_DEBUG, CURRENT_DEBUG,
DIRECT_DEBUG, TIMER_DEBUG), using the same flags the kernel build
itself uses. All compile cleanly now; before this fix, each failed
with a "passing argument to parameter 'level'" type error.
riscv64/interrupt.c's INT_DEBUG could not be compile-verified for lack
of a riscv64 cross toolchain, but follows the identical, already-
verified fix pattern.

How this was found
-------------------

While tracing a UDP GSO bug in the network stack (see #2187), I temporarily enabled
NETSYSCALL_DEBUG and LWIP_DEBUG to get visibility into what lwIP was
doing with a specific sendmsg() call, and hit this compile error
first.